### PR TITLE
feat(workflow-engine): Use Step.DatabaseId as idempotency source in commands

### DIFF
--- a/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/.snapshots/AppCommandIntegrationTests.AppCommand_FullHttpChatter_DocumentsExchange.http
+++ b/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/.snapshots/AppCommandIntegrationTests.AppCommand_FullHttpChatter_DocumentsExchange.http
@@ -82,7 +82,7 @@ POST http://localhost:{PORT}/ttd/e2e-tests/instances/50001/Guid_2/chatter-step-1
 Host: localhost
 Content-Type: application/json; charset=utf-8
 Correlation-Id: Guid_1
-Idempotency-Key: app-chatter-idem/chatter-step-1
+Idempotency-Key: Guid_4
 Namespace: chatter-app-test
 Operation-Id: chatter-step-1
 Workflow-Id: Guid_3
@@ -115,7 +115,7 @@ POST http://localhost:{PORT}/ttd/e2e-tests/instances/50001/Guid_2/chatter-step-2
 Host: localhost
 Content-Type: application/json; charset=utf-8
 Correlation-Id: Guid_1
-Idempotency-Key: app-chatter-idem/chatter-step-2
+Idempotency-Key: Guid_5
 Namespace: chatter-app-test
 Operation-Id: chatter-step-2
 Workflow-Id: Guid_3
@@ -168,7 +168,6 @@ Content-Type: application/json; charset=utf-8
   "steps": [
     {
       "databaseId": "Guid_4",
-      "idempotencyKey": "app-chatter-idem/chatter-step-1",
       "operationId": "chatter-step-1",
       "processingOrder": 0,
       "updatedAt": "{Scrubbed}",
@@ -181,7 +180,6 @@ Content-Type: application/json; charset=utf-8
     },
     {
       "databaseId": "Guid_5",
-      "idempotencyKey": "app-chatter-idem/chatter-step-2",
       "operationId": "chatter-step-2",
       "processingOrder": 1,
       "updatedAt": "{Scrubbed}",

--- a/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/.snapshots/AppCommandIntegrationTests.Response_GetWorkflow_CompletedAppCommand_ReturnsFullDetailsShape.verified.txt
+++ b/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/.snapshots/AppCommandIntegrationTests.Response_GetWorkflow_CompletedAppCommand_ReturnsFullDetailsShape.verified.txt
@@ -13,7 +13,6 @@
   steps: [
     {
       databaseId: {Scrubbed},
-      idempotencyKey: idem-Guid_1//details-shape,
       operationId: /details-shape,
       processingOrder: 0,
       updatedAt: {Scrubbed},

--- a/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/.snapshots/AppCommandIntegrationTests.Response_GetWorkflow_MultipleAppCommandSteps_ReturnsAllSteps.verified.txt
+++ b/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/.snapshots/AppCommandIntegrationTests.Response_GetWorkflow_MultipleAppCommandSteps_ReturnsAllSteps.verified.txt
@@ -13,7 +13,6 @@
   steps: [
     {
       databaseId: {Scrubbed},
-      idempotencyKey: idem-Guid_1//multi-step-1,
       operationId: /multi-step-1,
       processingOrder: 0,
       updatedAt: {Scrubbed},
@@ -25,7 +24,6 @@
     },
     {
       databaseId: {Scrubbed},
-      idempotencyKey: idem-Guid_1//multi-step-2,
       operationId: /multi-step-2,
       processingOrder: 1,
       updatedAt: {Scrubbed},
@@ -37,7 +35,6 @@
     },
     {
       databaseId: {Scrubbed},
-      idempotencyKey: idem-Guid_1//multi-step-3,
       operationId: /multi-step-3,
       processingOrder: 2,
       updatedAt: {Scrubbed},

--- a/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/Fixtures/AppCommandTestFixture.cs
+++ b/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/Fixtures/AppCommandTestFixture.cs
@@ -145,7 +145,6 @@ internal sealed record AppCommandTestFixture(
         new()
         {
             OperationId = operationId,
-            IdempotencyKey = $"test-step-key/{operationId}",
             ProcessingOrder = 0,
             Command = command,
         };

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Commands/Extensions/OutboundHeaderExtensions.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Commands/Extensions/OutboundHeaderExtensions.cs
@@ -14,7 +14,7 @@ public static class OutboundHeaderExtensions
     /// </summary>
     public static void AddWorkflowMetadataHeaders(this HttpRequestMessage request, CommandExecutionContext context)
     {
-        request.Headers.Add(WorkflowMetadataConstants.Headers.IdempotencyKey, context.Step.IdempotencyKey);
+        request.Headers.Add(WorkflowMetadataConstants.Headers.IdempotencyKey, context.Step.DatabaseId.ToString());
         request.Headers.Add(WorkflowMetadataConstants.Headers.WorkflowId, context.Workflow.DatabaseId.ToString());
         request.Headers.Add(WorkflowMetadataConstants.Headers.OperationId, context.Step.OperationId);
         request.Headers.Add(WorkflowMetadataConstants.Headers.Namespace, context.Workflow.Namespace);

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Core/DashboardMapper.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Core/DashboardMapper.cs
@@ -39,7 +39,7 @@ internal static class DashboardMapper
 {
     internal static DashboardStepDto MapStep(Step step, bool stateChanged) =>
         new(
-            step.IdempotencyKey,
+            step.DatabaseId.ToString(),
             step.OperationId,
             step.Command.Type,
             step.OperationId,

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Core/Endpoints/DashboardEndpoints.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Core/Endpoints/DashboardEndpoints.cs
@@ -462,7 +462,7 @@ internal static class DashboardEndpoints
                     if (workflow is null)
                         return Results.NotFound();
 
-                    Step? s = workflow.Steps.FirstOrDefault(st => st.IdempotencyKey == step);
+                    Step? s = workflow.Steps.FirstOrDefault(st => st.DatabaseId.ToString() == step);
                     if (s is null)
                         return Results.NotFound();
 
@@ -478,7 +478,7 @@ internal static class DashboardEndpoints
                     return Results.Json(
                         new
                         {
-                            idempotencyKey = s.IdempotencyKey,
+                            idempotencyKey = s.DatabaseId.ToString(),
                             operationId = s.OperationId,
                             status = s.Status.ToString(),
                             processingOrder = s.ProcessingOrder,

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Data/Entities/StepEntity.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Data/Entities/StepEntity.cs
@@ -17,8 +17,6 @@ internal sealed class StepEntity
     [MaxLength(100)]
     public required string OperationId { get; set; }
 
-    public required string IdempotencyKey { get; set; }
-
     [MaxLength(100)]
     public string? EngineTraceContext { get; set; }
 
@@ -57,7 +55,6 @@ internal sealed class StepEntity
         {
             Id = step.DatabaseId,
             OperationId = step.OperationId,
-            IdempotencyKey = step.IdempotencyKey,
             EngineTraceContext = step.EngineTraceContext,
             Status = step.Status,
             CreatedAt = step.CreatedAt,
@@ -87,7 +84,6 @@ internal sealed class StepEntity
         {
             DatabaseId = Id,
             OperationId = OperationId,
-            IdempotencyKey = IdempotencyKey,
             EngineTraceContext = EngineTraceContext,
             Status = Status,
             ProcessingOrder = ProcessingOrder,

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Data/Extensions/WorkflowRequestExtensions.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Data/Extensions/WorkflowRequestExtensions.cs
@@ -40,7 +40,6 @@ internal static class WorkflowRequestExtensions
                         {
                             DatabaseId = Guid.CreateVersion7(),
                             OperationId = s.OperationId,
-                            IdempotencyKey = $"{idempotencyKey}/{s.OperationId}",
                             Status = PersistentItemStatus.Enqueued,
                             CreatedAt = metadata.CreatedAt,
                             ProcessingOrder = i,

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Data/Migrations/20260414083144_RemoveStepIdempotencyKey.Designer.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Data/Migrations/20260414083144_RemoveStepIdempotencyKey.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WorkflowEngine.Data.Context;
@@ -11,9 +12,11 @@ using WorkflowEngine.Data.Context;
 namespace WorkflowEngine.Data.Migrations
 {
     [DbContext(typeof(EngineDbContext))]
-    partial class EngineDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260414083144_RemoveStepIdempotencyKey")]
+    partial class RemoveStepIdempotencyKey
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Data/Migrations/20260414083144_RemoveStepIdempotencyKey.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Data/Migrations/20260414083144_RemoveStepIdempotencyKey.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WorkflowEngine.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveStepIdempotencyKey : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(name: "IdempotencyKey", schema: "engine", table: "Steps");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "IdempotencyKey",
+                schema: "engine",
+                table: "Steps",
+                type: "text",
+                nullable: false,
+                defaultValue: ""
+            );
+        }
+    }
+}

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/PersistentItem.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/PersistentItem.cs
@@ -7,7 +7,6 @@ public abstract record PersistentItem
     public Guid DatabaseId { get; internal set; }
     public required string OperationId { get; init; }
 
-    public required string IdempotencyKey { get; set; }
     public PersistentItemStatus Status { get; set; }
     public DateTimeOffset CreatedAt { get; init; }
     public DateTimeOffset? UpdatedAt { get; internal set; }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/StepStatusResponse.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/StepStatusResponse.cs
@@ -15,12 +15,6 @@ public sealed record StepStatusResponse
     public Guid DatabaseId { get; init; }
 
     /// <summary>
-    /// An idempotency key for this workflow.
-    /// </summary>
-    [JsonPropertyName("idempotencyKey")]
-    public string? IdempotencyKey { get; init; }
-
-    /// <summary>
     /// An identifier for this operation.
     /// </summary>
     [JsonPropertyName("operationId")]
@@ -80,7 +74,6 @@ public sealed record StepStatusResponse
         new()
         {
             DatabaseId = step.DatabaseId,
-            IdempotencyKey = step.IdempotencyKey,
             OperationId = step.OperationId,
             Command = new CommandDetails { Type = step.Command.Type },
             ProcessingOrder = step.ProcessingOrder,

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Workflow.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Workflow.cs
@@ -11,6 +11,11 @@ public sealed record Workflow : PersistentItem
     public Guid? CorrelationId { get; init; }
 
     /// <summary>
+    /// The idempotency key for this workflow, unique within a namespace.
+    /// </summary>
+    public required string IdempotencyKey { get; set; }
+
+    /// <summary>
     /// Primary isolation boundary. Idempotency keys are unique within a namespace.
     /// Example: an instance GUID, a customer ID, a project ID — whatever the host defines.
     /// </summary>

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Core.Tests/CancellationTests.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Core.Tests/CancellationTests.cs
@@ -78,7 +78,6 @@ public class CancellationTests
         new()
         {
             OperationId = operationId,
-            IdempotencyKey = $"test-step-key/{operationId}",
             ProcessingOrder = processingOrder,
             Command = CommandDefinition.Create("webhook"),
         };

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Core.Tests/Fixtures/WorkflowEngineTestFixture.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Core.Tests/Fixtures/WorkflowEngineTestFixture.cs
@@ -108,7 +108,6 @@ internal sealed record WorkflowEngineTestFixture(
         new()
         {
             OperationId = operationId,
-            IdempotencyKey = $"test-step-key/{operationId}",
             ProcessingOrder = 0,
             Command = command,
         };

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Core.Tests/WorkflowExecutorStateTests.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Core.Tests/WorkflowExecutorStateTests.cs
@@ -38,7 +38,6 @@ public class WorkflowExecutorStateTests
         new()
         {
             OperationId = $"step-{order}",
-            IdempotencyKey = $"key/step-{order}",
             ProcessingOrder = order,
             Command = CommandDefinition.Create("state-capture"),
             StateOut = stateOut,

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Core.Tests/WorkflowHandlerTests.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Core.Tests/WorkflowHandlerTests.cs
@@ -80,7 +80,6 @@ public class WorkflowHandlerTests
         new()
         {
             OperationId = operationId,
-            IdempotencyKey = $"test-step-key/{operationId}",
             ProcessingOrder = processingOrder,
             Command = CommandDefinition.Create("webhook"),
             RetryStrategy = retryStrategy,

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Core.Tests/WorkflowUpdateBufferTests.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Core.Tests/WorkflowUpdateBufferTests.cs
@@ -74,7 +74,6 @@ public class WorkflowUpdateBufferTests
             .Select(i => new Step
             {
                 OperationId = $"{operationId}-step-{i}",
-                IdempotencyKey = $"key-{operationId}-{i}",
                 ProcessingOrder = i,
                 Command = CommandDefinition.Create("webhook"),
                 Status = PersistentItemStatus.Completed,

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Data.Tests/Entities/StepEntityTests.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Data.Tests/Entities/StepEntityTests.cs
@@ -15,7 +15,6 @@ public class StepEntityTests
         {
             Id = Guid.Parse("99999999-aaaa-bbbb-cccc-dddddddddddd"),
             OperationId = "send-email",
-            IdempotencyKey = "step-key",
             Status = PersistentItemStatus.Processing,
             ProcessingOrder = 3,
             CreatedAt = new DateTimeOffset(2025, 6, 15, 10, 30, 0, TimeSpan.Zero),

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Data.Tests/Entities/WorkflowEntityTests.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Data.Tests/Entities/WorkflowEntityTests.cs
@@ -29,7 +29,6 @@ public class WorkflowEntityTests
         {
             Id = Guid.NewGuid(),
             OperationId = "noop",
-            IdempotencyKey = $"step-key-{order}",
             Status = PersistentItemStatus.Enqueued,
             ProcessingOrder = order,
             CreatedAt = new DateTimeOffset(2025, 6, 15, 10, 30, 0, TimeSpan.Zero),

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Integration.Tests/.snapshots/EngineTests.Response_GetWorkflow_AfterRetries_ShowsRetryState.verified.txt
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Integration.Tests/.snapshots/EngineTests.Response_GetWorkflow_AfterRetries_ShowsRetryState.verified.txt
@@ -14,7 +14,6 @@
   steps: [
     {
       databaseId: {Scrubbed},
-      idempotencyKey: idem-Guid_1//retry-target,
       operationId: /retry-target,
       processingOrder: 0,
       updatedAt: {Scrubbed},

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Integration.Tests/.snapshots/EngineTests.Response_GetWorkflow_CompletedWebhook_ReturnsFullDetailsShape.verified.txt
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Integration.Tests/.snapshots/EngineTests.Response_GetWorkflow_CompletedWebhook_ReturnsFullDetailsShape.verified.txt
@@ -13,7 +13,6 @@
   steps: [
     {
       databaseId: {Scrubbed},
-      idempotencyKey: idem-Guid_1//ping,
       operationId: /ping,
       processingOrder: 0,
       updatedAt: {Scrubbed},

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Integration.Tests/.snapshots/EngineTests.Response_GetWorkflow_MultipleSteps_ReturnsAllSteps.verified.txt
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Integration.Tests/.snapshots/EngineTests.Response_GetWorkflow_MultipleSteps_ReturnsAllSteps.verified.txt
@@ -13,7 +13,6 @@
   steps: [
     {
       databaseId: {Scrubbed},
-      idempotencyKey: idem-Guid_1//step-1,
       operationId: /step-1,
       processingOrder: 0,
       updatedAt: {Scrubbed},
@@ -25,7 +24,6 @@
     },
     {
       databaseId: {Scrubbed},
-      idempotencyKey: idem-Guid_1//step-2,
       operationId: /step-2,
       processingOrder: 1,
       updatedAt: {Scrubbed},
@@ -37,7 +35,6 @@
     },
     {
       databaseId: {Scrubbed},
-      idempotencyKey: idem-Guid_1//step-3,
       operationId: /step-3,
       processingOrder: 2,
       updatedAt: {Scrubbed},

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Integration.Tests/.snapshots/EngineTests.Response_GetWorkflow_WithDependencies_ShowsDependencyStatus.verified.txt
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Integration.Tests/.snapshots/EngineTests.Response_GetWorkflow_WithDependencies_ShowsDependencyStatus.verified.txt
@@ -16,7 +16,6 @@
   steps: [
     {
       databaseId: {Scrubbed},
-      idempotencyKey: idem-Guid_1//ping-b,
       operationId: /ping-b,
       processingOrder: 0,
       updatedAt: {Scrubbed},

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Integration.Tests/.snapshots/EngineTests.Response_GetWorkflow_WithStepLabels_ReturnsLabelsInShape.verified.txt
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Integration.Tests/.snapshots/EngineTests.Response_GetWorkflow_WithStepLabels_ReturnsLabelsInShape.verified.txt
@@ -13,7 +13,6 @@
   steps: [
     {
       databaseId: {Scrubbed},
-      idempotencyKey: idem-Guid_1//ping,
       operationId: /ping,
       processingOrder: 0,
       updatedAt: {Scrubbed},

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Integration.Tests/.snapshots/EngineTests.Response_ListActiveWorkflows_WhileProcessing_ReturnsWorkflowsShape.verified.txt
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Integration.Tests/.snapshots/EngineTests.Response_ListActiveWorkflows_WhileProcessing_ReturnsWorkflowsShape.verified.txt
@@ -15,7 +15,6 @@
       steps: [
         {
           databaseId: {Scrubbed},
-          idempotencyKey: idem-Guid_1//slow,
           operationId: /slow,
           processingOrder: 0,
           updatedAt: {Scrubbed},

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Integration.Tests/.snapshots/EngineTests.WebhookCommand_FullHttpChatter_DocumentsExchange.http
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Integration.Tests/.snapshots/EngineTests.WebhookCommand_FullHttpChatter_DocumentsExchange.http
@@ -74,7 +74,7 @@ POST http://localhost:{PORT}/step-1 HTTP/1.1
 Host: localhost
 Content-Type: text/plain
 Correlation-Id: Guid_1
-Idempotency-Key: chatter-idem-key//step-1
+Idempotency-Key: Guid_3
 Namespace: chatter-test
 Operation-Id: /step-1
 Workflow-Id: Guid_2
@@ -90,7 +90,7 @@ HTTP/1.1 200
 GET http://localhost:{PORT}/step-2 HTTP/1.1
 Host: localhost
 Correlation-Id: Guid_1
-Idempotency-Key: chatter-idem-key//step-2
+Idempotency-Key: Guid_4
 Namespace: chatter-test
 Operation-Id: /step-2
 Workflow-Id: Guid_2
@@ -124,7 +124,6 @@ Content-Type: application/json; charset=utf-8
   "steps": [
     {
       "databaseId": "Guid_3",
-      "idempotencyKey": "chatter-idem-key//step-1",
       "operationId": "/step-1",
       "processingOrder": 0,
       "updatedAt": "{Scrubbed}",
@@ -136,7 +135,6 @@ Content-Type: application/json; charset=utf-8
     },
     {
       "databaseId": "Guid_4",
-      "idempotencyKey": "chatter-idem-key//step-2",
       "operationId": "/step-2",
       "processingOrder": 1,
       "updatedAt": "{Scrubbed}",

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Integration.Tests/DashboardEndpointTests.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Integration.Tests/DashboardEndpointTests.cs
@@ -227,7 +227,7 @@ public sealed class DashboardEndpointTests(EngineAppFixture<Program> fixture) : 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         using var doc = JsonDocument.Parse(json);
-        Assert.True(doc.RootElement.TryGetProperty("databaseId", out var id));
+        Assert.True(doc.RootElement.TryGetProperty("idempotencyKey", out var id));
         Assert.Equal(stepId.ToString(), id.GetString());
         Assert.True(doc.RootElement.TryGetProperty("status", out _));
     }

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Integration.Tests/DashboardEndpointTests.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Integration.Tests/DashboardEndpointTests.cs
@@ -213,13 +213,13 @@ public sealed class DashboardEndpointTests(EngineAppFixture<Program> fixture) : 
         var workflowId = enqueueResponse.Workflows.Single().DatabaseId;
         var status = await _client.WaitForWorkflowStatus(workflowId, PersistentItemStatus.Completed);
 
-        var stepKey = status.Steps[0].IdempotencyKey ?? throw new Exception("This is not null here");
+        var stepId = status.Steps[0].DatabaseId;
 
         using var client = fixture.CreateEngineClient();
 
         // Act
         using var response = await client.GetAsync(
-            $"/dashboard/step?wf={workflowId}&ns={Uri.EscapeDataString(EngineApiClient.DefaultNamespace)}&step={Uri.EscapeDataString(stepKey)}",
+            $"/dashboard/step?wf={workflowId}&ns={Uri.EscapeDataString(EngineApiClient.DefaultNamespace)}&step={stepId}",
             TestContext.Current.CancellationToken
         );
 
@@ -227,8 +227,8 @@ public sealed class DashboardEndpointTests(EngineAppFixture<Program> fixture) : 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         using var doc = JsonDocument.Parse(json);
-        Assert.True(doc.RootElement.TryGetProperty("idempotencyKey", out var key));
-        Assert.Equal(stepKey, key.GetString());
+        Assert.True(doc.RootElement.TryGetProperty("databaseId", out var id));
+        Assert.Equal(stepId.ToString(), id.GetString());
         Assert.True(doc.RootElement.TryGetProperty("status", out _));
     }
 

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Integration.Tests/EngineTests.HttpChatter.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Integration.Tests/EngineTests.HttpChatter.cs
@@ -113,23 +113,21 @@ public partial class EngineTests
         Assert.Contains("/step-2", logs[1].RequestMessage.AbsolutePath, StringComparison.OrdinalIgnoreCase);
 
         // Assert metadata headers on each outbound request
-        foreach (var log in logs)
+        for (int i = 0; i < logs.Count; i++)
         {
-            var headers = log.RequestMessage.Headers;
+            var step = status.Steps[i];
+
+            var headers = logs[i].RequestMessage.Headers;
             Assert.NotNull(headers);
 
             var workflowIdHeader = HttpChatterHelpers.GetHeader(headers, WorkflowMetadataConstants.Headers.WorkflowId);
-            Assert.True(
-                Guid.TryParse(workflowIdHeader, out var parsedWorkflowId),
-                $"{WorkflowMetadataConstants.Headers.WorkflowId} should be a valid GUID"
-            );
-            Assert.Equal(workflowId, parsedWorkflowId);
+            Assert.Equal(workflowId.ToString(), workflowIdHeader);
 
-            var stepOpId = HttpChatterHelpers.GetHeader(headers, WorkflowMetadataConstants.Headers.OperationId);
-            Assert.NotEmpty(stepOpId);
+            var stepOpIdHeader = HttpChatterHelpers.GetHeader(headers, WorkflowMetadataConstants.Headers.OperationId);
+            Assert.Equal(step.OperationId, stepOpIdHeader);
 
-            var idemKey = HttpChatterHelpers.GetHeader(headers, WorkflowMetadataConstants.Headers.IdempotencyKey);
-            Assert.Equal($"chatter-idem-key/{stepOpId}", idemKey);
+            var idemKeyHeader = HttpChatterHelpers.GetHeader(headers, WorkflowMetadataConstants.Headers.IdempotencyKey);
+            Assert.Equal(step.DatabaseId.ToString(), idemKeyHeader);
 
             Assert.Equal(
                 "chatter-test",

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Models.Tests/Extensions/StepExtensionsTests.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Models.Tests/Extensions/StepExtensionsTests.cs
@@ -11,7 +11,6 @@ public class StepExtensionsTests
         new()
         {
             OperationId = "test-op",
-            IdempotencyKey = "test-key",
             ProcessingOrder = 0,
             Command = new CommandDefinition { Type = "noop" },
             Status = status,

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Models.Tests/Extensions/WorkflowExtensionsTests.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Models.Tests/Extensions/WorkflowExtensionsTests.cs
@@ -8,7 +8,6 @@ public class WorkflowExtensionsTests
         new()
         {
             OperationId = "op",
-            IdempotencyKey = $"step-key-{order}",
             ProcessingOrder = order,
             Command = new CommandDefinition { Type = "noop" },
             Status = status,

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Models.Tests/StepTests.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Models.Tests/StepTests.cs
@@ -17,7 +17,6 @@ public class StepTests
         {
             DatabaseId = sharedGuid,
             OperationId = "step-1-command",
-            IdempotencyKey = "key-1",
             ProcessingOrder = 0,
             Command = _randomCommand,
         };
@@ -25,7 +24,6 @@ public class StepTests
         {
             DatabaseId = sharedGuid,
             OperationId = "step-2-command",
-            IdempotencyKey = "key-2",
             ProcessingOrder = 0,
             Command = _randomCommand,
         };
@@ -33,7 +31,6 @@ public class StepTests
         {
             DatabaseId = Guid.NewGuid(),
             OperationId = "step-3-command",
-            IdempotencyKey = "key-3",
             ProcessingOrder = 0,
             Command = _randomCommand,
         };
@@ -69,7 +66,6 @@ public class StepTests
         var step = new Step
         {
             OperationId = "process-payment",
-            IdempotencyKey = "step-key",
             CreatedAt = createdAt,
             ProcessingOrder = 2,
             Command = command,
@@ -93,7 +89,6 @@ public class StepTests
         var step = new Step
         {
             OperationId = "noop",
-            IdempotencyKey = "step-key",
             ProcessingOrder = 0,
             Command = new CommandDefinition { Type = "noop" },
         };

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Models.Tests/WorkflowTests.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Models.Tests/WorkflowTests.cs
@@ -71,7 +71,6 @@ public class WorkflowTests
             new()
             {
                 OperationId = "step-1",
-                IdempotencyKey = "step-key-1",
                 ProcessingOrder = 0,
                 Command = new CommandDefinition { Type = "app" },
                 CreatedAt = createdAt,
@@ -79,7 +78,6 @@ public class WorkflowTests
             new()
             {
                 OperationId = "step-2",
-                IdempotencyKey = "step-key-2",
                 ProcessingOrder = 1,
                 Command = new CommandDefinition { Type = "app" },
                 CreatedAt = createdAt,
@@ -136,7 +134,6 @@ public class WorkflowTests
                 new Step
                 {
                     OperationId = "noop",
-                    IdempotencyKey = "step-key",
                     ProcessingOrder = 0,
                     Command = new CommandDefinition { Type = "noop" },
                 },
@@ -189,7 +186,6 @@ public class WorkflowTests
                 new Step
                 {
                     OperationId = "noop",
-                    IdempotencyKey = "step-key",
                     ProcessingOrder = 0,
                     Command = new CommandDefinition { Type = "noop" },
                 },

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Repository.Tests/QueryPlanTests.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Repository.Tests/QueryPlanTests.cs
@@ -211,15 +211,14 @@ public sealed class QueryPlanTests(PostgresFixture fixture) : IAsyncLifetime
                 await using var stepCmd = dataSource.CreateCommand(
                     """
                     INSERT INTO engine."Steps"
-                        ("Id", "JobId", "OperationId", "IdempotencyKey", "CommandJson",
+                        ("Id", "JobId", "OperationId", "CommandJson",
                          "Status", "CreatedAt", "ProcessingOrder", "RequeueCount")
-                    VALUES (@id, @jobId, 'step-op', @idemKey, '{"type":"webhook"}',
+                    VALUES (@id, @jobId, 'step-op', '{"type":"webhook"}',
                             @status, @createdAt, @order, 0)
                     """
                 );
                 stepCmd.Parameters.AddWithValue("id", Guid.NewGuid());
                 stepCmd.Parameters.AddWithValue("jobId", id);
-                stepCmd.Parameters.AddWithValue("idemKey", Guid.NewGuid().ToString("N"));
                 stepCmd.Parameters.AddWithValue("status", status);
                 stepCmd.Parameters.AddWithValue("createdAt", createdAt);
                 stepCmd.Parameters.AddWithValue("order", s);

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Repository.Tests/RetentionTests.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Repository.Tests/RetentionTests.cs
@@ -265,8 +265,8 @@ public sealed class RetentionTests(PostgresFixture fixture) : IAsyncLifetime
     {
         await using var cmd = dataSource.CreateCommand(
             """
-            INSERT INTO engine."Steps" ("Id", "JobId", "OperationId", "IdempotencyKey", "CommandJson", "Status", "CreatedAt", "ProcessingOrder", "RequeueCount")
-            VALUES (@id, @jobId, 'test-step', @id::text, '{"type":"webhook"}', 3, @createdAt, 0, 0)
+            INSERT INTO engine."Steps" ("Id", "JobId", "OperationId", "CommandJson", "Status", "CreatedAt", "ProcessingOrder", "RequeueCount")
+            VALUES (@id, @jobId, 'test-step', '{"type":"webhook"}', 3, @createdAt, 0, 0)
             """
         );
         cmd.Parameters.AddWithValue("id", Guid.NewGuid());

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Repository.Tests/WorkflowCrudTests.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Repository.Tests/WorkflowCrudTests.cs
@@ -750,7 +750,6 @@ public sealed class WorkflowCrudTests(PostgresFixture fixture) : IAsyncLifetime
         Assert.Equal(BackoffType.Exponential, step0.RetryStrategy.BackoffType);
         Assert.Equal(5, step0.RetryStrategy.MaxRetries);
         Assert.Equal(PersistentItemStatus.Enqueued, step0.Status);
-        Assert.NotNull(step0.IdempotencyKey);
 
         // Step 1: webhook command
         var step1 = dbWorkflow.Steps[1];


### PR DESCRIPTION
## Summary

- Removes the `IdempotencyKey` property from `Step` (moves it from `PersistentItem` base class to `Workflow` only)
- Outbound `Idempotency-Key` HTTP header now sends `Step.DatabaseId` instead
- Dashboard DTO and UI retain the `idempotencyKey` field name, populated with `DatabaseId`
- Includes EF migration to drop the `IdempotencyKey` column from the `Steps` table
- Updates all test fixtures, raw SQL inserts, and verified snapshots

## Test plan

- [ ] Integration tests pass (enqueue, execute, status, dashboard endpoints)
- [ ] Outbound HTTP calls include correct `Idempotency-Key` header (step DatabaseId)
- [ ] Dashboard step modal and pipeline views display correctly
- [ ] Migration applies cleanly on fresh and existing databases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Removed per-step idempotency key fields from workflow API responses. Workflows retain their top-level idempotency key, while steps are now identified by database IDs instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->