### PR TITLE
feat: studioctl - `--json` output for more commands

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `--json` output for `app build`.
+- Add `--json` output for `env up`, `env down`, `env status`, and `env logs`.
+- Add `--json` output for `servers up`, `servers status`, and `servers down`.
+- Add `--json` output for detached `run` and `app run`.
+
 ## [0.1.0-preview.5] - 2026-04-16
 
 ### Added

--- a/src/cli/internal/appmanager/client.go
+++ b/src/cli/internal/appmanager/client.go
@@ -57,29 +57,29 @@ type runtimeState struct {
 
 // Status describes the current app-manager status.
 type Status struct {
-	AppManagerVersion string
-	DotnetVersion     string
-	StudioctlPath     string
-	Tunnel            TunnelStatus
-	Apps              []DiscoveredApp
-	ProcessID         int
-	InternalDev       bool
+	AppManagerVersion string          `json:"appManagerVersion"`
+	DotnetVersion     string          `json:"dotnetVersion"`
+	StudioctlPath     string          `json:"studioctlPath"`
+	Tunnel            TunnelStatus    `json:"tunnel"`
+	Apps              []DiscoveredApp `json:"apps"`
+	ProcessID         int             `json:"processId"`
+	InternalDev       bool            `json:"internalDev"`
 }
 
 // TunnelStatus describes the configured app tunnel.
 type TunnelStatus struct {
-	URL       string
-	Enabled   bool
-	Connected bool
+	URL       string `json:"url"`
+	Enabled   bool   `json:"enabled"`
+	Connected bool   `json:"connected"`
 }
 
 // DiscoveredApp describes one discovered app endpoint.
 type DiscoveredApp struct {
-	ProcessID   *int
-	AppID       string
-	BaseURL     string
-	Source      string
-	Description string
+	ProcessID   *int   `json:"processId"`
+	AppID       string `json:"appId"`
+	BaseURL     string `json:"baseUrl"`
+	Source      string `json:"source"`
+	Description string `json:"description"`
 }
 
 var (

--- a/src/cli/internal/cmd/app.go
+++ b/src/cli/internal/cmd/app.go
@@ -28,6 +28,38 @@ type AppCommand struct {
 	service *appsvc.Service
 }
 
+type appBuildOutput struct {
+	ImageTag   string `json:"imageTag"`
+	Pushed     bool   `json:"pushed"`
+	JSONOutput bool   `json:"-"`
+}
+
+type appBuildFlags struct {
+	appPath    string
+	mode       string
+	imageTag   string
+	push       bool
+	jsonOutput bool
+}
+
+func (o appBuildOutput) PrintImage(out *ui.Output) error {
+	if o.JSONOutput {
+		return nil
+	}
+	out.Printlnf("Image: %s", o.ImageTag)
+	return nil
+}
+
+func (o appBuildOutput) PrintFinal(out *ui.Output) error {
+	if o.JSONOutput {
+		return printJSONOutput(out, "app build", o)
+	}
+	if o.Pushed {
+		out.Printlnf("Pushed: %s", o.ImageTag)
+	}
+	return nil
+}
+
 // NewAppCommand creates a new app command.
 func NewAppCommand(cfg *config.Config, out *ui.Output) *AppCommand {
 	service := appsvc.NewService(cfg.Home)
@@ -89,34 +121,16 @@ func (c *AppCommand) Run(ctx context.Context, args []string) error {
 }
 
 func (c *AppCommand) runBuild(ctx context.Context, args []string) error {
-	fs := flag.NewFlagSet("app build", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	var appPath string
-	var mode string
-	var imageTag string
-	var push bool
-	fs.StringVar(&appPath, "p", "", "App directory path")
-	fs.StringVar(&appPath, "path", "", "App directory path")
-	fs.StringVar(&mode, "m", runModeContainer, "Build mode")
-	fs.StringVar(&mode, "mode", runModeContainer, "Build mode")
-	fs.StringVar(&imageTag, "image-tag", "", "App container image tag")
-	fs.BoolVar(&push, "push", false, "Push app container image after build")
-
-	if err := fs.Parse(args); err != nil {
-		if errors.Is(err, flag.ErrHelp) {
-			c.out.Print(c.appBuildUsage())
-			return nil
-		}
-		return fmt.Errorf("parsing flags: %w", err)
+	flags, help, err := c.parseAppBuildFlags(args)
+	if err != nil {
+		return err
 	}
-	if mode != runModeContainer {
-		return fmt.Errorf("%w: %s", ErrUnsupportedRuntime, mode)
-	}
-	if push && imageTag == "" {
-		return fmt.Errorf("%w: --push requires --image-tag", ErrInvalidFlagValue)
+	if help {
+		c.out.Print(c.appBuildUsage())
+		return nil
 	}
 
-	result, err := c.service.ResolveTarget(ctx, appPath)
+	result, err := c.service.ResolveTarget(ctx, flags.appPath)
 	if err != nil {
 		if errors.Is(err, repocontext.ErrAppNotFound) {
 			return fmt.Errorf("%w: run from an app directory or use -p to specify path", ErrNoAppFound)
@@ -124,7 +138,7 @@ func (c *AppCommand) runBuild(ctx context.Context, args []string) error {
 		return fmt.Errorf("detect app: %w", err)
 	}
 
-	spec, err := appimage.BuildSpecForApp(result, imageTag)
+	spec, err := appimage.BuildSpecForApp(result, flags.imageTag)
 	if err != nil {
 		return fmt.Errorf("build docker image spec: %w", err)
 	}
@@ -148,17 +162,48 @@ func (c *AppCommand) runBuild(ctx context.Context, args []string) error {
 	if err := client.Build(ctx, spec.ContextPath, spec.Dockerfile, spec.ImageTag, spec.Build); err != nil {
 		return fmt.Errorf("build app image: %w", err)
 	}
-	c.out.Printlnf("Image: %s", spec.ImageTag)
+	output := appBuildOutput{ImageTag: spec.ImageTag, Pushed: false, JSONOutput: flags.jsonOutput}
+	if err := output.PrintImage(c.out); err != nil {
+		return err
+	}
 
-	if push {
+	if flags.push {
 		c.out.Verbosef("Pushing app image %s", spec.ImageTag)
 		if err := client.Push(ctx, spec.ImageTag); err != nil {
 			return fmt.Errorf("push app image: %w", err)
 		}
-		c.out.Printlnf("Pushed: %s", spec.ImageTag)
+		output.Pushed = true
 	}
 
-	return nil
+	return output.PrintFinal(c.out)
+}
+
+func (c *AppCommand) parseAppBuildFlags(args []string) (appBuildFlags, bool, error) {
+	fs := flag.NewFlagSet("app build", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	var flags appBuildFlags
+	fs.StringVar(&flags.appPath, "p", "", "App directory path")
+	fs.StringVar(&flags.appPath, "path", "", "App directory path")
+	fs.StringVar(&flags.mode, "m", runModeContainer, "Build mode")
+	fs.StringVar(&flags.mode, "mode", runModeContainer, "Build mode")
+	fs.StringVar(&flags.imageTag, "image-tag", "", "App container image tag")
+	fs.BoolVar(&flags.push, "push", false, "Push app container image after build")
+	fs.BoolVar(&flags.jsonOutput, "json", false, "Output as JSON")
+
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return flags, true, nil
+		}
+		return flags, false, fmt.Errorf("parsing flags: %w", err)
+	}
+	if flags.mode != runModeContainer {
+		return flags, false, fmt.Errorf("%w: %s", ErrUnsupportedRuntime, flags.mode)
+	}
+	if flags.push && flags.imageTag == "" {
+		return flags, false, fmt.Errorf("%w: --push requires --image-tag", ErrInvalidFlagValue)
+	}
+
+	return flags, false, nil
 }
 
 func (c *AppCommand) appBuildUsage() string {
@@ -172,6 +217,7 @@ func (c *AppCommand) appBuildUsage() string {
 		"  -m, --mode MODE       Build mode: container (default: container)",
 		"  --image-tag IMAGE     App container image tag",
 		"  --push                Push app container image after build",
+		"  --json                Output as JSON",
 		"  -h, --help            Show this help",
 	)
 }

--- a/src/cli/internal/cmd/app_internal_test.go
+++ b/src/cli/internal/cmd/app_internal_test.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+
+	"altinn.studio/studioctl/internal/ui"
+)
+
+func TestAppBuildOutputPrintText(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	output := appBuildOutput{ImageTag: "example/app:test", Pushed: true}
+	if err := output.PrintImage(ui.NewOutput(&out, io.Discard, false)); err != nil {
+		t.Fatalf("PrintImage() error = %v", err)
+	}
+	if err := output.PrintFinal(ui.NewOutput(&out, io.Discard, false)); err != nil {
+		t.Fatalf("PrintFinal() error = %v", err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "Image: example/app:test") {
+		t.Fatalf("output = %q, want image line", got)
+	}
+	if !strings.Contains(got, "Pushed: example/app:test") {
+		t.Fatalf("output = %q, want pushed line", got)
+	}
+}
+
+func TestAppBuildOutputPrintJSON(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	output := appBuildOutput{ImageTag: "example/app:test", Pushed: true, JSONOutput: true}
+	writer := ui.NewOutput(&out, io.Discard, false)
+	if err := output.PrintImage(writer); err != nil {
+		t.Fatalf("PrintImage() error = %v", err)
+	}
+	if err := output.PrintFinal(writer); err != nil {
+		t.Fatalf("PrintFinal() error = %v", err)
+	}
+
+	var got appBuildOutput
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out.String())), &got); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if got.ImageTag != output.ImageTag || !got.Pushed {
+		t.Fatalf("output = %+v, want image tag and pushed true", got)
+	}
+}

--- a/src/cli/internal/cmd/env.go
+++ b/src/cli/internal/cmd/env.go
@@ -2,10 +2,10 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 
 	"altinn.studio/devenv/pkg/container"
 	envtypes "altinn.studio/studioctl/internal/cmd/env"
@@ -21,6 +21,67 @@ const runtimeLocaltest = "localtest"
 type EnvCommand struct {
 	cfg *config.Config
 	out *ui.Output
+}
+
+type envUpOutput struct {
+	Runtime        string `json:"runtime"`
+	Running        bool   `json:"running"`
+	Started        bool   `json:"started"`
+	AlreadyRunning bool   `json:"alreadyRunning"`
+	JSONOutput     bool   `json:"-"`
+}
+
+func (o envUpOutput) Print(out *ui.Output) error {
+	if o.JSONOutput {
+		return printJSONOutput(out, "env up", o)
+	}
+	if o.AlreadyRunning {
+		out.Printlnf("%s already running.", o.Runtime)
+	}
+	return nil
+}
+
+type envDownOutput struct {
+	Runtime        string `json:"runtime"`
+	Stopped        bool   `json:"stopped"`
+	AlreadyStopped bool   `json:"alreadyStopped"`
+	JSONOutput     bool   `json:"-"`
+}
+
+func (o envDownOutput) Print(out *ui.Output) error {
+	if o.JSONOutput {
+		return printJSONOutput(out, "env down", o)
+	}
+	if o.AlreadyStopped {
+		out.Printlnf("%s is already stopped.", o.Runtime)
+	}
+	return nil
+}
+
+type envStatusOutput struct {
+	Status     *envlocaltest.Status `json:"-"`
+	Runtime    string               `json:"-"`
+	JSONOutput bool                 `json:"-"`
+}
+
+func (o envStatusOutput) Print(out *ui.Output) error {
+	if o.JSONOutput {
+		return printJSONOutput(out, "env status", o.Status)
+	}
+	if !o.Status.AnyRunning {
+		out.Printlnf("%s is not running.", o.Runtime)
+		return nil
+	}
+	if !o.Status.Running {
+		out.Printlnf("%s is running with issues.", o.Runtime)
+		out.Println("")
+		renderLocaltestStatus(out, o.Status)
+		return nil
+	}
+	out.Printlnf("%s is running.", o.Runtime)
+	out.Println("")
+	renderLocaltestStatus(out, o.Status)
+	return nil
 }
 
 // NewEnvCommand creates a new env command.
@@ -93,9 +154,18 @@ func (c *EnvCommand) getEnv(
 	runtime string,
 	client container.ContainerClient,
 ) (envtypes.Env, error) {
+	return c.getEnvWithOutput(runtime, client, c.out)
+}
+
+//nolint:ireturn // factory helper returns interface by design
+func (c *EnvCommand) getEnvWithOutput(
+	runtime string,
+	client container.ContainerClient,
+	out *ui.Output,
+) (envtypes.Env, error) {
 	switch runtime {
 	case runtimeLocaltest:
-		return envlocaltest.NewEnv(c.cfg, c.out, client), nil
+		return envlocaltest.NewEnv(c.cfg, out, client), nil
 	default:
 		return nil, fmt.Errorf("%w: %s", ErrUnsupportedRuntime, runtime)
 	}
@@ -124,6 +194,7 @@ type envUpFlags struct {
 	detach      bool
 	monitoring  bool
 	openBrowser bool
+	jsonOutput  bool
 }
 
 func (c *EnvCommand) parseUpFlags(args []string) (envUpFlags, bool, error) {
@@ -135,6 +206,7 @@ func (c *EnvCommand) parseUpFlags(args []string) (envUpFlags, bool, error) {
 	fs.BoolVar(&f.detach, "detach", true, "Run in background")
 	fs.BoolVar(&f.monitoring, "monitoring", false, "Start monitoring stack")
 	fs.BoolVar(&f.openBrowser, "open", false, "Open localtest in browser after starting")
+	fs.BoolVar(&f.jsonOutput, "json", false, "Output as JSON")
 
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -154,6 +226,9 @@ func (c *EnvCommand) runUp(ctx context.Context, args []string) error {
 	if helpShown {
 		return nil
 	}
+	if flags.jsonOutput && !flags.detach {
+		return fmt.Errorf("%w: --json requires --detach=true", ErrInvalidFlagValue)
+	}
 
 	return c.withContainerClient(ctx, func(client container.ContainerClient) error {
 		switch flags.runtime {
@@ -170,7 +245,7 @@ func (c *EnvCommand) runLocaltestUp(
 	client container.ContainerClient,
 	flags envUpFlags,
 ) error {
-	env := envlocaltest.NewEnv(c.cfg, c.out, client)
+	env := envlocaltest.NewEnv(c.cfg, commandOutput(c.out, flags.jsonOutput), client)
 
 	preflightErr := env.Preflight(ctx)
 	if preflightErr != nil {
@@ -182,8 +257,13 @@ func (c *EnvCommand) runLocaltestUp(
 		return fmt.Errorf("get status: %w", err)
 	}
 	if status.Running {
-		c.out.Printlnf("%s already running.", runtimeLocaltest)
-		return nil
+		return envUpOutput{
+			Runtime:        runtimeLocaltest,
+			Running:        true,
+			Started:        false,
+			AlreadyRunning: true,
+			JSONOutput:     flags.jsonOutput,
+		}.Print(c.out)
 	}
 
 	if err := env.Up(ctx, envtypes.UpOptions{
@@ -193,12 +273,19 @@ func (c *EnvCommand) runLocaltestUp(
 	}); err != nil {
 		return fmt.Errorf("env up: %w", err)
 	}
-	return nil
+	return envUpOutput{
+		Runtime:        runtimeLocaltest,
+		Running:        true,
+		Started:        true,
+		AlreadyRunning: false,
+		JSONOutput:     flags.jsonOutput,
+	}.Print(c.out)
 }
 
 // envDownFlags holds parsed flags for the env down command.
 type envDownFlags struct {
-	runtime string
+	runtime    string
+	jsonOutput bool
 }
 
 func (c *EnvCommand) parseDownFlags(args []string) (envDownFlags, bool, error) {
@@ -206,6 +293,7 @@ func (c *EnvCommand) parseDownFlags(args []string) (envDownFlags, bool, error) {
 	var f envDownFlags
 	fs.StringVar(&f.runtime, "r", runtimeLocaltest, "Runtime to use")
 	fs.StringVar(&f.runtime, "runtime", runtimeLocaltest, "Runtime to use")
+	fs.BoolVar(&f.jsonOutput, "json", false, "Output as JSON")
 
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -227,18 +315,27 @@ func (c *EnvCommand) runDown(ctx context.Context, args []string) error {
 	}
 
 	return c.withContainerClient(ctx, func(client container.ContainerClient) error {
-		env, err := c.getEnv(flags.runtime, client)
+		env, err := c.getEnvWithOutput(flags.runtime, client, commandOutput(c.out, flags.jsonOutput))
 		if err != nil {
 			return err
 		}
 		if err := env.Down(ctx); err != nil {
 			if errors.Is(err, envtypes.ErrAlreadyStopped) {
-				c.out.Printlnf("%s is already stopped.", flags.runtime)
-				return nil
+				return envDownOutput{
+					Runtime:        flags.runtime,
+					Stopped:        false,
+					AlreadyStopped: true,
+					JSONOutput:     flags.jsonOutput,
+				}.Print(c.out)
 			}
 			return fmt.Errorf("env down: %w", err)
 		}
-		return nil
+		return envDownOutput{
+			Runtime:        flags.runtime,
+			Stopped:        true,
+			AlreadyStopped: false,
+			JSONOutput:     flags.jsonOutput,
+		}.Print(c.out)
 	})
 }
 
@@ -295,49 +392,29 @@ func (c *EnvCommand) runLocaltestStatus(
 		return fmt.Errorf("get status: %w", err)
 	}
 
-	if jsonOutput {
-		payload, err := json.Marshal(status)
-		if err != nil {
-			return fmt.Errorf("marshal status json: %w", err)
-		}
-		c.out.Println(string(payload))
-		return nil
-	}
-
-	if !status.AnyRunning {
-		c.out.Printlnf("%s is not running.", runtimeLocaltest)
-		return nil
-	}
-
-	if !status.Running {
-		c.out.Printlnf("%s is running with issues.", runtimeLocaltest)
-		c.out.Println("")
-		c.renderLocaltestStatus(status)
-		return nil
-	}
-
-	c.out.Printlnf("%s is running.", runtimeLocaltest)
-	c.out.Println("")
-	c.renderLocaltestStatus(status)
-
-	return nil
+	return envStatusOutput{
+		Runtime:    runtimeLocaltest,
+		Status:     status,
+		JSONOutput: jsonOutput,
+	}.Print(c.out)
 }
 
-func (c *EnvCommand) renderLocaltestStatus(status *envlocaltest.Status) {
+func renderLocaltestStatus(out *ui.Output, status *envlocaltest.Status) {
 	rows := make([][]string, 1, len(status.Containers)+1)
 	rows[0] = []string{"Container", "Status"}
 
 	for _, ctr := range status.Containers {
 		rows = append(rows, []string{ctr.Name, ctr.Status})
 	}
-	c.out.Table(rows)
+	out.Table(rows)
 }
 
 // envLogsFlags holds parsed flags for the env logs command.
 type envLogsFlags struct {
-	runtime   string
-	component string
-	follow    bool
+	runtime    string
+	component  string
+	follow     bool
+	jsonOutput bool
 }
 
 func (c *EnvCommand) parseLogsFlags(args []string) (envLogsFlags, bool, error) {
@@ -349,6 +426,7 @@ func (c *EnvCommand) parseLogsFlags(args []string) (envLogsFlags, bool, error) {
 	fs.StringVar(&f.component, "component", "", "Filter by component")
 	fs.BoolVar(&f.follow, "f", true, "Follow log output")
 	fs.BoolVar(&f.follow, "follow", true, "Follow log output")
+	fs.BoolVar(&f.jsonOutput, "json", false, "Output as newline-delimited JSON")
 
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -378,9 +456,21 @@ func (c *EnvCommand) runLogs(ctx context.Context, args []string) error {
 		if err := env.Logs(ctx, envtypes.LogsOptions{
 			Component: flags.component,
 			Follow:    flags.follow,
+			JSON:      flags.jsonOutput,
 		}); err != nil {
 			return fmt.Errorf("env logs: %w", err)
 		}
 		return nil
 	})
+}
+
+func silentOutput() *ui.Output {
+	return ui.NewOutput(io.Discard, io.Discard, false)
+}
+
+func commandOutput(out *ui.Output, jsonOutput bool) *ui.Output {
+	if jsonOutput {
+		return silentOutput()
+	}
+	return out
 }

--- a/src/cli/internal/cmd/env/localtest/env.go
+++ b/src/cli/internal/cmd/env/localtest/env.go
@@ -167,7 +167,7 @@ func (e *Env) Status(ctx context.Context) (*Status, error) {
 
 // Logs streams localtest environment logs.
 func (e *Env) Logs(ctx context.Context, opts envtypes.LogsOptions) error {
-	return e.logs.Stream(ctx, opts.Component, opts.Follow)
+	return e.logs.Stream(ctx, opts.Component, opts.Follow, opts.JSON)
 }
 
 func (e *Env) ensureAppManager(ctx context.Context, runtimeCfg RuntimeConfig) error {
@@ -217,7 +217,7 @@ func (e *Env) runForeground(
 	e.out.Println("Localtest is running. Press Ctrl+C to stop.")
 	e.out.Printlnf("Access the platform at: %s", localtestURL)
 
-	if err := e.logs.Stream(ctx, "", true); err != nil {
+	if err := e.logs.Stream(ctx, "", true, false); err != nil {
 		e.out.Verbosef("log streaming ended: %v", err)
 	}
 

--- a/src/cli/internal/cmd/env/localtest/env_test.go
+++ b/src/cli/internal/cmd/env/localtest/env_test.go
@@ -1,14 +1,18 @@
 package localtest_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
+	"strings"
 	"testing"
 
 	"altinn.studio/devenv/pkg/container"
 	"altinn.studio/devenv/pkg/container/mock"
 	"altinn.studio/devenv/pkg/container/types"
+	envtypes "altinn.studio/studioctl/internal/cmd/env"
 	"altinn.studio/studioctl/internal/cmd/env/localtest"
 	"altinn.studio/studioctl/internal/config"
 	"altinn.studio/studioctl/internal/ui"
@@ -103,6 +107,60 @@ func TestStatus_ReturnsErrorForNonNotFoundStateError(t *testing.T) {
 	_, err := env.Status(context.Background())
 	if !errors.Is(err, errStateUnavailable) {
 		t.Fatalf("Status() error = %v, want wrapped %v", err, errStateUnavailable)
+	}
+}
+
+func TestLogs_JSONOutputsOneObjectPerLine(t *testing.T) {
+	t.Parallel()
+
+	client := mock.New()
+	client.ContainerStateFunc = func(_ context.Context, nameOrID string) (types.ContainerState, error) {
+		if nameOrID == localtest.ContainerLocaltest {
+			return types.ContainerState{Status: "running", Running: true}, nil
+		}
+		return types.ContainerState{}, types.ErrContainerNotFound
+	}
+	client.ContainerLogsFunc = func(_ context.Context, nameOrID string, follow bool, tail string) (io.ReadCloser, error) {
+		if nameOrID != localtest.ContainerLocaltest {
+			t.Fatalf("ContainerLogs() name = %q, want %q", nameOrID, localtest.ContainerLocaltest)
+		}
+		if follow {
+			t.Fatal("ContainerLogs() follow = true, want false")
+		}
+		if tail != "100" {
+			t.Fatalf("ContainerLogs() tail = %q, want 100", tail)
+		}
+		return io.NopCloser(strings.NewReader("one\ntwo\n")), nil
+	}
+
+	var out bytes.Buffer
+	env := localtest.NewEnv(&config.Config{}, ui.NewOutput(&out, io.Discard, false), client)
+	if err := env.Logs(context.Background(), envtypes.LogsOptions{
+		Component: localtest.ContainerLocaltest,
+		Follow:    false,
+		JSON:      true,
+	}); err != nil {
+		t.Fatalf("Logs() error = %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("output lines = %d, want 2: %q", len(lines), out.String())
+	}
+	for i, line := range lines {
+		var got struct {
+			Component string `json:"component"`
+			Line      string `json:"line"`
+		}
+		if err := json.Unmarshal([]byte(line), &got); err != nil {
+			t.Fatalf("json.Unmarshal(line %d) error = %v", i, err)
+		}
+		if got.Component != localtest.ContainerLocaltest {
+			t.Fatalf("line %d component = %q, want %q", i, got.Component, localtest.ContainerLocaltest)
+		}
+	}
+	if !strings.Contains(lines[0], `"line":"one"`) || !strings.Contains(lines[1], `"line":"two"`) {
+		t.Fatalf("lines = %v, want one and two log lines", lines)
 	}
 }
 

--- a/src/cli/internal/cmd/env/localtest/log_streamer.go
+++ b/src/cli/internal/cmd/env/localtest/log_streamer.go
@@ -3,6 +3,7 @@ package localtest
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"sync"
@@ -21,6 +22,27 @@ type logStreamer struct {
 	out    *ui.Output
 }
 
+type logLine struct {
+	Component string `json:"component"`
+	Line      string `json:"line"`
+	Prefix    string `json:"-"`
+	JSON      bool   `json:"-"`
+}
+
+func (l logLine) Print(out *ui.Output) error {
+	if !l.JSON {
+		out.Println(l.Prefix + l.Line)
+		return nil
+	}
+
+	payload, err := json.Marshal(l)
+	if err != nil {
+		return fmt.Errorf("marshal log line json: %w", err)
+	}
+	out.Println(string(payload))
+	return nil
+}
+
 func newLogStreamer(client container.ContainerClient, out *ui.Output) *logStreamer {
 	return &logStreamer{
 		client: client,
@@ -28,7 +50,7 @@ func newLogStreamer(client container.ContainerClient, out *ui.Output) *logStream
 	}
 }
 
-func (s *logStreamer) Stream(ctx context.Context, component string, follow bool) error {
+func (s *logStreamer) Stream(ctx context.Context, component string, follow, jsonOutput bool) error {
 	allContainers := AllContainerNames(true)
 
 	var containers []string
@@ -78,7 +100,7 @@ func (s *logStreamer) Stream(ctx context.Context, component string, follow bool)
 		}
 
 		wg.Add(1)
-		go s.streamContainerLogs(ctx, &wg, logs, name, i)
+		go s.streamContainerLogs(ctx, &wg, logs, name, i, jsonOutput)
 	}
 
 	wg.Wait()
@@ -91,6 +113,7 @@ func (s *logStreamer) streamContainerLogs(
 	logs io.ReadCloser,
 	name string,
 	colorIdx int,
+	jsonOutput bool,
 ) {
 	defer wg.Done()
 	defer func() {
@@ -110,7 +133,14 @@ func (s *logStreamer) streamContainerLogs(
 		case <-ctx.Done():
 			return
 		default:
-			s.out.Println(prefix + scanner.Text())
+			if err := (logLine{
+				Component: name,
+				Line:      scanner.Text(),
+				Prefix:    prefix,
+				JSON:      jsonOutput,
+			}).Print(s.out); err != nil {
+				s.out.Warningf("Failed to print log line for %s: %v", name, err)
+			}
 		}
 	}
 }

--- a/src/cli/internal/cmd/env/types.go
+++ b/src/cli/internal/cmd/env/types.go
@@ -28,4 +28,5 @@ type UpOptions struct {
 type LogsOptions struct {
 	Component string
 	Follow    bool
+	JSON      bool
 }

--- a/src/cli/internal/cmd/env_internal_test.go
+++ b/src/cli/internal/cmd/env_internal_test.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+
+	"altinn.studio/devenv/pkg/container/mock"
+	containertypes "altinn.studio/devenv/pkg/container/types"
+	"altinn.studio/studioctl/internal/config"
+	"altinn.studio/studioctl/internal/ui"
+)
+
+func TestEnvUpJSON_AlreadyRunning(t *testing.T) {
+	t.Parallel()
+
+	client := mock.New()
+	client.ContainerStateFunc = func(context.Context, string) (containertypes.ContainerState, error) {
+		return containertypes.ContainerState{Status: "running", Running: true}, nil
+	}
+
+	var out bytes.Buffer
+	command := &EnvCommand{
+		cfg: &config.Config{},
+		out: ui.NewOutput(&out, io.Discard, false),
+	}
+	err := command.runLocaltestUp(context.Background(), client, envUpFlags{
+		runtime:    runtimeLocaltest,
+		detach:     true,
+		jsonOutput: true,
+	})
+	if err != nil {
+		t.Fatalf("runLocaltestUp() error = %v", err)
+	}
+
+	var got envUpOutput
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out.String())), &got); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if got.Runtime != runtimeLocaltest || !got.Running || got.Started || !got.AlreadyRunning {
+		t.Fatalf("output = %+v, want already running result", got)
+	}
+}
+
+func TestEnvUpJSONRejectsForeground(t *testing.T) {
+	t.Parallel()
+
+	command := &EnvCommand{out: ui.NewOutput(io.Discard, io.Discard, false)}
+	err := command.runUp(context.Background(), []string{"--json", "--detach=false"})
+	if err == nil {
+		t.Fatal("runUp() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "--json requires --detach=true") {
+		t.Fatalf("runUp() error = %v, want detach/json error", err)
+	}
+}

--- a/src/cli/internal/cmd/json_output.go
+++ b/src/cli/internal/cmd/json_output.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"altinn.studio/studioctl/internal/ui"
+)
+
+func printJSONOutput(out *ui.Output, operation string, value any) error {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("marshal %s json: %w", operation, err)
+	}
+	out.Println(string(payload))
+	return nil
+}

--- a/src/cli/internal/cmd/run.go
+++ b/src/cli/internal/cmd/run.go
@@ -96,6 +96,7 @@ func (c *RunCommand) UsageFor(commandPath string) string {
 		"  --image-tag IMAGE     Use a specific app container image tag (container mode)",
 		"  --pull                Pull app container image before start (container mode)",
 		"  --skip-build          Skip building the app container image (container mode)",
+		"  --json                Output as JSON (requires --detach)",
 		"  -h, --help            Show this help",
 	)
 }
@@ -108,6 +109,32 @@ type runFlags struct {
 	pullImage      bool
 	randomHostPort bool
 	skipBuild      bool
+	jsonOutput     bool
+}
+
+type runDetachedOutput struct {
+	AppID         string `json:"appId"`
+	Mode          string `json:"mode"`
+	URL           string `json:"url"`
+	LogPath       string `json:"logPath,omitempty"`
+	ContainerID   string `json:"containerId,omitempty"`
+	ContainerName string `json:"containerName,omitempty"`
+	ProcessID     int    `json:"processId,omitempty"`
+	HostPort      int    `json:"hostPort,omitempty"`
+	JSONOutput    bool   `json:"-"`
+}
+
+func (o runDetachedOutput) Print(out *ui.Output) error {
+	if o.JSONOutput {
+		return printJSONOutput(out, "run", o)
+	}
+	if o.Mode != runModeNative {
+		return nil
+	}
+	out.Printlnf("App running in background.")
+	out.Printlnf("Process: %d", o.ProcessID)
+	out.Printlnf("URL: %s", o.URL)
+	return nil
 }
 
 // Run executes the top-level run alias.
@@ -117,6 +144,36 @@ func (c *RunCommand) Run(ctx context.Context, args []string) error {
 
 // RunWithCommandPath executes run with usage text bound to commandPath.
 func (c *RunCommand) RunWithCommandPath(ctx context.Context, args []string, commandPath string) error {
+	flags, dotnetArgs, help, err := c.parseRunFlags(args, commandPath)
+	if err != nil {
+		return err
+	}
+	if help {
+		c.out.Print(c.UsageFor(commandPath))
+		return nil
+	}
+
+	target, err := c.service.ResolveRunTarget(ctx, flags.appPath)
+	if err != nil {
+		if errors.Is(err, repocontext.ErrAppNotFound) {
+			return fmt.Errorf("%w: run from an app directory or use -p to specify path", ErrNoAppFound)
+		}
+		return fmt.Errorf("resolve app: %w", err)
+	}
+
+	if err := c.printResolvedRunTarget(target); err != nil {
+		return err
+	}
+
+	runErr := c.runTarget(ctx, target, dotnetArgs, flags)
+	if errors.Is(runErr, errAppRunStopped) {
+		c.out.Println("App stopped.")
+		return nil
+	}
+	return runErr
+}
+
+func (c *RunCommand) parseRunFlags(args []string, commandPath string) (runFlags, []string, bool, error) {
 	fs := flag.NewFlagSet(commandPath, flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	var flags runFlags
@@ -130,6 +187,7 @@ func (c *RunCommand) RunWithCommandPath(ctx context.Context, args []string, comm
 	fs.BoolVar(&flags.pullImage, "pull", false, "Pull app container image before start")
 	fs.BoolVar(&flags.randomHostPort, "random-host-port", false, "Use a random host port")
 	fs.BoolVar(&flags.skipBuild, "skip-build", false, "Skip building the app container image")
+	fs.BoolVar(&flags.jsonOutput, "json", false, "Output as JSON")
 
 	var cmdArgs, dotnetArgs []string
 	for i, arg := range args {
@@ -145,23 +203,27 @@ func (c *RunCommand) RunWithCommandPath(ctx context.Context, args []string, comm
 
 	if err := fs.Parse(cmdArgs); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
-			c.out.Print(c.UsageFor(commandPath))
-			return nil
+			return flags, nil, true, nil
 		}
-		return fmt.Errorf("parsing flags: %w", err)
+		return flags, nil, false, fmt.Errorf("parsing flags: %w", err)
 	}
+	if err := validateRunFlags(flags); err != nil {
+		return flags, nil, false, err
+	}
+	return flags, dotnetArgs, false, nil
+}
+
+func validateRunFlags(flags runFlags) error {
 	if flags.mode != runModeNative && flags.mode != runModeContainer {
 		return fmt.Errorf("%w: %s", ErrUnsupportedRuntime, flags.mode)
 	}
-
-	target, err := c.service.ResolveRunTarget(ctx, flags.appPath)
-	if err != nil {
-		if errors.Is(err, repocontext.ErrAppNotFound) {
-			return fmt.Errorf("%w: run from an app directory or use -p to specify path", ErrNoAppFound)
-		}
-		return fmt.Errorf("resolve app: %w", err)
+	if flags.jsonOutput && !flags.detach {
+		return fmt.Errorf("%w: --json requires --detach", ErrInvalidFlagValue)
 	}
+	return nil
+}
 
+func (c *RunCommand) printResolvedRunTarget(target appsvc.RunTarget) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("get working directory: %w", err)
@@ -169,21 +231,23 @@ func (c *RunCommand) RunWithCommandPath(ctx context.Context, args []string, comm
 	if target.Detection.AppRoot != cwd {
 		c.out.Verbosef("Using app at %s (detected via %s)", target.Detection.AppRoot, target.Detection.AppDetectedFrom)
 	}
+	return nil
+}
 
-	var runErr error
+func (c *RunCommand) runTarget(
+	ctx context.Context,
+	target appsvc.RunTarget,
+	dotnetArgs []string,
+	flags runFlags,
+) error {
 	switch flags.mode {
 	case runModeNative:
-		runErr = c.runDotnet(ctx, target, dotnetArgs, flags)
+		return c.runDotnet(ctx, target, dotnetArgs, flags)
 	case runModeContainer:
-		runErr = c.runDocker(ctx, target, dotnetArgs, flags)
+		return c.runDocker(ctx, target, dotnetArgs, flags)
 	default:
 		return fmt.Errorf("%w: %s", ErrUnsupportedRuntime, flags.mode)
 	}
-	if errors.Is(runErr, errAppRunStopped) {
-		c.out.Println("App stopped.")
-		return nil
-	}
-	return runErr
 }
 
 func (c *RunCommand) runDotnet(ctx context.Context, target appsvc.RunTarget, args []string, flags runFlags) error {
@@ -199,7 +263,7 @@ func (c *RunCommand) runDotnet(ctx context.Context, target appsvc.RunTarget, arg
 		return fmt.Errorf("build native run spec: %w", specErr)
 	}
 
-	if err := c.buildDotnetApp(ctx, spec); err != nil {
+	if err := c.buildDotnetApp(ctx, spec, flags.jsonOutput); err != nil {
 		return err
 	}
 
@@ -211,23 +275,13 @@ func (c *RunCommand) runDotnet(ctx context.Context, target appsvc.RunTarget, arg
 	c.out.Verbosef("Running: %s %v", command, commandArgs)
 
 	cmd := processutil.CommandContext(context.WithoutCancel(ctx), command, commandArgs...)
-	cmd.Dir = spec.Dir
-	if flags.detach {
-		logFile, logErr := c.openDetachedAppLog(target.AppID)
-		if logErr != nil {
-			return logErr
-		}
-		defer closeDetachedAppLog(c.out, logFile)
-		cmd.Stdout = logFile
-		cmd.Stderr = logFile
-		osutil.ApplyDetachedAttrs(cmd)
-	} else {
-		cmd.Stdin = os.Stdin
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
+	logPath, cleanupLog, err := c.configureDotnetRunCommand(cmd, target, spec, flags)
+	if err != nil {
+		return err
 	}
-
-	cmd.Env = spec.Env
+	if cleanupLog != nil {
+		defer cleanupLog()
+	}
 
 	if startErr := cmd.Start(); startErr != nil {
 		return fmt.Errorf("start dotnet: %w", startErr)
@@ -243,10 +297,17 @@ func (c *RunCommand) runDotnet(ctx context.Context, target appsvc.RunTarget, arg
 		return err
 	}
 	if flags.detach {
-		c.out.Printlnf("App running in background.")
-		c.out.Printlnf("Process: %d", cmd.Process.Pid)
-		c.out.Printlnf("URL: %s", baseURL)
-		return nil
+		return runDetachedOutput{
+			AppID:         target.AppID,
+			Mode:          runModeNative,
+			URL:           baseURL,
+			LogPath:       logPath,
+			ContainerID:   "",
+			ContainerName: "",
+			ProcessID:     cmd.Process.Pid,
+			HostPort:      0,
+			JSONOutput:    flags.jsonOutput,
+		}.Print(c.out)
 	}
 	defer c.unregisterAppBestEffort(ctx, target.AppID, baseURL)
 
@@ -268,6 +329,31 @@ func (c *RunCommand) runDotnet(ctx context.Context, target appsvc.RunTarget, arg
 	}
 }
 
+func (c *RunCommand) configureDotnetRunCommand(
+	cmd *exec.Cmd,
+	target appsvc.RunTarget,
+	spec appsvc.DotnetRunSpec,
+	flags runFlags,
+) (string, func(), error) {
+	cmd.Dir = spec.Dir
+	cmd.Env = spec.Env
+	if !flags.detach {
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return "", nil, nil
+	}
+
+	logFile, logPath, err := c.openDetachedAppLog(target.AppID, flags.jsonOutput)
+	if err != nil {
+		return "", nil, err
+	}
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	osutil.ApplyDetachedAttrs(cmd)
+	return logPath, func() { closeDetachedAppLog(c.out, logFile) }, nil
+}
+
 func (c *RunCommand) registerStartedDotnetApp(
 	ctx context.Context,
 	target appsvc.RunTarget,
@@ -280,9 +366,15 @@ func (c *RunCommand) registerStartedDotnetApp(
 	var baseURL string
 	var registerErr error
 	if flags.randomHostPort {
-		baseURL, registerErr = c.registerProcessAndWaitForApp(ctx, target.AppID, cmd.Process.Pid, monitor)
+		baseURL, registerErr = c.registerProcessAndWaitForApp(
+			ctx,
+			target.AppID,
+			cmd.Process.Pid,
+			monitor,
+			flags.jsonOutput,
+		)
 	} else {
-		baseURL, registerErr = c.registerPortAndWaitForApp(ctx, target.AppID, spec.Port, monitor)
+		baseURL, registerErr = c.registerPortAndWaitForApp(ctx, target.AppID, spec.Port, monitor, flags.jsonOutput)
 	}
 	if registerErr != nil {
 		stopDotnetProcess(cmd.Process, waitErr)
@@ -291,13 +383,25 @@ func (c *RunCommand) registerStartedDotnetApp(
 	return baseURL, nil
 }
 
-func (c *RunCommand) buildDotnetApp(ctx context.Context, spec appsvc.DotnetRunSpec) error {
+func (c *RunCommand) buildDotnetApp(ctx context.Context, spec appsvc.DotnetRunSpec, quiet bool) error {
 	c.out.Verbosef("Running: dotnet %v", spec.BuildArgs)
 	cmd := processutil.CommandContext(ctx, "dotnet", spec.BuildArgs...)
 	cmd.Dir = spec.Dir
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	var stderr bytes.Buffer
+	if quiet {
+		cmd.Stdout = io.Discard
+		cmd.Stderr = &stderr
+	} else {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	}
 	if err := cmd.Run(); err != nil {
+		if quiet {
+			stderrText := strings.TrimSpace(stderr.String())
+			if stderrText != "" {
+				return fmt.Errorf("build dotnet app: %w: %s", err, stderrText)
+			}
+		}
 		return fmt.Errorf("build dotnet app: %w", err)
 	}
 	return nil
@@ -338,21 +442,23 @@ func lastNonEmptyLine(output []byte) string {
 	return ""
 }
 
-func (c *RunCommand) openDetachedAppLog(appID string) (*os.File, error) {
+func (c *RunCommand) openDetachedAppLog(appID string, jsonOutput bool) (*os.File, string, error) {
 	if c.cfg == nil {
-		return nil, errStudioctlConfigRequired
+		return nil, "", errStudioctlConfigRequired
 	}
 	if err := os.MkdirAll(c.cfg.LogDir, osutil.DirPermOwnerOnly); err != nil {
-		return nil, fmt.Errorf("create log directory: %w", err)
+		return nil, "", fmt.Errorf("create log directory: %w", err)
 	}
 	logPath := filepath.Join(c.cfg.LogDir, "app-"+sanitizeAppIDForPath(appID)+".log")
 	//nolint:gosec // G304: log path stays under the configured studioctl log directory; app ID is path-sanitized.
 	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, osutil.FilePermOwnerOnly)
 	if err != nil {
-		return nil, fmt.Errorf("open app log: %w", err)
+		return nil, "", fmt.Errorf("open app log: %w", err)
 	}
-	c.out.Printlnf("Log: %s", logPath)
-	return logFile, nil
+	if !jsonOutput {
+		c.out.Printlnf("Log: %s", logPath)
+	}
+	return logFile, logPath, nil
 }
 
 func sanitizeAppIDForPath(appID string) string {
@@ -433,6 +539,7 @@ func (c *RunCommand) registerPortAndWaitForApp(
 	appID string,
 	port int,
 	monitor readinessMonitor,
+	jsonOutput bool,
 ) (string, error) {
 	if c.cfg == nil {
 		return "", errStudioctlConfigRequired
@@ -447,7 +554,9 @@ func (c *RunCommand) registerPortAndWaitForApp(
 		return "", err
 	}
 
-	c.out.Printlnf("App ready: %s", baseURL)
+	if !jsonOutput {
+		c.out.Printlnf("App ready: %s", baseURL)
+	}
 	return baseURL, nil
 }
 
@@ -488,6 +597,7 @@ func (c *RunCommand) registerContainerAndWaitForApp(
 	appID string,
 	hostPort int,
 	monitor readinessMonitor,
+	jsonOutput bool,
 ) (string, error) {
 	if c.cfg == nil {
 		return "", errStudioctlConfigRequired
@@ -502,7 +612,9 @@ func (c *RunCommand) registerContainerAndWaitForApp(
 		return "", err
 	}
 
-	c.out.Printlnf("App ready: %s", baseURL)
+	if !jsonOutput {
+		c.out.Printlnf("App ready: %s", baseURL)
+	}
 	return baseURL, nil
 }
 
@@ -511,6 +623,7 @@ func (c *RunCommand) registerProcessAndWaitForApp(
 	appID string,
 	processID int,
 	monitor readinessMonitor,
+	jsonOutput bool,
 ) (string, error) {
 	if c.cfg == nil {
 		return "", errStudioctlConfigRequired
@@ -525,7 +638,9 @@ func (c *RunCommand) registerProcessAndWaitForApp(
 		return "", err
 	}
 
-	c.out.Printlnf("App ready: %s", baseURL)
+	if !jsonOutput {
+		c.out.Printlnf("App ready: %s", baseURL)
+	}
 	return baseURL, nil
 }
 
@@ -707,15 +822,17 @@ func (c *RunCommand) runDocker(ctx context.Context, target appsvc.RunTarget, arg
 			fmt.Errorf("inspect app container: %w", err),
 		)
 	}
-	c.printDockerRunInfo(info)
+	if !flags.jsonOutput {
+		c.printDockerRunInfo(info)
+	}
 
-	baseURL, err := c.waitForDockerAppReady(ctx, client, containerID, info, target.AppID)
+	baseURL, err := c.waitForDockerAppReady(ctx, client, containerID, info, target.AppID, flags.jsonOutput)
 	if err != nil {
 		return c.withAppContainerCleanup(ctx, client, containerID, err)
 	}
 
 	if flags.detach {
-		return nil
+		return c.detachedDockerOutput(target.AppID, containerID, info, baseURL, flags).Print(c.out)
 	}
 	defer c.unregisterAppBestEffort(ctx, target.AppID, baseURL)
 
@@ -752,6 +869,7 @@ func (c *RunCommand) waitForDockerAppReady(
 	containerID string,
 	info containerruntime.ContainerInfo,
 	appID string,
+	jsonOutput bool,
 ) (string, error) {
 	candidate, ok := appcontainers.CandidateFromContainer(info)
 	if !ok {
@@ -763,11 +881,36 @@ func (c *RunCommand) waitForDockerAppReady(
 		appID,
 		candidate.HostPort,
 		containerReadinessMonitor(client, containerID),
+		jsonOutput,
 	)
 	if err != nil {
 		return "", err
 	}
 	return baseURL, nil
+}
+
+func (c *RunCommand) detachedDockerOutput(
+	appID string,
+	containerID string,
+	info containerruntime.ContainerInfo,
+	baseURL string,
+	flags runFlags,
+) runDetachedOutput {
+	output := runDetachedOutput{
+		AppID:         appID,
+		Mode:          runModeContainer,
+		URL:           baseURL,
+		LogPath:       "",
+		ContainerID:   containerID,
+		ContainerName: info.Name,
+		ProcessID:     0,
+		HostPort:      0,
+		JSONOutput:    flags.jsonOutput,
+	}
+	if candidate, ok := appcontainers.CandidateFromContainer(info); ok {
+		output.HostPort = candidate.HostPort
+	}
+	return output
 }
 
 func (c *RunCommand) removeForegroundContainer(

--- a/src/cli/internal/cmd/run_internal_test.go
+++ b/src/cli/internal/cmd/run_internal_test.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -70,5 +72,57 @@ func TestStartupMonitorError_ContextCancelledReturnsRunStopped(t *testing.T) {
 	err := startupMonitorError(ctx, t.Context(), context.Canceled, errAppStartupTimedOut)
 	if !errors.Is(err, errAppRunStopped) {
 		t.Fatalf("startupMonitorError() error = %v, want errAppRunStopped", err)
+	}
+}
+
+func TestRunJSONRequiresDetach(t *testing.T) {
+	t.Parallel()
+
+	cmd := &RunCommand{out: ui.NewOutput(io.Discard, io.Discard, false)}
+	err := cmd.RunWithCommandPath(t.Context(), []string{"--json"}, "run")
+	if err == nil {
+		t.Fatal("RunWithCommandPath() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "--json requires --detach") {
+		t.Fatalf("RunWithCommandPath() error = %v, want detach/json error", err)
+	}
+}
+
+func TestAppRunJSONRequiresDetach(t *testing.T) {
+	t.Parallel()
+
+	cmd := &RunCommand{out: ui.NewOutput(io.Discard, io.Discard, false)}
+	err := cmd.RunWithCommandPath(t.Context(), []string{"--json"}, "app run")
+	if err == nil {
+		t.Fatal("RunWithCommandPath() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "--json requires --detach") {
+		t.Fatalf("RunWithCommandPath() error = %v, want detach/json error", err)
+	}
+}
+
+func TestRunDetachedOutputPrintJSON(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	result := runDetachedOutput{
+		AppID:      "ttd/app",
+		Mode:       runModeNative,
+		URL:        "http://localtest.localhost/app",
+		LogPath:    "/tmp/app.log",
+		ProcessID:  123,
+		JSONOutput: true,
+	}
+	if err := result.Print(ui.NewOutput(&out, io.Discard, false)); err != nil {
+		t.Fatalf("Print() error = %v", err)
+	}
+
+	var got runDetachedOutput
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out.String())), &got); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if got.AppID != result.AppID || got.Mode != result.Mode || got.URL != result.URL ||
+		got.LogPath != result.LogPath || got.ProcessID != result.ProcessID {
+		t.Fatalf("output = %+v, want %+v", got, result)
 	}
 }

--- a/src/cli/internal/cmd/servers.go
+++ b/src/cli/internal/cmd/servers.go
@@ -15,17 +15,101 @@ import (
 
 // ServersCommand implements the 'servers' subcommand.
 type ServersCommand struct {
-	cfg    *config.Config
-	out    *ui.Output
-	client *appmanager.Client
+	cfg           *config.Config
+	out           *ui.Output
+	client        serversClient
+	ensureStarted ensureStartedFunc
+	shutdown      shutdownFunc
+}
+
+type serversClient interface {
+	Health(ctx context.Context) error
+	Status(ctx context.Context) (*appmanager.Status, error)
+}
+
+type ensureStartedFunc func(ctx context.Context, cfg *config.Config, loadBalancerPort string) error
+type shutdownFunc func(ctx context.Context, cfg *config.Config) (<-chan error, error)
+
+type serversUpOutput struct {
+	Running    bool `json:"running"`
+	Started    bool `json:"started"`
+	JSONOutput bool `json:"-"`
+}
+
+type serversStatusOutput struct {
+	Status     *appmanager.Status `json:"status,omitempty"`
+	Running    bool               `json:"running"`
+	JSONOutput bool               `json:"-"`
+}
+
+type serversDownOutput struct {
+	ShutdownRequested bool `json:"shutdownRequested"`
+	WasRunning        bool `json:"wasRunning"`
+	JSONOutput        bool `json:"-"`
+}
+
+func (o serversUpOutput) Print(out *ui.Output) error {
+	if o.JSONOutput {
+		return printJSONOutput(out, "servers up", o)
+	}
+	if o.Started {
+		out.Println("app-manager started.")
+		return nil
+	}
+	out.Println("app-manager is already running.")
+	return nil
+}
+
+func (o serversStatusOutput) Print(out *ui.Output) error {
+	if o.Status != nil && o.Status.Apps == nil {
+		o.Status.Apps = make([]appmanager.DiscoveredApp, 0)
+	}
+	if o.JSONOutput {
+		return printJSONOutput(out, "servers status", o)
+	}
+	if !o.Running {
+		out.Println("app-manager is not running.")
+		return nil
+	}
+	// TODO: table output. Should be refactored to be descriptive table subsequently rendered (columns are sometimes messed up)
+	out.Println("app-manager is running.")
+	out.Printlnf("Process ID: %d", o.Status.ProcessID)
+	out.Println("app-manager version: " + o.Status.AppManagerVersion)
+	out.Println(".NET version: " + o.Status.DotnetVersion)
+	if o.Status.Tunnel.Enabled {
+		state := "disconnected"
+		if o.Status.Tunnel.Connected {
+			state = "connected"
+		}
+		out.Println("tunnel: " + state)
+		out.Println("tunnel url: " + o.Status.Tunnel.URL)
+	} else {
+		out.Println("tunnel: disabled")
+	}
+	out.Printlnf("discovered apps: %d", len(o.Status.Apps))
+	return nil
+}
+
+func (o serversDownOutput) Print(out *ui.Output) error {
+	if o.JSONOutput {
+		return printJSONOutput(out, "servers down", o)
+	}
+	if !o.WasRunning {
+		out.Println("app-manager is not running.")
+		return nil
+	}
+	out.Println("app-manager shutdown requested.")
+	return nil
 }
 
 // NewServersCommand creates a new servers command.
 func NewServersCommand(cfg *config.Config, out *ui.Output) *ServersCommand {
 	return &ServersCommand{
-		cfg:    cfg,
-		out:    out,
-		client: appmanager.NewClient(cfg),
+		cfg:           cfg,
+		out:           out,
+		client:        appmanager.NewClient(cfg),
+		ensureStarted: appmanager.EnsureStarted,
+		shutdown:      appmanager.Shutdown,
 	}
 }
 
@@ -80,6 +164,8 @@ func (c *ServersCommand) Run(ctx context.Context, args []string) error {
 
 func (c *ServersCommand) runUp(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("servers up", flag.ContinueOnError)
+	var jsonOutput bool
+	fs.BoolVar(&jsonOutput, "json", false, "Output as JSON")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return nil
@@ -88,23 +174,18 @@ func (c *ServersCommand) runUp(ctx context.Context, args []string) error {
 	}
 
 	if err := c.client.Health(ctx); err == nil {
-		c.out.Println("app-manager is already running.")
-		return nil
+		return serversUpOutput{Running: true, Started: false, JSONOutput: jsonOutput}.Print(c.out)
 	}
-	if err := appmanager.EnsureStarted(
-		ctx,
-		c.cfg,
-		envlocaltest.DefaultLoadBalancerPortString(),
-	); err != nil {
+	if err := c.startAppManager(ctx); err != nil {
 		return fmt.Errorf("start app-manager: %w", err)
 	}
-	c.out.Println("app-manager started.")
-
-	return nil
+	return serversUpOutput{Running: true, Started: true, JSONOutput: jsonOutput}.Print(c.out)
 }
 
 func (c *ServersCommand) runStatus(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("servers status", flag.ContinueOnError)
+	var jsonOutput bool
+	fs.BoolVar(&jsonOutput, "json", false, "Output as JSON")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return nil
@@ -115,33 +196,17 @@ func (c *ServersCommand) runStatus(ctx context.Context, args []string) error {
 	status, err := c.client.Status(ctx)
 	if err != nil {
 		if errors.Is(err, appmanager.ErrNotRunning) {
-			c.out.Println("app-manager is not running.")
-			return nil
+			return serversStatusOutput{Status: nil, Running: false, JSONOutput: jsonOutput}.Print(c.out)
 		}
 		return fmt.Errorf("get app-manager status: %w", err)
 	}
-	// TODO: table output. Should be refactored to be descriptive table subsequently rendered (columns are sometimes messed up)
-	c.out.Println("app-manager is running.")
-	c.out.Printlnf("Process ID: %d", status.ProcessID)
-	c.out.Println("app-manager version: " + status.AppManagerVersion)
-	c.out.Println(".NET version: " + status.DotnetVersion)
-	if status.Tunnel.Enabled {
-		state := "disconnected"
-		if status.Tunnel.Connected {
-			state = "connected"
-		}
-		c.out.Println("tunnel: " + state)
-		c.out.Println("tunnel url: " + status.Tunnel.URL)
-	} else {
-		c.out.Println("tunnel: disabled")
-	}
-	c.out.Printlnf("discovered apps: %d", len(status.Apps))
-
-	return nil
+	return serversStatusOutput{Running: true, Status: status, JSONOutput: jsonOutput}.Print(c.out)
 }
 
 func (c *ServersCommand) runDown(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("servers down", flag.ContinueOnError)
+	var jsonOutput bool
+	fs.BoolVar(&jsonOutput, "json", false, "Output as JSON")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return nil
@@ -149,16 +214,46 @@ func (c *ServersCommand) runDown(ctx context.Context, args []string) error {
 		return fmt.Errorf("parsing flags: %w", err)
 	}
 
-	done, err := appmanager.Shutdown(ctx, c.cfg)
+	done, err := c.stopAppManager(ctx)
 	if err != nil {
 		if errors.Is(err, appmanager.ErrNotRunning) {
-			c.out.Println("app-manager is not running.")
-			return nil
+			return serversDownOutput{
+				WasRunning:        false,
+				ShutdownRequested: false,
+				JSONOutput:        jsonOutput,
+			}.Print(c.out)
 		}
 		return fmt.Errorf("shutdown app-manager: %w", err)
 	}
-	_ = done
-	c.out.Println("app-manager shutdown requested.")
 
-	return nil
+	select {
+	case err := <-done:
+		if err != nil {
+			return fmt.Errorf("shutdown app-manager: %w", err)
+		}
+	case <-ctx.Done():
+		return fmt.Errorf("shutdown app-manager: %w", ctx.Err())
+	}
+
+	return serversDownOutput{
+		WasRunning:        true,
+		ShutdownRequested: true,
+		JSONOutput:        jsonOutput,
+	}.Print(c.out)
+}
+
+func (c *ServersCommand) startAppManager(ctx context.Context) error {
+	ensureStarted := c.ensureStarted
+	if ensureStarted == nil {
+		ensureStarted = appmanager.EnsureStarted
+	}
+	return ensureStarted(ctx, c.cfg, envlocaltest.DefaultLoadBalancerPortString())
+}
+
+func (c *ServersCommand) stopAppManager(ctx context.Context) (<-chan error, error) {
+	shutdown := c.shutdown
+	if shutdown == nil {
+		shutdown = appmanager.Shutdown
+	}
+	return shutdown(ctx, c.cfg)
 }

--- a/src/cli/internal/cmd/servers_internal_test.go
+++ b/src/cli/internal/cmd/servers_internal_test.go
@@ -1,0 +1,250 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"altinn.studio/studioctl/internal/appmanager"
+	"altinn.studio/studioctl/internal/config"
+	"altinn.studio/studioctl/internal/ui"
+)
+
+var errShutdownWaitFailed = errors.New("wait failed")
+
+func TestServersStatusJSON_Running(t *testing.T) {
+	t.Parallel()
+
+	processID := 1234
+	var out bytes.Buffer
+	command := &ServersCommand{
+		out: ui.NewOutput(&out, io.Discard, false),
+		client: fakeServersClient{
+			status: &appmanager.Status{
+				ProcessID:         42,
+				AppManagerVersion: "1.2.3",
+				DotnetVersion:     "10.0.0",
+				StudioctlPath:     "/tmp/studioctl",
+				InternalDev:       true,
+				Tunnel: appmanager.TunnelStatus{
+					Enabled:   true,
+					Connected: true,
+					URL:       "https://example.test",
+				},
+				Apps: []appmanager.DiscoveredApp{
+					{
+						ProcessID:   &processID,
+						AppID:       "ttd/app",
+						BaseURL:     "http://localhost:5000",
+						Source:      "registered",
+						Description: "test app",
+					},
+				},
+			},
+		},
+	}
+
+	if err := command.Run(context.Background(), []string{"status", "--json"}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	var got serversStatusOutput
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out.String())), &got); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	if !got.Running {
+		t.Fatal("running = false, want true")
+	}
+	if got.Status == nil {
+		t.Fatal("status = nil, want value")
+	}
+	if got.Status.ProcessID != 42 {
+		t.Fatalf("status.processId = %d, want 42", got.Status.ProcessID)
+	}
+	if len(got.Status.Apps) != 1 || got.Status.Apps[0].AppID != "ttd/app" {
+		t.Fatalf("status.apps = %+v, want one app with appId ttd/app", got.Status.Apps)
+	}
+}
+
+func TestServersUpJSON_AlreadyRunning(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	command := &ServersCommand{
+		out:    ui.NewOutput(&out, io.Discard, false),
+		client: fakeServersClient{},
+	}
+
+	if err := command.Run(context.Background(), []string{"up", "--json"}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	var got serversUpOutput
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out.String())), &got); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if !got.Running || got.Started {
+		t.Fatalf("output = %+v, want running true and started false", got)
+	}
+}
+
+func TestServersUpJSON_Started(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	command := &ServersCommand{
+		out:    ui.NewOutput(&out, io.Discard, false),
+		client: fakeServersClient{healthErr: appmanager.ErrNotRunning},
+		ensureStarted: func(context.Context, *config.Config, string) error {
+			return nil
+		},
+	}
+
+	if err := command.Run(context.Background(), []string{"up", "--json"}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	var got serversUpOutput
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out.String())), &got); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if !got.Running || !got.Started {
+		t.Fatalf("output = %+v, want running true and started true", got)
+	}
+}
+
+func TestServersStatusJSON_NotRunning(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	command := &ServersCommand{
+		out:    ui.NewOutput(&out, io.Discard, false),
+		client: fakeServersClient{statusErr: appmanager.ErrNotRunning},
+	}
+
+	if err := command.Run(context.Background(), []string{"status", "--json"}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	got := strings.TrimSpace(out.String())
+	if got != `{"running":false}` {
+		t.Fatalf("output = %s, want {\"running\":false}", got)
+	}
+}
+
+func TestServersDownJSON_NotRunning(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	command := &ServersCommand{
+		out: ui.NewOutput(&out, io.Discard, false),
+		shutdown: func(context.Context, *config.Config) (<-chan error, error) {
+			return nil, appmanager.ErrNotRunning
+		},
+	}
+
+	if err := command.Run(context.Background(), []string{"down", "--json"}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	var got serversDownOutput
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out.String())), &got); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if got.WasRunning || got.ShutdownRequested {
+		t.Fatalf("output = %+v, want wasRunning false and shutdownRequested false", got)
+	}
+}
+
+func TestServersDownJSON_ShutdownRequested(t *testing.T) {
+	t.Parallel()
+
+	done := make(chan error)
+	close(done)
+
+	var out bytes.Buffer
+	command := &ServersCommand{
+		out: ui.NewOutput(&out, io.Discard, false),
+		shutdown: func(context.Context, *config.Config) (<-chan error, error) {
+			return done, nil
+		},
+	}
+
+	if err := command.Run(context.Background(), []string{"down", "--json"}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	var got serversDownOutput
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out.String())), &got); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if !got.WasRunning || !got.ShutdownRequested {
+		t.Fatalf("output = %+v, want wasRunning true and shutdownRequested true", got)
+	}
+}
+
+func TestServersDownJSON_ShutdownFailure(t *testing.T) {
+	t.Parallel()
+
+	done := make(chan error, 1)
+	done <- errShutdownWaitFailed
+	close(done)
+
+	var out bytes.Buffer
+	command := &ServersCommand{
+		out: ui.NewOutput(&out, io.Discard, false),
+		shutdown: func(context.Context, *config.Config) (<-chan error, error) {
+			return done, nil
+		},
+	}
+
+	err := command.Run(context.Background(), []string{"down", "--json"})
+	if !errors.Is(err, errShutdownWaitFailed) {
+		t.Fatalf("Run() error = %v, want %v", err, errShutdownWaitFailed)
+	}
+	if out.String() != "" {
+		t.Fatalf("output = %q, want empty output on failure", out.String())
+	}
+}
+
+func TestServersDownJSON_ContextCancelledWhileWaiting(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var out bytes.Buffer
+	command := &ServersCommand{
+		out: ui.NewOutput(&out, io.Discard, false),
+		shutdown: func(context.Context, *config.Config) (<-chan error, error) {
+			return make(chan error), nil
+		},
+	}
+
+	err := command.Run(ctx, []string{"down", "--json"})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run() error = %v, want %v", err, context.Canceled)
+	}
+	if out.String() != "" {
+		t.Fatalf("output = %q, want empty output on failure", out.String())
+	}
+}
+
+type fakeServersClient struct {
+	status    *appmanager.Status
+	statusErr error
+	healthErr error
+}
+
+func (f fakeServersClient) Health(context.Context) error {
+	return f.healthErr
+}
+
+func (f fakeServersClient) Status(context.Context) (*appmanager.Status, error) {
+	return f.status, f.statusErr
+}

--- a/src/cli/internal/ui/output.go
+++ b/src/cli/internal/ui/output.go
@@ -191,13 +191,13 @@ func (o *Output) Infolnf(format string, args ...any) {
 	o.Info(fmt.Sprintf(format, args...))
 }
 
-// Verbose writes a message only if verbose mode is enabled.
+// Verbose writes a message to stderr only if verbose mode is enabled.
 func (o *Output) Verbose(msg string) {
 	if o.verbose {
 		if Colors() {
 			msg = dimStyle().Render(msg)
 		}
-		err := o.write(o.out, msg, true)
+		err := o.write(o.err, msg, true)
 		if err != nil {
 			o.logWriteErr(err)
 		}

--- a/src/cli/internal/ui/output_test.go
+++ b/src/cli/internal/ui/output_test.go
@@ -1,0 +1,26 @@
+package ui_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"altinn.studio/studioctl/internal/ui"
+)
+
+func TestVerboseWritesToStderr(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	out := ui.NewOutput(&stdout, &stderr, true)
+
+	out.Verbose("details")
+
+	if stdout.String() != "" {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	if got := stderr.String(); !strings.Contains(got, "details") {
+		t.Fatalf("stderr = %q, want verbose output", got)
+	}
+}


### PR DESCRIPTION
## Description

- servers
- env
- app build/run

also writes verbose mode to stderr

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--json` output across CLI: `app build`, `env` (up/down/status/logs), `servers` (up/status/down) and detached `run`/`app run`.
  * Logs can emit one JSON object per line for easier parsing.
  * JSON output uses consistent lower camelCase keys and suppresses non-JSON text.

* **Bug Fixes / Behaviour**
  * `--json` now requires detached mode where applicable and avoids mixing human text with JSON.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->