### PR TITLE
chore: studioctl - remove host port mappings for workflow-engine and pgadmin

### DIFF
--- a/src/Runtime/localtest/src/Configuration/LocalPlatformSettings.cs
+++ b/src/Runtime/localtest/src/Configuration/LocalPlatformSettings.cs
@@ -89,6 +89,10 @@ namespace LocalTest.Configuration
 
         public string LocalPdfServiceUrl { get; set; }
 
+        public string LocalWorkflowEngineUrl { get; set; }
+
+        public string LocalPgAdminUrl { get; set; }
+
         public string LocalReceiptUrl { get; set; }
     }
 }

--- a/src/Runtime/localtest/src/Filters/ProxyMiddleware.cs
+++ b/src/Runtime/localtest/src/Filters/ProxyMiddleware.cs
@@ -24,6 +24,8 @@ public class ProxyMiddleware
 
     // Cookie name for frontend version override (URL-encoded URL)
     private const string FrontendVersionCookie = "frontendVersion";
+    private const string PgAdminHost = "pgadmin.local.altinn.cloud";
+    private const string WorkflowEngineHost = "workflow-engine.local.altinn.cloud";
 
     public ProxyMiddleware(
         RequestDelegate nextMiddleware,
@@ -65,6 +67,11 @@ public class ProxyMiddleware
         if (path == null)
         {
             await _nextMiddleware(context);
+            return;
+        }
+
+        if (await TryProxyToHostService(context))
+        {
             return;
         }
 
@@ -121,41 +128,67 @@ public class ProxyMiddleware
         await _nextMiddleware(context);
     }
 
-    private async Task<bool> TryProxyToExternalService(HttpContext context, string path)
+    private async Task<bool> TryProxyToHostService(HttpContext context)
     {
-        if (path.StartsWith("/pdfservice/", StringComparison.OrdinalIgnoreCase))
+        var host = context.Request.Host.Host;
+        if (string.IsNullOrWhiteSpace(host))
         {
-            if (!string.IsNullOrEmpty(_settings.LocalPdfServiceUrl))
-            {
-                context.Request.Path = path["/pdfservice".Length..];
-                await ProxyRequest(context, _settings.LocalPdfServiceUrl);
-                return true;
-            }
             return false;
         }
 
-        if (path.StartsWith("/grafana/", StringComparison.OrdinalIgnoreCase) || path == "/grafana")
+        if (IsHost(host, WorkflowEngineHost))
         {
-            if (!string.IsNullOrEmpty(_settings.LocalGrafanaUrl))
-            {
-                await ProxyRequest(context, _settings.LocalGrafanaUrl);
-                return true;
-            }
-            return false;
+            return await TryProxyToConfiguredService(context, _settings.LocalWorkflowEngineUrl);
         }
 
-        if (path.StartsWith("/receipt/", StringComparison.OrdinalIgnoreCase))
+        if (IsHost(host, PgAdminHost))
         {
-            if (!string.IsNullOrEmpty(_settings.LocalReceiptUrl))
-            {
-                await ProxyRequest(context, _settings.LocalReceiptUrl);
-                return true;
-            }
-            return false;
+            return await TryProxyToConfiguredService(context, _settings.LocalPgAdminUrl);
         }
 
         return false;
     }
+
+    private async Task<bool> TryProxyToExternalService(HttpContext context, string path)
+    {
+        if (path.StartsWith("/pdfservice/", StringComparison.OrdinalIgnoreCase))
+        {
+            if (string.IsNullOrEmpty(_settings.LocalPdfServiceUrl))
+            {
+                return false;
+            }
+
+            context.Request.Path = path["/pdfservice".Length..];
+            await ProxyRequest(context, _settings.LocalPdfServiceUrl);
+            return true;
+        }
+
+        if (path.StartsWith("/grafana/", StringComparison.OrdinalIgnoreCase) || path == "/grafana")
+        {
+            return await TryProxyToConfiguredService(context, _settings.LocalGrafanaUrl);
+        }
+
+        if (path.StartsWith("/receipt/", StringComparison.OrdinalIgnoreCase))
+        {
+            return await TryProxyToConfiguredService(context, _settings.LocalReceiptUrl);
+        }
+
+        return false;
+    }
+
+    private async Task<bool> TryProxyToConfiguredService(HttpContext context, string? targetUrl)
+    {
+        if (string.IsNullOrEmpty(targetUrl))
+        {
+            return false;
+        }
+
+        await ProxyRequest(context, targetUrl);
+        return true;
+    }
+
+    private static bool IsHost(string host, string expected) =>
+        string.Equals(host, expected, StringComparison.OrdinalIgnoreCase);
 
     private static bool IsLocaltestPath(string path)
     {

--- a/src/Runtime/localtest/src/appsettings.Docker.json
+++ b/src/Runtime/localtest/src/appsettings.Docker.json
@@ -7,6 +7,8 @@
     "LocalTestingStaticTestDataPath": "/testdata/",
     "LocalGrafanaUrl": "http://monitoring_grafana:3000",
     "LocalPdfServiceUrl": "http://localtest-pdf3:5031",
+    "LocalWorkflowEngineUrl": "http://localtest-workflow-engine:8080",
+    "LocalPgAdminUrl": "http://localtest-pgadmin:80",
     "LocalReceiptUrl": "http://host.docker.internal:5060"
   }
 }

--- a/src/Runtime/localtest/src/appsettings.Podman.json
+++ b/src/Runtime/localtest/src/appsettings.Podman.json
@@ -10,6 +10,8 @@
     "LocalTestingStaticTestDataPath": "/testdata/",
     "LocalGrafanaUrl": "http://monitoring_grafana:3000",
     "LocalPdfServiceUrl": "http://localtest-pdf3:5031",
+    "LocalWorkflowEngineUrl": "http://localtest-workflow-engine:8080",
+    "LocalPgAdminUrl": "http://localtest-pgadmin:80",
     "LocalReceiptUrl": "http://host.docker.internal:5060"
   }
 }

--- a/src/cli/internal/cmd/app/run.go
+++ b/src/cli/internal/cmd/app/run.go
@@ -32,21 +32,23 @@ const (
 	appMetadataFile                 = "App/config/applicationmetadata.json"
 )
 
-func localtestEnvDefaults(host, otelEndpoint, pdfEndpoint, workflowEngineEndpoint string) map[string]string {
+func localtestEnvDefaults(
+	platformEndpoint, otelEndpoint, pdfEndpoint, workflowEngineEndpoint string,
+) map[string]string {
 	return map[string]string{
-		"AppSettings__OpenIdWellKnownEndpoint":          "http://" + host + ":5101/authentication/api/v1/openid/",
+		"AppSettings__OpenIdWellKnownEndpoint":          platformEndpoint + "/authentication/api/v1/openid/",
 		"GeneralSettings__ExternalAppBaseUrl":           localtestExternalAppBaseURL(),
 		"OTEL_EXPORTER_OTLP_ENDPOINT":                   otelEndpoint,
-		"PlatformSettings__ApiStorageEndpoint":          "http://" + host + ":5101/storage/api/v1/",
-		"PlatformSettings__ApiRegisterEndpoint":         "http://" + host + ":5101/register/api/v1/",
-		"PlatformSettings__ApiProfileEndpoint":          "http://" + host + ":5101/profile/api/v1/",
-		"PlatformSettings__ApiAuthenticationEndpoint":   "http://" + host + ":5101/authentication/api/v1/",
-		"PlatformSettings__ApiAuthorizationEndpoint":    "http://" + host + ":5101/authorization/api/v1/",
-		"PlatformSettings__ApiEventsEndpoint":           "http://" + host + ":5101/events/api/v1/",
+		"PlatformSettings__ApiStorageEndpoint":          platformEndpoint + "/storage/api/v1/",
+		"PlatformSettings__ApiRegisterEndpoint":         platformEndpoint + "/register/api/v1/",
+		"PlatformSettings__ApiProfileEndpoint":          platformEndpoint + "/profile/api/v1/",
+		"PlatformSettings__ApiAuthenticationEndpoint":   platformEndpoint + "/authentication/api/v1/",
+		"PlatformSettings__ApiAuthorizationEndpoint":    platformEndpoint + "/authorization/api/v1/",
+		"PlatformSettings__ApiEventsEndpoint":           platformEndpoint + "/events/api/v1/",
 		"PlatformSettings__ApiPdf2Endpoint":             pdfEndpoint,
-		"PlatformSettings__ApiNotificationEndpoint":     "http://" + host + ":5101/notifications/api/v1/",
-		"PlatformSettings__ApiCorrespondenceEndpoint":   "http://" + host + ":5101/correspondence/api/v1/",
-		"PlatformSettings__ApiAccessManagementEndpoint": "http://" + host + ":5101/accessmanagement/api/v1/",
+		"PlatformSettings__ApiNotificationEndpoint":     platformEndpoint + "/notifications/api/v1/",
+		"PlatformSettings__ApiCorrespondenceEndpoint":   platformEndpoint + "/correspondence/api/v1/",
+		"PlatformSettings__ApiAccessManagementEndpoint": platformEndpoint + "/accessmanagement/api/v1/",
 		"PlatformSettings__ApiWorkflowEngineEndpoint":   workflowEngineEndpoint,
 	}
 }
@@ -57,16 +59,16 @@ func localtestExternalAppBaseURL() string {
 
 func nativeLocaltestEnvDefaults() map[string]string {
 	return localtestEnvDefaults(
-		localtestLoopbackHost,
+		"http://"+localtestLoopbackHost+":5101",
 		"http://"+localtestLoopbackHost+":4317",
 		"http://"+localtestLoopbackHost+":5300/pdf",
-		"http://"+localtestLoopbackHost+":8080/api/v1/",
+		"http://workflow-engine."+networking.LocalDomain+":"+envlocaltest.DefaultLoadBalancerPortString()+"/api/v1/",
 	)
 }
 
 func dockerLocaltestEnvDefaults() map[string]string {
 	return localtestEnvDefaults(
-		envlocaltest.ContainerLocaltest,
+		"http://"+envlocaltest.ContainerLocaltest+":5101",
 		"http://"+envlocaltest.ContainerMonitoringOtelCollector+":4317",
 		"http://"+envlocaltest.ContainerPDF3+":5031/pdf",
 		"http://"+envlocaltest.ContainerWorkflowEngine+":8080/api/v1/",

--- a/src/cli/internal/cmd/app/run_test.go
+++ b/src/cli/internal/cmd/app/run_test.go
@@ -26,6 +26,7 @@ func TestBuildDockerRunSpec_AddsDockerLocaltestEnv(t *testing.T) {
 		"OTEL_EXPORTER_OTLP_ENDPOINT=http://monitoring_otel_collector:4317",
 		"PlatformSettings__ApiStorageEndpoint=http://localtest:5101/storage/api/v1/",
 		"PlatformSettings__ApiPdf2Endpoint=http://localtest-pdf3:5031/pdf",
+		"PlatformSettings__ApiWorkflowEngineEndpoint=http://localtest-workflow-engine:8080/api/v1/",
 	})
 }
 
@@ -59,6 +60,9 @@ func TestBuildDotnetRunSpec_BindsNativeAppPort(t *testing.T) {
 
 	assertEnvContainsAll(t, spec.Env, []string{
 		"Kestrel__EndPoints__Http__Url=http://127.0.0.1:5005",
+		"PlatformSettings__ApiStorageEndpoint=http://127.0.0.1:5101/storage/api/v1/",
+		"PlatformSettings__ApiPdf2Endpoint=http://127.0.0.1:5300/pdf",
+		"PlatformSettings__ApiWorkflowEngineEndpoint=http://workflow-engine.local.altinn.cloud:8000/api/v1/",
 	})
 	if spec.ProjectPath != projectPath {
 		t.Fatalf("ProjectPath = %q, want %q", spec.ProjectPath, projectPath)

--- a/src/cli/internal/cmd/env/localtest/resources.go
+++ b/src/cli/internal/cmd/env/localtest/resources.go
@@ -213,7 +213,7 @@ func coreContainers(dataDir string, cfg RuntimeConfig) []ContainerSpec {
 func workflowEngineDbContainerSpec(dataDir string) ContainerSpec {
 	spec := newContainerSpec(
 		ContainerWorkflowEngineDb,
-		[]types.PortMapping{newPort("5433", postgresPort)},
+		nil,
 		map[string]string{
 			"POSTGRES_DB":       postgresDB,
 			"POSTGRES_USER":     postgresUser,
@@ -245,10 +245,7 @@ func workflowEngineDbContainerSpec(dataDir string) ContainerSpec {
 func workflowEngineContainerSpec() ContainerSpec {
 	return newContainerSpec(
 		ContainerWorkflowEngine,
-		[]types.PortMapping{
-			newPort("9080", "8080"),
-			newPort("9081", "8081"),
-		},
+		nil,
 		map[string]string{
 			"ASPNETCORE_ENVIRONMENT":              "Docker",
 			"ConnectionStrings__WorkflowEngine":   "Host=" + ContainerWorkflowEngineDb + ";Port=" + postgresPort + ";Database=" + workflowEngineDB + ";Username=" + postgresUser + ";Password=" + postgresPassword,
@@ -269,7 +266,7 @@ func localtestInternalBaseURL() string {
 func pgAdminContainerSpec(dataDir string) ContainerSpec {
 	spec := newContainerSpec(
 		ContainerPgAdmin,
-		[]types.PortMapping{newPort("5050", pgAdminContainerPort)},
+		nil,
 		map[string]string{
 			"PGADMIN_DEFAULT_EMAIL":                   pgAdminEmail,
 			"PGADMIN_DEFAULT_PASSWORD":                pgAdminPassword,

--- a/src/cli/internal/cmd/env/localtest/resources_internal_test.go
+++ b/src/cli/internal/cmd/env/localtest/resources_internal_test.go
@@ -112,6 +112,9 @@ func TestCoreContainers_ServiceCallbacksUseLocaltestNetworkAlias(t *testing.T) {
 	}
 
 	pdf3 := containers[1]
+	if got := pdf3.Ports; len(got) != 1 || got[0] != newPort("5300", "5031") {
+		t.Fatalf("pdf3.Ports = %v, want [5300:5031]", got)
+	}
 	for _, host := range pdf3.ExtraHosts {
 		if strings.HasPrefix(host, "local.altinn.cloud:") {
 			t.Fatalf("pdf3.ExtraHosts unexpectedly contains local.altinn.cloud host override: %v", pdf3.ExtraHosts)
@@ -126,29 +129,14 @@ func TestCoreContainers_ServiceCallbacksUseLocaltestNetworkAlias(t *testing.T) {
 		)
 	}
 
+	workflowEngineDb := containers[2]
+	if got := workflowEngineDb.Ports; got != nil {
+		t.Fatalf("workflowEngineDb.Ports = %v, want nil", got)
+	}
+
 	workflowEngine := containers[3]
-	wantPorts := []struct {
-		hostPort      string
-		containerPort string
-	}{
-		{hostPort: "9080", containerPort: "8080"},
-		{hostPort: "9081", containerPort: "8081"},
-	}
-	gotPorts := make([]struct {
-		hostPort      string
-		containerPort string
-	}, 0, len(workflowEngine.Ports))
-	for _, port := range workflowEngine.Ports {
-		gotPorts = append(gotPorts, struct {
-			hostPort      string
-			containerPort string
-		}{
-			hostPort:      port.HostPort,
-			containerPort: port.ContainerPort,
-		})
-	}
-	if !slices.Equal(gotPorts, wantPorts) {
-		t.Fatalf("workflowEngine.Ports = %v, want %v", gotPorts, wantPorts)
+	if got := workflowEngine.Ports; got != nil {
+		t.Fatalf("workflowEngine.Ports = %v, want nil", got)
 	}
 	if got := workflowEngine.ExtraHosts; got != nil {
 		t.Fatalf("workflowEngine.ExtraHosts = %v, want nil", got)
@@ -262,6 +250,9 @@ func TestCoreContainers_PgAdminUsesImportedPassfile(t *testing.T) {
 	}
 
 	pgAdmin := containers[index]
+	if got := pgAdmin.Ports; got != nil {
+		t.Fatalf("pgAdmin.Ports = %v, want nil", got)
+	}
 	if got := pgAdmin.Environment["PGPASS_FILE"]; got != pgAdminConnectionSource {
 		t.Fatalf("pgAdmin.Environment[PGPASS_FILE] = %q, want %q", got, pgAdminConnectionSource)
 	}


### PR DESCRIPTION
## Description

As discussed, as we will soon have more and more containers used in localtest. Having host port mappings for all exposed ports are sooner or later going to cause collisions (already did for workflow-engine and app frontend during cypress tests due to yarn start taking 8080, same port as workflow-engine). We have localtest and the YARP-based ProxyMiddleware. Suggested heuristic:

- Use host-based localtest reverse proxy routing for exposing services inside the container network that arent meant to be public (but still useful for developers)
  - dont have to worry about port collision
  - get reliable URLs (e.g. `pgadmin.local.altinn.cloud:8000`)
  - lots of services cant be configured to tolerate path-based routing
- Use path-based routing for what is considered public platform-level APIs (e.g. Storage)


<img width="1020" height="335" alt="image" src="https://github.com/user-attachments/assets/a6f15dd2-9597-4915-83df-4e846d7a7168" />

I've left the injected env/configuration to match roughtly what is in the default values of `PlatformSettings`, and normal v8 apps still work through `dotnet run`, though v9+ apps will require studioctl run since we need to inject configuration


TODO: we should refactor the options/settings file thing. We shouldnt need separate configs for podman and docker, and we could have a generic representations of the config to proxy based on

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Local development environment now supports routing to Workflow Engine and pgAdmin services via configurable URLs
  * Enhanced proxy middleware to intelligently route requests to these services in local setups

* **Configuration**
  * Added configuration properties for Workflow Engine and pgAdmin endpoints in local platform settings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->