### PR TITLE
fix(workflow-engine-app): resolve CommandEndpoint tokens before URL validation

### DIFF
--- a/src/Runtime/workflow-engine-app/.editorconfig
+++ b/src/Runtime/workflow-engine-app/.editorconfig
@@ -129,13 +129,6 @@ dotnet_diagnostic.CA1031.severity = none
 resharper_explicit_caller_info_argument_highlighting = none
 
 
-## WorkflowEngine.Data ##
-
-[src/WorkflowEngine.Data/Migrations/*.cs]
-# CA1861: Prefer 'static readonly' fields over constant array arguments
-dotnet_diagnostic.CA1861.severity = none
-
-
 ## Test projects ##
 
 [tests/**/*.cs]

--- a/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/Constants/Defaults.cs
+++ b/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/Constants/Defaults.cs
@@ -7,6 +7,6 @@ internal static class Defaults
     public static readonly AppCommandSettings AppCommandSettings = new()
     {
         CommandEndpoint =
-            "http://local.altinn.cloud/{Org}/{App}/instances/{InstanceOwnerPartyId}/{InstanceGuid}/workflow-engine-callbacks",
+            "http://{Org}-{App}-deployment.default.svc.cluster.local/{Org}/{App}/instances/{InstanceOwnerPartyId}/{InstanceGuid}/workflow-engine-callbacks",
     };
 }

--- a/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/Extensions/AppCommandExtensions.cs
+++ b/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/Extensions/AppCommandExtensions.cs
@@ -1,6 +1,10 @@
 using Microsoft.Extensions.Options;
 using WorkflowEngine.App.Commands.AppCommand;
 using WorkflowEngine.App.Constants;
+using WorkflowEngine.Commands.Extensions;
+
+// CA1305: Specify IFormatProvider
+#pragma warning disable CA1305
 
 namespace WorkflowEngine.App.Extensions;
 
@@ -39,9 +43,18 @@ internal static class AppCommandOptionsBuilderExtensions
         public OptionsBuilder<AppCommandSettings> ValidateAppCommandSettings()
         {
             const string ns = nameof(AppCommandSettings);
+            AppWorkflowContext dummyContext = new()
+            {
+                Actor = new Actor { UserIdOrOrgNumber = "501337" },
+                App = "app",
+                Org = "org",
+                InstanceOwnerPartyId = 12345,
+                InstanceGuid = Guid.NewGuid(),
+                LockToken = "asdf",
+            };
 
             builder.Validate(
-                config => Uri.TryCreate(config.CommandEndpoint, UriKind.Absolute, out _),
+                config => Uri.TryCreate(config.CommandEndpoint.FormatWith(dummyContext), UriKind.Absolute, out _),
                 $"{ns}.{nameof(AppCommandSettings.CommandEndpoint)} does not appear to be a valid URL."
             );
 


### PR DESCRIPTION
## Summary
Resolves placeholder tokens (e.g. `{Org}`, `{App}`) in `CommandEndpoint` before validating the URL, preventing false validation failures on templated URLs.