### PR TITLE
fix(workflow-engine-app): normalize CommandEndpoint trailing slash

### DIFF
--- a/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/Commands/AppCommand/AppCommand.cs
+++ b/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/Commands/AppCommand/AppCommand.cs
@@ -162,7 +162,7 @@ internal sealed class AppCommand : Command<AppCommandData, AppWorkflowContext>
 
     private HttpClient CreateAuthorizedClient(AppWorkflowContext workflowContext)
     {
-        var baseUrl = _settings.CommandEndpoint.FormatWith(workflowContext);
+        var baseUrl = _settings.CommandEndpoint.FormatWith(workflowContext).TrimEnd('/') + '/';
         var client = _httpClientFactory.CreateClient();
         client.BaseAddress = new Uri(baseUrl);
 

--- a/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/Constants/Defaults.cs
+++ b/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/Constants/Defaults.cs
@@ -7,6 +7,6 @@ internal static class Defaults
     public static readonly AppCommandSettings AppCommandSettings = new()
     {
         CommandEndpoint =
-            "http://{Org}-{App}-deployment.default.svc.cluster.local/{Org}/{App}/instances/{InstanceOwnerPartyId}/{InstanceGuid}/workflow-engine-callbacks",
+            "http://{Org}-{App}-deployment.default.svc.cluster.local/{Org}/{App}/instances/{InstanceOwnerPartyId}/{InstanceGuid}/workflow-engine-callbacks/",
     };
 }

--- a/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/appsettings.Development.json
+++ b/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/appsettings.Development.json
@@ -1,6 +1,6 @@
 {
   "EngineSettings": {},
   "AppCommandSettings": {
-    "CommandEndpoint": "http://local.altinn.cloud/{Org}/{App}/instances/{InstanceOwnerPartyId}/{InstanceGuid}/workflow-engine-callbacks"
+    "CommandEndpoint": "http://local.altinn.cloud/{Org}/{App}/instances/{InstanceOwnerPartyId}/{InstanceGuid}/workflow-engine-callbacks/"
   }
 }

--- a/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/appsettings.json
+++ b/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/appsettings.json
@@ -34,6 +34,6 @@
     }
   },
   "AppCommandSettings": {
-    "CommandEndpoint": "http://{Org}-{App}-deployment.default.svc.cluster.local/{Org}/{App}/instances/{InstanceOwnerPartyId}/{InstanceGuid}/workflow-engine-callbacks"
+    "CommandEndpoint": "http://{Org}-{App}-deployment.default.svc.cluster.local/{Org}/{App}/instances/{InstanceOwnerPartyId}/{InstanceGuid}/workflow-engine-callbacks/"
   }
 }

--- a/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/.snapshots/AppCommandIntegrationTests.AppCommand_FullHttpChatter_DocumentsExchange.http
+++ b/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/.snapshots/AppCommandIntegrationTests.AppCommand_FullHttpChatter_DocumentsExchange.http
@@ -75,10 +75,10 @@ Content-Type: application/json; charset=utf-8
 }
 
 ###
-### 2. Engine → App: Step 1 callback (/ttd/e2e-tests/instances/50001/Guid_2/chatter-step-1)
+### 2. Engine → App: Step 1 callback (/ttd/e2e-tests/instances/50001/Guid_2/workflow-engine-callbacks/chatter-step-1)
 ###
 
-POST http://localhost:{PORT}/ttd/e2e-tests/instances/50001/Guid_2/chatter-step-1 HTTP/1.1
+POST http://localhost:{PORT}/ttd/e2e-tests/instances/50001/Guid_2/workflow-engine-callbacks/chatter-step-1 HTTP/1.1
 Host: localhost
 Content-Type: application/json; charset=utf-8
 Correlation-Id: Guid_1
@@ -107,10 +107,10 @@ Content-Type: application/json
 }
 
 ###
-### 3. Engine → App: Step 2 callback (/ttd/e2e-tests/instances/50001/Guid_2/chatter-step-2)
+### 3. Engine → App: Step 2 callback (/ttd/e2e-tests/instances/50001/Guid_2/workflow-engine-callbacks/chatter-step-2)
 ###
 
-POST http://localhost:{PORT}/ttd/e2e-tests/instances/50001/Guid_2/chatter-step-2 HTTP/1.1
+POST http://localhost:{PORT}/ttd/e2e-tests/instances/50001/Guid_2/workflow-engine-callbacks/chatter-step-2 HTTP/1.1
 Host: localhost
 Content-Type: application/json; charset=utf-8
 Correlation-Id: Guid_1

--- a/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/Fixtures/AppTestFixture.cs
+++ b/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/Fixtures/AppTestFixture.cs
@@ -13,7 +13,7 @@ public sealed class AppTestFixture : EngineAppFixture<Program>
     public const string DefaultInstanceLockToken = "e2e-lock-token-abc123";
 
     private string AppCommandEndpoint =>
-        $"http://localhost:{WireMock.Port}/{{Org}}/{{App}}/instances/{{InstanceOwnerPartyId}}/{{InstanceGuid}}/workflow-engine-callbacks";
+        $"http://localhost:{WireMock.Port}/{{Org}}/{{App}}/instances/{{InstanceOwnerPartyId}}/{{InstanceGuid}}/workflow-engine-callbacks/";
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {

--- a/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/Integration/AppCommandIntegrationTests.HttpChatter.cs
+++ b/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/Integration/AppCommandIntegrationTests.HttpChatter.cs
@@ -33,7 +33,8 @@ public sealed partial class AppCommandIntegrationTests
 
         var callbackBasePath =
             $"/{EngineAppFixture.DefaultOrg}/{EngineAppFixture.DefaultApp}"
-            + $"/instances/{EngineAppFixture.DefaultPartyId}/{EngineAppFixture.DefaultInstanceGuid}";
+            + $"/instances/{EngineAppFixture.DefaultPartyId}/{EngineAppFixture.DefaultInstanceGuid}"
+            + "/workflow-engine-callbacks";
 
         fixture
             .WireMock.Given(Request.Create().WithPath($"{callbackBasePath}/chatter-step-1"))


### PR DESCRIPTION
## Summary
- Ensure `CommandEndpoint` URLs always end with `/` so `HttpClient.BaseAddress` resolves relative URIs correctly
- Normalize defensively at runtime and update all config defaults and tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardised workflow engine callback endpoint URL formatting by implementing consistent trailing slash handling across all configuration layers (development and production settings), default values, client initialisation, and test fixtures. This resolves potential endpoint routing inconsistencies and improves callback reliability throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->