### PR TITLE
fix: localtest - fix warning for async method without await-point

### DIFF
--- a/src/Runtime/localtest/src/Tunnel/AppTunnelProxy.cs
+++ b/src/Runtime/localtest/src/Tunnel/AppTunnelProxy.cs
@@ -23,14 +23,11 @@ public sealed class AppTunnelProxy
         CancellationToken cancellationToken
     )
     {
-        using var request = await CreateRequestAsync(context, cancellationToken);
+        using var request = CreateRequest(context);
         await _client.Proxy(request, appId, context, cancellationToken);
     }
 
-    private static async Task<HttpRequestMessage> CreateRequestAsync(
-        HttpContext context,
-        CancellationToken cancellationToken
-    )
+    private static HttpRequestMessage CreateRequest(HttpContext context)
     {
         if (RequestRequiresUpgrade(context.Request))
             throw new InvalidOperationException("upgrade requests are not supported by the app tunnel");


### PR DESCRIPTION
## Description

since we dont have treatwarningsaserrors or anything in localtest yet, missed this in #18437

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
