### PR TITLE
fix: text color in navigation buttons in home page

### DIFF
--- a/src/Designer/frontend/app-development/features/overview/components/Navigation/Navigation.module.css
+++ b/src/Designer/frontend/app-development/features/overview/components/Navigation/Navigation.module.css
@@ -41,12 +41,18 @@
   background: var(--fds-semantic-surface-action-second-default);
 }
 
-.link,
-.link:focus,
-.link:hover,
-.link:active,
-.link:visited {
+a.link,
+a.link:link,
+a.link:focus,
+a.link:hover,
+a.link:active,
+a.link:visited {
   color: var(--fds-semantic-text-action-on_action);
+}
+
+a.link span,
+a.link svg {
+  color: inherit;
 }
 
 .link:active {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description




<details><summary> BRFORE</summary>#18452 </details>




<details><summary> AFTER</summary>

 https://github.com/user-attachments/assets/8c313e25-1113-4bb8-8cd3-e97c284daefb


</details>

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated link styling selectors for enhanced specificity and consistency across the navigation component.
  * Icons and text elements nested within links now properly inherit the link colour, ensuring visual uniformity across all interaction states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->