### PR TITLE
feat(workflow-engine): remove ApiKey from AppCommand

### DIFF
--- a/src/Runtime/workflow-engine-app/AGENTS.md
+++ b/src/Runtime/workflow-engine-app/AGENTS.md
@@ -36,7 +36,6 @@ The Altinn-specific command that calls back into Altinn apps via HTTP POST.
 
 Configuration via `appsettings.json` under `AppCommandSettings`:
 
-- `ApiKey` — API key sent to the app
 - `CommandEndpoint` — URL template with `{Org}`, `{App}`, `{InstanceOwnerPartyId}`, `{InstanceGuid}` placeholders
 
 ## Tests

--- a/src/Runtime/workflow-engine-app/infra/kustomize/local/secret.yaml
+++ b/src/Runtime/workflow-engine-app/infra/kustomize/local/secret.yaml
@@ -10,7 +10,6 @@ stringData:
         "WorkflowEngine": "Host=postgres;Port=5432;Database=workflow_engine;Username=postgres;Password=postgres123"
       },
       "AppCommandSettings": {
-        "ApiKey": "local-test-api-key",
         "CommandEndpoint": "http://wiremock:6060/{Org}/{App}/instances/{InstanceOwnerPartyId}/{InstanceGuid}/workflow-engine-callbacks"
       }
     }

--- a/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/Commands/AppCommand/AppCommand.cs
+++ b/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/Commands/AppCommand/AppCommand.cs
@@ -164,7 +164,6 @@ internal sealed class AppCommand : Command<AppCommandData, AppWorkflowContext>
     {
         var baseUrl = _settings.CommandEndpoint.FormatWith(workflowContext);
         var client = _httpClientFactory.CreateClient();
-        client.DefaultRequestHeaders.Add(_settings.ApiKeyHeaderName, _settings.ApiKey);
         client.BaseAddress = new Uri(baseUrl);
 
         return client;

--- a/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/Commands/AppCommand/AppCommandSettings.cs
+++ b/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/Commands/AppCommand/AppCommandSettings.cs
@@ -8,21 +8,9 @@ namespace WorkflowEngine.App.Commands.AppCommand;
 internal sealed record AppCommandSettings
 {
     /// <summary>
-    /// The API key used to authenticate requests between the engine and the app.
-    /// </summary>
-    [JsonPropertyName("apiKey")]
-    public required string ApiKey { get; set; }
-
-    /// <summary>
     /// The full endpoint URL for application callbacks. String template supports
     /// Org, App, InstanceOwnerPartyId, InstanceGuid placeholders.
     /// </summary>
     [JsonPropertyName("commandEndpoint")]
     public required string CommandEndpoint { get; set; }
-
-    /// <summary>
-    /// The header name used for API key authentication between the engine and the app.
-    /// </summary>
-    [JsonPropertyName("apiKeyHeaderName")]
-    public string ApiKeyHeaderName { get; set; } = "X-Api-Key";
 }

--- a/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/Constants/Defaults.cs
+++ b/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/Constants/Defaults.cs
@@ -6,7 +6,6 @@ internal static class Defaults
 {
     public static readonly AppCommandSettings AppCommandSettings = new()
     {
-        ApiKey = "injected-at-runtime",
         CommandEndpoint =
             "http://local.altinn.cloud/{Org}/{App}/instances/{InstanceOwnerPartyId}/{InstanceGuid}/workflow-engine-callbacks",
     };

--- a/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/Extensions/AppCommandExtensions.cs
+++ b/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/Extensions/AppCommandExtensions.cs
@@ -41,11 +41,6 @@ internal static class AppCommandOptionsBuilderExtensions
             const string ns = nameof(AppCommandSettings);
 
             builder.Validate(
-                config => !string.IsNullOrEmpty(config.ApiKey),
-                $"{ns}.{nameof(AppCommandSettings.ApiKey)} value is missing."
-            );
-
-            builder.Validate(
                 config => Uri.TryCreate(config.CommandEndpoint, UriKind.Absolute, out _),
                 $"{ns}.{nameof(AppCommandSettings.CommandEndpoint)} does not appear to be a valid URL."
             );

--- a/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/appsettings.json
+++ b/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/appsettings.json
@@ -34,7 +34,6 @@
     }
   },
   "AppCommandSettings": {
-    "ApiKey": "afc64bcf-fedf-442d-8d41-09b8c5f03c59",
     "CommandEndpoint":  "http://local.altinn.cloud/{Org}/{App}/instances/{InstanceOwnerPartyId}/{InstanceGuid}/workflow-engine-callbacks"
   }
 }

--- a/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/.snapshots/AppCommandIntegrationTests.AppCommand_FullHttpChatter_DocumentsExchange.http
+++ b/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/.snapshots/AppCommandIntegrationTests.AppCommand_FullHttpChatter_DocumentsExchange.http
@@ -86,7 +86,6 @@ Idempotency-Key: app-chatter-idem/chatter-step-1
 Namespace: chatter-app-test
 Operation-Id: chatter-step-1
 Workflow-Id: Guid_3
-X-Api-Key: outgoing-app-lib-api-key
 
 {
   "commandKey": "chatter-step-1",
@@ -119,7 +118,6 @@ Idempotency-Key: app-chatter-idem/chatter-step-2
 Namespace: chatter-app-test
 Operation-Id: chatter-step-2
 Workflow-Id: Guid_3
-X-Api-Key: outgoing-app-lib-api-key
 
 {
   "commandKey": "chatter-step-2",

--- a/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/Commands/AppCommand/AppCommandExecutionTests.cs
+++ b/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/Commands/AppCommand/AppCommandExecutionTests.cs
@@ -63,23 +63,6 @@ public class AppCommandExecutionTests
     }
 
     [Fact]
-    public async Task Execute_SetsApiKeyHeader()
-    {
-        using var fixture = AppCommandTestFixture.Create();
-        var command = GetAppCommand(fixture);
-        var data = CreateCommandData("test-command");
-        var step = AppCommandTestFixture.CreateStep(CreateCommand("test-command"));
-        var workflow = AppCommandTestFixture.CreateWorkflow(step);
-        var context = AppCommandTestFixture.CreateExecutionContext(workflow, step, data);
-
-        await command.Execute(context, TestContext.Current.CancellationToken);
-
-        var captured = fixture.HttpHandler.Requests[0];
-        Assert.True(captured.Headers.ContainsKey("X-Api-Key"));
-        Assert.Contains("test-api-key", captured.Headers["X-Api-Key"]);
-    }
-
-    [Fact]
     public async Task Execute_UsesCommandKeyAsRelativeUri()
     {
         using var fixture = AppCommandTestFixture.Create();

--- a/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/Commands/AppCommand/AppCommandValidationTests.cs
+++ b/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/Commands/AppCommand/AppCommandValidationTests.cs
@@ -161,11 +161,7 @@ public class AppCommandValidationTests
     private static App.Commands.AppCommand.AppCommand CreateCommand()
     {
         var settings = Options.Create(
-            new AppCommandSettings
-            {
-                ApiKey = "test-key",
-                CommandEndpoint = "https://example.com/{Org}/{App}/callbacks",
-            }
+            new AppCommandSettings { CommandEndpoint = "https://example.com/{Org}/{App}/callbacks" }
         );
         var httpFactory = new Mock<IHttpClientFactory>();
         var limiter = new Mock<IConcurrencyLimiter>();

--- a/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/Extensions/AppCommandExtensionsTests.cs
+++ b/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/Extensions/AppCommandExtensionsTests.cs
@@ -17,49 +17,13 @@ public class AppCommandExtensionsTests
         var services = new ServiceCollection();
         services.ConfigureAppCommand(opts =>
         {
-            opts.ApiKey = "my-api-key";
             opts.CommandEndpoint = "https://example.com/{Org}/{App}/callbacks";
         });
 
         using var sp = services.BuildServiceProvider();
         var options = sp.GetRequiredService<IOptions<AppCommandSettings>>();
 
-        Assert.Equal("my-api-key", options.Value.ApiKey);
         Assert.Equal("https://example.com/{Org}/{App}/callbacks", options.Value.CommandEndpoint);
-    }
-
-    [Fact]
-    public void ConfigureAppCommand_DefaultApiKeyHeaderName()
-    {
-        var services = new ServiceCollection();
-        services.ConfigureAppCommand(opts =>
-        {
-            opts.ApiKey = "my-api-key";
-            opts.CommandEndpoint = "https://example.com/{Org}/{App}/callbacks";
-        });
-
-        using var sp = services.BuildServiceProvider();
-        var options = sp.GetRequiredService<IOptions<AppCommandSettings>>();
-
-        Assert.Equal("X-Api-Key", options.Value.ApiKeyHeaderName);
-    }
-
-    [Fact]
-    public void ConfigureAppCommand_EmptyApiKey_ThrowsOnResolve()
-    {
-        var services = new ServiceCollection();
-        services.ConfigureAppCommand(opts =>
-        {
-            opts.ApiKey = "";
-            opts.CommandEndpoint = "https://example.com/{Org}/{App}/callbacks";
-        });
-
-        using var sp = services.BuildServiceProvider();
-
-        var ex = Assert.Throws<OptionsValidationException>(() =>
-            sp.GetRequiredService<IOptions<AppCommandSettings>>().Value
-        );
-        Assert.Contains("ApiKey", ex.Message, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -68,7 +32,6 @@ public class AppCommandExtensionsTests
         var services = new ServiceCollection();
         services.ConfigureAppCommand(opts =>
         {
-            opts.ApiKey = "my-key";
             opts.CommandEndpoint = "not a valid url";
         });
 
@@ -86,7 +49,6 @@ public class AppCommandExtensionsTests
         var services = new ServiceCollection();
         services.ConfigureAppCommand(opts =>
         {
-            opts.ApiKey = "my-key";
             opts.CommandEndpoint = null!;
         });
 
@@ -95,22 +57,5 @@ public class AppCommandExtensionsTests
 
         Assert.NotNull(options.Value.CommandEndpoint);
         Assert.Contains("workflow-engine-callbacks", options.Value.CommandEndpoint, StringComparison.Ordinal);
-    }
-
-    [Fact]
-    public void ConfigureAppCommand_CustomApiKeyHeaderName_Preserved()
-    {
-        var services = new ServiceCollection();
-        services.ConfigureAppCommand(opts =>
-        {
-            opts.ApiKey = "my-key";
-            opts.CommandEndpoint = "https://example.com/callbacks";
-            opts.ApiKeyHeaderName = "Authorization";
-        });
-
-        using var sp = services.BuildServiceProvider();
-        var options = sp.GetRequiredService<IOptions<AppCommandSettings>>();
-
-        Assert.Equal("Authorization", options.Value.ApiKeyHeaderName);
     }
 }

--- a/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/Fixtures/AppCommandTestFixture.cs
+++ b/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/Fixtures/AppCommandTestFixture.cs
@@ -60,7 +60,6 @@ internal sealed record AppCommandTestFixture(
 
         appCommandSettings ??= new AppCommandSettings
         {
-            ApiKey = "test-api-key",
             CommandEndpoint = "https://app.example.com/{Org}/{App}/commands/",
         };
 

--- a/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/Fixtures/AppTestFixture.cs
+++ b/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/Fixtures/AppTestFixture.cs
@@ -11,7 +11,6 @@ namespace WorkflowEngine.App.Tests.Fixtures;
 public sealed class AppTestFixture : EngineAppFixture<Program>
 {
     public const string DefaultInstanceLockToken = "e2e-lock-token-abc123";
-    private const string TestApiKey = "outgoing-app-lib-api-key";
 
     private string AppCommandEndpoint =>
         $"http://localhost:{WireMock.Port}/{{Org}}/{{App}}/instances/{{InstanceOwnerPartyId}}/{{InstanceGuid}}/workflow-engine-callbacks";
@@ -24,7 +23,6 @@ public sealed class AppTestFixture : EngineAppFixture<Program>
                     $$"""
                     {
                       "AppCommandSettings": {
-                        "ApiKey": "{{TestApiKey}}",
                         "CommandEndpoint": "{{AppCommandEndpoint}}"
                       }
                     }

--- a/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/Integration/AppCommandIntegrationTests.HttpChatter.cs
+++ b/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/Integration/AppCommandIntegrationTests.HttpChatter.cs
@@ -165,8 +165,6 @@ public sealed partial class AppCommandIntegrationTests
             var headers = log.RequestMessage.Headers;
             Assert.NotNull(headers);
 
-            Assert.NotEqual("(missing)", HttpChatterHelpers.GetHeader(headers, "X-Api-Key"));
-
             var workflowIdHeader = HttpChatterHelpers.GetHeader(headers, WorkflowMetadataConstants.Headers.WorkflowId);
             Assert.True(
                 Guid.TryParse(workflowIdHeader, out var parsedWorkflowId),


### PR DESCRIPTION
## Summary

- Removes `ApiKey` and `ApiKeyHeaderName` from `AppCommandSettings` and all usages
- Drops the `X-Api-Key` header from outgoing HTTP requests to app callbacks
- Removes associated validation, tests, config entries, and snapshot references

Authentication between the workflow engine and apps will be handled by a different mechanism — the static API key approach is no longer needed.

## Related issues
- closes https://github.com/Altinn/altinn-studio/issues/18450

## Test plan

- [x] Removed `Execute_SetsApiKeyHeader` unit test (no longer applicable)
- [x] Removed `EmptyApiKey_ThrowsOnResolve` and `CustomApiKeyHeaderName_Preserved` validation tests
- [x] Updated remaining tests and fixtures to not reference `ApiKey`
- [x] Updated HTTP chatter snapshot to reflect removed header
- [x] Run `dotnet test` to verify all tests pass
- [ ] Verify app callback requests no longer include the `X-Api-Key` header in a live environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)