### PR TITLE
ADR: added ADR for move children and reusable components

### DIFF
--- a/docs/adr/2026-04-14-move-children.md
+++ b/docs/adr/2026-04-14-move-children.md
@@ -25,8 +25,8 @@ Currently, layouts for rows of data in list structures are defined like this:
 
 This has several disadvantages:
 
-- When creating layouts you you must define a component somewhere on the page, copy the ID and put it into the children array. This forces you to scroll up and down to see what components are rendered where.
-- You will have components in your layout that is not actually rendered where the appear in the layout file. This is confusing.
+- When creating layouts you must define a component somewhere on the page, copy the ID and put it into the children array. This forces you to scroll up and down to see what components are rendered where.
+- You will have components in your layout that are not actually rendered where they appear in the layout file. This is confusing.
 - It also complicates layout rendering in the application code:
   - When rendering we must iterate through the layout and replace IDs with actual components
   - We must somehow indicate that the component has been moved and then prevent rendering that component.
@@ -96,7 +96,7 @@ A2: Wrap the child components in an object to indicate that they are not part of
 - Breaking change: will require support in Altinn Studio
 - Blocks [2026-04-14-reusable-components.md](2026-04-14-reusable-components.md) solution A2
 
-#### A2
+### A2
 
 #### Pros
 

--- a/docs/adr/2026-04-14-move-children.md
+++ b/docs/adr/2026-04-14-move-children.md
@@ -8,7 +8,8 @@
 
 Currently, layouts for rows of data in list structures are defined like this:
 
-```[
+```
+[
 	{
 		"type": "RepeatingGroup",
 		"children": [ "childOne" ],
@@ -42,7 +43,8 @@ A1: Define full components as children instead of IDs
 
 We define the full components as children:
 
-`[
+```
+[
 	{
 		"type": "VehicleRepeatingGroup",
 		"extends": "RepeatingGroup",
@@ -53,23 +55,28 @@ We define the full components as children:
 			}
 		 ]
 	}
-]`
+]
+```
 
 A2: Wrap the child components in an object to indicate that they are not part of the normal layout flow:
 
+```
 {
-layout: [
-{
-id: 'A',
-children: ['B'],
-},
-],
-components: [
-{
-id: 'B',
-},
-],
-};`
+  "layout":
+    [
+    {
+      "id":"A",
+       "children":
+        ["B"]
+       }
+     ],
+     "components":[
+     {
+     "id":"B"
+     }
+   ]
+ }
+```
 
 ## Pros and cons
 

--- a/docs/adr/2026-04-14-move-children.md
+++ b/docs/adr/2026-04-14-move-children.md
@@ -1,0 +1,103 @@
+# Full components in children replaces IDs
+
+- Status: proposed
+- Deciders: Team | Product Owners
+- Date: 14.4.2026
+
+## Problem context
+
+Currently, layouts for rows of data in list structures are defined like this:
+
+```[
+	{
+		"type": "RepeatingGroup",
+		"children": [ "childOne" ],
+		"datamodelBinding": "people"
+	},
+	{
+		"id": "childOne",
+		"type": "input",
+		"datamodelBinding": "people.name"
+	}
+]
+```
+
+This has several disadvantages:
+
+- When creating layouts you you must define a component somewhere on the page, copy the ID and put it into the children array. This forces you to scroll up and down to see what components are rendered where.
+- You will have components in your layout that is not actually rendered where the appear in the layout file. This is confusing.
+- It also complicates layout rendering in the application code:
+  - When rendering we must iterate through the layout and replace IDs with actual components
+  - We must somehow indicate that the component has been moved and then prevent rendering that component.
+
+## Decision drivers
+
+- B1: Make it easier to work with layout files
+- B2: Makes layout rendering more intuitive in the source code
+- B3: Aligns with future implementation of reusable components/custom component libraries
+
+## Alternatives considered
+
+A1: Define full components as children instead of IDs
+
+We define the full components as children:
+
+`[
+	{
+		"type": "VehicleRepeatingGroup",
+		"extends": "RepeatingGroup",
+		"children": [
+			{
+				"id": "childOne",
+				"type": "input",
+			}
+		 ]
+	}
+]`
+
+A2: Wrap the child components in an object to indicate that they are not part of the normal layout flow:
+
+{
+layout: [
+{
+id: 'A',
+children: ['B'],
+},
+],
+components: [
+{
+id: 'B',
+},
+],
+};`
+
+## Pros and cons
+
+### A1
+
+#### Pros
+
+- Supports B1 because children components are defined directly in the children array so you dont have to scroll down to see what component will be rendered where.
+- Supports B1 because you will no longer have components defined on the page that will not be rendered where they are defined.
+- Supports B2 because we do not have to replace IDs with the actual component
+- Supports B2 because we do not have to block rendering of components that is used in a children array
+- Aligns well with reusable components if we go for custom components pattern (described in ADR: [2026-04-14-reusable-components.md](2026-04-14-reusable-components.md), option A1)
+
+#### Cons
+
+- Breaking change: will require migration script
+- Breaking change: will require support in Altinn Studio
+- Blocks [2026-04-14-reusable-components.md](2026-04-14-reusable-components.md) solution A2
+
+#### A2
+
+#### Pros
+
+- Supports B1 because it will be clear that certain components are not part of the normal layout
+- Supports B2 because it will be clear that components inside the components object are not part of the normal layout flow, and does not need to be marked as 'claimed'
+- Aligns well with both Reusable Components options A1 and A2
+
+#### Cons
+
+- Users will still have to scroll up and down to see what components are rendered where
+- Code will still have to replace IDs with components

--- a/docs/adr/2026-04-14-reusable-components.md
+++ b/docs/adr/2026-04-14-reusable-components.md
@@ -13,7 +13,7 @@ As an app developer I want to be able to create custom components that can be ea
 ## Decision drivers
 
 - B1: Makes it intuitive to create and use reusable components when working with layouts in source code
-- B2: Fascilitates making a good UI for reusable components in Altinn Studio
+- B2: Facilitates making a good UI for reusable components in Altinn Studio
 
 ## Alternatives considered
 
@@ -98,7 +98,7 @@ In this solution, the same component can be used inside multiple repeating group
 
 - More complex to implement than A2
 
-### A1
+### A2
 
 #### Pros
 

--- a/docs/adr/2026-04-14-reusable-components.md
+++ b/docs/adr/2026-04-14-reusable-components.md
@@ -24,24 +24,27 @@ A1: custom components folder in your ui folder
 
 `Vehicles.json`:
 
-`{
-"type": "RepeatingGroup",
-"dataModelBinding": "vehicles",
-"children" : [
+```
 {
-"type": "Input",
-"dataModelBinding": ".regNo"
-},
-{
-"type": "Input",
-"dataModelBinding": ".manufacturer"
+  "type": "RepeatingGroup",
+  "dataModelBinding": "vehicles",
+  "children" : [
+    {
+      "type": "Input",
+      "dataModelBinding": ".regNo"
+    },
+  {
+    "type": "Input",
+    "dataModelBinding": ".manufacturer"
+    }
+  ]
 }
-]
-}
+```
 
 This can then be used in your layout like this:
 
-`{
+```
+{
 	"layout" : [
 		{
 			"type": "Vehicles",
@@ -52,11 +55,13 @@ This can then be used in your layout like this:
 			"dataModelBinding": "MyDataModel.Mopeds"
 		}
 		]
-}`
+}
+```
 
 A2: Reuse of components defined in the same layout file
 
-`{
+```
+{
 "layout": [
 	{
 		"type": "RepeatingGroup",
@@ -74,7 +79,8 @@ A2: Reuse of components defined in the same layout file
 		"datamodelBinding": ".name"
 	},
 ]
-}`
+}
+```
 
 In this solution, the same component can be used inside multiple repeating groups in the same layout file.
 

--- a/docs/adr/2026-04-14-reusable-components.md
+++ b/docs/adr/2026-04-14-reusable-components.md
@@ -1,0 +1,105 @@
+# Reusable components
+
+- Status: proposed
+- Deciders: Team | Product Owners
+- Date: 14.4.2026
+
+Result
+
+## Problem context
+
+As an app developer I want to be able to create custom components that can be easily reused.
+
+## Decision drivers
+
+- B1: Makes it intuitive to create and use reusable components when working with layouts in source code
+- B2: Fascilitates making a good UI for reusable components in Altinn Studio
+
+## Alternatives considered
+
+A1: custom components folder in your ui folder
+
+- We support a new folder called `App/ui/custom-components`
+- In this folder you can create your own components like this:
+
+`Vehicles.json`:
+
+`{
+"type": "RepeatingGroup",
+"dataModelBinding": "vehicles",
+"children" : [
+{
+"type": "Input",
+"dataModelBinding": ".regNo"
+},
+{
+"type": "Input",
+"dataModelBinding": ".manufacturer"
+}
+]
+}
+
+This can then be used in your layout like this:
+
+`{
+	"layout" : [
+		{
+			"type": "Vehicles",
+			"dataModelBinding": "MyDataModel.Cars"
+		},
+		{
+			"type": "Vehicles",
+			"dataModelBinding": "MyDataModel.Mopeds"
+		}
+		]
+}`
+
+A2: Reuse of components defined in the same layout file
+
+`{
+"layout": [
+	{
+		"type": "RepeatingGroup",
+		"children": [ "childOne" ],
+		"datamodelBinding": "mopeds"
+	},
+	{
+		"type": "RepeatingGroup",
+		"children": [ "childOne" ],
+		"datamodelBinding": "cars"
+	},
+	{
+		"id": "childOne",
+		"type": "input",
+		"datamodelBinding": ".name"
+	},
+]
+}`
+
+In this solution, the same component can be used inside multiple repeating groups in the same layout file.
+
+## Pros and cons
+
+### A1
+
+#### Pros
+
+- Supports B1 because you can neatly keep your custom components in a separate folder
+- Supports B1 because you can reuse your custom components across several layout files
+- Supports B2 because this structure aligns well with creating an intuitive UI for a component library in Altinn Studio
+
+#### Cons
+
+- More complex to implement than A2
+
+### A1
+
+#### Pros
+
+- Easy to implement with the current system where you specify component IDs in children
+
+#### Cons:
+
+- Not particularly intuitive to understand the connection between child and parent components
+- Possibly harder to make an intuitive UI in studio
+- Does not align with component library


### PR DESCRIPTION
Ads ADRs for:

- Full components in children
- Reusable components


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added architectural decision records documenting proposed changes to component structure and layout definition semantics.
  * Recorded design decisions for introducing reusable custom component patterns across layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->