### PR TITLE
fix: avoid mutating random clientdefinition in resourceregistry services

### DIFF
--- a/src/Designer/backend/src/Designer/Repository/Implementation/ResourceRegistryRepository.cs
+++ b/src/Designer/backend/src/Designer/Repository/Implementation/ResourceRegistryRepository.cs
@@ -13,7 +13,6 @@ namespace Altinn.Studio.Designer.Repository.Implementation;
 public class ResourceRegistryRepository(
     PlatformSettings platformSettings,
     IMaskinportenService maskinPortenService,
-    IClientDefinition maskinportenClientDefinition,
     IOptions<ResourceRegistryIntegrationSettings> resourceRegistrySettings,
     IOptions<ResourceRegistryMaskinportenIntegrationSettings> maskinportenIntegrationSettings
 ) : IResourceRegistryRepository
@@ -24,8 +23,7 @@ public class ResourceRegistryRepository(
         bool includeAltinn2 = false
     )
     {
-        maskinportenClientDefinition.ClientSettings = GetMaskinportenIntegrationSettings(env);
-        TokenResponse tokenResponse = await GetBearerTokenFromMaskinporten();
+        TokenResponse tokenResponse = await GetBearerTokenFromMaskinporten(GetMaskinportenIntegrationSettings(env));
 
         using (HttpClient httpClient = new HttpClient())
         {
@@ -52,15 +50,15 @@ public class ResourceRegistryRepository(
         return $"{GetResourceRegistryBaseUrl(env)}/resourcelist?includeApps={includeApps}&includeAltinn2={includeAltinn2}";
     }
 
-    private async Task<TokenResponse> GetBearerTokenFromMaskinporten()
+    private async Task<TokenResponse> GetBearerTokenFromMaskinporten(IMaskinportenSettings settings)
     {
         return await maskinPortenService.GetToken(
-            maskinportenClientDefinition.ClientSettings.EncodedJwk,
-            maskinportenClientDefinition.ClientSettings.Environment,
-            maskinportenClientDefinition.ClientSettings.ClientId,
-            maskinportenClientDefinition.ClientSettings.Scope,
-            maskinportenClientDefinition.ClientSettings.Resource,
-            maskinportenClientDefinition.ClientSettings.ConsumerOrgNo
+            settings.EncodedJwk,
+            settings.Environment,
+            settings.ClientId,
+            settings.Scope,
+            settings.Resource,
+            settings.ConsumerOrgNo
         );
     }
 

--- a/src/Designer/backend/src/Designer/Services/Implementation/ResourceRegistryService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/ResourceRegistryService.cs
@@ -30,7 +30,6 @@ public class ResourceRegistryService : IResourceRegistry
     private readonly HttpClient _httpClient;
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IMaskinportenService _maskinPortenService;
-    private readonly IClientDefinition _maskinportenClientDefinition;
     private readonly PlatformSettings _platformSettings;
     private readonly ResourceRegistryIntegrationSettings _resourceRegistrySettings;
     private readonly ResourceRegistryMaskinportenIntegrationSettings _maskinportenIntegrationSettings;
@@ -45,7 +44,6 @@ public class ResourceRegistryService : IResourceRegistry
         HttpClient httpClient,
         IHttpClientFactory httpClientFactory,
         IMaskinportenService maskinportenService,
-        IClientDefinition maskinPortenClientDefinition,
         PlatformSettings platformSettings,
         IOptions<ResourceRegistryIntegrationSettings> resourceRegistryEnvironment,
         IOptions<ResourceRegistryMaskinportenIntegrationSettings> maskinportenIntegrationSettings,
@@ -55,7 +53,6 @@ public class ResourceRegistryService : IResourceRegistry
         _httpClient = httpClient;
         _httpClientFactory = httpClientFactory;
         _maskinPortenService = maskinportenService;
-        _maskinportenClientDefinition = maskinPortenClientDefinition;
         _platformSettings = platformSettings;
         _resourceRegistrySettings = resourceRegistryEnvironment.Value;
         _maskinportenIntegrationSettings = maskinportenIntegrationSettings.Value;
@@ -83,8 +80,7 @@ public class ResourceRegistryService : IResourceRegistry
         byte[] policyContent = null
     )
     {
-        _maskinportenClientDefinition.ClientSettings = GetMaskinportenIntegrationSettings(env);
-        TokenResponse tokenResponse = await GetBearerTokenFromMaskinporten();
+        TokenResponse tokenResponse = await GetBearerTokenFromMaskinporten(GetMaskinportenIntegrationSettings(env));
         string publishResourceToResourceRegistryUrl;
         string fullWritePolicyToResourceRegistryUrl;
 
@@ -321,8 +317,9 @@ public class ResourceRegistryService : IResourceRegistry
         string environment
     )
     {
-        _maskinportenClientDefinition.ClientSettings = GetMaskinportenIntegrationSettings(environment);
-        TokenResponse tokenResponse = await GetBearerTokenFromMaskinporten();
+        TokenResponse tokenResponse = await GetBearerTokenFromMaskinporten(
+            GetMaskinportenIntegrationSettings(environment)
+        );
 
         string resourceRegisterUrl = GetResourceRegistryBaseUrl(environment);
         string url =
@@ -342,8 +339,9 @@ public class ResourceRegistryService : IResourceRegistry
         string environment
     )
     {
-        _maskinportenClientDefinition.ClientSettings = GetMaskinportenIntegrationSettings(environment);
-        TokenResponse tokenResponse = await GetBearerTokenFromMaskinporten();
+        TokenResponse tokenResponse = await GetBearerTokenFromMaskinporten(
+            GetMaskinportenIntegrationSettings(environment)
+        );
 
         string resourceRegisterUrl = GetResourceRegistryBaseUrl(environment);
 
@@ -765,8 +763,7 @@ public class ResourceRegistryService : IResourceRegistry
         string eTag = null
     )
     {
-        _maskinportenClientDefinition.ClientSettings = GetMaskinportenIntegrationSettings(env);
-        TokenResponse tokenResponse = await GetBearerTokenFromMaskinporten();
+        TokenResponse tokenResponse = await GetBearerTokenFromMaskinporten(GetMaskinportenIntegrationSettings(env));
         //Checks if not tested locally by passing dev as env parameter
         string baseUrl = !env.ToLower().Equals("dev")
             ? $"{GetResourceRegistryBaseUrl(env)}{_platformSettings.ResourceRegistryAccessListUrl}"
@@ -797,15 +794,15 @@ public class ResourceRegistryService : IResourceRegistry
 
     // RRR end
 
-    private async Task<TokenResponse> GetBearerTokenFromMaskinporten()
+    private async Task<TokenResponse> GetBearerTokenFromMaskinporten(IMaskinportenSettings settings)
     {
         return await _maskinPortenService.GetToken(
-            _maskinportenClientDefinition.ClientSettings.EncodedJwk,
-            _maskinportenClientDefinition.ClientSettings.Environment,
-            _maskinportenClientDefinition.ClientSettings.ClientId,
-            _maskinportenClientDefinition.ClientSettings.Scope,
-            _maskinportenClientDefinition.ClientSettings.Resource,
-            _maskinportenClientDefinition.ClientSettings.ConsumerOrgNo
+            settings.EncodedJwk,
+            settings.Environment,
+            settings.ClientId,
+            settings.Scope,
+            settings.Resource,
+            settings.ConsumerOrgNo
         );
     }
 


### PR DESCRIPTION
## Description

noticed 401's in prod due to invalid issuer on the Maskinporten token for requests from Designer -> Gateway. Altinn was the issuer, which points to the token being exchanged for some reason. This code in resource registry services mutates a random `IClientDefinition` for some reason. It's actually not random in the sense that what gets injected is the last registered service of that type, but from the POV of the resource registry it doesnt make sense.. Runtime gateway client was recently added so its' clientdefinition is the last registered DI service. appsettings.json sets `ExhangeToAltinnToken` to true. If gateway accepted Altinn exchanged tokens I assume we would have failed on invalid scope

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
