### PR TITLE
chore(template)/Add altinncdn.no as trusted domain for json schema

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,8 @@
   "cSpell.words": [
     "avmerkingsbokser",
     "filstørrelsen"
-  ]
+  ],
+  "json.schemaDownload.trustedDomains": {
+    "https://altinncdn.no/": true
+  }
 }

--- a/src/App/template/.vscode/settings.json
+++ b/src/App/template/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-    "dotnet-test-explorer.testProjectPath": "**/*Tests*.csproj"
+    "dotnet-test-explorer.testProjectPath": "**/*Tests*.csproj",
+    "json.schemaDownload.trustedDomains": {
+        "https://altinncdn.no/": true
+    }
 }


### PR DESCRIPTION
Just noted that VSCode no longer downloads `https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/application/application-metadata.schema.v1.json` correctly, and the fix seems to be to add `altinncdn.no` as a trusted domain.

I think this should be the default for apps :)

The error message currently looks like this:
<img width="2532" height="183" alt="image" src="https://github.com/user-attachments/assets/eefe899c-8acf-489b-a2f8-ac9c46dfa03b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated VS Code configuration to trust JSON schema downloads from additional sources, improving schema validation experience in the development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->