### PR TITLE
chore: release studioctl v0.1.0-preview.5

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-preview.5] - 2026-04-16
+
 ### Added
 
 - Windows support, including Podman Desktop


### PR DESCRIPTION
## Description

Prepare release v0.1.0-preview.5

- [Added] Windows support, including Podman Desktop
- [Added] Support for running apps as containers with `studioctl run --mode container`
- [Changed] Improve networking reliability across runtime configurations
- [Changed] `studioctl run` now waits for the app to be ready before returning

@coderabbitai ignore

**Full Changelog**: https://github.com/Altinn/altinn-studio/compare/studioctl/v0.1.0-preview.4...studioctl/v0.1.0-preview.5