### PR TITLE
docs: streamline workflow engine technical presentation

### DIFF
--- a/src/Runtime/workflow-engine/docs/presentation-technical.md
+++ b/src/Runtime/workflow-engine/docs/presentation-technical.md
@@ -19,8 +19,8 @@ style: |
     }
     h3 {
       font-size: 1.1em;
-      margin-top: 0.4em;
-      margin-bottom: 0.2em;
+      margin-top: 1em;
+      margin-bottom: 0.3em;
     }
     pre {
       font-size: 0.85em;
@@ -74,7 +74,7 @@ ProcessController.NextElement()
             │     ├── HandleEvents()       ← task start/end handlers, PDF, signing, payment...
             │     └── DispatchToStorage()  ← PUT to Platform Storage (events + state)
             │
-            └── if next is service task → loop again
+            └── if next is service task    → loop again
 ```
 
 If the task after the current one is a service task (PDF, signing, payment), the loop continues automatically within the same request. Every handler, every validation, every storage call happens inline.
@@ -127,7 +127,7 @@ The app enqueues and returns immediately. The engine handles execution, retries,
 
 # How it handles the same failures
 
-| Failure point             | Current behavior                | Workflow Engine behavior                                |
+| Failure point             | Current behaviour               | Workflow Engine behaviour                               |
 | ------------------------- | ------------------------------- | ------------------------------------------------------- |
 | Service task crashes      | Lost. Manual recovery.          | Requeued with backoff. Retried automatically.           |
 | Storage/network timeout   | Unknown state. No retry.        | Step marked retryable. Engine retries.                  |
@@ -145,7 +145,7 @@ Every failure path ends in either **successful retry** or **explicit, visible fa
 | Component        | Technology                                                   |
 | ---------------- | ------------------------------------------------------------ |
 | Runtime          | .NET 10, C# 14                                               |
-| Database         | PostgreSQL (EF Core, `FOR UPDATE SKIP LOCKED`)               |
+| Database         | PostgreSQL (EF Core + raw SQL for hot paths)                  |
 | Telemetry        | OpenTelemetry &rarr; OTLP &rarr; Grafana (Tempo, Prometheus) |
 | Testing          | xUnit v3, Testcontainers (PostgreSQL), WireMock, Verify.Net  |
 | Dashboard        | Vanilla JS ES modules (no build step), embedded in Core      |
@@ -175,93 +175,44 @@ Host Application (e.g. WorkflowEngine.App)
 
 `WorkflowEngine.App` is the Altinn-specific host. It adds `AppCommand` &mdash; an HTTP callback into Altinn apps carrying full instance context (org, app, actor, lockToken, instanceGuid).
 
-Database is the single source of truth. No in-memory queue.
+Database is the single source of truth. No in-memory queue. Enqueue and status-update paths use channel-based write buffers for throughput.
 
 ---
 
 # Processing model
 
-### How work is picked up
+### How work flows through the engine
 
-- `WorkflowProcessor` (BackgroundService) polls PostgreSQL in a loop
-- `FOR UPDATE SKIP LOCKED` provides atomic, non-blocking row locking
+- `WorkflowProcessor` polls PostgreSQL &mdash; `FOR UPDATE SKIP LOCKED` for atomic, non-blocking row locking
 - Multiple engine instances can run against the same database safely
-
-### How work is executed
-
 - Each workflow's steps are executed sequentially by `WorkflowExecutor`
-- Commands return `Success`, `RetryableError`, or `CriticalError`
-- On retryable error: workflow requeued with configurable backoff (exponential, linear, constant)
-- On critical error: workflow marked Failed immediately
+- Three independent semaphore pools (workers, DB connections, HTTP calls) prevent resource exhaustion
+- When load exceeds capacity, the engine returns **HTTP 429** on enqueue requests
+
+### How failures are classified
+
+| HTTP response  | Classification | Action                     |
+| -------------- | -------------- | -------------------------- |
+| 2xx            | Success        | Next step                  |
+| 408, 429, 5xx  | Retryable      | Requeue with backoff       |
+| Other 4xx      | Critical       | Fail immediately, no retry |
+
+Retries are per-step with configurable backoff (exponential, linear, constant), delay caps, and total deadline.
 
 ### How crashes are handled
 
-- `HeartbeatService` updates a timestamp for all in-flight workflows on a regular interval
-- If heartbeat expires, another worker reclaims the workflow
-- After a configurable number of reclaim attempts: marked Failed (poison workflow protection)
-
----
-
-# Retry strategy
-
-Per-step, configurable:
-
-| Parameter      | Purpose                                      |
-| -------------- | -------------------------------------------- |
-| `BackoffType`  | Exponential, Linear, or Constant             |
-| `BaseInterval` | Initial delay between retries                |
-| `MaxRetries`   | Max retry count (optional)                   |
-| `MaxDelay`     | Cap on individual delay (optional)           |
-| `MaxDuration`  | Total deadline from first attempt (optional) |
-
-Error classification drives retry behavior:
-
-| HTTP response | Classification | Action                     |
-| ------------- | -------------- | -------------------------- |
-| 2xx           | Success        | Next step                  |
-| 408, 429, 5xx | Retryable      | Requeue with backoff       |
-| Other 4xx     | Critical       | Fail immediately, no retry |
-
----
-
-# Concurrency & backpressure
-
-Three independent semaphore pools prevent resource exhaustion:
-
-| Pool           | Controls                                |
-| -------------- | --------------------------------------- |
-| Workers        | Concurrent workflow processing tasks    |
-| DB connections | PostgreSQL connection slots             |
-| HTTP calls     | Outbound HTTP requests to apps/webhooks |
-
-When active workflows exceed the backpressure threshold, the engine returns **HTTP 429** on enqueue requests.
-
-### Cancellation
-
-- `POST /api/v1/{namespace}/workflows/{id}/cancel`
-- Propagated across pods via DB polling
-- Idempotent &mdash; safe to call multiple times
-
-### Resume
-
-- `POST /api/v1/{namespace}/workflows/{id}/resume?cascade=false`
-- Resumes failed, canceled, or dependency-failed workflows
-- Optional `cascade=true` to resume transitively dependent workflows
+- `HeartbeatService` proves worker liveness &mdash; if heartbeat expires, another worker reclaims the workflow
+- Poison workflow protection after configurable max reclaim attempts
+- Cross-pod cancellation propagation via DB polling; resume support for failed/canceled workflows
 
 ---
 
 # Observability
 
-### Metrics (OpenTelemetry &rarr; Grafana)
+### OpenTelemetry &rarr; Grafana
 
-- Workflow counters: received, accepted, succeeded, failed, requeued, reclaimed
-- Timing histograms: queue time, service time, total time (workflow + step level)
-- Resource gauges: worker/DB/HTTP slot utilization
-
-### Traces
-
-- Full distributed trace per workflow (W3C trace context)
-- Spans for: processing, step execution, command callbacks, slot acquisition
+- Counters, histograms, and gauges across the full workflow and step lifecycle
+- Distributed tracing with W3C trace context &mdash; spans for processing, execution, callbacks, slot acquisition
 - Activity links between dependent workflows
 
 ### Dashboard (built-in)
@@ -269,12 +220,6 @@ When active workflows exceed the backpressure threshold, the engine returns **HT
 - Real-time SSE streams: engine health, active workflows, step pipelines
 - Query interface with namespace/status/label filters
 - Click-through to Grafana Tempo traces
-
-### API
-
-- `GET /api/v1/{namespace}/workflows/{id}` &mdash; status, steps, errors, retry counts
-- `GET /api/v1/{namespace}/workflows?page=1&pageSize=25` &mdash; paginated list with filtering
-- Health endpoints: `/health`, `/health/ready`, `/health/live`
 
 ---
 
@@ -305,21 +250,3 @@ A single enqueue request can express **fan-out / fan-in** patterns:
 - DAG resolution via topological sort. Cycle detection. Atomic insert.
 - A workflow only starts when all its dependencies have completed.
 - If a dependency fails, dependents are marked `DependencyFailed`.
-
----
-
-# Current Status
-
-| Area                                                           | Status      |
-| -------------------------------------------------------------- | ----------- |
-| Core engine (processing, retries, heartbeat, cancellation)     | Implemented |
-| Command system (Webhook, AppCommand)                           | Implemented |
-| PostgreSQL persistence (EF Core, migrations, batch operations) | Implemented |
-| Telemetry (metrics, traces, OTLP export)                       | Implemented |
-| Dashboard (real-time monitoring, query, step detail)           | Implemented |
-| API (enqueue, query, cancel, health)                           | Implemented |
-| Workflow dependencies (DAG, topological sort)                  | Implemented |
-| Integration tests (Testcontainers, WireMock)                   | Implemented |
-| Load testing (k6 scripts)                                      | Implemented |
-| Integration with Altinn app process engine                     | In progress |
-| Production deployment                                          | In progress |

--- a/src/Runtime/workflow-engine/docs/presentation/presentation-technical.html
+++ b/src/Runtime/workflow-engine/docs/presentation/presentation-technical.html
@@ -1,0 +1,1272 @@
+<!DOCTYPE html><html lang="C"><head><title>Workflow Engine</title><meta property="og:title" content="Workflow Engine"><meta charset="UTF-8"><meta name="viewport" content="width=device-width,height=device-height,initial-scale=1.0"><meta name="apple-mobile-web-app-capable" content="yes"><meta http-equiv="X-UA-Compatible" content="ie=edge"><meta property="og:type" content="website"><meta name="twitter:card" content="summary"><style>@media screen{body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button,body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button,body[data-bespoke-view=overview] button.bespoke-marp-overview-close,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area .bespoke-marp-presenter-info-page,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button{appearance:none;background-color:initial;border:0;color:inherit;cursor:pointer;font-size:inherit;opacity:.8;outline:none;padding:0;transition:opacity .2s linear;-webkit-tap-highlight-color:transparent}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button:disabled,body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button:disabled,body[data-bespoke-view=overview] button.bespoke-marp-overview-close:disabled,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area .bespoke-marp-presenter-info-page:disabled,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button:disabled,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button:disabled{cursor:not-allowed;opacity:.15!important}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button:hover,body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button:hover,body[data-bespoke-view=overview] button.bespoke-marp-overview-close:hover,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area .bespoke-marp-presenter-info-page:hover,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button:hover,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button:hover{opacity:1}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button:hover:active,body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button:hover:active,body[data-bespoke-view=overview] button.bespoke-marp-overview-close:hover:active,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area .bespoke-marp-presenter-info-page:hover:active,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button:hover:active,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button:hover:active{opacity:.6}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button:hover:not(:disabled),body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button:hover:not(:disabled),body[data-bespoke-view=overview] button.bespoke-marp-overview-close:hover:not(:disabled),body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area .bespoke-marp-presenter-info-page:hover:not(:disabled),body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button:hover:not(:disabled),body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button:hover:not(:disabled){transition:none}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=prev],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=prev],body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button.bespoke-marp-presenter-info-page-prev{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48cGF0aCBmaWxsPSJub25lIiBzdHJva2U9IiNmZmYiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgc3Ryb2tlLXdpZHRoPSI1IiBkPSJNNjggOTAgMjggNTBsNDAtNDAiLz48L3N2Zz4=") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=next],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=next],body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button.bespoke-marp-presenter-info-page-next{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48cGF0aCBmaWxsPSJub25lIiBzdHJva2U9IiNmZmYiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgc3Ryb2tlLXdpZHRoPSI1IiBkPSJtMzIgOTAgNDAtNDAtNDAtNDAiLz48L3N2Zz4=") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=fullscreen],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=fullscreen]{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmF7ZmlsbDpub25lO3N0cm9rZTojZmZmO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2Utd2lkdGg6NXB4fTwvc3R5bGU+PC9kZWZzPjxyZWN0IHdpZHRoPSI4MCIgaGVpZ2h0PSI2MCIgeD0iMTAiIHk9IjIwIiBjbGFzcz0iYSIgcng9IjUuNjciLz48cGF0aCBkPSJNNDAgNzBIMjBWNTBtMjAgMEwyMCA3MG00MC00MGgyMHYyMG0tMjAgMCAyMC0yMCIgY2xhc3M9ImEiLz48L3N2Zz4=") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button.exit[data-bespoke-marp-osc=fullscreen],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button.exit[data-bespoke-marp-osc=fullscreen]{background-image:url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmF7ZmlsbDpub25lO3N0cm9rZTojZmZmO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2Utd2lkdGg6NXB4fTwvc3R5bGU+PC9kZWZzPjxyZWN0IHdpZHRoPSI4MCIgaGVpZ2h0PSI2MCIgeD0iMTAiIHk9IjIwIiBjbGFzcz0iYSIgcng9IjUuNjciLz48cGF0aCBkPSJNMjAgNTBoMjB2MjBtLTIwIDAgMjAtMjBtNDAgMEg2MFYzMG0yMCAwTDYwIDUwIiBjbGFzcz0iYSIvPjwvc3ZnPg==")}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=presenter],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=presenter]{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48cGF0aCBmaWxsPSJub25lIiBzdHJva2U9IiNmZmYiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgc3Ryb2tlLXdpZHRoPSI1IiBkPSJNODcuOCA0Ny41Qzg5IDUwIDg3LjcgNTIgODUgNTJIMzVhOC43IDguNyAwIDAgMS03LjItNC41bC0xNS42LTMxQzExIDE0IDEyLjIgMTIgMTUgMTJoNTBhOC44IDguOCAwIDAgMSA3LjIgNC41ek02MCA1MnYzNm0tMTAgMGgyME00NSA0MmgyMCIvPjwvc3ZnPg==") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}body[data-bespoke-view=overview] button.bespoke-marp-overview-close,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button.bespoke-marp-presenter-note-bigger{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48cGF0aCBzdHJva2U9IiNmZmYiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgc3Ryb2tlLXdpZHRoPSI1IiBkPSJNMTIgNTBoODBNNTIgOTBWMTAiLz48L3N2Zz4=") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button.bespoke-marp-presenter-note-smaller{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48cGF0aCBmaWxsPSJub25lIiBzdHJva2U9IiNmZmYiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgc3Ryb2tlLXdpZHRoPSI1IiBkPSJNMTIgNTBoODAiLz48L3N2Zz4=") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=overview],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=overview]{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmF7ZmlsbDpub25lO3N0cm9rZTojZmZmO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2Utd2lkdGg6NXB4O3J4OjVweDtyeTo1cHg7d2lkdGg6MjVweDtoZWlnaHQ6MjVweH08L3N0eWxlPjwvZGVmcz48cmVjdCB4PSIyMCIgeT0iMjAiIGNsYXNzPSJhIi8+PHJlY3QgeD0iNTUiIHk9IjIwIiBjbGFzcz0iYSIvPjxyZWN0IHg9IjIwIiB5PSI1NSIgY2xhc3M9ImEiLz48cmVjdCB4PSI1NSIgeT0iNTUiIGNsYXNzPSJhIi8+PC9zdmc+") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}}@keyframes __bespoke_marp_transition_reduced_outgoing__{0%{opacity:1}to{opacity:0}}@keyframes __bespoke_marp_transition_reduced_incoming__{0%{mix-blend-mode:plus-lighter;opacity:0}to{mix-blend-mode:plus-lighter;opacity:1}}.bespoke-marp-note,.bespoke-marp-osc,.bespoke-progress-parent{display:none;transition:none}@media screen{::view-transition-group(*){animation-duration:var(--marp-bespoke-transition-animation-duration,.5s);animation-timing-function:ease}::view-transition-new(*),::view-transition-old(*){animation-delay:0s;animation-direction:var(--marp-bespoke-transition-animation-direction,normal);animation-duration:var(--marp-bespoke-transition-animation-duration,.5s);animation-fill-mode:both;animation-name:var(--marp-bespoke-transition-animation-name,var(--marp-bespoke-transition-animation-name-fallback,__bespoke_marp_transition_no_animation__));mix-blend-mode:normal}::view-transition-old(*){--marp-bespoke-transition-animation-name-fallback:__bespoke_marp_transition_reduced_outgoing__;animation-timing-function:ease}::view-transition-new(*){--marp-bespoke-transition-animation-name-fallback:__bespoke_marp_transition_reduced_incoming__;animation-timing-function:ease}::view-transition-new(root),::view-transition-old(root){animation-timing-function:linear}::view-transition-new(__bespoke_marp_transition_osc__),::view-transition-old(__bespoke_marp_transition_osc__){animation-duration:0s!important;animation-name:__bespoke_marp_transition_osc__!important}::view-transition-new(__bespoke_marp_transition_osc__){opacity:0!important}.bespoke-marp-transition-warming-up::view-transition-group(*),.bespoke-marp-transition-warming-up::view-transition-new(*),.bespoke-marp-transition-warming-up::view-transition-old(*){animation-play-state:paused!important}body,html{height:100%;margin:0}body{background:#000;overflow:hidden}svg.bespoke-marp-slide{content-visibility:hidden;interactivity:inert;opacity:0;pointer-events:none;z-index:-1}svg.bespoke-marp-slide:not(.bespoke-marp-active) *{view-transition-name:none!important}svg.bespoke-marp-slide.bespoke-marp-active{content-visibility:visible;interactivity:auto;opacity:1;pointer-events:auto;z-index:0}svg.bespoke-marp-slide.bespoke-marp-active.bespoke-marp-active-ready *{animation-name:__bespoke_marp__!important}@supports not (content-visibility:hidden){svg.bespoke-marp-slide[data-bespoke-marp-load=hideable]{display:none}svg.bespoke-marp-slide[data-bespoke-marp-load=hideable].bespoke-marp-active{display:block}}}@media screen and (prefers-reduced-motion:reduce){svg.bespoke-marp-slide *{view-transition-name:none!important}}@media screen{[data-bespoke-marp-fragment=inactive]{visibility:hidden}body[data-bespoke-view=""] .bespoke-marp-parent,body[data-bespoke-view=next] .bespoke-marp-parent{inset:0;position:absolute}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc,body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc{background:#000000a6;border-radius:7px;bottom:50px;color:#fff;contain:paint;display:block;font-family:Helvetica,Arial,sans-serif;font-size:16px;left:50%;line-height:0;opacity:1;padding:12px;position:absolute;touch-action:manipulation;transform:translateX(-50%);transition:opacity .2s linear;-webkit-user-select:none;user-select:none;view-transition-name:__bespoke_marp_transition_osc__;white-space:nowrap;will-change:transform;z-index:1}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>:where(*),body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>:where(*){margin-left:6px}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>:where(*):where(:first-child),body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>:where(*):where(:first-child){margin-left:0}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>span,body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>span{opacity:.8}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>span[data-bespoke-marp-osc=page],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>span[data-bespoke-marp-osc=page]{display:inline-block;min-width:140px;text-align:center}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=fullscreen],body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=next],body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=overview],body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=presenter],body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=prev],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=fullscreen],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=next],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=overview],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=presenter],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=prev]{height:32px;line-height:32px;width:32px}body[data-bespoke-view=""] .bespoke-marp-parent.bespoke-marp-inactive,body[data-bespoke-view=next] .bespoke-marp-parent.bespoke-marp-inactive{cursor:none}body[data-bespoke-view=""] .bespoke-marp-parent.bespoke-marp-inactive>.bespoke-marp-osc,body[data-bespoke-view=next] .bespoke-marp-parent.bespoke-marp-inactive>.bespoke-marp-osc{opacity:0;pointer-events:none}body[data-bespoke-view=""] svg.bespoke-marp-slide,body[data-bespoke-view=next] svg.bespoke-marp-slide{height:100%;left:0;position:absolute;top:0;width:100%}body[data-bespoke-view=""] .bespoke-progress-parent{background:#222;display:flex;height:5px;width:100%}body[data-bespoke-view=""] .bespoke-progress-parent+:where(.bespoke-marp-parent){top:5px}body[data-bespoke-view=""] .bespoke-progress-parent .bespoke-progress-bar{background:#0288d1;flex:0 0 0;transition:flex-basis .2s cubic-bezier(0,1,1,1)}body[data-bespoke-view=next]{background:#0000}body[data-bespoke-view=presenter]{background:#161616}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container{display:grid;font-family:Helvetica,Arial,sans-serif;grid-template:"current dragbar next" minmax(140px,1fr) "current dragbar note" 2fr "info    dragbar note" 3em;grid-template-columns:minmax(3px,var(--bespoke-marp-presenter-split-ratio,66%)) 0 minmax(3px,1fr);height:100%;left:0;position:absolute;top:0;width:100%}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container :where(.bespoke-marp-parent){grid-area:current;overflow:hidden;position:relative}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container :where(.bespoke-marp-parent) :where(svg.bespoke-marp-slide){height:calc(100% - 40px);left:20px;pointer-events:none;position:absolute;top:20px;-webkit-user-select:none;user-select:none;width:calc(100% - 40px)}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container :where(.bespoke-marp-parent) :where(svg.bespoke-marp-slide).bespoke-marp-active{filter:drop-shadow(0 3px 10px rgba(0,0,0,.5))}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-dragbar-container{background:#0288d1;cursor:col-resize;grid-area:dragbar;margin-left:-3px;opacity:0;position:relative;transition:opacity .4s linear .1s;width:6px;z-index:10}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-dragbar-container:hover{opacity:1}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-dragbar-container.active{opacity:1;transition-delay:0s}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-next-container{background:#222;cursor:pointer;display:none;grid-area:next;overflow:hidden;position:relative}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-next-container.active{display:block}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-next-container iframe.bespoke-marp-presenter-next{background:#0000;border:0;display:block;filter:drop-shadow(0 3px 10px rgba(0,0,0,.5));height:calc(100% - 40px);left:20px;pointer-events:none;position:absolute;interactivity:inert;top:20px;-webkit-user-select:none;user-select:none;width:calc(100% - 40px)}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container{background:#222;color:#eee;grid-area:note;position:relative;z-index:1}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button{height:1.5em;line-height:1.5em;width:1.5em}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-presenter-note-wrapper{display:block;inset:0;position:absolute}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-presenter-note-buttons{background:#000000a6;border-radius:4px;bottom:0;display:flex;gap:4px;margin:12px;opacity:0;padding:6px;pointer-events:none;position:absolute;right:0;transition:opacity .2s linear}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-presenter-note-buttons:focus-within,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-presenter-note-wrapper:focus-within+.bespoke-marp-presenter-note-buttons,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container:hover .bespoke-marp-presenter-note-buttons{opacity:1;pointer-events:auto}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note{box-sizing:border-box;font-size:calc(1.1em*var(--bespoke-marp-note-font-scale, 1));height:calc(100% - 40px);margin:20px;overflow:auto;padding-right:3px;white-space:pre-wrap;width:calc(100% - 40px);word-wrap:break-word;scrollbar-color:#eeeeee80 #0000;scrollbar-width:thin}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note::-webkit-scrollbar{width:6px}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note::-webkit-scrollbar-track{background:#0000}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note::-webkit-scrollbar-thumb{background:#eeeeee80;border-radius:6px}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note:empty{pointer-events:none}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note.active{display:block}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note p:first-child{margin-top:0}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note p:last-child{margin-bottom:0}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container{align-items:center;box-sizing:border-box;color:#eee;display:flex;flex-wrap:nowrap;grid-area:info;justify-content:center;overflow:hidden;padding:0 10px}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-time,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-timer{box-sizing:border-box;display:block;padding:0 10px;white-space:nowrap;width:100%}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button{height:1.5em;line-height:1.5em;width:1.5em}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area{order:2;text-align:center}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area .bespoke-marp-presenter-info-page{display:inline-block;min-width:120px;text-align:center}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-time{color:#999;order:1;text-align:left}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-timer{color:#999;order:3;text-align:right}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-timer:hover{cursor:pointer}body[data-bespoke-view=overview]{background:#161616;overflow:auto}body[data-bespoke-view=overview] [data-bespoke-marp-fragment=inactive]{visibility:visible}body[data-bespoke-view=overview] .bespoke-marp-overview-header{backdrop-filter:blur(4px);background:#222222d9;box-shadow:0 3px 10px #00000080;box-sizing:border-box;display:flex;height:48px;inset:0 0 auto;justify-content:flex-end;padding:10px;position:fixed;z-index:1}body[data-bespoke-view=overview] button.bespoke-marp-overview-close{height:28px;line-height:28px;transform:rotate(45deg);width:28px}body[data-bespoke-view=overview] .bespoke-marp-parent{display:grid;gap:40px;grid-template-columns:repeat(auto-fit,minmax(0,240px));justify-content:space-around;padding:30px}body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide{--bov-selected:#0000;--bov-focus:#161616;--bov-focus-outline:#0000;background-image:conic-gradient(#161616 0 0),conic-gradient(var(--bov-focus) 0 0),conic-gradient(var(--bov-focus-outline) 0 0),conic-gradient(var(--bov-selected) 0 0);background-position:5px 5px,3px 3px,2px 2px,0 0;background-repeat:no-repeat;background-size:calc(100% - 10px) calc(100% - 10px),calc(100% - 6px) calc(100% - 6px),calc(100% - 4px) calc(100% - 4px),100% 100%;content-visibility:visible;cursor:pointer;filter:drop-shadow(0 3px 10px rgba(0,0,0,.5));margin:-6px;padding:6px;interactivity:auto;opacity:1;outline:0;pointer-events:auto;scroll-margin-block:30px;width:100%;z-index:0}body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide *,body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide.bespoke-marp-active *{pointer-events:none;interactivity:inert}body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide:active,body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide:focus-visible,body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide:hover{--bov-focus-outline:#161616}body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide:focus-visible,body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide:hover{--bov-focus:#999}body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide:active{--bov-focus:#eee}body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide.bespoke-marp-active{--bov-selected:#0288d1}body[data-bespoke-view=overview]:has(.bespoke-marp-overview-header) .bespoke-marp-parent{padding-top:78px}body[data-bespoke-view=overview]:has(.bespoke-marp-overview-header) .bespoke-marp-parent svg.bespoke-marp-slide{scroll-margin-top:78px}.bespoke-marp-overview{background:#000000a6;inset:0;opacity:0;pointer-events:none;position:fixed;transition:opacity .1s ease;z-index:10}.bespoke-marp-overview iframe{background:#222;border:0;display:block;height:100%;left:0;position:absolute;top:0;width:100%}.bespoke-marp-overview[data-open="1"]{opacity:1;pointer-events:auto}}@media print{.bespoke-marp-overview,.bespoke-marp-presenter-info-container,.bespoke-marp-presenter-next-container,.bespoke-marp-presenter-note-container{display:none}}</style><style>@charset "UTF-8";@import "https://fonts.bunny.net/css?family=Lato:400,900|Roboto+Mono:400,700&display=swap";div#\:\$p > svg > foreignObject > section{width:1280px;height:720px;box-sizing:border-box;overflow:hidden;position:relative;scroll-snap-align:center center;-webkit-text-size-adjust:100%;text-size-adjust:100%}div#\:\$p > svg > foreignObject > section::after{bottom:0;content:attr(data-marpit-pagination);padding:inherit;pointer-events:none;position:absolute;right:0}div#\:\$p > svg > foreignObject > section:not([data-marpit-pagination])::after{display:none}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1){font-size:2em;margin-block:0.67em}div#\:\$p > svg > foreignObject > section video::-webkit-media-controls{will-change:transform}@page {size:1280px 720px;margin:0}@media print{html, body{background-color:#fff;margin:0;page-break-inside:avoid;break-inside:avoid-page}div#\:\$p > svg > foreignObject > section{page-break-before:always;break-before:page}div#\:\$p > svg > foreignObject > section, div#\:\$p > svg > foreignObject > section *{-webkit-print-color-adjust:exact!important;animation-delay:0s!important;animation-duration:0s!important;color-adjust:exact!important;print-color-adjust:exact!important;transition:none!important}div#\:\$p > svg[data-marpit-svg]{display:block;height:100vh;width:100vw}}div#\:\$p > svg > foreignObject > :where(section){container-type:size}div#\:\$p > svg > foreignObject > section img[data-marp-twemoji]{background:transparent;height:1em;margin:0 .05em 0 .1em;vertical-align:-.1em;width:1em}/*!
+ * Marp / Marpit Gaia theme.
+ *
+ * @theme gaia
+ * @author Yuki Hattori
+ *
+ * @auto-scaling true
+ * @size 16:9 1280px 720px
+ * @size 4:3 960px 720px
+ */div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) code.hljs{display:block;overflow-x:auto;padding:1em}div#\:\$p > svg > foreignObject > section code.hljs{padding:3px 5px}div#\:\$p > svg > foreignObject > section .hljs{background:#000;color:#f8f8f8}div#\:\$p > svg > foreignObject > section .hljs-comment,div#\:\$p > svg > foreignObject > section .hljs-quote{color:#aeaeae;font-style:italic}div#\:\$p > svg > foreignObject > section .hljs-keyword,div#\:\$p > svg > foreignObject > section .hljs-selector-tag,div#\:\$p > svg > foreignObject > section .hljs-type{color:#e28964}div#\:\$p > svg > foreignObject > section .hljs-string{color:#65b042}div#\:\$p > svg > foreignObject > section .hljs-subst{color:#daefa3}div#\:\$p > svg > foreignObject > section .hljs-link,div#\:\$p > svg > foreignObject > section .hljs-regexp{color:#e9c062}div#\:\$p > svg > foreignObject > section .hljs-name,div#\:\$p > svg > foreignObject > section .hljs-section,div#\:\$p > svg > foreignObject > section .hljs-tag,div#\:\$p > svg > foreignObject > section .hljs-title{color:#89bdff}div#\:\$p > svg > foreignObject > section .hljs-class .hljs-title,div#\:\$p > svg > foreignObject > section .hljs-doctag,div#\:\$p > svg > foreignObject > section .hljs-title.class_{text-decoration:underline}div#\:\$p > svg > foreignObject > section .hljs-bullet,div#\:\$p > svg > foreignObject > section .hljs-number,div#\:\$p > svg > foreignObject > section .hljs-symbol{color:#3387cc}div#\:\$p > svg > foreignObject > section .hljs-params,div#\:\$p > svg > foreignObject > section .hljs-template-variable,div#\:\$p > svg > foreignObject > section .hljs-variable{color:#3e87e3}div#\:\$p > svg > foreignObject > section .hljs-attribute{color:#cda869}div#\:\$p > svg > foreignObject > section .hljs-meta{color:#8996a8}div#\:\$p > svg > foreignObject > section .hljs-formula{background-color:#0e2231;color:#f8f8f8;font-style:italic}div#\:\$p > svg > foreignObject > section .hljs-addition{background-color:#253b22;color:#f8f8f8}div#\:\$p > svg > foreignObject > section .hljs-deletion{background-color:#420e09;color:#f8f8f8}div#\:\$p > svg > foreignObject > section .hljs-selector-class{color:#9b703f}div#\:\$p > svg > foreignObject > section .hljs-selector-id{color:#8b98ab}div#\:\$p > svg > foreignObject > section .hljs-emphasis{font-style:italic}div#\:\$p > svg > foreignObject > section .hljs-strong{font-weight:700}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1),div#\:\$p > svg > foreignObject > section :is(h2, marp-h2),div#\:\$p > svg > foreignObject > section :is(h3, marp-h3),div#\:\$p > svg > foreignObject > section :is(h4, marp-h4),div#\:\$p > svg > foreignObject > section :is(h5, marp-h5),div#\:\$p > svg > foreignObject > section :is(h6, marp-h6){margin:.5em 0 0}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1) strong,div#\:\$p > svg > foreignObject > section :is(h2, marp-h2) strong,div#\:\$p > svg > foreignObject > section :is(h3, marp-h3) strong,div#\:\$p > svg > foreignObject > section :is(h4, marp-h4) strong,div#\:\$p > svg > foreignObject > section :is(h5, marp-h5) strong,div#\:\$p > svg > foreignObject > section :is(h6, marp-h6) strong{font-weight:inherit}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1)::part(auto-scaling),div#\:\$p > svg > foreignObject > section :is(h2, marp-h2)::part(auto-scaling),div#\:\$p > svg > foreignObject > section :is(h3, marp-h3)::part(auto-scaling),div#\:\$p > svg > foreignObject > section :is(h4, marp-h4)::part(auto-scaling),div#\:\$p > svg > foreignObject > section :is(h5, marp-h5)::part(auto-scaling),div#\:\$p > svg > foreignObject > section :is(h6, marp-h6)::part(auto-scaling){max-height:580px}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1){font-size:1.8em}div#\:\$p > svg > foreignObject > section :is(h2, marp-h2){font-size:1.5em}div#\:\$p > svg > foreignObject > section :is(h3, marp-h3){font-size:1.3em}div#\:\$p > svg > foreignObject > section :is(h4, marp-h4){font-size:1.1em}div#\:\$p > svg > foreignObject > section :is(h5, marp-h5){font-size:1em}div#\:\$p > svg > foreignObject > section :is(h6, marp-h6){font-size:.9em}div#\:\$p > svg > foreignObject > section blockquote,div#\:\$p > svg > foreignObject > section p{margin:1em 0 0}div#\:\$p > svg > foreignObject > section ol>li,div#\:\$p > svg > foreignObject > section ul>li{margin:.3em 0 0}div#\:\$p > svg > foreignObject > section ol>li>p,div#\:\$p > svg > foreignObject > section ul>li>p{margin:.6em 0 0}div#\:\$p > svg > foreignObject > section code{display:inline-block;font-family:Roboto Mono,monospace;font-size:.8em;letter-spacing:0;margin:-.1em .15em;padding:.1em .2em;vertical-align:baseline}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre){display:block;margin:1em 0 0;overflow:visible}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) code{box-sizing:border-box;font-size:.7em;margin:0;min-width:100%;padding:.5em}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre)::part(auto-scaling){max-height:calc(580px - 1em)}div#\:\$p > svg > foreignObject > section blockquote{margin:1em 0 0;padding:0 1em;position:relative}div#\:\$p > svg > foreignObject > section blockquote:after,div#\:\$p > svg > foreignObject > section blockquote:before{content:"“";display:block;font-family:Times New Roman,serif;font-weight:700;position:absolute}div#\:\$p > svg > foreignObject > section blockquote:before{left:0;top:0}div#\:\$p > svg > foreignObject > section blockquote:after{bottom:0;right:0;transform:rotate(180deg)}div#\:\$p > svg > foreignObject > section blockquote>:first-child{margin-top:0}div#\:\$p > svg > foreignObject > section mark{background:transparent}div#\:\$p > svg > foreignObject > section table{border-collapse:collapse;border-spacing:0;margin:1em 0 0}div#\:\$p > svg > foreignObject > section table td,div#\:\$p > svg > foreignObject > section table th{border-style:solid;border-width:1px;padding:.2em .4em}div#\:\$p > svg > foreignObject > section footer,div#\:\$p > svg > foreignObject > section header,div#\:\$p > svg > foreignObject > section:after{box-sizing:border-box;font-size:66%;height:70px;line-height:50px;overflow:hidden;padding:10px 25px;position:absolute}div#\:\$p > svg > foreignObject > section:after{--marpit-root-font-size:66%}div#\:\$p > svg > foreignObject > section header{top:0}div#\:\$p > svg > foreignObject > section footer,div#\:\$p > svg > foreignObject > section header{left:0;right:0}div#\:\$p > svg > foreignObject > section footer{bottom:0}div#\:\$p > svg > foreignObject > section{--color-background:light-dark(#fff8e1, #455a64);--color-background-stripe:light-dark(
+    rgba(69,90,100,.1),
+    rgba(255,248,225,.1)
+  );--color-foreground:light-dark(#455a64, #fff8e1);--color-dimmed:light-dark(
+    #6a7a7d,
+    #dad8c8
+  );--color-highlight:light-dark(#0288d1, #81d4fa);background-color:var(--color-background);background-image:linear-gradient(135deg, hsla(0,0%,53%,0), hsla(0,0%,53%,.02) 50%, hsla(0,0%,100%,0) 0, hsla(0,0%,100%,.05));color:var(--color-foreground);color-scheme:light;font-family:Lato,Avenir Next,Avenir,Trebuchet MS,Segoe UI,sans-serif;font-size:35px;height:720px;letter-spacing:1.25px;line-height:1.35;overflow-wrap:break-word;padding:70px;width:1280px}div#\:\$p > svg > foreignObject > section{--marpit-root-font-size:35px}div#\:\$p > svg > foreignObject > section:after{bottom:0;font-size:80%;right:0}div#\:\$p > svg > foreignObject > section:after{--marpit-root-font-size:80%}div#\:\$p > svg > foreignObject > section a,div#\:\$p > svg > foreignObject > section mark{color:var(--color-highlight)}div#\:\$p > svg > foreignObject > section code{background:var(--color-dimmed);color:var(--color-background)}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1) strong,div#\:\$p > svg > foreignObject > section :is(h2, marp-h2) strong,div#\:\$p > svg > foreignObject > section :is(h3, marp-h3) strong,div#\:\$p > svg > foreignObject > section :is(h4, marp-h4) strong,div#\:\$p > svg > foreignObject > section :is(h5, marp-h5) strong,div#\:\$p > svg > foreignObject > section :is(h6, marp-h6) strong{color:var(--color-highlight)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre){background:var(--color-foreground)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre)>code{background:transparent}div#\:\$p > svg > foreignObject > section blockquote:after,div#\:\$p > svg > foreignObject > section blockquote:before,div#\:\$p > svg > foreignObject > section footer,div#\:\$p > svg > foreignObject > section header,div#\:\$p > svg > foreignObject > section section:after{color:var(--color-dimmed)}div#\:\$p > svg > foreignObject > section table td,div#\:\$p > svg > foreignObject > section table th{border-color:var(--color-foreground)}div#\:\$p > svg > foreignObject > section table thead th{background:var(--color-foreground);color:var(--color-background)}div#\:\$p > svg > foreignObject > section table tbody>tr:nth-child(odd) td,div#\:\$p > svg > foreignObject > section table tbody>tr:nth-child(odd) th{background:var(--color-background-stripe, transparent)}div#\:\$p > svg > foreignObject > section>:first-child,div#\:\$p > svg > foreignObject > section>header:first-child+*{margin-top:0}div#\:\$p > svg > foreignObject > section:where(.invert){color-scheme:dark}div#\:\$p > svg > foreignObject > section:where(.gaia){--color-background:#0288d1;--color-background-stripe:rgba(255,248,225,.1);--color-foreground:#fff8e1;--color-dimmed:#cce2de;--color-highlight:#81d4fa;}div#\:\$p > svg > foreignObject > section:where(.lead){align-items:stretch;flex-flow:column nowrap;place-content:safe center center}div#\:\$p > svg > foreignObject > section:where(.lead) :is(h1, marp-h1),div#\:\$p > svg > foreignObject > section:where(.lead) :is(h2, marp-h2),div#\:\$p > svg > foreignObject > section:where(.lead) :is(h3, marp-h3),div#\:\$p > svg > foreignObject > section:where(.lead) :is(h4, marp-h4),div#\:\$p > svg > foreignObject > section:where(.lead) :is(h5, marp-h5),div#\:\$p > svg > foreignObject > section:where(.lead) :is(h6, marp-h6){text-align:center}div#\:\$p > svg > foreignObject > section:where(.lead) p{text-align:center}div#\:\$p > svg > foreignObject > section:where(.lead) blockquote>:is(h1, marp-h1),div#\:\$p > svg > foreignObject > section:where(.lead) blockquote>:is(h2, marp-h2),div#\:\$p > svg > foreignObject > section:where(.lead) blockquote>:is(h3, marp-h3),div#\:\$p > svg > foreignObject > section:where(.lead) blockquote>:is(h4, marp-h4),div#\:\$p > svg > foreignObject > section:where(.lead) blockquote>:is(h5, marp-h5),div#\:\$p > svg > foreignObject > section:where(.lead) blockquote>:is(h6, marp-h6),div#\:\$p > svg > foreignObject > section:where(.lead) blockquote>p{text-align:left}div#\:\$p > svg > foreignObject > section:where(.lead) ol>li>p,div#\:\$p > svg > foreignObject > section:where(.lead) ul>li>p{text-align:left}div#\:\$p > svg > foreignObject > section:where(.lead) table{margin-left:auto;margin-right:auto}div#\:\$p > svg > foreignObject > section{width:1280px;height:720px}div#\:\$p > svg > foreignObject > :where(section):not([\20 root]){--color-background: #1e2a3a;--color-foreground: #cfd8dc;--color-highlight: #4fc3f7;--color-dimmed: #78909c;}div#\:\$p > svg > foreignObject > section{font-size:20px;padding:30px 40px}div#\:\$p > svg > foreignObject > section{--marpit-root-font-size: 20px}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1){margin-bottom:0.5em}div#\:\$p > svg > foreignObject > section :is(h3, marp-h3){font-size:1.1em;margin-top:1em;margin-bottom:0.3em}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre){font-size:0.85em;margin:1em 0;font-family:"Menlo", "Consolas", "DejaVu Sans Mono", "Courier New", monospace}div#\:\$p > svg > foreignObject > section code{font-size:0.85em;font-family:"Menlo", "Consolas", "DejaVu Sans Mono", "Courier New", monospace;padding:0.1em 0.3em;margin:0}div#\:\$p > svg > foreignObject > section table{font-size:0.8em;margin:1em 0;width:100%}div#\:\$p > svg > foreignObject > section th, div#\:\$p > svg > foreignObject > section td{padding:0.5em 1em}div#\:\$p > svg > foreignObject > section ul, div#\:\$p > svg > foreignObject > section ol{margin:0.2em 0}div#\:\$p > svg > foreignObject > section li{margin:0.1em 0}div#\:\$p > svg > foreignObject > section p{margin:0.3em 0}div#\:\$p > svg > foreignObject > section blockquote{padding:0.4em 0.8em;margin:0.4em 0}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"]{columns:initial!important;display:block!important;padding:0!important}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"]::before, div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"]::after, div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="content"]::before, div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="content"]::after{display:none!important}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"] > div[data-marpit-advanced-background-container]{all:initial;display:flex;flex-direction:row;height:100%;overflow:hidden;width:100%}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"] > div[data-marpit-advanced-background-container][data-marpit-advanced-background-direction="vertical"]{flex-direction:column}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"][data-marpit-advanced-background-split] > div[data-marpit-advanced-background-container]{width:var(--marpit-advanced-background-split, 50%)}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"][data-marpit-advanced-background-split="right"] > div[data-marpit-advanced-background-container]{margin-left:calc(100% - var(--marpit-advanced-background-split, 50%))}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"] > div[data-marpit-advanced-background-container] > figure{all:initial;background-position:center;background-repeat:no-repeat;background-size:cover;flex:auto;margin:0}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"] > div[data-marpit-advanced-background-container] > figure > figcaption{position:absolute;border:0;clip:rect(0, 0, 0, 0);height:1px;margin:-1px;overflow:hidden;padding:0;white-space:nowrap;width:1px}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="content"], div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="pseudo"]{background:transparent!important}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="pseudo"], div#\:\$p > svg[data-marpit-svg] > foreignObject[data-marpit-advanced-background="pseudo"]{pointer-events:none!important}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background-split]{width:100%;height:100%}
+</style></head><body><div class="bespoke-marp-osc"><button data-bespoke-marp-osc="prev" tabindex="-1" title="Previous slide">Previous slide</button><span data-bespoke-marp-osc="page"></span><button data-bespoke-marp-osc="next" tabindex="-1" title="Next slide">Next slide</button><button data-bespoke-marp-osc="fullscreen" tabindex="-1" title="Toggle fullscreen (f)">Toggle fullscreen</button><button data-bespoke-marp-osc="overview" tabindex="-1" title="Toggle overview view (o)">Toggle overview view</button><button data-bespoke-marp-osc="presenter" tabindex="-1" title="Open presenter view (p)">Open presenter view</button></div><div id=":$p"><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="1" data-paginate="true" data-class="lead" data-theme="gaia" data-style=":root {
+  --color-background: #1e2a3a;
+  --color-foreground: #cfd8dc;
+  --color-highlight: #4fc3f7;
+  --color-dimmed: #78909c;
+}
+section {
+  font-size: 20px;
+  padding: 30px 40px;
+}
+h1 {
+  margin-bottom: 0.5em;
+}
+h3 {
+  font-size: 1.1em;
+  margin-top: 1em;
+  margin-bottom: 0.3em;
+}
+pre {
+  font-size: 0.85em;
+  margin: 1em 0;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+}
+code {
+  font-size: 0.85em;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+  padding: 0.1em 0.3em;
+  margin: 0;
+}
+table {
+  font-size: 0.8em;
+  margin: 1em 0;
+  width: 100%;
+}
+th, td {
+  padding: 0.5em 1em;
+}
+ul, ol {
+  margin: 0.2em 0;
+}
+li {
+  margin: 0.1em 0;
+}
+p {
+  margin: 0.3em 0;
+}
+blockquote {
+  padding: 0.4em 0.8em;
+  margin: 0.4em 0;
+}
+" lang="C" class="lead" data-marpit-pagination="1" style="--paginate:true;--class:lead;--theme:gaia;--style::root {
+  --color-background: #1e2a3a;
+  --color-foreground: #cfd8dc;
+  --color-highlight: #4fc3f7;
+  --color-dimmed: #78909c;
+}
+section {
+  font-size: 20px;
+  padding: 30px 40px;
+}
+h1 {
+  margin-bottom: 0.5em;
+}
+h3 {
+  font-size: 1.1em;
+  margin-top: 1em;
+  margin-bottom: 0.3em;
+}
+pre {
+  font-size: 0.85em;
+  margin: 1em 0;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+}
+code {
+  font-size: 0.85em;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+  padding: 0.1em 0.3em;
+  margin: 0;
+}
+table {
+  font-size: 0.8em;
+  margin: 1em 0;
+  width: 100%;
+}
+th, td {
+  padding: 0.5em 1em;
+}
+ul, ol {
+  margin: 0.2em 0;
+}
+li {
+  margin: 0.1em 0;
+}
+p {
+  margin: 0.3em 0;
+}
+blockquote {
+  padding: 0.4em 0.8em;
+  margin: 0.4em 0;
+}
+;" data-marpit-pagination-total="10" data-size="16:9">
+<h1 id="workflow-engine">Workflow Engine</h1>
+<p>Async process orchestration for Altinn</p>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="2" data-paginate="true" data-theme="gaia" data-style=":root {
+  --color-background: #1e2a3a;
+  --color-foreground: #cfd8dc;
+  --color-highlight: #4fc3f7;
+  --color-dimmed: #78909c;
+}
+section {
+  font-size: 20px;
+  padding: 30px 40px;
+}
+h1 {
+  margin-bottom: 0.5em;
+}
+h3 {
+  font-size: 1.1em;
+  margin-top: 1em;
+  margin-bottom: 0.3em;
+}
+pre {
+  font-size: 0.85em;
+  margin: 1em 0;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+}
+code {
+  font-size: 0.85em;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+  padding: 0.1em 0.3em;
+  margin: 0;
+}
+table {
+  font-size: 0.8em;
+  margin: 1em 0;
+  width: 100%;
+}
+th, td {
+  padding: 0.5em 1em;
+}
+ul, ol {
+  margin: 0.2em 0;
+}
+li {
+  margin: 0.1em 0;
+}
+p {
+  margin: 0.3em 0;
+}
+blockquote {
+  padding: 0.4em 0.8em;
+  margin: 0.4em 0;
+}
+" lang="C" data-marpit-pagination="2" style="--paginate:true;--theme:gaia;--style::root {
+  --color-background: #1e2a3a;
+  --color-foreground: #cfd8dc;
+  --color-highlight: #4fc3f7;
+  --color-dimmed: #78909c;
+}
+section {
+  font-size: 20px;
+  padding: 30px 40px;
+}
+h1 {
+  margin-bottom: 0.5em;
+}
+h3 {
+  font-size: 1.1em;
+  margin-top: 1em;
+  margin-bottom: 0.3em;
+}
+pre {
+  font-size: 0.85em;
+  margin: 1em 0;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+}
+code {
+  font-size: 0.85em;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+  padding: 0.1em 0.3em;
+  margin: 0;
+}
+table {
+  font-size: 0.8em;
+  margin: 1em 0;
+  width: 100%;
+}
+th, td {
+  padding: 0.5em 1em;
+}
+ul, ol {
+  margin: 0.2em 0;
+}
+li {
+  margin: 0.1em 0;
+}
+p {
+  margin: 0.3em 0;
+}
+blockquote {
+  padding: 0.4em 0.8em;
+  margin: 0.4em 0;
+}
+;" data-marpit-pagination-total="10" data-size="16:9">
+<h1 id="how-processnext-works-today">How <em>process/next</em> works today</h1>
+<p><code>PUT /process/next</code> executes the entire process transition in a single HTTP request:</p>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code>ProcessController.NextElement()
+    │
+    └── ProcessEngine.Next()               ← in-memory loop (max 100 iterations)
+            │
+            ├── Authorize
+            ├── AcquireInstanceLock        ← 5-minute TTL via Platform Storage
+            ├── HandleServiceTask()        ← or HandleUserAction()
+            ├── Validate()
+            ├── HandleMoveToNext()
+            │     ├── HandleEvents()       ← task start/end handlers, PDF, signing, payment...
+            │     └── DispatchToStorage()  ← PUT to Platform Storage (events + state)
+            │
+            └── if next is service task    → loop again
+</code></pre>
+<p>If the task after the current one is a service task (PDF, signing, payment), the loop continues automatically within the same request. Every handler, every validation, every storage call happens inline.</p>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="3" data-paginate="true" data-theme="gaia" data-style=":root {
+  --color-background: #1e2a3a;
+  --color-foreground: #cfd8dc;
+  --color-highlight: #4fc3f7;
+  --color-dimmed: #78909c;
+}
+section {
+  font-size: 20px;
+  padding: 30px 40px;
+}
+h1 {
+  margin-bottom: 0.5em;
+}
+h3 {
+  font-size: 1.1em;
+  margin-top: 1em;
+  margin-bottom: 0.3em;
+}
+pre {
+  font-size: 0.85em;
+  margin: 1em 0;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+}
+code {
+  font-size: 0.85em;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+  padding: 0.1em 0.3em;
+  margin: 0;
+}
+table {
+  font-size: 0.8em;
+  margin: 1em 0;
+  width: 100%;
+}
+th, td {
+  padding: 0.5em 1em;
+}
+ul, ol {
+  margin: 0.2em 0;
+}
+li {
+  margin: 0.1em 0;
+}
+p {
+  margin: 0.3em 0;
+}
+blockquote {
+  padding: 0.4em 0.8em;
+  margin: 0.4em 0;
+}
+" lang="C" data-marpit-pagination="3" style="--paginate:true;--theme:gaia;--style::root {
+  --color-background: #1e2a3a;
+  --color-foreground: #cfd8dc;
+  --color-highlight: #4fc3f7;
+  --color-dimmed: #78909c;
+}
+section {
+  font-size: 20px;
+  padding: 30px 40px;
+}
+h1 {
+  margin-bottom: 0.5em;
+}
+h3 {
+  font-size: 1.1em;
+  margin-top: 1em;
+  margin-bottom: 0.3em;
+}
+pre {
+  font-size: 0.85em;
+  margin: 1em 0;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+}
+code {
+  font-size: 0.85em;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+  padding: 0.1em 0.3em;
+  margin: 0;
+}
+table {
+  font-size: 0.8em;
+  margin: 1em 0;
+  width: 100%;
+}
+th, td {
+  padding: 0.5em 1em;
+}
+ul, ol {
+  margin: 0.2em 0;
+}
+li {
+  margin: 0.1em 0;
+}
+p {
+  margin: 0.3em 0;
+}
+blockquote {
+  padding: 0.4em 0.8em;
+  margin: 0.4em 0;
+}
+;" data-marpit-pagination-total="10" data-size="16:9">
+<h1 id="where-it-breaks">Where it breaks</h1>
+<p>The entire chain runs synchronously inside one HTTP request/response cycle.</p>
+<table>
+<thead>
+<tr>
+<th>Failure point</th>
+<th>What happens</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Service task crashes (PDF, signing, payment)</td>
+<td>In-memory changes lost. Instance stays at previous state.</td>
+</tr>
+<tr>
+<td>Storage API call times out</td>
+<td>State unknown. May or may not have persisted. No idempotency.</td>
+</tr>
+<tr>
+<td>Pod killed mid-processing</td>
+<td>Instance lock held for 5 minutes. Data state unclear.</td>
+</tr>
+<tr>
+<td>Timeout during auto-loop iteration N</td>
+<td>Iterations 1..N-1 persisted. Iteration N partially executed.</td>
+</tr>
+<tr>
+<td>Network failure to Platform Storage</td>
+<td>Client gets 5xx. No retry. Manual intervention required.</td>
+</tr>
+</tbody>
+</table>
+<p>The common thread: <strong>no automatic recovery</strong>. If it fails, someone has to investigate and fix it.</p>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="4" data-paginate="true" data-theme="gaia" data-style=":root {
+  --color-background: #1e2a3a;
+  --color-foreground: #cfd8dc;
+  --color-highlight: #4fc3f7;
+  --color-dimmed: #78909c;
+}
+section {
+  font-size: 20px;
+  padding: 30px 40px;
+}
+h1 {
+  margin-bottom: 0.5em;
+}
+h3 {
+  font-size: 1.1em;
+  margin-top: 1em;
+  margin-bottom: 0.3em;
+}
+pre {
+  font-size: 0.85em;
+  margin: 1em 0;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+}
+code {
+  font-size: 0.85em;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+  padding: 0.1em 0.3em;
+  margin: 0;
+}
+table {
+  font-size: 0.8em;
+  margin: 1em 0;
+  width: 100%;
+}
+th, td {
+  padding: 0.5em 1em;
+}
+ul, ol {
+  margin: 0.2em 0;
+}
+li {
+  margin: 0.1em 0;
+}
+p {
+  margin: 0.3em 0;
+}
+blockquote {
+  padding: 0.4em 0.8em;
+  margin: 0.4em 0;
+}
+" lang="C" data-marpit-pagination="4" style="--paginate:true;--theme:gaia;--style::root {
+  --color-background: #1e2a3a;
+  --color-foreground: #cfd8dc;
+  --color-highlight: #4fc3f7;
+  --color-dimmed: #78909c;
+}
+section {
+  font-size: 20px;
+  padding: 30px 40px;
+}
+h1 {
+  margin-bottom: 0.5em;
+}
+h3 {
+  font-size: 1.1em;
+  margin-top: 1em;
+  margin-bottom: 0.3em;
+}
+pre {
+  font-size: 0.85em;
+  margin: 1em 0;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+}
+code {
+  font-size: 0.85em;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+  padding: 0.1em 0.3em;
+  margin: 0;
+}
+table {
+  font-size: 0.8em;
+  margin: 1em 0;
+  width: 100%;
+}
+th, td {
+  padding: 0.5em 1em;
+}
+ul, ol {
+  margin: 0.2em 0;
+}
+li {
+  margin: 0.1em 0;
+}
+p {
+  margin: 0.3em 0;
+}
+blockquote {
+  padding: 0.4em 0.8em;
+  margin: 0.4em 0;
+}
+;" data-marpit-pagination-total="10" data-size="16:9">
+<h1 id="what-we-built">What we built</h1>
+<p>A dedicated workflow engine that moves process execution out of the HTTP request cycle.</p>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code>Altinn App                              Workflow Engine
+    │                                          │
+    │──── POST /workflows ────────────────────►│  Validate &amp; persist
+    │◄─── 201 Created ─────────────────────────│  to PostgreSQL
+    │                                          │
+    │                                          │
+    │                                          │
+    │                                   Processor picks up
+    │                                    workflow from DB
+    │                                          │
+    │◄─── POST /callbacks ─────────────────────│  Step 1
+    │──── 200 + { state } ────────────────────►│
+    │                                          │
+    │◄─── POST /callbacks ─────────────────────│  Step 2
+    │──── 200 + { state } ────────────────────►│
+    │                                          │
+    │                                  Completed or Failed
+</code></pre>
+<p>The app enqueues and returns immediately. The engine handles execution, retries, and failure.</p>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="5" data-paginate="true" data-theme="gaia" data-style=":root {
+  --color-background: #1e2a3a;
+  --color-foreground: #cfd8dc;
+  --color-highlight: #4fc3f7;
+  --color-dimmed: #78909c;
+}
+section {
+  font-size: 20px;
+  padding: 30px 40px;
+}
+h1 {
+  margin-bottom: 0.5em;
+}
+h3 {
+  font-size: 1.1em;
+  margin-top: 1em;
+  margin-bottom: 0.3em;
+}
+pre {
+  font-size: 0.85em;
+  margin: 1em 0;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+}
+code {
+  font-size: 0.85em;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+  padding: 0.1em 0.3em;
+  margin: 0;
+}
+table {
+  font-size: 0.8em;
+  margin: 1em 0;
+  width: 100%;
+}
+th, td {
+  padding: 0.5em 1em;
+}
+ul, ol {
+  margin: 0.2em 0;
+}
+li {
+  margin: 0.1em 0;
+}
+p {
+  margin: 0.3em 0;
+}
+blockquote {
+  padding: 0.4em 0.8em;
+  margin: 0.4em 0;
+}
+" lang="C" data-marpit-pagination="5" style="--paginate:true;--theme:gaia;--style::root {
+  --color-background: #1e2a3a;
+  --color-foreground: #cfd8dc;
+  --color-highlight: #4fc3f7;
+  --color-dimmed: #78909c;
+}
+section {
+  font-size: 20px;
+  padding: 30px 40px;
+}
+h1 {
+  margin-bottom: 0.5em;
+}
+h3 {
+  font-size: 1.1em;
+  margin-top: 1em;
+  margin-bottom: 0.3em;
+}
+pre {
+  font-size: 0.85em;
+  margin: 1em 0;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+}
+code {
+  font-size: 0.85em;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+  padding: 0.1em 0.3em;
+  margin: 0;
+}
+table {
+  font-size: 0.8em;
+  margin: 1em 0;
+  width: 100%;
+}
+th, td {
+  padding: 0.5em 1em;
+}
+ul, ol {
+  margin: 0.2em 0;
+}
+li {
+  margin: 0.1em 0;
+}
+p {
+  margin: 0.3em 0;
+}
+blockquote {
+  padding: 0.4em 0.8em;
+  margin: 0.4em 0;
+}
+;" data-marpit-pagination-total="10" data-size="16:9">
+<h1 id="how-it-handles-the-same-failures">How it handles the same failures</h1>
+<table>
+<thead>
+<tr>
+<th>Failure point</th>
+<th>Current behaviour</th>
+<th>Workflow Engine behaviour</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Service task crashes</td>
+<td>Lost. Manual recovery.</td>
+<td>Requeued with backoff. Retried automatically.</td>
+</tr>
+<tr>
+<td>Storage/network timeout</td>
+<td>Unknown state. No retry.</td>
+<td>Step marked retryable. Engine retries.</td>
+</tr>
+<tr>
+<td>Pod killed mid-processing</td>
+<td>Lock held 5 min. State unclear.</td>
+<td>Heartbeat expires. Another worker reclaims.</td>
+</tr>
+<tr>
+<td>Retries exhausted</td>
+<td>N/A (no retries exist)</td>
+<td>Workflow marked Failed with error detail. Queryable.</td>
+</tr>
+<tr>
+<td>Downstream 5xx</td>
+<td>Request fails. User sees error.</td>
+<td>Retried with exponential backoff up to deadline.</td>
+</tr>
+<tr>
+<td>Downstream 4xx</td>
+<td>Request fails. User sees error.</td>
+<td>Marked as critical error. No retry. Clear in dashboard.</td>
+</tr>
+</tbody>
+</table>
+<p>Every failure path ends in either <strong>successful retry</strong> or <strong>explicit, visible failure</strong>.</p>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="6" data-paginate="true" data-theme="gaia" data-style=":root {
+  --color-background: #1e2a3a;
+  --color-foreground: #cfd8dc;
+  --color-highlight: #4fc3f7;
+  --color-dimmed: #78909c;
+}
+section {
+  font-size: 20px;
+  padding: 30px 40px;
+}
+h1 {
+  margin-bottom: 0.5em;
+}
+h3 {
+  font-size: 1.1em;
+  margin-top: 1em;
+  margin-bottom: 0.3em;
+}
+pre {
+  font-size: 0.85em;
+  margin: 1em 0;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+}
+code {
+  font-size: 0.85em;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+  padding: 0.1em 0.3em;
+  margin: 0;
+}
+table {
+  font-size: 0.8em;
+  margin: 1em 0;
+  width: 100%;
+}
+th, td {
+  padding: 0.5em 1em;
+}
+ul, ol {
+  margin: 0.2em 0;
+}
+li {
+  margin: 0.1em 0;
+}
+p {
+  margin: 0.3em 0;
+}
+blockquote {
+  padding: 0.4em 0.8em;
+  margin: 0.4em 0;
+}
+" lang="C" data-marpit-pagination="6" style="--paginate:true;--theme:gaia;--style::root {
+  --color-background: #1e2a3a;
+  --color-foreground: #cfd8dc;
+  --color-highlight: #4fc3f7;
+  --color-dimmed: #78909c;
+}
+section {
+  font-size: 20px;
+  padding: 30px 40px;
+}
+h1 {
+  margin-bottom: 0.5em;
+}
+h3 {
+  font-size: 1.1em;
+  margin-top: 1em;
+  margin-bottom: 0.3em;
+}
+pre {
+  font-size: 0.85em;
+  margin: 1em 0;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+}
+code {
+  font-size: 0.85em;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+  padding: 0.1em 0.3em;
+  margin: 0;
+}
+table {
+  font-size: 0.8em;
+  margin: 1em 0;
+  width: 100%;
+}
+th, td {
+  padding: 0.5em 1em;
+}
+ul, ol {
+  margin: 0.2em 0;
+}
+li {
+  margin: 0.1em 0;
+}
+p {
+  margin: 0.3em 0;
+}
+blockquote {
+  padding: 0.4em 0.8em;
+  margin: 0.4em 0;
+}
+;" data-marpit-pagination-total="10" data-size="16:9">
+<h1 id="tech-stack">Tech stack</h1>
+<table>
+<thead>
+<tr>
+<th>Component</th>
+<th>Technology</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Runtime</td>
+<td>.NET 10, C# 14</td>
+</tr>
+<tr>
+<td>Database</td>
+<td>PostgreSQL (EF Core + raw SQL for hot paths)</td>
+</tr>
+<tr>
+<td>Telemetry</td>
+<td>OpenTelemetry → OTLP → Grafana (Tempo, Prometheus)</td>
+</tr>
+<tr>
+<td>Testing</td>
+<td>xUnit v3, Testcontainers (PostgreSQL), WireMock, Verify.Net</td>
+</tr>
+<tr>
+<td>Dashboard</td>
+<td>Vanilla JS ES modules (no build step), embedded in Core</td>
+</tr>
+<tr>
+<td>Containerization</td>
+<td>Docker, multi-stage build</td>
+</tr>
+</tbody>
+</table>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="7" data-paginate="true" data-theme="gaia" data-style=":root {
+  --color-background: #1e2a3a;
+  --color-foreground: #cfd8dc;
+  --color-highlight: #4fc3f7;
+  --color-dimmed: #78909c;
+}
+section {
+  font-size: 20px;
+  padding: 30px 40px;
+}
+h1 {
+  margin-bottom: 0.5em;
+}
+h3 {
+  font-size: 1.1em;
+  margin-top: 1em;
+  margin-bottom: 0.3em;
+}
+pre {
+  font-size: 0.85em;
+  margin: 1em 0;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+}
+code {
+  font-size: 0.85em;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+  padding: 0.1em 0.3em;
+  margin: 0;
+}
+table {
+  font-size: 0.8em;
+  margin: 1em 0;
+  width: 100%;
+}
+th, td {
+  padding: 0.5em 1em;
+}
+ul, ol {
+  margin: 0.2em 0;
+}
+li {
+  margin: 0.1em 0;
+}
+p {
+  margin: 0.3em 0;
+}
+blockquote {
+  padding: 0.4em 0.8em;
+  margin: 0.4em 0;
+}
+" lang="C" data-marpit-pagination="7" style="--paginate:true;--theme:gaia;--style::root {
+  --color-background: #1e2a3a;
+  --color-foreground: #cfd8dc;
+  --color-highlight: #4fc3f7;
+  --color-dimmed: #78909c;
+}
+section {
+  font-size: 20px;
+  padding: 30px 40px;
+}
+h1 {
+  margin-bottom: 0.5em;
+}
+h3 {
+  font-size: 1.1em;
+  margin-top: 1em;
+  margin-bottom: 0.3em;
+}
+pre {
+  font-size: 0.85em;
+  margin: 1em 0;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+}
+code {
+  font-size: 0.85em;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+  padding: 0.1em 0.3em;
+  margin: 0;
+}
+table {
+  font-size: 0.8em;
+  margin: 1em 0;
+  width: 100%;
+}
+th, td {
+  padding: 0.5em 1em;
+}
+ul, ol {
+  margin: 0.2em 0;
+}
+li {
+  margin: 0.1em 0;
+}
+p {
+  margin: 0.3em 0;
+}
+blockquote {
+  padding: 0.4em 0.8em;
+  margin: 0.4em 0;
+}
+;" data-marpit-pagination-total="10" data-size="16:9">
+<h1 id="architecture">Architecture</h1>
+<p>The engine is a <strong>reusable class library</strong>. Hosts compose it and register their own commands.</p>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code>Host Application (e.g. WorkflowEngine.App)
+│
+├── AddWorkflowEngine(connectionString)  // registers everything
+├── AddCommand&lt;AppCommand&gt;()             // host-specific command
+├── UseWorkflowEngine()                  // wires pipeline
+│
+└── WorkflowEngine.Core (class library)
+      ├── Processor   // background loop, fetches from DB
+      ├── Executor    // executes the actual step commands
+      ├── Commands    // pluggable: Webhook, App, &lt;future&gt;
+      ├── Data        // repository, EF Core entities
+      ├── Resilience  // concurrency limiters, retry strategies
+      └── Telemetry   // OpenTelemetry via OTLP
+</code></pre>
+<p><code>WorkflowEngine.App</code> is the Altinn-specific host. It adds <code>AppCommand</code> — an HTTP callback into Altinn apps carrying full instance context (org, app, actor, lockToken, instanceGuid).</p>
+<p>Database is the single source of truth. No in-memory queue. Enqueue and status-update paths use channel-based write buffers for throughput.</p>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="8" data-paginate="true" data-theme="gaia" data-style=":root {
+  --color-background: #1e2a3a;
+  --color-foreground: #cfd8dc;
+  --color-highlight: #4fc3f7;
+  --color-dimmed: #78909c;
+}
+section {
+  font-size: 20px;
+  padding: 30px 40px;
+}
+h1 {
+  margin-bottom: 0.5em;
+}
+h3 {
+  font-size: 1.1em;
+  margin-top: 1em;
+  margin-bottom: 0.3em;
+}
+pre {
+  font-size: 0.85em;
+  margin: 1em 0;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+}
+code {
+  font-size: 0.85em;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+  padding: 0.1em 0.3em;
+  margin: 0;
+}
+table {
+  font-size: 0.8em;
+  margin: 1em 0;
+  width: 100%;
+}
+th, td {
+  padding: 0.5em 1em;
+}
+ul, ol {
+  margin: 0.2em 0;
+}
+li {
+  margin: 0.1em 0;
+}
+p {
+  margin: 0.3em 0;
+}
+blockquote {
+  padding: 0.4em 0.8em;
+  margin: 0.4em 0;
+}
+" lang="C" data-marpit-pagination="8" style="--paginate:true;--theme:gaia;--style::root {
+  --color-background: #1e2a3a;
+  --color-foreground: #cfd8dc;
+  --color-highlight: #4fc3f7;
+  --color-dimmed: #78909c;
+}
+section {
+  font-size: 20px;
+  padding: 30px 40px;
+}
+h1 {
+  margin-bottom: 0.5em;
+}
+h3 {
+  font-size: 1.1em;
+  margin-top: 1em;
+  margin-bottom: 0.3em;
+}
+pre {
+  font-size: 0.85em;
+  margin: 1em 0;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+}
+code {
+  font-size: 0.85em;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+  padding: 0.1em 0.3em;
+  margin: 0;
+}
+table {
+  font-size: 0.8em;
+  margin: 1em 0;
+  width: 100%;
+}
+th, td {
+  padding: 0.5em 1em;
+}
+ul, ol {
+  margin: 0.2em 0;
+}
+li {
+  margin: 0.1em 0;
+}
+p {
+  margin: 0.3em 0;
+}
+blockquote {
+  padding: 0.4em 0.8em;
+  margin: 0.4em 0;
+}
+;" data-marpit-pagination-total="10" data-size="16:9">
+<h1 id="processing-model">Processing model</h1>
+<h3 id="how-work-flows-through-the-engine">How work flows through the engine</h3>
+<ul>
+<li><code>WorkflowProcessor</code> polls PostgreSQL — <code>FOR UPDATE SKIP LOCKED</code> for atomic, non-blocking row locking</li>
+<li>Multiple engine instances can run against the same database safely</li>
+<li>Each workflow's steps are executed sequentially by <code>WorkflowExecutor</code></li>
+<li>Three independent semaphore pools (workers, DB connections, HTTP calls) prevent resource exhaustion</li>
+<li>When load exceeds capacity, the engine returns <strong>HTTP 429</strong> on enqueue requests</li>
+</ul>
+<h3 id="how-failures-are-classified">How failures are classified</h3>
+<table>
+<thead>
+<tr>
+<th>HTTP response</th>
+<th>Classification</th>
+<th>Action</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>2xx</td>
+<td>Success</td>
+<td>Next step</td>
+</tr>
+<tr>
+<td>408, 429, 5xx</td>
+<td>Retryable</td>
+<td>Requeue with backoff</td>
+</tr>
+<tr>
+<td>Other 4xx</td>
+<td>Critical</td>
+<td>Fail immediately, no retry</td>
+</tr>
+</tbody>
+</table>
+<p>Retries are per-step with configurable backoff (exponential, linear, constant), delay caps, and total deadline.</p>
+<h3 id="how-crashes-are-handled">How crashes are handled</h3>
+<ul>
+<li><code>HeartbeatService</code> proves worker liveness — if heartbeat expires, another worker reclaims the workflow</li>
+<li>Poison workflow protection after configurable max reclaim attempts</li>
+<li>Cross-pod cancellation propagation via DB polling; resume support for failed/canceled workflows</li>
+</ul>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="9" data-paginate="true" data-theme="gaia" data-style=":root {
+  --color-background: #1e2a3a;
+  --color-foreground: #cfd8dc;
+  --color-highlight: #4fc3f7;
+  --color-dimmed: #78909c;
+}
+section {
+  font-size: 20px;
+  padding: 30px 40px;
+}
+h1 {
+  margin-bottom: 0.5em;
+}
+h3 {
+  font-size: 1.1em;
+  margin-top: 1em;
+  margin-bottom: 0.3em;
+}
+pre {
+  font-size: 0.85em;
+  margin: 1em 0;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+}
+code {
+  font-size: 0.85em;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+  padding: 0.1em 0.3em;
+  margin: 0;
+}
+table {
+  font-size: 0.8em;
+  margin: 1em 0;
+  width: 100%;
+}
+th, td {
+  padding: 0.5em 1em;
+}
+ul, ol {
+  margin: 0.2em 0;
+}
+li {
+  margin: 0.1em 0;
+}
+p {
+  margin: 0.3em 0;
+}
+blockquote {
+  padding: 0.4em 0.8em;
+  margin: 0.4em 0;
+}
+" lang="C" data-marpit-pagination="9" style="--paginate:true;--theme:gaia;--style::root {
+  --color-background: #1e2a3a;
+  --color-foreground: #cfd8dc;
+  --color-highlight: #4fc3f7;
+  --color-dimmed: #78909c;
+}
+section {
+  font-size: 20px;
+  padding: 30px 40px;
+}
+h1 {
+  margin-bottom: 0.5em;
+}
+h3 {
+  font-size: 1.1em;
+  margin-top: 1em;
+  margin-bottom: 0.3em;
+}
+pre {
+  font-size: 0.85em;
+  margin: 1em 0;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+}
+code {
+  font-size: 0.85em;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+  padding: 0.1em 0.3em;
+  margin: 0;
+}
+table {
+  font-size: 0.8em;
+  margin: 1em 0;
+  width: 100%;
+}
+th, td {
+  padding: 0.5em 1em;
+}
+ul, ol {
+  margin: 0.2em 0;
+}
+li {
+  margin: 0.1em 0;
+}
+p {
+  margin: 0.3em 0;
+}
+blockquote {
+  padding: 0.4em 0.8em;
+  margin: 0.4em 0;
+}
+;" data-marpit-pagination-total="10" data-size="16:9">
+<h1 id="observability">Observability</h1>
+<h3 id="opentelemetry-%E2%86%92-grafana">OpenTelemetry → Grafana</h3>
+<ul>
+<li>Counters, histograms, and gauges across the full workflow and step lifecycle</li>
+<li>Distributed tracing with W3C trace context — spans for processing, execution, callbacks, slot acquisition</li>
+<li>Activity links between dependent workflows</li>
+</ul>
+<h3 id="dashboard-built-in">Dashboard (built-in)</h3>
+<ul>
+<li>Real-time SSE streams: engine health, active workflows, step pipelines</li>
+<li>Query interface with namespace/status/label filters</li>
+<li>Click-through to Grafana Tempo traces</li>
+</ul>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="10" data-paginate="true" data-theme="gaia" data-style=":root {
+  --color-background: #1e2a3a;
+  --color-foreground: #cfd8dc;
+  --color-highlight: #4fc3f7;
+  --color-dimmed: #78909c;
+}
+section {
+  font-size: 20px;
+  padding: 30px 40px;
+}
+h1 {
+  margin-bottom: 0.5em;
+}
+h3 {
+  font-size: 1.1em;
+  margin-top: 1em;
+  margin-bottom: 0.3em;
+}
+pre {
+  font-size: 0.85em;
+  margin: 1em 0;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+}
+code {
+  font-size: 0.85em;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+  padding: 0.1em 0.3em;
+  margin: 0;
+}
+table {
+  font-size: 0.8em;
+  margin: 1em 0;
+  width: 100%;
+}
+th, td {
+  padding: 0.5em 1em;
+}
+ul, ol {
+  margin: 0.2em 0;
+}
+li {
+  margin: 0.1em 0;
+}
+p {
+  margin: 0.3em 0;
+}
+blockquote {
+  padding: 0.4em 0.8em;
+  margin: 0.4em 0;
+}
+" lang="C" data-marpit-pagination="10" style="--paginate:true;--theme:gaia;--style::root {
+  --color-background: #1e2a3a;
+  --color-foreground: #cfd8dc;
+  --color-highlight: #4fc3f7;
+  --color-dimmed: #78909c;
+}
+section {
+  font-size: 20px;
+  padding: 30px 40px;
+}
+h1 {
+  margin-bottom: 0.5em;
+}
+h3 {
+  font-size: 1.1em;
+  margin-top: 1em;
+  margin-bottom: 0.3em;
+}
+pre {
+  font-size: 0.85em;
+  margin: 1em 0;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+}
+code {
+  font-size: 0.85em;
+  font-family: &quot;Menlo&quot;, &quot;Consolas&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace;
+  padding: 0.1em 0.3em;
+  margin: 0;
+}
+table {
+  font-size: 0.8em;
+  margin: 1em 0;
+  width: 100%;
+}
+th, td {
+  padding: 0.5em 1em;
+}
+ul, ol {
+  margin: 0.2em 0;
+}
+li {
+  margin: 0.1em 0;
+}
+p {
+  margin: 0.3em 0;
+}
+blockquote {
+  padding: 0.4em 0.8em;
+  margin: 0.4em 0;
+}
+;" data-marpit-pagination-total="10" data-size="16:9">
+<h1 id="workflow-dependencies">Workflow Dependencies</h1>
+<p><img src="workflow-dependencies.drawio.svg" alt="" /></p>
+<ul>
+<li>Workflows are submitted as dependency graphs — resolved via topological sort with cycle detection.</li>
+<li>A workflow starts only when all its dependencies have completed.</li>
+<li>If a dependency fails, all dependents are transitively marked <code>DependencyFailed</code>.</li>
+<li>Graphs can span multiple requests — later submissions reference existing workflows by ID.</li>
+</ul>
+</section>
+<script>!function(){"use strict";const t={h1:{proto:()=>HTMLHeadingElement,attrs:{role:"heading","aria-level":"1"},style:"display: block; font-size: 2em; margin-block-start: 0.67em; margin-block-end: 0.67em; margin-inline-start: 0px; margin-inline-end: 0px; font-weight: bold;"},h2:{proto:()=>HTMLHeadingElement,attrs:{role:"heading","aria-level":"2"},style:"display: block; font-size: 1.5em; margin-block-start: 0.83em; margin-block-end: 0.83em; margin-inline-start: 0px; margin-inline-end: 0px; font-weight: bold;"},h3:{proto:()=>HTMLHeadingElement,attrs:{role:"heading","aria-level":"3"},style:"display: block; font-size: 1.17em; margin-block-start: 1em; margin-block-end: 1em; margin-inline-start: 0px; margin-inline-end: 0px; font-weight: bold;"},h4:{proto:()=>HTMLHeadingElement,attrs:{role:"heading","aria-level":"4"},style:"display: block; margin-block-start: 1.33em; margin-block-end: 1.33em; margin-inline-start: 0px; margin-inline-end: 0px; font-weight: bold;"},h5:{proto:()=>HTMLHeadingElement,attrs:{role:"heading","aria-level":"5"},style:"display: block; font-size: 0.83em; margin-block-start: 1.67em; margin-block-end: 1.67em; margin-inline-start: 0px; margin-inline-end: 0px; font-weight: bold;"},h6:{proto:()=>HTMLHeadingElement,attrs:{role:"heading","aria-level":"6"},style:"display: block; font-size: 0.67em; margin-block-start: 2.33em; margin-block-end: 2.33em; margin-inline-start: 0px; margin-inline-end: 0px; font-weight: bold;"},span:{proto:()=>HTMLSpanElement},pre:{proto:()=>HTMLElement,style:"display: block; font-family: monospace; white-space: pre; margin: 1em 0; --marp-auto-scaling-white-space: pre;"}},e="data-marp-auto-scaling-wrapper",i="data-marp-auto-scaling-svg",n="data-marp-auto-scaling-container";class s extends HTMLElement{container;containerSize;containerObserver;svg;svgComputedStyle;svgPreserveAspectRatio="xMinYMid meet";wrapper;wrapperSize;wrapperObserver;constructor(){super();const t=t=>([e])=>{const{width:i,height:n}=e.contentRect;this[t]={width:i,height:n},this.updateSVGRect()};this.attachShadow({mode:"open"}),this.containerObserver=new ResizeObserver(t("containerSize")),this.wrapperObserver=new ResizeObserver((...e)=>{t("wrapperSize")(...e),this.flushSvgDisplay()})}static get observedAttributes(){return["data-downscale-only"]}connectedCallback(){this.shadowRoot.innerHTML=`\n<style>\n  svg[${i}] { display: block; width: 100%; height: auto; vertical-align: top; }\n  span[${n}] { display: table; white-space: var(--marp-auto-scaling-white-space, nowrap); width: max-content; }\n</style>\n<div ${e}>\n  <svg part="svg" ${i}>\n    <foreignObject><span ${n}><slot></slot></span></foreignObject>\n  </svg>\n</div>\n    `.split(/\n\s*/).join(""),this.wrapper=this.shadowRoot.querySelector(`div[${e}]`)??void 0;const t=this.svg;this.svg=this.wrapper?.querySelector(`svg[${i}]`)??void 0,this.svg!==t&&(this.svgComputedStyle=this.svg?window.getComputedStyle(this.svg):void 0),this.container=this.svg?.querySelector(`span[${n}]`)??void 0,this.observe()}disconnectedCallback(){this.svg=void 0,this.svgComputedStyle=void 0,this.wrapper=void 0,this.container=void 0,this.observe()}attributeChangedCallback(){this.observe()}flushSvgDisplay(){const{svg:t}=this;t&&(t.style.display="inline",requestAnimationFrame(()=>{t.style.display=""}))}observe(){this.containerObserver.disconnect(),this.wrapperObserver.disconnect(),this.wrapper&&this.wrapperObserver.observe(this.wrapper),this.container&&this.containerObserver.observe(this.container),this.svgComputedStyle&&this.observeSVGStyle(this.svgComputedStyle)}observeSVGStyle(t){const e=()=>{const i=(()=>{const e=t.getPropertyValue("--preserve-aspect-ratio");if(e)return e.trim();return`x${(({textAlign:t,direction:e})=>{if(t.endsWith("left"))return"Min";if(t.endsWith("right"))return"Max";if("start"===t||"end"===t){let i="rtl"===e;return"end"===t&&(i=!i),i?"Max":"Min"}return"Mid"})(t)}YMid meet`})();i!==this.svgPreserveAspectRatio&&(this.svgPreserveAspectRatio=i,this.updateSVGRect()),t===this.svgComputedStyle&&requestAnimationFrame(e)};e()}updateSVGRect(){let t=Math.ceil(this.containerSize?.width??0);const e=Math.ceil(this.containerSize?.height??0);void 0!==this.dataset.downscaleOnly&&(t=Math.max(t,this.wrapperSize?.width??0));const i=this.svg?.querySelector(":scope > foreignObject");if(i?.setAttribute("width",`${t}`),i?.setAttribute("height",`${e}`),this.svg&&(this.svg.setAttribute("viewBox",`0 0 ${t} ${e}`),this.svg.setAttribute("preserveAspectRatio",this.svgPreserveAspectRatio),this.svg.style.height=t<=0||e<=0?"0":""),this.container){const t=this.svgPreserveAspectRatio.toLowerCase();this.container.style.marginLeft=t.startsWith("xmid")||t.startsWith("xmax")?"auto":"0",this.container.style.marginRight=t.startsWith("xmi")?"auto":"0"}}}const r=(t,{attrs:e={},style:i})=>class extends t{constructor(...t){super(...t);for(const[t,i]of Object.entries(e))this.hasAttribute(t)||this.setAttribute(t,i);this._shadow()}static get observedAttributes(){return["data-auto-scaling"]}connectedCallback(){this._update()}attributeChangedCallback(){this._update()}_shadow(){if(!this.shadowRoot)try{this.attachShadow({mode:"open"})}catch(t){if(!(t instanceof Error&&"NotSupportedError"===t.name))throw t}return this.shadowRoot}_update(){const t=this._shadow();if(t){const e=i?`<style>:host { ${i} }</style>`:"";let n="<slot></slot>";const{autoScaling:s}=this.dataset;if(void 0!==s){n=`<marp-auto-scaling exportparts="svg:auto-scaling" ${"downscale-only"===s?"data-downscale-only":""}>${n}</marp-auto-scaling>`}t.innerHTML=e+n}}};let o;const a=Symbol(),l=()=>o??(o=!!document.createElement("div",{is:"marp-auto-scaling"}).outerHTML.startsWith("<div is"),o);let c;const d="marpitSVGPolyfill:setZoomFactor,",h=Symbol(),g=Symbol();const p=()=>{const t="Apple Computer, Inc."===navigator.vendor,e=t?[v]:[],i={then:e=>(t?(async()=>{if(void 0===c){const t=document.createElement("canvas");t.width=10,t.height=10;const e=t.getContext("2d"),i=new Image(10,10),n=new Promise(t=>{i.addEventListener("load",()=>t())});i.crossOrigin="anonymous",i.src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2210%22%20height%3D%2210%22%20viewBox%3D%220%200%201%201%22%3E%3CforeignObject%20width%3D%221%22%20height%3D%221%22%20requiredExtensions%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxhtml%22%3E%3Cdiv%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxhtml%22%20style%3D%22width%3A%201px%3B%20height%3A%201px%3B%20background%3A%20red%3B%20position%3A%20relative%22%3E%3C%2Fdiv%3E%3C%2FforeignObject%3E%3C%2Fsvg%3E",await n,e.drawImage(i,0,0),c=e.getImageData(5,5,1,1).data[3]<128}return c})().then(t=>{null==e||e(t?[v]:[])}):null==e||e([]),i)};return Object.assign(e,i)};let m,u;function v(t){const e="object"==typeof t&&t.target||document,i="object"==typeof t?t.zoom:t;window[g]||(Object.defineProperty(window,g,{configurable:!0,value:!0}),document.body.style.zoom=1.0001,document.body.offsetHeight,document.body.style.zoom=1,window.addEventListener("message",({data:t,origin:e})=>{if(e===window.origin)try{if(t&&"string"==typeof t&&t.startsWith(d)){const[,e]=t.split(","),i=Number.parseFloat(e);Number.isNaN(i)||(u=i)}}catch(t){console.error(t)}}));let n=!1;Array.from(e.querySelectorAll("svg[data-marpit-svg]"),t=>{var e,s,r,o;t.style.transform||(t.style.transform="translateZ(0)");const a=i||u||t.currentScale||1;m!==a&&(m=a,n=a);const l=t.getBoundingClientRect(),{length:c}=t.children;for(let i=0;i<c;i+=1){const n=t.children[i];if(n.getScreenCTM){const t=n.getScreenCTM();if(t){const i=null!==(s=null===(e=n.x)||void 0===e?void 0:e.baseVal.value)&&void 0!==s?s:0,c=null!==(o=null===(r=n.y)||void 0===r?void 0:r.baseVal.value)&&void 0!==o?o:0,d=n.children.length;for(let e=0;e<d;e+=1){const s=n.children[e];if("SECTION"===s.tagName){const{style:e}=s;e.transformOrigin||(e.transformOrigin=`${-i}px ${-c}px`),e.transform=`scale(${a}) matrix(${t.a}, ${t.b}, ${t.c}, ${t.d}, ${t.e-l.left}, ${t.f-l.top}) translateZ(0.0001px)`;break}}}}}}),!1!==n&&Array.from(e.querySelectorAll("iframe"),({contentWindow:t})=>{null==t||t.postMessage(`${d}${n}`,"null"===window.origin?"*":window.origin)})}function w({once:t=!1,target:e=document}={}){const i=function(t=document){if(t[h])return t[h];let e=!0;const i=()=>{e=!1,delete t[h]};Object.defineProperty(t,h,{configurable:!0,value:i});let n=[],s=!1;(async()=>{try{n=await p()}finally{s=!0}})();const r=()=>{for(const e of n)e({target:t});s&&0===n.length||e&&window.requestAnimationFrame(r)};return r(),i}(e);return t?(i(),()=>{}):i}m=1,u=void 0;const b=Symbol(),y=(e=document)=>{if("undefined"==typeof window)throw new Error("Marp Core's browser script is valid only in browser context.");if(((e=document)=>{const i=window[a];i||customElements.define("marp-auto-scaling",s);for(const n of Object.keys(t)){const s=`marp-${n}`,o=t[n].proto();l()&&o!==HTMLElement?i||customElements.define(s,r(o,{style:t[n].style}),{extends:n}):(i||customElements.define(s,r(HTMLElement,t[n])),e.querySelectorAll(`${n}[is="${s}"]`).forEach(t=>{t.outerHTML=t.outerHTML.replace(new RegExp(`^<${n}`,"i"),`<${s}`).replace(new RegExp(`</${n}>$`,"i"),`</${s}>`)}))}window[a]=!0})(e),e[b])return e[b];const i=w({target:e}),n=()=>{i(),delete e[b]},o=Object.assign(n,{cleanup:n,update:()=>y(e)});return Object.defineProperty(e,b,{configurable:!0,value:o}),o},f=document.currentScript;y(f?f.getRootNode():document)}();
+</script></foreignObject></svg></div><script>/*!! License: https://unpkg.com/@marp-team/marp-cli@4.3.1/lib/bespoke.js.LICENSE.txt */
+!function(){"use strict";function e(e){return e&&e.__esModule&&Object.prototype.hasOwnProperty.call(e,"default")?e.default:e}var t,n,r=(n||(n=1,t={from:function(e,t){var n,r=1===(e.parent||e).nodeType?e.parent||e:document.querySelector(e.parent||e),o=[].filter.call("string"==typeof e.slides?r.querySelectorAll(e.slides):e.slides||r.children,function(e){return"SCRIPT"!==e.nodeName}),i={},a=function(e,t){return(t=t||{}).index=o.indexOf(e),t.slide=e,t},s=function(e,t){i[e]=(i[e]||[]).filter(function(e){return e!==t})},l=function(e,t){return(i[e]||[]).reduce(function(e,n){return e&&!1!==n(t)},!0)},c=function(e,t){o[e]&&(n&&l("deactivate",a(n,t)),n=o[e],l("activate",a(n,t)))},d=function(e,t){var r=o.indexOf(n)+e;l(e>0?"next":"prev",a(n,t))&&c(r,t)},u={off:s,on:function(e,t){return(i[e]||(i[e]=[])).push(t),s.bind(null,e,t)},fire:l,slide:function(e,t){if(!arguments.length)return o.indexOf(n);l("slide",a(o[e],t))&&c(e,t)},next:d.bind(null,1),prev:d.bind(null,-1),parent:r,slides:o,destroy:function(e){l("destroy",a(n,e)),i={}}};return(t||[]).forEach(function(e){e(u)}),n||c(0),u}}),t),o=e(r);const i=document.body,a=(...e)=>history.replaceState(...e),s="",l="presenter",c="next",d="overview",u=["",l,d,c],f="bespoke-marp-",m=`data-${f}`,g=(e,{protocol:t,host:n,pathname:r,hash:o}=location)=>{const i=e.toString();return`${t}//${n}${r}${i?"?":""}${i}${o}`},p=()=>i.dataset.bespokeView,v=e=>new URLSearchParams(location.search).get(e),h=(e,t={})=>{const n={location,setter:a,...t},r=new URLSearchParams(n.location.search);for(const t of Object.keys(e)){const n=e[t];"string"==typeof n?r.set(t,n):r.delete(t)}try{n.setter({...window.history.state??{}},"",g(r,n.location))}catch(e){console.error(e)}},w=(()=>{const e="bespoke-marp";try{return localStorage.setItem(e,e),localStorage.removeItem(e),!0}catch{return!1}})(),y=e=>{try{return localStorage.getItem(e)}catch{return null}},b=(e,t)=>{try{return localStorage.setItem(e,t),!0}catch{return!1}},k=e=>{try{return localStorage.removeItem(e),!0}catch{return!1}},x=(e,t)=>{const n="aria-hidden";t?e.setAttribute(n,"true"):e.removeAttribute(n)},E=e=>{e.parent.classList.add(`${f}parent`),e.slides.forEach(e=>e.classList.add(`${f}slide`)),e.on("activate",t=>{const n=`${f}active`,r=t.slide,o=r.classList,i=!o.contains(n);if(e.slides.forEach(e=>{e.classList.remove(n),x(e,!0)}),o.add(n),x(r,!1),i){const e=`${n}-ready`;o.add(e),document.body.clientHeight,o.remove(e)}})},$=e=>{let t=0,n=0;Object.defineProperty(e,"fragments",{enumerable:!0,value:e.slides.map(e=>[null,...e.querySelectorAll("[data-marpit-fragment]")])});const r=r=>void 0!==e.fragments[t][n+r],o=(r,o)=>{t=r,n=o,e.fragments.forEach((e,t)=>{e.forEach((e,n)=>{if(null==e)return;const i=t<r||t===r&&n<=o;e.setAttribute(`${m}fragment`,(i?"":"in")+"active");const a=`${m}current-fragment`;t===r&&n===o?e.setAttribute(a,"current"):e.removeAttribute(a)})}),e.fragmentIndex=o;const i={slide:e.slides[r],index:r,fragments:e.fragments[r],fragmentIndex:o};e.fire("fragment",i)};e.on("next",({fragment:i=!0})=>{if(i){if(r(1))return o(t,n+1),!1;const i=t+1;e.fragments[i]&&o(i,0)}else{const r=e.fragments[t].length;if(n+1<r)return o(t,r-1),!1;const i=e.fragments[t+1];i&&o(t+1,i.length-1)}}),e.on("prev",({fragment:i=!0})=>{if(r(-1)&&i)return o(t,n-1),!1;const a=t-1;e.fragments[a]&&o(a,e.fragments[a].length-1)}),e.on("slide",({index:t,fragment:n})=>{let r=0;if(void 0!==n){const o=e.fragments[t];if(o){const{length:e}=o;r=-1===n?e-1:Math.min(Math.max(n,0),e-1)}}o(t,r)}),o(0,0)},L=document,S=()=>!(!L.fullscreenEnabled&&!L.webkitFullscreenEnabled),P=()=>!(!L.fullscreenElement&&!L.webkitFullscreenElement),_=e=>{e.fullscreen=()=>{S()&&(async()=>{P()?(L.exitFullscreen||L.webkitExitFullscreen)?.call(L):((e=L.body)=>{(e.requestFullscreen||e.webkitRequestFullscreen)?.call(e)})()})()},document.addEventListener("keydown",t=>{"f"!==t.key&&"F11"!==t.key||t.altKey||t.ctrlKey||t.metaKey||!S()||(e.fullscreen(),t.preventDefault())})},O=`${f}inactive`,T=(e=2e3)=>({parent:t,fire:n})=>{const r=t.classList,o=e=>n(`marp-${e?"":"in"}active`);let i;const a=()=>{i&&clearTimeout(i),i=setTimeout(()=>{r.add(O),o()},e),r.contains(O)&&(r.remove(O),o(!0))};for(const e of["mousedown","mousemove","touchend"])document.addEventListener(e,a);setTimeout(a,0)},I=["AUDIO","BUTTON","INPUT","SELECT","TEXTAREA","VIDEO"],M=e=>{e.parent.addEventListener("keydown",e=>{if(!e.target)return;const t=e.target;(I.includes(t.nodeName)||"true"===t.contentEditable)&&e.stopPropagation()})},A=e=>{window.addEventListener("load",()=>{for(const t of e.slides){const e=t.querySelector("marp-auto-scaling, [data-auto-scaling], [data-marp-fitting]");t.setAttribute(`${m}load`,e?"":"hideable")}})},C=({interval:e=250}={})=>t=>{document.addEventListener("keydown",e=>{if(" "===e.key&&e.shiftKey)t.prev();else if("ArrowLeft"===e.key||"ArrowUp"===e.key||"PageUp"===e.key)t.prev({fragment:!e.shiftKey});else if(" "!==e.key||e.shiftKey)if("ArrowRight"===e.key||"ArrowDown"===e.key||"PageDown"===e.key)t.next({fragment:!e.shiftKey});else if("End"===e.key)t.slide(t.slides.length-1,{fragment:-1});else{if("Home"!==e.key)return;t.slide(0)}else t.next();e.preventDefault()});let n,r,o=0;t.parent.addEventListener("wheel",i=>{let a=!1;const s=(e,t)=>{e&&(a=a||((e,t)=>((e,t)=>{const n="X"===t?"Width":"Height";return e[`client${n}`]<e[`scroll${n}`]})(e,t)&&((e,t)=>{const{overflow:n}=e,r=e[`overflow${t}`];return"auto"===n||"scroll"===n||"auto"===r||"scroll"===r})(getComputedStyle(e),t))(e,t)),e?.parentElement&&s(e.parentElement,t)};if(0!==i.deltaX&&s(i.target,"X"),0!==i.deltaY&&s(i.target,"Y"),a)return;i.preventDefault();const l=Math.sqrt(i.deltaX**2+i.deltaY**2);if(void 0!==i.wheelDelta){if(void 0===i.webkitForce&&Math.abs(i.wheelDelta)<40)return;if(i.deltaMode===i.DOM_DELTA_PIXEL&&l<4)return}else if(i.deltaMode===i.DOM_DELTA_PIXEL&&l<12)return;r&&clearTimeout(r),r=setTimeout(()=>{n=0},e);const c=Date.now()-o<e,d=l<=n;if(n=l,c||d)return;let u;(i.deltaX>0||i.deltaY>0)&&(u="next"),(i.deltaX<0||i.deltaY<0)&&(u="prev"),u&&(t[u](),o=Date.now())})},D=(e=`.${f}osc`)=>{const t=document.querySelector(e);if(!t)return()=>{};const n=(e,n)=>{t.querySelectorAll(`[${m}osc=${JSON.stringify(e)}]`).forEach(n)};if(S()||n("fullscreen",e=>e.style.display="none"),!w){const e=(e,t)=>{e.disabled=!0,e.title=`${t} is disabled due to restricted localStorage.`};n("presenter",t=>e(t,"Presenter view")),n("overview",t=>e(t,"Overview view"))}return e=>{t.addEventListener("click",t=>{if(t.target instanceof HTMLElement){const{bespokeMarpOsc:n}=t.target.dataset;n&&t.target.blur();const r={fragment:!t.shiftKey};"next"===n?e.next(r):"prev"===n?e.prev(r):"fullscreen"===n?e?.fullscreen():"presenter"===n?e.openPresenterView():"overview"===n&&e.toggleOverviewView()}}),e.parent.appendChild(t),e.on("activate",({index:t})=>{n("page",n=>n.textContent=`Page ${t+1} of ${e.slides.length}`)}),e.on("fragment",({index:t,fragments:r,fragmentIndex:o})=>{n("prev",e=>e.disabled=0===t&&0===o),n("next",n=>n.disabled=t===e.slides.length-1&&o===r.length-1)}),e.on("marp-active",()=>x(t,!1)),e.on("marp-inactive",()=>x(t,!0)),S()&&(e=>{for(const t of["","webkit"])L.addEventListener(t+"fullscreenchange",e)})(()=>n("fullscreen",e=>e.classList.toggle("exit",S()&&P())))}},N=e=>{if(e.syncKey&&"string"==typeof e.syncKey)return!0;throw new Error("The current instance of Bespoke.js is incompatible with Marp bespoke sync plugin.")},B=(e={})=>{const t=e.key||window.history.state?.marpBespokeSyncKey||Math.random().toString(36).slice(2),n=`bespoke-marp-sync-${t}`;var r;r={marpBespokeSyncKey:t},h({},{setter:(e,...t)=>a({...e,...r},...t)});const o=()=>{const e=y(n);return e?JSON.parse(e):Object.create(null)},i=e=>{const t=o(),r={...t,...e(t)};return b(n,JSON.stringify(r)),r},s=()=>{window.removeEventListener("pageshow",s),i(e=>({reference:(e.reference||0)+1}))};return e=>{s(),Object.defineProperty(e,"syncKey",{value:t,enumerable:!0});let r=!0;setTimeout(()=>{e.on("fragment",e=>{r&&i(()=>({index:e.index,fragmentIndex:e.fragmentIndex}))})},0),window.addEventListener("storage",t=>{if(t.key===n&&t.oldValue&&t.newValue){const n=JSON.parse(t.oldValue),o=JSON.parse(t.newValue);if(n.index!==o.index||n.fragmentIndex!==o.fragmentIndex)try{r=!1,e.slide(o.index,{fragment:o.fragmentIndex,forSync:!0})}finally{r=!0}}});const a=()=>{const{reference:e}=o();void 0===e||e<=1?k(n):i(()=>({reference:e-1}))};window.addEventListener("pagehide",e=>{e.persisted&&window.addEventListener("pageshow",s),a()}),e.on("destroy",a)}},K=e=>{w&&document.addEventListener("keydown",t=>{("o"!==t.key||t.altKey||t.ctrlKey||t.metaKey)&&"Escape"!==t.key||(t.preventDefault(),e())})};let q=null;const V=({closeOnSelect:e=!0}={})=>t=>{N(t);const n=n=>{const r=(()=>{if(!q||!q.isConnected){q=document.createElement("div"),q.className=`${f}overview`,q.inert=!0;const n=document.createElement("iframe");n.src=(()=>{const n=new URLSearchParams(location.search);return n.set("view","overview"),n.set("sync",t.syncKey),e&&n.set("closeOnSelect","1"),g(n)})(),q.append(n),document.body.append(q)}return q})(),o=n??!r.dataset.open;setTimeout(()=>{if(r.dataset.open=o?"1":"",r.inert=!o,t.skipTransition=o,o){const e=r.querySelector("iframe");try{e?.contentWindow?.focus()}catch{e?.focus()}}else window.focus()},0)};Object.defineProperties(t,{toggleOverviewView:{enumerable:!0,value:n}}),window.addEventListener("message",e=>{e.origin===window.origin&&"closeOverview"===e.data&&n(!1)}),K(n)},j=e=>{const{title:t}=document;document.title="[Overview]"+(t?` - ${t}`:"");const n=!!v("closeOnSelect"),r=()=>{window.parent.postMessage("closeOverview","null"===window.origin?"*":window.origin)};if(e.slides.forEach((t,o)=>{t.tabIndex=0;const i=()=>{e.slide(o,{fragment:-1}),n&&r()};t.addEventListener("click",i),t.addEventListener("keydown",e=>{"Enter"!==e.key&&" "!==e.key||(e.preventDefault(),i())})}),window.addEventListener("keydown",t=>{const n=e.slide(),r=t=>{const r=t=>{const n=e.slides[t].getBoundingClientRect();return[Math.round((n.left+n.right)/2),Math.round((n.top+n.bottom)/2)]};let o=null,i=n;do{const e=r(i);if(o){if(Math.abs(e[0]-o[0])<2)return i}else o=e;i+=t}while(i>=0&&i<e.slides.length);return n};if("ArrowLeft"===t.key)e.slide(Math.max(n-1,0),{fragment:-1});else if("ArrowRight"===t.key)e.slide(Math.min(n+1,e.slides.length-1),{fragment:-1});else if("ArrowUp"===t.key)e.slide(r(-1),{fragment:-1});else if("ArrowDown"===t.key)e.slide(r(1),{fragment:-1});else if("End"===t.key)e.slide(e.slides.length-1,{fragment:-1});else{if("Home"!==t.key)return;e.slide(0,{fragment:-1})}t.preventDefault();const o=e.slide();e.slides[o]?.focus?.(),e.slides[o]?.scrollIntoView?.({behavior:"smooth",block:"nearest"})}),e.on("slide",({index:t})=>{e.slides[t]?.scrollIntoView?.({behavior:"smooth",block:"nearest"})}),window.parent!==window){K(r);const e=document.createElement("header");e.className=`${f}overview-header`;const t=document.createElement("button");t.className=`${f}overview-close`,t.type="button",t.title="Close overview",t.textContent=t.title,t.addEventListener("click",r),e.append(t),document.body.prepend(e)}},F=()=>{const e=p();return{[s]:V(),[l]:V({closeOnSelect:!1}),[d]:j}[e]},U=e=>{window.addEventListener("message",t=>{if(t.origin!==window.origin)return;const[n,r]=t.data.split(":");if("navigate"===n){const[t,n]=r.split(",");let o=Number.parseInt(t,10),i=Number.parseInt(n,10)+1;i>=e.fragments[o].length&&(o+=1,i=0),e.slide(o,{fragment:i})}})};var R,X,H,W,J,Y,z,G={exports:{}},Q=(R||(R=1,G.exports=(X=["area","base","br","col","command","embed","hr","img","input","keygen","link","meta","param","source","track","wbr"],H=function(e){return String(e).replace(/[&<>"']/g,function(e){return"&"+W[e]+";"})},W={"&":"amp","<":"lt",">":"gt",'"':"quot","'":"apos"},J="dangerouslySetInnerHTML",Y={className:"class",htmlFor:"for"},z={},function(e,t){var n=[],r="";t=t||{};for(var o=arguments.length;o-- >2;)n.push(arguments[o]);if("function"==typeof e)return t.children=n.reverse(),e(t);if(e){if(r+="<"+e,t)for(var i in t)!1!==t[i]&&null!=t[i]&&i!==J&&(r+=" "+(Y[i]?Y[i]:H(i))+'="'+H(t[i])+'"');r+=">"}if(-1===X.indexOf(e)){if(t[J])r+=t[J].__html;else for(;n.length;){var a=n.pop();if(a)if(a.pop)for(var s=a.length;s--;)n.push(a[s]);else r+=!0===z[a]?a:H(a)}r+=e?"</"+e+">":""}return z[r]=!0,r})),G.exports),Z=e(Q);const ee=({children:e})=>Z(null,null,...e),te=`${f}presenter-`,ne={container:`${te}container`,dragbar:`${te}dragbar-container`,next:`${te}next`,nextContainer:`${te}next-container`,noteContainer:`${te}note-container`,noteWrapper:`${te}note-wrapper`,noteButtons:`${te}note-buttons`,infoContainer:`${te}info-container`,infoPageArea:`${te}info-page-area`,infoPage:`${te}info-page`,infoPagePrev:`${te}info-page-prev`,infoPageNext:`${te}info-page-next`,noteButtonsBigger:`${te}note-bigger`,noteButtonsSmaller:`${te}note-smaller`,infoTime:`${te}info-time`,infoTimer:`${te}info-timer`},re=e=>{const{title:t}=document;document.title="[Presenter view]"+(t?` - ${t}`:"");const n={},r=e=>(n[e]=n[e]||document.querySelector(`.${e}`),n[e]);document.body.appendChild((e=>{const t=document.createElement("div");return t.className=ne.container,t.appendChild(e),t.insertAdjacentHTML("beforeend",Z(ee,null,Z("div",{class:ne.nextContainer},Z("iframe",{class:ne.next,src:"?view=next"})),Z("div",{class:ne.dragbar}),Z("div",{class:ne.noteContainer},Z("div",{class:ne.noteWrapper}),Z("div",{class:ne.noteButtons},Z("button",{class:ne.noteButtonsSmaller,tabindex:"-1",title:"Smaller notes font size"},"Smaller notes font size"),Z("button",{class:ne.noteButtonsBigger,tabindex:"-1",title:"Bigger notes font size"},"Bigger notes font size"))),Z("div",{class:ne.infoContainer},Z("div",{class:ne.infoPageArea},Z("button",{class:ne.infoPagePrev,tabindex:"-1",title:"Previous"},"Previous"),Z("button",{class:ne.infoPage}),Z("button",{class:ne.infoPageNext,tabindex:"-1",title:"Next"},"Next")),Z("time",{class:ne.infoTime,title:"Current time"}),Z("time",{class:ne.infoTimer,title:"Timer"})))),t})(e.parent)),(e=>{let t=!1;r(ne.dragbar).addEventListener("mousedown",()=>{t=!0,r(ne.dragbar).classList.add("active")}),window.addEventListener("mouseup",()=>{t=!1,r(ne.dragbar).classList.remove("active")}),window.addEventListener("mousemove",e=>{if(!t)return;const n=e.clientX/document.documentElement.clientWidth*100;r(ne.container).style.setProperty("--bespoke-marp-presenter-split-ratio",`${Math.max(0,Math.min(100,n))}%`)}),r(ne.nextContainer).addEventListener("click",()=>e.next());const n=r(ne.next),o=(i=n,(e,t)=>i.contentWindow?.postMessage(`navigate:${e},${t}`,"null"===window.origin?"*":window.origin));var i;n.addEventListener("load",()=>{r(ne.nextContainer).classList.add("active"),o(e.slide(),e.fragmentIndex),e.on("fragment",({index:e,fragmentIndex:t})=>o(e,t))});const a=document.querySelectorAll(".bespoke-marp-note");a.forEach(e=>{e.addEventListener("keydown",e=>e.stopPropagation()),r(ne.noteWrapper).appendChild(e)}),e.on("activate",()=>a.forEach(t=>t.classList.toggle("active",t.dataset.index==e.slide())));let s=0;const l=e=>{s=Math.max(-5,s+e),r(ne.noteContainer).style.setProperty("--bespoke-marp-note-font-scale",(1.2**s).toFixed(4))},c=()=>l(1),d=()=>l(-1),u=r(ne.noteButtonsBigger),f=r(ne.noteButtonsSmaller);u.addEventListener("click",()=>{u.blur(),c()}),f.addEventListener("click",()=>{f.blur(),d()}),document.addEventListener("keydown",e=>{"+"===e.key&&c(),"-"===e.key&&d()},!0);const m=r(ne.infoPage);e.on("activate",({index:t})=>{m.textContent=`${t+1} / ${e.slides.length}`}),m.addEventListener("click",()=>{m.blur(),e.toggleOverviewView()});const g=r(ne.infoPagePrev),p=r(ne.infoPageNext);g.addEventListener("click",t=>{g.blur(),e.prev({fragment:!t.shiftKey})}),p.addEventListener("click",t=>{p.blur(),e.next({fragment:!t.shiftKey})}),e.on("fragment",({index:t,fragments:n,fragmentIndex:r})=>{g.disabled=0===t&&0===r,p.disabled=t===e.slides.length-1&&r===n.length-1});let v=new Date;const h=()=>{const e=new Date,t=e=>`${Math.floor(e)}`.padStart(2,"0"),n=e.getTime()-v.getTime(),o=t(n/1e3%60),i=t(n/1e3/60%60),a=t(n/36e5%24);r(ne.infoTime).textContent=e.toLocaleTimeString(),r(ne.infoTimer).textContent=`${a}:${i}:${o}`};h(),setInterval(h,250),r(ne.infoTimer).addEventListener("click",()=>{v=new Date})})(e)},oe=e=>{N(e),Object.defineProperties(e,{openPresenterView:{enumerable:!0,value:ie},presenterUrl:{enumerable:!0,get:ae}}),w&&document.addEventListener("keydown",t=>{"p"!==t.key||t.altKey||t.ctrlKey||t.metaKey||(t.preventDefault(),e.openPresenterView())})};function ie(){const{max:e,floor:t}=Math,n=e(t(.85*window.innerWidth),640),r=e(t(.85*window.innerHeight),360);return window.open(this.presenterUrl,te+this.syncKey,`width=${n},height=${r},menubar=no,toolbar=no`)}function ae(){const e=new URLSearchParams(location.search);return e.set("view","presenter"),e.set("sync",this.syncKey),g(e)}const se=e=>{const t=p();return t===c&&e.appendChild(document.createElement("span")),{[s]:oe,[l]:re,[c]:U}[t]},le=e=>{e.on("activate",t=>{document.querySelectorAll(".bespoke-progress-parent > .bespoke-progress-bar").forEach(n=>{n.style.flexBasis=100*t.index/(e.slides.length-1)+"%"})})},ce=e=>{const t=Number.parseInt(e,10);return Number.isNaN(t)?null:t},de=(e={})=>{const t={history:!0,...e};return e=>{let n=!0;const r=e=>{const t=n;try{return n=!0,e()}finally{n=t}},o=(t={fragment:!0})=>{let n=t.fragment?ce(v("f")||""):null;((t,n)=>{const{min:r,max:o}=Math,{fragments:i,slides:a}=e,s=o(0,r(t,a.length-1)),l=o(0,r(n||0,i[s].length-1));s===e.slide()&&l===e.fragmentIndex||e.slide(s,{fragment:l})})((()=>{if(location.hash){const[t]=location.hash.slice(1).split(":~:");if(/^\d+$/.test(t))return(ce(t)??1)-1;const r=document.getElementById(t)||document.querySelector(`a[name="${CSS.escape(t)}"]`);if(r){const{length:t}=e.slides;for(let o=0;o<t;o+=1)if(e.slides[o].contains(r)){const t=e.fragments?.[o],i=r.closest("[data-marpit-fragment]");if(t&&i){const e=t.indexOf(i);e>=0&&(n=e)}return o}}}return 0})(),n)};e.on("fragment",({index:e,fragmentIndex:r})=>{n||h({f:0===r||r.toString()},{location:{...location,hash:`#${e+1}`},setter:(...e)=>t.history?history.pushState(...e):history.replaceState(...e)})}),setTimeout(()=>{o(),window.addEventListener("hashchange",()=>r(()=>{o({fragment:!1}),h({f:void 0})})),window.addEventListener("popstate",()=>{n||r(()=>o())}),n=!1},0)}},{PI:ue,abs:fe,sqrt:me,atan2:ge}=Math,pe={passive:!0},ve=({slope:e=-.7,swipeThreshold:t=30}={})=>n=>{let r;const o=n.parent,i=e=>{const t=o.getBoundingClientRect();return{x:e.pageX-(t.left+t.right)/2,y:e.pageY-(t.top+t.bottom)/2}};o.addEventListener("touchstart",({touches:e})=>{r=1===e.length?i(e[0]):void 0},pe),o.addEventListener("touchmove",e=>{if(r)if(1===e.touches.length){e.preventDefault();const t=i(e.touches[0]),n=t.x-r.x,o=t.y-r.y;r.delta=me(fe(n)**2+fe(o)**2),r.radian=ge(n,o)}else r=void 0}),o.addEventListener("touchend",o=>{if(r){if(r.delta&&r.delta>=t&&r.radian){const t=(r.radian-e+ue)%(2*ue)-ue;n[t<0?"next":"prev"](),o.stopPropagation()}r=void 0}},pe)},he=new Map;he.clear(),he.set("none",{backward:{both:void 0,incoming:void 0,outgoing:void 0},forward:{both:void 0,incoming:void 0,outgoing:void 0}});const we={both:"",outgoing:"outgoing-",incoming:"incoming-"},ye={forward:"",backward:"-backward"},be=e=>`--marp-bespoke-transition-animation-${e}`,ke=e=>`--marp-transition-${e}`,xe=be("name"),Ee=be("duration"),$e=e=>new Promise(t=>{const n={},r=document.createElement("div"),o=e=>{r.remove(),t(e)};r.addEventListener("animationstart",()=>o(n)),Object.assign(r.style,{animationName:e,animationDuration:"1s",animationFillMode:"both",animationPlayState:"paused",position:"absolute",pointerEvents:"none"}),document.body.appendChild(r);const i=getComputedStyle(r).getPropertyValue(ke("duration"));i&&Number.parseFloat(i)>=0&&(n.defaultDuration=i),((e,t)=>{requestAnimationFrame(()=>{e.style.animationPlayState="running",requestAnimationFrame(()=>t(void 0))})})(r,o)}),Le=async e=>he.has(e)?he.get(e):(e=>{const t={},n=[];for(const[r,o]of Object.entries(we))for(const[i,a]of Object.entries(ye)){const s=`marp-${o}transition${a}-${e}`;n.push($e(s).then(e=>{t[i]=t[i]||{},t[i][r]=e?{...e,name:s}:void 0}))}return Promise.all(n).then(()=>t)})(e).then(t=>(he.set(e,t),t)),Se=e=>Object.values(e).flatMap(Object.values).every(e=>!e),Pe=(e,{type:t,backward:n})=>{const r=e[n?"backward":"forward"],o=(()=>{const e=r[t],n=e=>({[xe]:e.name});if(e)return n(e);if(r.both){const e=n(r.both);return"incoming"===t&&(e[be("direction")]="reverse"),e}})();return!o&&n?Pe(e,{type:t,backward:!1}):o||{[xe]:"__bespoke_marp_transition_no_animation__"}},_e=e=>{if(e)try{const t=JSON.parse(e);if((e=>{if("object"!=typeof e)return!1;const t=e;return"string"==typeof t.name&&(void 0===t.duration||"string"==typeof t.duration)})(t))return t}catch{}},Oe="_tSId",Te="_tA",Ie="bespoke-marp-transition-warming-up",Me=window.matchMedia("(prefers-reduced-motion: reduce)"),Ae="__bespoke_marp_transition_reduced_outgoing__",Ce="__bespoke_marp_transition_reduced_incoming__",De={forward:{both:void 0,incoming:{name:Ce},outgoing:{name:Ae}},backward:{both:void 0,incoming:{name:Ce},outgoing:{name:Ae}}},Ne=e=>{if(!document.startViewTransition)return;const t=t=>(void 0!==t&&(e._tD=t),e._tD);let n;t(!1),((...e)=>{CSS.registerProperty({name:ke("duration"),syntax:"<time>",inherits:!0,initialValue:"-1s"});const t=[...new Set(e).values()];return Promise.all(t.map(e=>Le(e))).then()})(...Array.from(document.querySelectorAll("section[data-transition], section[data-transition-back]")).flatMap(e=>[e.dataset.transition,e.dataset.transitionBack].flatMap(e=>{const t=_e(e);return[t?.name,t?.builtinFallback?`__builtin__${t.name}`:void 0]}).filter(e=>!!e))).then(()=>{document.querySelectorAll("style").forEach(e=>{e.innerHTML=e.innerHTML.replace(/--marp-transition-duration:[^;}]*[;}]/g,e=>e.slice(0,-1)+"!important"+e.slice(-1))})});const r=(n,{back:r,cond:o})=>i=>{const a=t();if(a)return!!i[Te]||!("object"!=typeof a||(a.skipTransition(),!i.forSync));if(e.skipTransition)return!0;if(!o(i))return!0;const s=e.slides[e.slide()],l=()=>i.back??r,c="data-transition"+(l()?"-back":""),d=s.querySelector(`section[${c}]`);if(!d)return!0;const u=_e(d.getAttribute(c)??void 0);return!u||((async(e,{builtinFallback:t=!0}={})=>{let n=await Le(e);if(Se(n)){if(!t)return;return n=await Le(`__builtin__${e}`),Se(n)?void 0:n}return n})(u.name,{builtinFallback:u.builtinFallback}).then(e=>{if(!e){t(!0);try{n(i)}finally{t(!1)}return}let r=e;Me.matches&&(console.warn("Use a constant animation to transition because preferring reduced motion by viewer has detected."),r=De);const o=document.getElementById(Oe);o&&o.remove();const a=document.createElement("style");a.id=Oe,document.head.appendChild(a),((e,t)=>{const n=[`:root{${ke("direction")}:${t.backward?-1:1};}`,":root:has(.bespoke-marp-inactive){cursor:none;}"],r=t=>{const n=e[t].both?.defaultDuration||e[t].outgoing?.defaultDuration||e[t].incoming?.defaultDuration;return"forward"===t?n:n||r("forward")},o=t.duration||r(t.backward?"backward":"forward");void 0!==o&&n.push(`::view-transition-group(*){${Ee}:${o};}`);const i=e=>Object.entries(e).map(([e,t])=>`${e}:${t};`).join("");return n.push(`::view-transition-old(root){${i(Pe(e,{...t,type:"outgoing"}))}}`,`::view-transition-new(root){${i(Pe(e,{...t,type:"incoming"}))}}`),n})(r,{backward:l(),duration:u.duration}).forEach(e=>a.sheet?.insertRule(e));const s=document.documentElement.classList;s.add(Ie);let c=!1;const d=()=>{c||(n(i),c=!0,s.remove(Ie))},f=()=>{t(!1),a.remove(),s.remove(Ie)};try{t(!0);const e=document.startViewTransition(d);t(e),e.finished.finally(f)}catch(e){console.error(e),d(),f()}}),!1)};e.on("prev",r(t=>e.prev({...t,[Te]:!0}),{back:!0,cond:e=>e.index>0&&!((e.fragment??1)&&n.fragmentIndex>0)})),e.on("next",r(t=>e.next({...t,[Te]:!0}),{cond:t=>t.index+1<e.slides.length&&!(n.fragmentIndex+1<n.fragments.length)})),setTimeout(()=>{e.on("slide",r(t=>e.slide(t.index,{...t,[Te]:!0}),{cond:t=>{const n=e.slide();return t.index!==n&&(t.back=t.index<n,!0)}}))},0),e.on("fragment",e=>{n=e})};let Be;const Ke=()=>(void 0===Be&&(Be="wakeLock"in navigator&&navigator.wakeLock),Be),qe=async()=>{const e=Ke();if(e)try{return await e.request("screen")}catch(e){console.warn(e)}return null},Ve=async()=>{if(!Ke())return;let e;const t=()=>{e&&"visible"===document.visibilityState&&qe()};for(const e of["visibilitychange","fullscreenchange"])document.addEventListener(e,t);return e=await qe(),e};((e=document.getElementById(":$p"))=>{(()=>{const e=v("view");i.dataset.bespokeView=u.some(t=>t&&t===e)?e:""})();const t=(e=>{const t=v(e);return h({[e]:void 0}),t})("sync")||void 0;o.from(e,((...e)=>{const t=u.findIndex(e=>p()===e);return e.map(([e,n])=>e[t]&&n).filter(e=>e)})([[1,1,1,0],B({key:t})],[[1,1,0,1],se(e)],[[1,1,0,0],M],[[1,1,1,1],E],[[1,0,0,0],T()],[[1,1,1,1],A],[[1,1,1,1],de({history:!1})],[[1,1,0,0],C()],[[1,1,1,0],_],[[1,0,0,0],le],[[1,1,0,0],ve()],[[1,0,0,0],D()],[[1,1,1,0],F()],[[1,0,0,0],Ne],[[1,1,1,1],$],[[1,1,1,0],Ve]))})()}();</script></body></html>

--- a/src/Runtime/workflow-engine/docs/presentation/presentation-technical.md
+++ b/src/Runtime/workflow-engine/docs/presentation/presentation-technical.md
@@ -25,6 +25,13 @@ style: |
     pre {
       font-size: 0.85em;
       margin: 1em 0;
+      font-family: "Menlo", "Consolas", "DejaVu Sans Mono", "Courier New", monospace;
+    }
+    code {
+      font-size: 0.85em;
+      font-family: "Menlo", "Consolas", "DejaVu Sans Mono", "Courier New", monospace;
+      padding: 0.1em 0.3em;
+      margin: 0;
     }
     table {
       font-size: 0.8em;
@@ -104,19 +111,19 @@ A dedicated workflow engine that moves process execution out of the HTTP request
 ```
 Altinn App                              Workflow Engine
     │                                          │
-    │──── POST /workflows ───────────────────▶│  Validate & persist
-    │◀─── 201 Created ────────────────────────│  to PostgreSQL
+    │──── POST /workflows ────────────────────►│  Validate & persist
+    │◄─── 201 Created ─────────────────────────│  to PostgreSQL
     │                                          │
     │                                          │
     │                                          │
     │                                   Processor picks up
     │                                    workflow from DB
     │                                          │
-    │◀─── POST /callbacks ────────────────────│  Step 1
-    │──── 200 + { state } ───────────────────▶│
+    │◄─── POST /callbacks ─────────────────────│  Step 1
+    │──── 200 + { state } ────────────────────►│
     │                                          │
-    │◀─── POST /callbacks ────────────────────│  Step 2
-    │──── 200 + { state } ───────────────────▶│
+    │◄─── POST /callbacks ─────────────────────│  Step 2
+    │──── 200 + { state } ────────────────────►│
     │                                          │
     │                                  Completed or Failed
 ```
@@ -165,12 +172,12 @@ Host Application (e.g. WorkflowEngine.App)
 ├── UseWorkflowEngine()                  // wires pipeline
 │
 └── WorkflowEngine.Core (class library)
-      ├── Processor   (background loop, fetches from DB)
-      ├── Executor    (runs commands per step)
-      ├── Commands    (pluggable: Webhook, App, <future>)
-      ├── Data        (PostgreSQL, EF Core)
-      ├── Resilience  (concurrency limiters, retry strategies)
-      └── Telemetry   (OpenTelemetry via OTLP)
+      ├── Processor   // background loop, fetches from DB
+      ├── Executor    // executes the actual step commands
+      ├── Commands    // pluggable: Webhook, App, <future>
+      ├── Data        // repository, EF Core entities
+      ├── Resilience  // concurrency limiters, retry strategies
+      └── Telemetry   // OpenTelemetry via OTLP
 ```
 
 `WorkflowEngine.App` is the Altinn-specific host. It adds `AppCommand` &mdash; an HTTP callback into Altinn apps carrying full instance context (org, app, actor, lockToken, instanceGuid).
@@ -225,28 +232,9 @@ Retries are per-step with configurable backoff (exponential, linear, constant), 
 
 # Workflow Dependencies
 
-A single enqueue request can express **fan-out / fan-in** patterns:
+![](workflow-dependencies.drawio.svg)
 
-```
-              ┌──────────────────┐
-              │   process/next   │
-              │     (Task 1)     │
-              └────────┬─────────┘
-                       │
-            ┌──────────┴──────────┐
-            │                     │
-   ┌────────▼─────────┐   ┌───────▼──────────┐
-   │   notification   │   │   eFormidling    │
-   └────────┬─────────┘   └───────┬──────────┘
-            │                     │
-            └──────────┬──────────┘
-                       │
-              ┌────────▼─────────┐
-              │   process/next   │
-              │     (Task 2)     │
-              └──────────────────┘
-```
-
-- DAG resolution via topological sort. Cycle detection. Atomic insert.
-- A workflow only starts when all its dependencies have completed.
-- If a dependency fails, dependents are marked `DependencyFailed`.
+- Workflows are submitted as dependency graphs &mdash; resolved via topological sort with cycle detection.
+- A workflow starts only when all its dependencies have completed.
+- If a dependency fails, all dependents are transitively marked `DependencyFailed`.
+- Graphs can span multiple requests &mdash; later submissions reference existing workflows by ID.

--- a/src/Runtime/workflow-engine/docs/presentation/workflow-dependencies.drawio.svg
+++ b/src/Runtime/workflow-engine/docs/presentation/workflow-dependencies.drawio.svg
@@ -1,0 +1,347 @@
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: transparent; background-color: transparent;" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1040px" height="430px" viewBox="-0.5 -0.5 1040 430" content="&lt;mxfile&gt;&lt;diagram name=&quot;Workflow Dependencies&quot; id=&quot;workflow-deps&quot;&gt;7ZpLc9owEIB/jWfaQzv4AYRjAvQx03Y6k0PbE6NiYasYrSuLAP31lWzZlpFpCFXASQsHrNXqsd+upZWx449X27cMpfFHCHHieL1w6/gTx/Ncb9ATP1KyKySjoF8IIkZCpVQLbskvrISqXbQmIc4aihwg4SRtCudAKZ7zhgwxBpum2gKS5qgpirAhuJ2jxJR+ISGPldQdjOqKd5hEsRr6yhsWFStUKitLshiFsNFE/tTxxwyAF1er7RgnEl7JpWj35kBtNTGGKT+mwaBocIeStbJNzYvvSmMZrGmIpX7P8W82MeH4NkVzWbsR7hWymK8SUXLF5YIkyRgSYKKcSACvQsSWLxzPH7+ZXE1Ef+Pq+qXQzziDJS5bUKCi25sV3KHv+fCyS4Yz8ksvA0dcK4vgwnoZh0QvJjBfVrNXAaFVK/sx43h7kKFbeUaENIYV5mwnVDaa73uB8mis+T3wlRCpgIuqxrVPxIVyS7uLfMsuOmBeCwTTYlUbDJVd6v4tp6QB6fdbePgjCzy87vHw7sVRRYJ1HIRm3CDyXggR5QRx/Ac47hH3M1Cu1l/XL8uqr56lYNqDF5j03Labq28BHsKuwe5a7COUCtn0ThplDZ9nKdb27j23JdrctpsvsMCLAicLE9knKSZzxAnQ7gMbnhFYKLYqA9ckF/Y4ypaON0jEcDffmbiKeG5xIZEkGiAHP9dQVrzKckbXQsHtpduimaovO3qRMpjjLBNTpHjLX5Ydi3LRdzmeTX/p68OhjfRvnNe6OrQ5z8bqEBKUQGS6LxenIGzofrT7Z18ezP2508tDlagoYOdcHXJeZn73pHidf/8Jnjiwc0ZYRiJq4LoVQkKj/1vQSf476xaEaWi4b1rKOpzUD4/J6t1Hy+rNPajjWf3V6IK88EweImfVYUjjgsMIl6EhEp4YIqAomdbSm+ZZu9b5AJAqXj8w5zsFDK05NGkKaGz3VbXPC99k4XW/LE62euVkd1+UZrBmczX/+nTMEYswLwNEqUrz/ugehhOxq9w1n/tZYK0fpJ49bt3YixGvT2Ln5f0X3OopX46adgR69nGqG3sJ4tLfM/0M9TSIhyiLq63zKPx1YBvLhGcbf970mjG00xRSIJRnWs+fpUDL+Xp72/FgqLvyXv2Rt+f5YgJ1HFSWPDg0/H82NPxnERpu8HixEfyzsRE8j9h4nHWjfghw3siw5eF6/pfYleXoM9xy5u5K8ljj0aFVM74EMzH4rDqFdxBZBad5KrSefDwg98tzz0tBO+FO1XLljkA0nwt/AbZcJLCRc8c/15iK2cv/6n3z5H3yWy6it0Vffp39t1lCvEDr6kGqpl98LP3fc+KrBxYeG/WP520GtRXeh7g2/SBqBvnHDvGTX355OHJRrF8FK/b/+oU6f/ob&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs/>
+    <g>
+        <g>
+            <rect x="0" y="0" width="1040" height="430" fill="#cfd8dd" stroke="none" pointer-events="all" style="fill: light-dark(rgb(207, 216, 221), rgb(207, 216, 221));"/>
+        </g>
+        <g>
+            <rect x="470" y="22" width="550" height="390" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <rect x="20" y="22" width="430" height="390" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <rect x="40" y="242" width="140" height="50" rx="7.5" ry="7.5" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 138px; height: 1px; padding-top: 267px; margin-left: 41px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 13px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    Instantiate
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="110" y="271" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="13px" text-anchor="middle">
+                        Instantiate
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="270" y="122" width="150" height="40" rx="6" ry="6" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 148px; height: 1px; padding-top: 142px; margin-left: 271px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    Altinn Event
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="345" y="146" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        Altinn Event
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="270" y="172" width="150" height="40" rx="6" ry="6" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 148px; height: 1px; padding-top: 192px; margin-left: 271px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    Notification
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="345" y="196" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        Notification
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="270" y="242" width="150" height="50" rx="7.5" ry="7.5" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 148px; height: 1px; padding-top: 267px; margin-left: 271px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; word-wrap: normal; ">
+                                    Data task
+                                    <br/>
+                                    <font style="font-size: 10px;">
+                                        (process/next)
+                                    </font>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="345" y="271" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle" font-weight="bold">
+                        Data task...
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="270" y="322" width="150" height="40" rx="6" ry="6" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 148px; height: 1px; padding-top: 342px; margin-left: 271px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    Dialogporten
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="345" y="346" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        Dialogporten
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="550" y="72" width="150" height="40" rx="6" ry="6" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 148px; height: 1px; padding-top: 92px; margin-left: 551px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    Notification
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="625" y="96" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        Notification
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="550" y="122" width="150" height="40" rx="6" ry="6" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 148px; height: 1px; padding-top: 142px; margin-left: 551px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    Notification
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="625" y="146" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        Notification
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="550" y="172" width="150" height="40" rx="6" ry="6" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 148px; height: 1px; padding-top: 192px; margin-left: 551px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    Notification
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="625" y="196" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        Notification
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="550" y="242" width="150" height="50" rx="7.5" ry="7.5" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 148px; height: 1px; padding-top: 267px; margin-left: 551px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; word-wrap: normal; ">
+                                    Signing task
+                                    <br/>
+                                    <font style="font-size: 10px;">
+                                        (process/next)
+                                    </font>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="625" y="271" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle" font-weight="bold">
+                        Signing task...
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="740" y="242" width="110" height="50" rx="7.5" ry="7.5" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 267px; margin-left: 741px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 13px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    End
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="795" y="271" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="13px" text-anchor="middle">
+                        End
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="890" y="242" width="110" height="50" rx="7.5" ry="7.5" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 267px; margin-left: 891px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    Altinn Event
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="945" y="271" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        Altinn Event
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <path d="M 180 267 L 225 267 L 225 142 L 263.63 142" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 268.88 142 L 261.88 145.5 L 263.63 142 L 261.88 138.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <path d="M 180 267 L 225 267 L 225 192 L 263.63 192" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 268.88 192 L 261.88 195.5 L 263.63 192 L 261.88 188.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <path d="M 180 267 L 263.63 267" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 268.88 267 L 261.88 270.5 L 263.63 267 L 261.88 263.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <path d="M 180 267 L 225 267 L 225 342 L 263.63 342" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 268.88 342 L 261.88 345.5 L 263.63 342 L 261.88 338.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <path d="M 420 267 L 500 267 L 500 92 L 543.63 92" fill="none" stroke="#000000" stroke-miterlimit="10" stroke-dasharray="3 3" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 548.88 92 L 541.88 95.5 L 543.63 92 L 541.88 88.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <path d="M 420 267 L 500 267 L 500 142 L 543.63 142" fill="none" stroke="#000000" stroke-miterlimit="10" stroke-dasharray="3 3" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 548.88 142 L 541.88 145.5 L 543.63 142 L 541.88 138.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <path d="M 420 267 L 500 267 L 500 192 L 543.63 192" fill="none" stroke="#000000" stroke-miterlimit="10" stroke-dasharray="3 3" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 548.88 192 L 541.88 195.5 L 543.63 192 L 541.88 188.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <path d="M 420 267 L 543.63 267" fill="none" stroke="#000000" stroke-miterlimit="10" stroke-dasharray="3 3" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 548.88 267 L 541.88 270.5 L 543.63 267 L 541.88 263.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <path d="M 700 267 L 733.63 267" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 738.88 267 L 731.88 270.5 L 733.63 267 L 731.88 263.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <path d="M 850 267 L 883.63 267" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 888.88 267 L 881.88 270.5 L 883.63 267 L 881.88 263.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <path d="M 420 342 L 945 342 L 945 298.37" fill="none" stroke="#000000" stroke-miterlimit="10" stroke-dasharray="3 3" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 945 293.12 L 948.5 300.12 L 945 298.37 L 941.5 300.12 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <rect x="20" y="22" width="430" height="30" fill="#f5f5f5" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(245, 245, 245), rgb(26, 26, 26)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 428px; height: 1px; padding-top: 37px; margin-left: 21px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #333333; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#333333, #c1c1c1); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    Workflow sequence #1
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="235" y="41" fill="#333333" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        Workflow sequence #1
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="470" y="22" width="550" height="30" fill="#f5f5f5" stroke="#666666" pointer-events="all" style="fill: light-dark(rgb(245, 245, 245), rgb(26, 26, 26)); stroke: light-dark(rgb(102, 102, 102), rgb(149, 149, 149));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 548px; height: 1px; padding-top: 37px; margin-left: 471px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #333333; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#333333, #c1c1c1); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    Workflow sequence #2
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="745" y="41" fill="#333333" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        Workflow sequence #2
+                    </text>
+                </switch>
+            </g>
+        </g>
+    </g>
+    <switch>
+        <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+        <a transform="translate(0,-5)" xlink:href="https://www.drawio.com/doc/faq/svg-export-text-problems" target="_blank">
+            <text text-anchor="middle" font-size="10px" x="50%" y="100%">
+                Text is not SVG - cannot display
+            </text>
+        </a>
+    </switch>
+</svg>


### PR DESCRIPTION
## Summary
- Consolidate from 12 slides to 10 by merging retry strategy, concurrency/backpressure, and write buffering into their parent slides
- Trim observability slide to high-level story (detailed metrics shown via live Grafana demo)
- Drop the "Current Status" table slide
- Update stale content: cursor-based pagination, `/api/v1/health/*` endpoint paths, expanded telemetry coverage, database description

## Test plan
- [x] Render with Marp and verify no slide overflow
- [x] Confirm all slides are legible and well-spaced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new technical slide deck describing the workflow engine architecture and behaviour
  * Updated technical doc for clarity: renamed/reframed headings, wording/spelling fixes, and adjusted tech-stack wording
  * Restructured processing, crash handling and retry sections; consolidated failure classification and per-step retry details
  * Simplified concurrency/backpressure docs with semaphore-pool description and enqueue overload behaviour
  * Enhanced observability with OpenTelemetry → Grafana guidance; removed outdated API reference and status table
<!-- end of auto-generated comment: release notes by coderabbit.ai -->