### PR TITLE
fix: remove ResourceRegistryPublishFailed from final events

### DIFF
--- a/src/Designer/backend/src/Designer/Repository/Models/DeploymentEntity.cs
+++ b/src/Designer/backend/src/Designer/Repository/Models/DeploymentEntity.cs
@@ -52,7 +52,6 @@ public class DeploymentEntity : BaseEntity
         DeployEventType.UpgradeFailed,
         DeployEventType.UninstallSucceeded,
         DeployEventType.UninstallFailed,
-        DeployEventType.ResourceRegistryPublishFailed,
     ];
 
     /// <summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`DeployEventType.ResourceRegistryPublishFailed` on `s_finalEventTypes` caused deploy events added through webhook to get dropped:

https://github.com/Altinn/altinn-studio/blob/fix/remove-rr-fail-from-final-events/src/Designer/backend/src/Designer/Controllers/DeploymentWebhooksController.cs#L80-L80

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
