### PR TITLE
docs(workflow-engine): mention Makefile targets in READMEs

### DIFF
--- a/src/Runtime/workflow-engine-app/README.md
+++ b/src/Runtime/workflow-engine-app/README.md
@@ -11,6 +11,9 @@ Altinn-specific host for the [Workflow Engine](../workflow-engine/README.md). Th
 
 ### Running locally
 
+> [!TIP]
+> All Docker Compose commands below have `make` equivalents. Run `make help` to see available targets.
+
 Start infrastructure and the engine in Docker:
 
 ```sh

--- a/src/Runtime/workflow-engine/README.md
+++ b/src/Runtime/workflow-engine/README.md
@@ -13,6 +13,9 @@ Built on .NET 10, PostgreSQL, and OpenTelemetry.
 
 ### Running locally
 
+> [!TIP]
+> All Docker Compose commands below have `make` equivalents. Run `make help` to see available targets.
+
 Start the infrastructure (Postgres, PgAdmin, Grafana/LGTM, exporters, WireMock):
 
 ```sh


### PR DESCRIPTION
## Summary
- Add a tip admonition to the "Running locally" section of both workflow-engine and workflow-engine-app READMEs, pointing readers to `make help` as an alternative to the raw Docker Compose commands.

## Test plan
- [x] Verify the tip renders correctly on GitHub (blue admonition box)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local development guides to inform users that Docker Compose commands have corresponding `make` targets available for easier setup and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->