### PR TITLE
feat: studioctl discovery/tunnel refactor, `app ps` and `[app] stop`

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `--json` output for `env up`, `env down`, `env status`, and `env logs`.
 - Add `--json` output for `servers up`, `servers status`, and `servers down`.
 - Add `--json` output for detached `run` and `app run`.
+- Add `app ps` for listing running app processes and containers.
+- Add `app stop` and top-level `stop` for stopping discovered app processes and containers.
+- Support for multiple instances of the same app and round robin loadbalancing similar to deployed environments.
+
+### Changed
+
+- Rename app run mode `native` to `process`.
 
 ## [0.1.0-preview.5] - 2026-04-16
 

--- a/src/cli/app-manager/Discovery/AppDiscoveryCandidate.cs
+++ b/src/cli/app-manager/Discovery/AppDiscoveryCandidate.cs
@@ -1,3 +1,11 @@
 namespace Altinn.Studio.AppManager.Discovery;
 
-internal sealed record AppDiscoveryCandidate(string Source, Uri BaseUri, int? ProcessId, string Description);
+internal sealed record AppDiscoveryCandidate(
+    string Source,
+    Uri BaseUri,
+    int? ProcessId,
+    string Description,
+    string? ContainerId = null,
+    string? Name = null,
+    int? HostPort = null
+);

--- a/src/cli/app-manager/Discovery/AppEndpointUri.cs
+++ b/src/cli/app-manager/Discovery/AppEndpointUri.cs
@@ -3,11 +3,32 @@ using Altinn.Studio.AppManager.Platform.PortListeners;
 
 namespace Altinn.Studio.AppManager.Discovery;
 
-internal static class AppEndpointUri
+internal readonly record struct AppEndpointUri
 {
     private const string CanonicalLoopbackHost = "127.0.0.1";
+    private readonly string? _key;
 
-    public static Uri Canonicalize(Uri uri)
+    private AppEndpointUri(Uri uri)
+    {
+        Value = CanonicalizeUri(uri);
+        _key = EndpointKey(Value);
+    }
+
+    public Uri Value { get; }
+
+    public int Port => Value.Port;
+
+    public static AppEndpointUri From(Uri uri) => new(uri);
+
+    public bool Equals(AppEndpointUri other) => string.Equals(_key, other._key, StringComparison.OrdinalIgnoreCase);
+
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(_key ?? "");
+
+    public override string ToString() => Value.ToString();
+
+    public static Uri Canonicalize(Uri uri) => CanonicalizeUri(uri);
+
+    private static Uri CanonicalizeUri(Uri uri)
     {
         if (!IsLoopbackHost(uri.Host))
             return uri;
@@ -15,14 +36,7 @@ internal static class AppEndpointUri
         return new UriBuilder(uri) { Host = CanonicalLoopbackHost }.Uri;
     }
 
-    public static bool Same(Uri left, Uri right) =>
-        Uri.Compare(
-            Canonicalize(left),
-            Canonicalize(right),
-            UriComponents.AbsoluteUri,
-            UriFormat.SafeUnescaped,
-            StringComparison.OrdinalIgnoreCase
-        ) == 0;
+    private static string EndpointKey(Uri uri) => uri.GetComponents(UriComponents.AbsoluteUri, UriFormat.SafeUnescaped);
 
     public static bool TryLoopbackHttp(int port, out Uri? uri)
     {

--- a/src/cli/app-manager/Discovery/AppRegistry.cs
+++ b/src/cli/app-manager/Discovery/AppRegistry.cs
@@ -16,6 +16,7 @@ internal sealed class AppRegistry : BackgroundService
     private readonly List<AppStartWaiter> _pendingStarts = [];
 
     private DiscoveredApp[] _apps = [];
+    private bool _lastRefreshFailed;
 
     public AppRegistry(IEnumerable<IAppDiscovery> discoveries, AppMetadataProbe probe, ILogger<AppRegistry> logger)
     {
@@ -140,9 +141,13 @@ internal sealed class AppRegistry : BackgroundService
     )
     {
         var now = DateTimeOffset.UtcNow;
-        var shouldRefresh = message is not TimerTick || _pendingStarts.Count > 0 || now >= nextPoll;
+        var shouldRefresh =
+            message is not TimerTick || (_pendingStarts.Count > 0 && !_lastRefreshFailed) || now >= nextPoll;
         if (!shouldRefresh)
+        {
+            PrunePendingStarts(now);
             return nextPoll;
+        }
 
         switch (message)
         {
@@ -159,23 +164,35 @@ internal sealed class AppRegistry : BackgroundService
                 break;
         }
 
-        await Refresh(cancellationToken);
+        try
+        {
+            await Refresh(cancellationToken);
+            _lastRefreshFailed = false;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
+        {
+            _lastRefreshFailed = true;
+            _logger.LogError(ex, "App discovery refresh failed");
+        }
+        finally
+        {
+            PrunePendingStarts(DateTimeOffset.UtcNow);
+        }
 
         return now >= nextPoll ? now + _pollInterval : nextPoll;
     }
 
     private async Task Refresh(CancellationToken cancellationToken)
     {
-        var now = DateTimeOffset.UtcNow;
         var previous = Volatile.Read(ref _apps);
 
-        var apps = await DiscoverApps(now, cancellationToken);
+        var apps = await DiscoverApps(cancellationToken);
         Volatile.Write(ref _apps, apps);
 
         LogRefresh(previous, apps);
     }
 
-    private async Task<DiscoveredApp[]> DiscoverApps(DateTimeOffset now, CancellationToken cancellationToken)
+    private async Task<DiscoveredApp[]> DiscoverApps(CancellationToken cancellationToken)
     {
         var probeResults = new ConcurrentBag<ProbeResult>();
         var discoveryItems = _discoveries.Select(static (discovery, index) => new DiscoveryItem(index, discovery));
@@ -220,7 +237,6 @@ internal sealed class AppRegistry : BackgroundService
             CompleteMatchingStarts(result.App);
         }
 
-        PrunePendingStarts(now);
         return [.. apps.Values];
     }
 

--- a/src/cli/app-manager/Discovery/AppRegistry.cs
+++ b/src/cli/app-manager/Discovery/AppRegistry.cs
@@ -1,15 +1,21 @@
+using System.Collections.Concurrent;
+using System.Threading.Channels;
+
 namespace Altinn.Studio.AppManager.Discovery;
 
 internal sealed class AppRegistry : BackgroundService
 {
+    private const int MaxConcurrentProbes = 8;
     private static readonly TimeSpan _pollInterval = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan _startupPollInterval = TimeSpan.FromMilliseconds(500);
 
     private readonly IReadOnlyList<IAppDiscovery> _discoveries;
     private readonly AppMetadataProbe _probe;
     private readonly ILogger<AppRegistry> _logger;
-    private readonly object _lock = new();
+    private readonly Channel<AppRegistryMessage> _messages = Channel.CreateUnbounded<AppRegistryMessage>();
+    private readonly List<AppStartWaiter> _pendingStarts = [];
 
-    private Dictionary<string, AppEntry> _apps = new(StringComparer.OrdinalIgnoreCase);
+    private DiscoveredApp[] _apps = [];
 
     public AppRegistry(IEnumerable<IAppDiscovery> discoveries, AppMetadataProbe probe, ILogger<AppRegistry> logger)
     {
@@ -20,261 +26,379 @@ internal sealed class AppRegistry : BackgroundService
 
     public IReadOnlyList<DiscoveredApp> GetAll()
     {
-        lock (_lock)
-            return [.. _apps.Values.Select(static entry => entry.Metadata)];
+        return [.. Volatile.Read(ref _apps)];
     }
 
-    public bool TryGet(string appId, out DiscoveredApp? app)
+    public IReadOnlyList<DiscoveredApp> GetByAppId(string appId)
     {
-        lock (_lock)
+        List<DiscoveredApp>? apps = null;
+        foreach (var candidate in Volatile.Read(ref _apps))
         {
-            if (_apps.TryGetValue(appId, out var entry))
-            {
-                app = entry.Metadata;
-                return true;
-            }
+            if (!string.Equals(candidate.AppId, appId, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            apps ??= [];
+            apps.Add(candidate);
         }
 
-        app = null;
-        return false;
+        return apps ?? [];
     }
 
-    public void Register(string appId, Uri baseUri, string description, TimeSpan gracePeriod)
+    public async Task<Uri> AppStarted(
+        string appId,
+        int? processId,
+        string? containerId,
+        int? hostPort,
+        TimeSpan timeout,
+        CancellationToken cancellationToken
+    )
     {
-        var now = DateTimeOffset.UtcNow;
-        baseUri = AppEndpointUri.Canonicalize(baseUri);
-        var app = new DiscoveredApp(appId, baseUri, "studioctl", null, description, now);
-        lock (_lock)
-            _apps[appId] = new AppEntry(app, gracePeriod, now + gracePeriod);
-
-        if (_logger.IsEnabled(LogLevel.Information))
-            _logger.LogInformation("Registered app {AppId} on {BaseUri} via studioctl", appId, baseUri);
-    }
-
-    public void Unregister(string appId, Uri baseUri)
-    {
-        DiscoveredApp? removed = null;
-        lock (_lock)
-        {
-            if (_apps.TryGetValue(appId, out var entry) && AppEndpointUri.Same(entry.Metadata.BaseUri, baseUri))
+        var waiter = new AppStartWaiter(appId, processId, containerId, hostPort, DateTimeOffset.UtcNow + timeout);
+        using var cancellation = cancellationToken.Register(
+            static state =>
             {
-                _apps.Remove(appId);
-                removed = entry.Metadata;
-            }
-        }
+                if (state is not AppStartWaiter waiter)
+                    throw new InvalidOperationException("Missing app start waiter");
+                waiter.TrySetCanceled();
+            },
+            waiter
+        );
+        await _messages.Writer.WriteAsync(new AppStartedMessage(waiter), cancellationToken);
+        return await waiter.Task;
+    }
 
-        if (removed is not null && _logger.IsEnabled(LogLevel.Information))
-            _logger.LogInformation("Unregistered app {AppId} from {BaseUri}", removed.AppId, removed.BaseUri);
+    public void AppStopped(string? appId)
+    {
+        _messages.Writer.TryWrite(new AppStoppedMessage(string.IsNullOrWhiteSpace(appId) ? null : appId.Trim()));
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        while (!stoppingToken.IsCancellationRequested)
+        var nextPoll = DateTimeOffset.MinValue;
+        var readTask = _messages.Reader.ReadAsync(stoppingToken).AsTask();
+        var timerTask = Task.Delay(_startupPollInterval, stoppingToken);
+        AppRegistryMessage? currentMessage = null;
+
+        try
         {
             try
             {
-                await Refresh(stoppingToken);
+                nextPoll = await HandleMessage(new TimerTick(), nextPoll, stoppingToken);
             }
-            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
-            {
-                break;
-            }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException || !stoppingToken.IsCancellationRequested)
             {
                 _logger.LogError(ex, "App discovery refresh failed");
             }
 
-            await Task.Delay(_pollInterval, stoppingToken);
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                var completed = await Task.WhenAny(readTask, timerTask);
+
+                AppRegistryMessage message;
+                if (completed == readTask)
+                {
+                    message = await readTask;
+                    readTask = _messages.Reader.ReadAsync(stoppingToken).AsTask();
+                }
+                else
+                {
+                    await timerTask;
+                    message = new TimerTick();
+                    timerTask = Task.Delay(_startupPollInterval, stoppingToken);
+                }
+
+                currentMessage = message;
+                try
+                {
+                    nextPoll = await HandleMessage(message, nextPoll, stoppingToken);
+                    currentMessage = null;
+                }
+                catch (Exception ex)
+                    when (ex is not OperationCanceledException || !stoppingToken.IsCancellationRequested)
+                {
+                    currentMessage = null;
+                    _logger.LogError(ex, "App discovery refresh failed");
+                }
+            }
         }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            if (currentMessage is AppStartedMessage started)
+                started.Waiter.TrySetCanceled();
+        }
+        finally
+        {
+            CancelQueuedMessages();
+            CancelPendingStarts();
+        }
+    }
+
+    private async Task<DateTimeOffset> HandleMessage(
+        AppRegistryMessage message,
+        DateTimeOffset nextPoll,
+        CancellationToken cancellationToken
+    )
+    {
+        var now = DateTimeOffset.UtcNow;
+        var shouldRefresh = message is not TimerTick || _pendingStarts.Count > 0 || now >= nextPoll;
+        if (!shouldRefresh)
+            return nextPoll;
+
+        switch (message)
+        {
+            case AppStartedMessage started:
+                _pendingStarts.Add(started.Waiter);
+                break;
+            case AppStoppedMessage stopped when stopped.AppId is { } appId:
+                if (_logger.IsEnabled(LogLevel.Debug))
+                    _logger.LogDebug("App stopped notification received for {AppId}", appId);
+                break;
+            case AppStoppedMessage:
+                if (_logger.IsEnabled(LogLevel.Debug))
+                    _logger.LogDebug("App stopped notification received");
+                break;
+        }
+
+        await Refresh(cancellationToken);
+
+        return now >= nextPoll ? now + _pollInterval : nextPoll;
     }
 
     private async Task Refresh(CancellationToken cancellationToken)
     {
         var now = DateTimeOffset.UtcNow;
-        Dictionary<string, AppEntry> previous;
-        lock (_lock)
-            previous = new(_apps, StringComparer.OrdinalIgnoreCase);
+        var previous = Volatile.Read(ref _apps);
 
-        var previousApps = VisibleApps(previous);
-        var next = await DiscoverApps(now, previous, cancellationToken);
-        await ProbePreviousApps(now, previous, next, cancellationToken);
-        KeepAppsInGrace(now, previous, next);
+        var apps = await DiscoverApps(now, cancellationToken);
+        Volatile.Write(ref _apps, apps);
 
-        Dictionary<string, DiscoveredApp> apps;
-        lock (_lock)
-        {
-            ReconcileConcurrentChanges(previous, _apps, next);
-            _apps = next;
-            apps = VisibleApps(next);
-        }
-
-        LogRefresh(previousApps, apps, next.Count);
+        LogRefresh(previous, apps);
     }
 
-    private async Task<Dictionary<string, AppEntry>> DiscoverApps(
-        DateTimeOffset now,
-        IReadOnlyDictionary<string, AppEntry> previous,
-        CancellationToken cancellationToken
-    )
+    private async Task<DiscoveredApp[]> DiscoverApps(DateTimeOffset now, CancellationToken cancellationToken)
     {
-        var apps = new Dictionary<string, AppEntry>(StringComparer.OrdinalIgnoreCase);
+        var probeResults = new ConcurrentBag<ProbeResult>();
+        var discoveryItems = _discoveries.Select(static (discovery, index) => new DiscoveryItem(index, discovery));
+        var discoveryOptions = new ParallelOptions { CancellationToken = cancellationToken };
 
-        foreach (var discovery in _discoveries)
-        {
-            var candidates = await discovery.Discover(cancellationToken);
-            foreach (var candidate in candidates)
+        await Parallel.ForEachAsync(
+            discoveryItems,
+            discoveryOptions,
+            async (discoveryItem, discoveryCancellationToken) =>
             {
-                if (_logger.IsEnabled(LogLevel.Debug))
+                var candidates = await discoveryItem.Discovery.Discover(discoveryCancellationToken);
+                var candidateItems = candidates.Select(
+                    static (candidate, index) => new CandidateItem(index, candidate)
+                );
+                var candidateOptions = new ParallelOptions
                 {
-                    _logger.LogDebug(
-                        "Probing discovery candidate {Source} {BaseUri} {Description}",
-                        candidate.Source,
-                        candidate.BaseUri,
-                        candidate.Description
-                    );
-                }
+                    CancellationToken = discoveryCancellationToken,
+                    MaxDegreeOfParallelism = MaxConcurrentProbes,
+                };
 
-                var appId = await _probe.Probe(candidate.BaseUri, cancellationToken);
-                if (string.IsNullOrWhiteSpace(appId))
-                    continue;
-
-                var baseUri = AppEndpointUri.Canonicalize(candidate.BaseUri);
-                apps[appId] = new AppEntry(
-                    new DiscoveredApp(
-                        appId,
-                        baseUri,
-                        candidate.Source,
-                        candidate.ProcessId,
-                        candidate.Description,
-                        now
-                    ),
-                    PreviousGracePeriod(previous, appId),
-                    GraceDeadlineForSeenApp(now, previous, appId)
+                await Parallel.ForEachAsync(
+                    candidateItems,
+                    candidateOptions,
+                    async (candidateItem, probeCancellationToken) =>
+                    {
+                        var app = await ProbeCandidate(candidateItem.Candidate, probeCancellationToken);
+                        if (app is not null)
+                            probeResults.Add(new ProbeResult(discoveryItem.Index, candidateItem.Index, app));
+                    }
                 );
             }
+        );
+
+        var apps = new Dictionary<AppKey, DiscoveredApp>();
+        foreach (
+            var result in probeResults
+                .OrderBy(static result => result.DiscoveryIndex)
+                .ThenBy(static result => result.CandidateIndex)
+        )
+        {
+            apps[AppKey.From(result.App)] = result.App;
+            CompleteMatchingStarts(result.App);
         }
 
-        return apps;
+        PrunePendingStarts(now);
+        return [.. apps.Values];
     }
 
-    private async Task ProbePreviousApps(
-        DateTimeOffset now,
-        IReadOnlyDictionary<string, AppEntry> previous,
-        Dictionary<string, AppEntry> next,
+    private async Task<DiscoveredApp?> ProbeCandidate(
+        AppDiscoveryCandidate candidate,
         CancellationToken cancellationToken
     )
     {
-        foreach (var (appId, entry) in previous)
+        if (_logger.IsEnabled(LogLevel.Debug))
         {
-            if (next.ContainsKey(appId))
-                continue;
+            _logger.LogDebug(
+                "Probing discovery candidate {Source} {BaseUri} {Description}",
+                candidate.Source,
+                candidate.BaseUri,
+                candidate.Description
+            );
+        }
 
-            var resolvedAppId = await _probe.Probe(entry.Metadata.BaseUri, cancellationToken);
-            if (string.Equals(resolvedAppId, appId, StringComparison.OrdinalIgnoreCase))
+        var appId = await _probe.Probe(candidate.BaseUri, cancellationToken);
+        if (string.IsNullOrWhiteSpace(appId))
+            return null;
+
+        var baseUri = AppEndpointUri.From(candidate.BaseUri);
+        return new DiscoveredApp(
+            appId,
+            baseUri,
+            candidate.Source,
+            candidate.ProcessId,
+            candidate.Description,
+            candidate.ContainerId,
+            candidate.Name,
+            candidate.HostPort ?? baseUri.Port
+        );
+    }
+
+    private void CompleteMatchingStarts(DiscoveredApp app)
+    {
+        for (var i = _pendingStarts.Count - 1; i >= 0; i--)
+        {
+            var waiter = _pendingStarts[i];
+            if (waiter.IsCompleted)
             {
-                next[appId] = entry with
-                {
-                    Metadata = entry.Metadata with { LastSeen = now },
-                    GraceDeadline = now + entry.GracePeriod,
-                };
+                _pendingStarts.RemoveAt(i);
+                continue;
+            }
+
+            if (waiter.Matches(app))
+            {
+                waiter.TrySetResult(app.BaseUri.Value);
+                _pendingStarts.RemoveAt(i);
             }
         }
     }
 
-    private static void KeepAppsInGrace(
-        DateTimeOffset now,
-        Dictionary<string, AppEntry> previous,
-        Dictionary<string, AppEntry> next
-    )
+    private void PrunePendingStarts(DateTimeOffset now)
     {
-        foreach (var (appId, entry) in previous)
+        for (var i = _pendingStarts.Count - 1; i >= 0; i--)
         {
-            if (!next.ContainsKey(appId) && now <= entry.GraceDeadline)
-                next[appId] = entry;
+            var waiter = _pendingStarts[i];
+            if (waiter.IsCompleted)
+            {
+                _pendingStarts.RemoveAt(i);
+                continue;
+            }
+
+            if (now < waiter.Deadline)
+                continue;
+
+            waiter.TrySetException(new TimeoutException("matching app endpoint not found"));
+            _pendingStarts.RemoveAt(i);
         }
     }
 
-    private static void ReconcileConcurrentChanges(
-        IReadOnlyDictionary<string, AppEntry> previous,
-        IReadOnlyDictionary<string, AppEntry> current,
-        Dictionary<string, AppEntry> next
-    )
+    private void CancelPendingStarts()
     {
-        foreach (var appId in previous.Keys)
-            if (!current.ContainsKey(appId))
-                next.Remove(appId);
-
-        foreach (var (appId, entry) in current)
-        {
-            if (!previous.TryGetValue(appId, out var previousEntry) || NewerEntry(entry, previousEntry))
-                next[appId] = entry;
-        }
+        foreach (var waiter in _pendingStarts)
+            waiter.TrySetCanceled();
+        _pendingStarts.Clear();
     }
 
-    private static bool NewerEntry(AppEntry entry, AppEntry previousEntry) =>
-        !AppEndpointUri.Same(entry.Metadata.BaseUri, previousEntry.Metadata.BaseUri)
-        || entry.Metadata.LastSeen > previousEntry.Metadata.LastSeen
-        || entry.GracePeriod > previousEntry.GracePeriod
-        || entry.GraceDeadline > previousEntry.GraceDeadline;
+    private void CancelQueuedMessages()
+    {
+        while (_messages.Reader.TryRead(out var message))
+            if (message is AppStartedMessage started)
+                started.Waiter.TrySetCanceled();
+    }
 
-    private void LogRefresh(
-        IReadOnlyDictionary<string, DiscoveredApp> previousApps,
-        IReadOnlyDictionary<string, DiscoveredApp> apps,
-        int appCount
-    )
+    private void LogRefresh(IReadOnlyList<DiscoveredApp> previousApps, IReadOnlyList<DiscoveredApp> apps)
     {
         if (!_logger.IsEnabled(LogLevel.Information))
             return;
 
-        foreach (var (appId, app) in apps)
+        foreach (var app in apps)
         {
-            if (!previousApps.TryGetValue(appId, out var previous))
+            var appKey = AppKey.From(app);
+            var previous = previousApps.FirstOrDefault(previousApp => AppKey.From(previousApp) == appKey);
+            if (previous is null)
             {
                 _logger.LogInformation(
                     "Discovered app {AppId} on {BaseUri} via {Source}",
-                    appId,
+                    app.AppId,
                     app.BaseUri,
                     app.Source
                 );
-                continue;
             }
-
-            if (!AppEndpointUri.Same(previous.BaseUri, app.BaseUri))
-                _logger.LogInformation(
-                    "Updated app {AppId} from {PreviousBaseUri} to {BaseUri}",
-                    appId,
-                    previous.BaseUri,
-                    app.BaseUri
-                );
         }
 
-        foreach (var (appId, previous) in previousApps)
-            if (!apps.ContainsKey(appId))
-                _logger.LogInformation("Removed app {AppId} from {BaseUri}", appId, previous.BaseUri);
+        foreach (var previous in previousApps)
+        {
+            var previousKey = AppKey.From(previous);
+            if (apps.Any(app => AppKey.From(app) == previousKey))
+                continue;
 
-        _logger.LogInformation("Discovery refresh completed with {AppCount} apps", appCount);
+            _logger.LogInformation("Removed app {AppId} from {BaseUri}", previous.AppId, previous.BaseUri);
+        }
     }
 
-    private static DateTimeOffset GraceDeadlineForSeenApp(
-        DateTimeOffset now,
-        IReadOnlyDictionary<string, AppEntry> previous,
-        string appId
-    )
+    private readonly record struct AppKey(string AppId, AppEndpointUri BaseUri)
     {
-        return previous.TryGetValue(appId, out var entry) ? now + entry.GracePeriod : now;
+        public static AppKey From(DiscoveredApp app) => new(app.AppId.ToUpperInvariant(), app.BaseUri);
     }
 
-    private static TimeSpan PreviousGracePeriod(IReadOnlyDictionary<string, AppEntry> previous, string appId)
+    private abstract record AppRegistryMessage;
+
+    private sealed record TimerTick : AppRegistryMessage;
+
+    private sealed record AppStartedMessage(AppStartWaiter Waiter) : AppRegistryMessage;
+
+    private sealed record DiscoveryItem(int Index, IAppDiscovery Discovery);
+
+    private sealed record CandidateItem(int Index, AppDiscoveryCandidate Candidate);
+
+    private sealed record ProbeResult(int DiscoveryIndex, int CandidateIndex, DiscoveredApp App);
+
+    private sealed record AppStoppedMessage(string? AppId) : AppRegistryMessage;
+
+    private sealed class AppStartWaiter
     {
-        return previous.TryGetValue(appId, out var entry) ? entry.GracePeriod : TimeSpan.Zero;
+        private readonly TaskCompletionSource<Uri> _result = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public AppStartWaiter(string appId, int? processId, string? containerId, int? hostPort, DateTimeOffset deadline)
+        {
+            AppId = appId;
+            ProcessId = processId;
+            ContainerId = string.IsNullOrWhiteSpace(containerId) ? null : containerId.Trim();
+            HostPort = hostPort;
+            Deadline = deadline;
+        }
+
+        public string AppId { get; }
+        public int? ProcessId { get; }
+        public string? ContainerId { get; }
+        public int? HostPort { get; }
+        public DateTimeOffset Deadline { get; }
+        public Task<Uri> Task => _result.Task;
+        public bool IsCompleted => _result.Task.IsCompleted;
+
+        public bool Matches(DiscoveredApp app)
+        {
+            if (!string.Equals(app.AppId, AppId, StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            if (ProcessId.HasValue && app.ProcessId != ProcessId)
+                return false;
+
+            if (
+                !string.IsNullOrWhiteSpace(ContainerId)
+                && !string.Equals(app.ContainerId, ContainerId, StringComparison.Ordinal)
+            )
+                return false;
+
+            return !HostPort.HasValue || app.HostPort == HostPort || app.BaseUri.Port == HostPort;
+        }
+
+        public void TrySetResult(Uri baseUri) => _result.TrySetResult(baseUri);
+
+        public void TrySetException(Exception exception) => _result.TrySetException(exception);
+
+        public void TrySetCanceled() => _result.TrySetCanceled();
     }
-
-    private static Dictionary<string, DiscoveredApp> VisibleApps(Dictionary<string, AppEntry> entries) =>
-        entries.ToDictionary(
-            static pair => pair.Key,
-            static pair => pair.Value.Metadata,
-            StringComparer.OrdinalIgnoreCase
-        );
-
-    private sealed record AppEntry(DiscoveredApp Metadata, TimeSpan GracePeriod, DateTimeOffset GraceDeadline);
 }

--- a/src/cli/app-manager/Discovery/Container/ContainerDiscovery.cs
+++ b/src/cli/app-manager/Discovery/Container/ContainerDiscovery.cs
@@ -114,10 +114,20 @@ internal sealed class ContainerDiscovery : IAppDiscovery
         if (!AppEndpointUri.TryLoopbackHttp(candidate.HostPort, out var baseUri) || baseUri is null)
             yield break;
 
-        yield return new AppDiscoveryCandidate(candidate.Source, baseUri, null, candidate.Description);
+        yield return new AppDiscoveryCandidate(
+            candidate.Source,
+            baseUri,
+            null,
+            candidate.Description,
+            candidate.ContainerId,
+            candidate.Name,
+            candidate.HostPort
+        );
     }
 
     private sealed record ContainerCandidate(
+        [property: JsonPropertyName("containerId")] string ContainerId,
+        [property: JsonPropertyName("name")] string Name,
         [property: JsonPropertyName("hostPort")] int HostPort,
         [property: JsonPropertyName("source")] string Source,
         [property: JsonPropertyName("description")] string Description

--- a/src/cli/app-manager/Discovery/DiscoveredApp.cs
+++ b/src/cli/app-manager/Discovery/DiscoveredApp.cs
@@ -2,9 +2,11 @@ namespace Altinn.Studio.AppManager.Discovery;
 
 internal sealed record DiscoveredApp(
     string AppId,
-    Uri BaseUri,
+    AppEndpointUri BaseUri,
     string Source,
     int? ProcessId,
     string Description,
-    DateTimeOffset LastSeen
+    string? ContainerId,
+    string? Name,
+    int? HostPort
 );

--- a/src/cli/app-manager/Discovery/Process/ProcessDiscovery.cs
+++ b/src/cli/app-manager/Discovery/Process/ProcessDiscovery.cs
@@ -20,17 +20,52 @@ internal sealed class ProcessDiscovery : IAppDiscovery
             if (!AppEndpointUri.TryFromListener(listener, out var baseUri) || baseUri is null)
                 continue;
 
-            if (string.IsNullOrWhiteSpace(listener.ProcessName))
+            var name = StudioAppName(listener);
+            if (name is null)
                 continue;
 
-            // Process names for .NET apps comes from the assembly names, these are either
-            // "Altinn.App" or "Altinn.Application". This is seemingly true for both "dotnet run" and "studioctl run"
-            if (!listener.ProcessName.Contains("Altinn.App", StringComparison.OrdinalIgnoreCase))
-                continue;
-
-            candidates.Add(new AppDiscoveryCandidate("process", baseUri, listener.ProcessId, listener.ProcessName));
+            candidates.Add(
+                new AppDiscoveryCandidate(
+                    "process",
+                    baseUri,
+                    listener.ProcessId,
+                    name,
+                    Name: name,
+                    HostPort: listener.Port
+                )
+            );
         }
 
         return candidates;
     }
+
+    private static string? StudioAppName(PortListener listener)
+    {
+        if (IsStudioAppName(listener.ProcessName))
+            return listener.ProcessName;
+
+        if (string.IsNullOrWhiteSpace(listener.CommandLine))
+            return null;
+
+        foreach (
+            var part in listener.CommandLine.Split(
+                ' ',
+                StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
+            )
+        )
+        {
+            var name = Path.GetFileName(part.Trim('"'));
+            if (IsStudioAppName(name))
+                return name;
+        }
+
+        return null;
+    }
+
+    private static bool IsStudioAppName(string? value) =>
+        !string.IsNullOrWhiteSpace(value)
+        && (
+            value.Contains("Altinn.App", StringComparison.OrdinalIgnoreCase)
+            || value.Contains("Altinn.Application", StringComparison.OrdinalIgnoreCase)
+        );
 }

--- a/src/cli/app-manager/Discovery/Process/ProcessDiscovery.cs
+++ b/src/cli/app-manager/Discovery/Process/ProcessDiscovery.cs
@@ -44,22 +44,7 @@ internal sealed class ProcessDiscovery : IAppDiscovery
         if (IsStudioAppName(listener.ProcessName))
             return listener.ProcessName;
 
-        if (string.IsNullOrWhiteSpace(listener.CommandLine))
-            return null;
-
-        foreach (
-            var part in listener.CommandLine.Split(
-                ' ',
-                StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
-            )
-        )
-        {
-            var name = Path.GetFileName(part.Trim('"'));
-            if (IsStudioAppName(name))
-                return name;
-        }
-
-        return null;
+        return IsStudioAppName(listener.CommandLine) ? listener.CommandLine : null;
     }
 
     private static bool IsStudioAppName(string? value) =>

--- a/src/cli/app-manager/Platform/PortListeners/LinuxPortListeners.cs
+++ b/src/cli/app-manager/Platform/PortListeners/LinuxPortListeners.cs
@@ -19,6 +19,7 @@ internal sealed partial class LinuxPortListeners : IPortListenerSource
         if (listenerPorts.Count == 0)
         {
             _knownListeners.Clear();
+            _processNames.Clear();
             return [];
         }
 
@@ -44,7 +45,17 @@ internal sealed partial class LinuxPortListeners : IPortListenerSource
         foreach (var (inode, listener) in nextKnownListeners)
             _knownListeners[inode] = listener;
 
+        PruneProcessNames(nextKnownListeners.Values);
+
         return [.. listeners.Distinct()];
+    }
+
+    private void PruneProcessNames(IEnumerable<PortListener> listeners)
+    {
+        var activeProcessIds = listeners.Select(static listener => listener.ProcessId).ToHashSet();
+        foreach (var processId in _processNames.Keys.ToArray())
+            if (!activeProcessIds.Contains(processId))
+                _processNames.Remove(processId);
     }
 
     private async Task AddProcessListeners(
@@ -87,6 +98,7 @@ internal sealed partial class LinuxPortListeners : IPortListenerSource
             return;
 
         var processName = await ReadProcessName(procDir, processId, cancellationToken);
+        var commandLine = await ReadCommandLine(procDir, cancellationToken);
 
         foreach (var fdPath in EnumerateFdEntries(fdDir))
         {
@@ -111,7 +123,7 @@ internal sealed partial class LinuxPortListeners : IPortListenerSource
             if (!pendingInodes.Remove(inode, out var binding))
                 continue;
 
-            var listener = new PortListener(processId, binding.Port, binding.BindScope, processName);
+            var listener = new PortListener(processId, binding.Port, binding.BindScope, processName, commandLine);
             listeners.Add(listener);
             knownListeners[inode] = listener;
         }
@@ -159,6 +171,23 @@ internal sealed partial class LinuxPortListeners : IPortListenerSource
 
             _processNames[processId] = processName;
             return processName;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    private static async Task<string?> ReadCommandLine(string procDir, CancellationToken cancellationToken)
+    {
+        var cmdlinePath = Path.Join(procDir, "cmdline");
+        if (!File.Exists(cmdlinePath))
+            return null;
+
+        try
+        {
+            var commandLine = (await File.ReadAllTextAsync(cmdlinePath, cancellationToken)).Replace('\0', ' ').Trim();
+            return commandLine.Length == 0 ? null : commandLine;
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {

--- a/src/cli/app-manager/Platform/PortListeners/MacPortListeners.cs
+++ b/src/cli/app-manager/Platform/PortListeners/MacPortListeners.cs
@@ -71,6 +71,7 @@ internal sealed partial class MacPortListeners : IPortListenerSource
     )
     {
         var output = await RunCommand("lsof", "-Fpcn -nP -iTCP -sTCP:LISTEN", cancellationToken);
+        var commandLines = new Dictionary<int, string?>();
         var processName = string.Empty;
         var processId = 0;
         foreach (var line in output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries))
@@ -98,11 +99,13 @@ internal sealed partial class MacPortListeners : IPortListenerSource
                     if (!currentListeners.Contains(listenerKey))
                         continue;
 
+                    var commandLine = await ReadCommandLine(processId, commandLines, cancellationToken);
                     knownListeners[listenerKey] = new PortListener(
                         processId,
                         listenerKey.Port,
                         listenerKey.BindScope,
-                        processName
+                        processName,
+                        commandLine
                     );
                     break;
             }
@@ -170,6 +173,32 @@ internal sealed partial class MacPortListeners : IPortListenerSource
     {
         var result = Kill(processId, SignalZero);
         return result == 0 || Marshal.GetLastPInvokeError() == ErrorPermissionDenied;
+    }
+
+    private static async Task<string?> ReadCommandLine(
+        int processId,
+        Dictionary<int, string?> commandLines,
+        CancellationToken cancellationToken
+    )
+    {
+        if (commandLines.TryGetValue(processId, out var cached))
+            return cached;
+
+        string? commandLine = null;
+        try
+        {
+            commandLine = (await RunCommand("ps", $"-p {processId} -o command=", cancellationToken)).Trim();
+            if (commandLine.Length == 0)
+                commandLine = null;
+        }
+        catch (InvalidOperationException)
+        {
+            commandLines[processId] = null;
+            return null;
+        }
+
+        commandLines[processId] = commandLine;
+        return commandLine;
     }
 
     private static async Task<string> RunCommand(string fileName, string arguments, CancellationToken cancellationToken)

--- a/src/cli/app-manager/Platform/PortListeners/PortListener.cs
+++ b/src/cli/app-manager/Platform/PortListeners/PortListener.cs
@@ -2,7 +2,13 @@ using System.Net;
 
 namespace Altinn.Studio.AppManager.Platform.PortListeners;
 
-internal sealed record PortListener(int ProcessId, int Port, ListenerBindScope BindScope, string? ProcessName = null)
+internal sealed record PortListener(
+    int ProcessId,
+    int Port,
+    ListenerBindScope BindScope,
+    string? ProcessName = null,
+    string? CommandLine = null
+)
 {
     public static PortListener FromAddress(int processId, int port, IPAddress address, string? processName = null) =>
         new(processId, port, ClassifyAddress(address), processName);

--- a/src/cli/app-manager/Platform/PortListeners/WindowsPortListeners.cs
+++ b/src/cli/app-manager/Platform/PortListeners/WindowsPortListeners.cs
@@ -1,6 +1,8 @@
 using System.Buffers.Binary;
+using System.Globalization;
 using System.Net;
 using System.Runtime.InteropServices;
+using System.Text.Json;
 
 namespace Altinn.Studio.AppManager.Platform.PortListeners;
 
@@ -12,6 +14,7 @@ internal sealed partial class WindowsPortListeners : IPortListenerSource
     private const uint MaxTableSize = 10u << 20;
     private const uint TcpStateListen = 2;
     private readonly Dictionary<int, string> _processNames = [];
+    private readonly Dictionary<int, string?> _commandLines = [];
 
     public bool SupportsCurrentPlatform() => OperatingSystem.IsWindows();
 
@@ -29,10 +32,25 @@ internal sealed partial class WindowsPortListeners : IPortListenerSource
             cancellationToken
         );
 
+        await ResolveMissingCommandLines(listeners, cancellationToken);
+
         var resolvedListeners = new List<PortListener>(listeners.Count);
         foreach (var listener in listeners)
-            resolvedListeners.Add(ResolveProcessName(listener));
+            resolvedListeners.Add(ResolveProcessMetadata(listener));
+
+        PruneProcessCaches(resolvedListeners);
         return resolvedListeners;
+    }
+
+    private void PruneProcessCaches(IEnumerable<PortListener> listeners)
+    {
+        var activeProcessIds = listeners.Select(static listener => listener.ProcessId).ToHashSet();
+        foreach (var processId in _processNames.Keys.ToArray())
+            if (!activeProcessIds.Contains(processId))
+                _processNames.Remove(processId);
+        foreach (var processId in _commandLines.Keys.ToArray())
+            if (!activeProcessIds.Contains(processId))
+                _commandLines.Remove(processId);
     }
 
     private static IReadOnlyList<PortListener> ReadTcp4Listeners() =>
@@ -147,22 +165,127 @@ internal sealed partial class WindowsPortListeners : IPortListenerSource
         return new IPAddress(addressBytes);
     }
 
-    private PortListener ResolveProcessName(PortListener listener)
+    private PortListener ResolveProcessMetadata(PortListener listener)
     {
-        if (_processNames.TryGetValue(listener.ProcessId, out var processName))
-            return listener with { ProcessName = processName };
+        var processName = ResolveProcessName(listener.ProcessId);
+        _commandLines.TryGetValue(listener.ProcessId, out var commandLine);
+        return listener with { ProcessName = processName, CommandLine = commandLine };
+    }
+
+    private string? ResolveProcessName(int processId)
+    {
+        if (_processNames.TryGetValue(processId, out var processName))
+            return processName;
 
         try
         {
-            using var process = System.Diagnostics.Process.GetProcessById(listener.ProcessId);
+            using var process = System.Diagnostics.Process.GetProcessById(processId);
             processName = process.ProcessName;
-            _processNames[listener.ProcessId] = processName;
-            return listener with { ProcessName = processName };
+            _processNames[processId] = processName;
+            return processName;
         }
         catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
         {
-            return listener;
+            return null;
         }
+    }
+
+    private async Task ResolveMissingCommandLines(
+        IReadOnlyList<PortListener> listeners,
+        CancellationToken cancellationToken
+    )
+    {
+        var processIds = listeners
+            .Select(static listener => listener.ProcessId)
+            .Distinct()
+            .Where(processId => !_commandLines.ContainsKey(processId))
+            .ToArray();
+        if (processIds.Length == 0)
+            return;
+
+        foreach (var processId in processIds)
+            _commandLines[processId] = null;
+
+        try
+        {
+            var command = CimCommandLineQuery(processIds);
+            var output = await RunPowerShell(command, cancellationToken);
+            if (string.IsNullOrWhiteSpace(output))
+                return;
+
+            using var document = JsonDocument.Parse(output);
+            if (document.RootElement.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var element in document.RootElement.EnumerateArray())
+                    AddCommandLine(element);
+            }
+            else
+            {
+                AddCommandLine(document.RootElement);
+            }
+        }
+        catch (Exception ex) when (CommandLineLookupFailed(ex, cancellationToken))
+        {
+            MarkCommandLinesUnavailable(processIds);
+        }
+    }
+
+    private void MarkCommandLinesUnavailable(IEnumerable<int> processIds)
+    {
+        foreach (var processId in processIds)
+            _commandLines[processId] = null;
+    }
+
+    private void AddCommandLine(JsonElement element)
+    {
+        if (
+            element.ValueKind != JsonValueKind.Object
+            || !element.TryGetProperty("ProcessId", out var processIdProperty)
+            || !processIdProperty.TryGetInt32(out var processId)
+            || !element.TryGetProperty("CommandLine", out var commandLineProperty)
+        )
+            return;
+
+        var commandLine =
+            commandLineProperty.ValueKind == JsonValueKind.String ? commandLineProperty.GetString() : null;
+        _commandLines[processId] = string.IsNullOrWhiteSpace(commandLine) ? null : commandLine;
+    }
+
+    private static string CimCommandLineQuery(int[] processIds)
+    {
+        var filter = string.Join(
+            " OR ",
+            processIds.Select(static processId => $"ProcessId = {processId.ToString(CultureInfo.InvariantCulture)}")
+        );
+        return $"Get-CimInstance Win32_Process -Filter \"{filter}\" | Select-Object ProcessId,CommandLine | ConvertTo-Json -Compress";
+    }
+
+    private static bool CommandLineLookupFailed(Exception exception, CancellationToken cancellationToken) =>
+        exception is InvalidOperationException or JsonException or System.ComponentModel.Win32Exception
+        || (exception is OperationCanceledException && !cancellationToken.IsCancellationRequested);
+
+    private static async Task<string> RunPowerShell(string command, CancellationToken cancellationToken)
+    {
+        using var process = new System.Diagnostics.Process
+        {
+            StartInfo = ProcessUtil.CreateStartInfo("powershell.exe"),
+        };
+        process.StartInfo.RedirectStandardOutput = true;
+        process.StartInfo.RedirectStandardError = true;
+        process.StartInfo.ArgumentList.Add("-NoProfile");
+        process.StartInfo.ArgumentList.Add("-NonInteractive");
+        process.StartInfo.ArgumentList.Add("-Command");
+        process.StartInfo.ArgumentList.Add(command);
+
+        process.Start();
+        var stdout = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var stderr = process.StandardError.ReadToEndAsync(cancellationToken);
+        await process.WaitForExitAsync(cancellationToken);
+
+        if (process.ExitCode != 0)
+            throw new InvalidOperationException($"command 'powershell.exe' failed: {await stderr}");
+
+        return await stdout;
     }
 
     [LibraryImport("iphlpapi.dll", SetLastError = true)]

--- a/src/cli/app-manager/Studioctl/Endpoints.cs
+++ b/src/cli/app-manager/Studioctl/Endpoints.cs
@@ -37,7 +37,10 @@ internal static class Endpoints
                             app.BaseUri.ToString(),
                             app.Source,
                             app.ProcessId,
-                            app.Description
+                            app.Description,
+                            app.ContainerId,
+                            app.Name,
+                            app.HostPort
                         )),
                 ]
             )
@@ -56,10 +59,10 @@ internal static class Endpoints
         var result = await registerApp.Handle(
             new RegisterAppCommand(
                 request.AppId,
-                request.Port,
                 request.ProcessId,
-                request.Description,
-                TimeSpan.FromSeconds(request.GracePeriodSeconds)
+                TimeSpan.FromSeconds(request.TimeoutSeconds),
+                request.ContainerId,
+                request.HostPort
             ),
             cancellationToken
         );
@@ -75,22 +78,12 @@ internal static class Endpoints
         };
     }
 
-    private static IResult UnregisterApp(UnregisterApp unregisterApp, string? appId, string? baseUrl)
+    private static IResult UnregisterApp(UnregisterApp unregisterApp, string? appId)
     {
-        if (
-            string.IsNullOrWhiteSpace(baseUrl)
-            || !Uri.TryCreate(baseUrl, UriKind.Absolute, out var baseUri)
-            || (baseUri.Scheme != Uri.UriSchemeHttp && baseUri.Scheme != Uri.UriSchemeHttps)
-        )
-        {
-            return Results.BadRequest(new CommandResponse("baseUrl must be an absolute http or https URL"));
-        }
-
-        var result = unregisterApp.Handle(appId, baseUri);
+        var result = unregisterApp.Handle(appId);
         return result.Kind switch
         {
             UnregisterAppResultKind.Unregistered => Results.Accepted(value: new CommandResponse(result.Message)),
-            UnregisterAppResultKind.InvalidRequest => Results.BadRequest(new CommandResponse(result.Message)),
             _ => Results.StatusCode(StatusCodes.Status500InternalServerError),
         };
     }
@@ -129,10 +122,10 @@ internal static class Endpoints
 
     private sealed record RegisterAppRequest(
         string AppId,
-        int? Port,
         int? ProcessId,
-        string? Description,
-        int GracePeriodSeconds
+        int TimeoutSeconds,
+        string? ContainerId,
+        int? HostPort
     );
 
     private sealed record RegisterAppResponse(string Message, string BaseUrl);
@@ -142,7 +135,10 @@ internal static class Endpoints
         string BaseUrl,
         string Source,
         int? ProcessId,
-        string Description
+        string Description,
+        string? ContainerId,
+        string? Name,
+        int? HostPort
     );
 
     private sealed record CommandResponse(string Message);

--- a/src/cli/app-manager/Studioctl/RegisterApp.cs
+++ b/src/cli/app-manager/Studioctl/RegisterApp.cs
@@ -1,21 +1,14 @@
 using Altinn.Studio.AppManager.Discovery;
-using Altinn.Studio.AppManager.Platform.PortListeners;
 
 namespace Altinn.Studio.AppManager.Studioctl;
 
 internal sealed class RegisterApp
 {
-    private static readonly TimeSpan _pollInterval = TimeSpan.FromMilliseconds(500);
-
     private readonly AppRegistry _registry;
-    private readonly PortListeners _portListeners;
-    private readonly AppMetadataProbe _probe;
 
-    public RegisterApp(AppRegistry registry, PortListeners portListeners, AppMetadataProbe probe)
+    public RegisterApp(AppRegistry registry)
     {
         _registry = registry;
-        _portListeners = portListeners;
-        _probe = probe;
     }
 
     public async Task<RegisterAppResult> Handle(RegisterAppCommand command, CancellationToken cancellationToken)
@@ -23,95 +16,44 @@ internal sealed class RegisterApp
         if (string.IsNullOrWhiteSpace(command.AppId))
             return RegisterAppResult.InvalidRequest("appId is required");
 
-        if (command.GracePeriod <= TimeSpan.Zero)
-            return RegisterAppResult.InvalidRequest("gracePeriodSeconds must be positive");
+        if (command.Timeout <= TimeSpan.Zero)
+            return RegisterAppResult.InvalidRequest("timeoutSeconds must be positive");
 
-        var appId = command.AppId.Trim();
-        var description = string.IsNullOrWhiteSpace(command.Description)
-            ? $"studioctl app {appId}"
-            : command.Description;
-
-        var hasPort = command.Port.HasValue;
+        var hasPort = command.HostPort.HasValue;
         var hasProcessId = command.ProcessId.HasValue;
-        if (hasPort == hasProcessId)
-            return RegisterAppResult.InvalidRequest("exactly one of port or processId is required");
-
-        if (command.Port is { } port)
-        {
-            if (!AppEndpointUri.TryLoopbackHttp(port, out var baseUri) || baseUri is null)
-                return RegisterAppResult.InvalidRequest("port must be in range 1-65535");
-
-            return await WaitForMatchingApp(
-                appId,
-                _ => Task.FromResult<IReadOnlyList<Uri>>([baseUri]),
-                description,
-                command.GracePeriod,
-                cancellationToken
-            );
-        }
-
-        if (command.ProcessId is not { } processId || processId <= 0)
+        if (!hasPort && !hasProcessId)
+            return RegisterAppResult.InvalidRequest("hostPort or processId is required");
+        if (command.ProcessId is <= 0)
             return RegisterAppResult.InvalidRequest("processId must be positive");
 
-        return await WaitForMatchingApp(
-            appId,
-            token => ProcessListenerUris(processId, token),
-            description,
-            command.GracePeriod,
-            cancellationToken
-        );
-    }
+        if (command.HostPort is { } hostPort && !AppEndpointUri.TryLoopbackHttp(hostPort, out _))
+            return RegisterAppResult.InvalidRequest("hostPort must be in range 1-65535");
 
-    private async Task<RegisterAppResult> WaitForMatchingApp(
-        string appId,
-        Func<CancellationToken, Task<IReadOnlyList<Uri>>> candidateUris,
-        string description,
-        TimeSpan gracePeriod,
-        CancellationToken cancellationToken
-    )
-    {
-        var deadline = TimeProvider.System.GetUtcNow() + gracePeriod;
-        while (true)
+        try
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            foreach (var baseUri in await candidateUris(cancellationToken))
-            {
-                var resolvedAppId = await _probe.Probe(baseUri, cancellationToken);
-                if (!string.Equals(resolvedAppId, appId, StringComparison.OrdinalIgnoreCase))
-                    continue;
-
-                _registry.Register(appId, baseUri, description, gracePeriod);
-                return RegisterAppResult.Registered(baseUri);
-            }
-
-            var delay = deadline - TimeProvider.System.GetUtcNow();
-            if (delay <= TimeSpan.Zero)
-                return RegisterAppResult.NotFound("matching app endpoint not found");
-
-            await Task.Delay(delay < _pollInterval ? delay : _pollInterval, cancellationToken);
+            var baseUri = await _registry.AppStarted(
+                command.AppId.Trim(),
+                command.ProcessId,
+                command.ContainerId,
+                command.HostPort,
+                command.Timeout,
+                cancellationToken
+            );
+            return RegisterAppResult.Registered(baseUri);
         }
-    }
-
-    private async Task<IReadOnlyList<Uri>> ProcessListenerUris(int processId, CancellationToken cancellationToken)
-    {
-        var listeners = await _portListeners.Get(cancellationToken);
-        var uris = new List<Uri>();
-        foreach (var listener in listeners.Where(listener => listener.ProcessId == processId))
+        catch (TimeoutException ex)
         {
-            if (AppEndpointUri.TryFromListener(listener, out var baseUri) && baseUri is not null)
-                uris.Add(baseUri);
+            return RegisterAppResult.NotFound(ex.Message);
         }
-
-        return uris;
     }
 }
 
 internal sealed record RegisterAppCommand(
     string? AppId,
-    int? Port,
     int? ProcessId,
-    string? Description,
-    TimeSpan GracePeriod
+    TimeSpan Timeout,
+    string? ContainerId,
+    int? HostPort
 );
 
 internal sealed record RegisterAppResult(RegisterAppResultKind Kind, Uri? BaseUri, string Message)

--- a/src/cli/app-manager/Studioctl/UnregisterApp.cs
+++ b/src/cli/app-manager/Studioctl/UnregisterApp.cs
@@ -11,12 +11,9 @@ internal sealed class UnregisterApp
         _registry = registry;
     }
 
-    public UnregisterAppResult Handle(string? appId, Uri baseUri)
+    public UnregisterAppResult Handle(string? appId)
     {
-        if (string.IsNullOrWhiteSpace(appId))
-            return UnregisterAppResult.InvalidRequest("appId is required");
-
-        _registry.Unregister(appId.Trim(), baseUri);
+        _registry.AppStopped(appId);
         return UnregisterAppResult.Unregistered();
     }
 }
@@ -24,13 +21,9 @@ internal sealed class UnregisterApp
 internal sealed record UnregisterAppResult(UnregisterAppResultKind Kind, string Message)
 {
     public static UnregisterAppResult Unregistered() => new(UnregisterAppResultKind.Unregistered, "app unregistered");
-
-    public static UnregisterAppResult InvalidRequest(string message) =>
-        new(UnregisterAppResultKind.InvalidRequest, message);
 }
 
 internal enum UnregisterAppResultKind
 {
     Unregistered,
-    InvalidRequest,
 }

--- a/src/cli/app-manager/Tunnel/LoadBalancer.cs
+++ b/src/cli/app-manager/Tunnel/LoadBalancer.cs
@@ -1,0 +1,30 @@
+using System.Collections.Concurrent;
+using Altinn.Studio.AppManager.Discovery;
+
+namespace Altinn.Studio.AppManager.Tunnel;
+
+internal sealed class LoadBalancer
+{
+    private readonly ConcurrentDictionary<string, RoundRobinState> _roundRobinStates = new(
+        StringComparer.OrdinalIgnoreCase
+    );
+
+    public DiscoveredApp? Next(string appId, IReadOnlyList<DiscoveredApp> apps)
+    {
+        if (apps.Count == 0)
+            return null;
+
+        var state = _roundRobinStates.GetOrAdd(appId, static _ => new RoundRobinState());
+        return apps[state.Next(apps.Count)];
+    }
+
+    private sealed class RoundRobinState
+    {
+        private int _next = -1;
+
+        public int Next(int count)
+        {
+            return (int)((uint)Interlocked.Increment(ref _next) % (uint)count);
+        }
+    }
+}

--- a/src/cli/app-manager/Tunnel/ServiceCollectionExtensions.cs
+++ b/src/cli/app-manager/Tunnel/ServiceCollectionExtensions.cs
@@ -37,6 +37,7 @@ internal static class ServiceCollectionExtensions
             });
         services.AddSingleton(sp => sp.GetRequiredService<IOptions<TunnelOptions>>().Value);
         services.AddSingleton<TunnelState>();
+        services.AddSingleton<LoadBalancer>();
         services.AddHostedService<TunnelWorker>();
         return services;
     }

--- a/src/cli/app-manager/Tunnel/TunnelWorker.cs
+++ b/src/cli/app-manager/Tunnel/TunnelWorker.cs
@@ -26,13 +26,15 @@ internal sealed class TunnelWorker : BackgroundService
     private readonly TunnelOptions _options;
     private readonly TunnelState _state;
     private readonly ILogger<TunnelWorker> _logger;
+    private readonly LoadBalancer _loadBalancer;
 
     public TunnelWorker(
         IHttpClientFactory httpClientFactory,
         Discovery.AppRegistry appRegistry,
         IOptions<TunnelOptions> options,
         TunnelState state,
-        ILogger<TunnelWorker> logger
+        ILogger<TunnelWorker> logger,
+        LoadBalancer loadBalancer
     )
     {
         _httpClientFactory = httpClientFactory;
@@ -40,6 +42,7 @@ internal sealed class TunnelWorker : BackgroundService
         _options = options.Value;
         _state = state;
         _logger = logger;
+        _loadBalancer = loadBalancer;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -454,8 +457,9 @@ internal sealed class TunnelWorker : BackgroundService
         if (string.IsNullOrWhiteSpace(pendingRequest.AppId))
             return LocalFallbackUpstreamUri;
 
-        if (_appRegistry.TryGet(pendingRequest.AppId, out var app) && app is not null)
-            return app.BaseUri;
+        var apps = _appRegistry.GetByAppId(pendingRequest.AppId);
+        if (_loadBalancer.Next(pendingRequest.AppId, apps) is { } app)
+            return app.BaseUri.Value;
 
         return null;
     }

--- a/src/cli/internal/appmanager/client.go
+++ b/src/cli/internal/appmanager/client.go
@@ -76,10 +76,13 @@ type TunnelStatus struct {
 // DiscoveredApp describes one discovered app endpoint.
 type DiscoveredApp struct {
 	ProcessID   *int   `json:"processId"`
+	HostPort    *int   `json:"hostPort,omitempty"`
 	AppID       string `json:"appId"`
 	BaseURL     string `json:"baseUrl"`
 	Source      string `json:"source"`
 	Description string `json:"description"`
+	Name        string `json:"name,omitempty"`
+	ContainerID string `json:"containerId,omitempty"`
 }
 
 var (
@@ -106,11 +109,11 @@ type Client struct {
 
 // AppRegistration describes an app endpoint registered explicitly by studioctl.
 type AppRegistration struct {
-	AppID              string `json:"appId"`
-	Description        string `json:"description,omitempty"`
-	Port               int    `json:"port,omitempty"`
-	ProcessID          int    `json:"processId,omitempty"`
-	GracePeriodSeconds int    `json:"gracePeriodSeconds"`
+	AppID          string `json:"appId"`
+	ContainerID    string `json:"containerId,omitempty"`
+	HostPort       int    `json:"hostPort,omitempty"`
+	ProcessID      int    `json:"processId,omitempty"`
+	TimeoutSeconds int    `json:"timeoutSeconds"`
 }
 
 // NewClient constructs an app-manager control-plane client.
@@ -125,10 +128,10 @@ func NewClient(cfg *config.Config) *Client {
 }
 
 func appRegistrationTimeout(registration AppRegistration) time.Duration {
-	if registration.GracePeriodSeconds <= 0 {
+	if registration.TimeoutSeconds <= 0 {
 		return appManagerRegisterTimeoutMargin
 	}
-	return time.Duration(registration.GracePeriodSeconds)*time.Second + appManagerRegisterTimeoutMargin
+	return time.Duration(registration.TimeoutSeconds)*time.Second + appManagerRegisterTimeoutMargin
 }
 
 // Shutdown stops app-manager and returns a completion channel that resolves when shutdown is fully complete.
@@ -216,10 +219,13 @@ func (c *Client) Status(ctx context.Context) (*Status, error) {
 		} `json:"tunnel"`
 		Apps []struct {
 			ProcessID   *int   `json:"processId"`
+			HostPort    *int   `json:"hostPort"`
 			AppID       string `json:"appId"`
 			BaseURL     string `json:"baseUrl"`
 			Source      string `json:"source"`
 			Description string `json:"description"`
+			Name        string `json:"name"`
+			ContainerID string `json:"containerId"`
 		} `json:"apps"`
 		ProcessID   int  `json:"processId"`
 		InternalDev bool `json:"internalDev"`
@@ -247,7 +253,10 @@ func (c *Client) Status(ctx context.Context) (*Status, error) {
 			BaseURL:     app.BaseURL,
 			Source:      app.Source,
 			ProcessID:   app.ProcessID,
+			HostPort:    app.HostPort,
 			Description: app.Description,
+			Name:        app.Name,
+			ContainerID: app.ContainerID,
 		})
 	}
 
@@ -302,15 +311,12 @@ func (c *Client) RegisterApp(ctx context.Context, registration AppRegistration) 
 	return result.BaseURL, nil
 }
 
-// UnregisterApp removes an app endpoint explicitly registered with app-manager.
-func (c *Client) UnregisterApp(ctx context.Context, appID, baseURL string) error {
-	values := url.Values{}
-	values.Set("appId", appID)
-	values.Set("baseUrl", baseURL)
+// UnregisterApp notifies app-manager that studioctl stopped an app.
+func (c *Client) UnregisterApp(ctx context.Context, appID string) error {
 	req, err := http.NewRequestWithContext(
 		ctx,
 		http.MethodDelete,
-		controlBaseURL+registerPath+"?"+values.Encode(),
+		controlBaseURL+registerPath+"?appId="+url.QueryEscape(appID),
 		nil,
 	)
 	if err != nil {
@@ -403,7 +409,7 @@ func reconcilePersistedProcess(
 	state runtimeState,
 	desired startConfig,
 ) error {
-	running, err := isProcessRunning(state.PID)
+	running, err := osutil.ProcessRunning(state.PID)
 	if err != nil {
 		return fmt.Errorf("check persisted app-manager pid %d: %w", state.PID, err)
 	}
@@ -424,7 +430,7 @@ func reconcilePersistedProcess(
 
 func restartFromPersistedState(ctx context.Context, cfg *config.Config, desired startConfig, pid int) error {
 	if pid > 0 {
-		if err := killProcess(pid); err != nil {
+		if err := osutil.KillProcess(pid); err != nil {
 			return fmt.Errorf("stop persisted app-manager pid %d: %w", pid, err)
 		}
 	}
@@ -459,7 +465,7 @@ func restartManagedProcess(
 	}
 
 	if !waitForShutdown(ctx, client, cfg) {
-		if err := killProcess(pid); err != nil {
+		if err := osutil.KillProcess(pid); err != nil {
 			return fmt.Errorf("kill app-manager after shutdown timeout: %w", err)
 		}
 		if err := removeAppManagerState(cfg); err != nil {
@@ -527,7 +533,7 @@ func startProcess(ctx context.Context, cfg *config.Config, startConfig startConf
 		return writeAppManagerState(cfg, runtimeState{PID: status.ProcessID, Start: startConfig})
 	}
 
-	ignoreError(killProcess(cmd.Process.Pid))
+	ignoreError(osutil.KillProcess(cmd.Process.Pid))
 	ignoreError(removeAppManagerState(cfg))
 	return err
 }
@@ -627,12 +633,12 @@ func stopPersistedProcess(cfg *config.Config, pid int) error {
 		return removePersistedAppManagerState(cfg)
 	}
 
-	running, err := isProcessRunning(pid)
+	running, err := osutil.ProcessRunning(pid)
 	if err != nil {
 		return fmt.Errorf("check app-manager pid %d: %w", pid, err)
 	}
 	if running {
-		if err := killProcess(pid); err != nil {
+		if err := osutil.KillProcess(pid); err != nil {
 			return fmt.Errorf("kill app-manager pid %d: %w", pid, err)
 		}
 	}
@@ -651,7 +657,7 @@ func managedProcessStopped(pid int) (bool, error) {
 	if pid <= 0 {
 		return true, nil
 	}
-	running, err := isProcessRunning(pid)
+	running, err := osutil.ProcessRunning(pid)
 	if err != nil {
 		return false, fmt.Errorf("check app-manager pid %d: %w", pid, err)
 	}
@@ -727,18 +733,6 @@ func writeAppManagerState(cfg *config.Config, state runtimeState) error {
 func removeAppManagerState(cfg *config.Config) error {
 	if err := os.Remove(cfg.AppManagerPIDPath()); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("remove pid file: %w", err)
-	}
-
-	return nil
-}
-
-func killProcess(pid int) error {
-	process, err := os.FindProcess(pid)
-	if err != nil {
-		return fmt.Errorf("find process: %w", err)
-	}
-	if err := process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
-		return fmt.Errorf("kill process: %w", err)
 	}
 
 	return nil

--- a/src/cli/internal/cmd/app.go
+++ b/src/cli/internal/cmd/app.go
@@ -24,7 +24,9 @@ import (
 // AppCommand implements the 'app' subcommand.
 type AppCommand struct {
 	out     *ui.Output
+	ps      *AppPsCommand
 	run     *RunCommand
+	stop    *StopCommand
 	service *appsvc.Service
 }
 
@@ -65,7 +67,9 @@ func NewAppCommand(cfg *config.Config, out *ui.Output) *AppCommand {
 	service := appsvc.NewService(cfg.Home)
 	return &AppCommand{
 		out:     out,
+		ps:      newAppPsCommand(cfg, out, service),
 		run:     newRunCommand(cfg, out, service),
+		stop:    newStopCommand(cfg, out, service),
 		service: service,
 	}
 }
@@ -86,7 +90,9 @@ func (c *AppCommand) Usage() string {
 		"Subcommands:",
 		"  build     Build an app container image",
 		"  clone     Clone an app repository from Altinn Studio",
+		"  ps        List running apps",
 		"  run       Run app locally",
+		"  stop      Stop running apps",
 		"  update    Update Altinn.App NuGet packages and frontend",
 		"",
 		fmt.Sprintf("Run '%s app <subcommand> --help' for more information.", osutil.CurrentBin()),
@@ -108,8 +114,12 @@ func (c *AppCommand) Run(ctx context.Context, args []string) error {
 		return c.runBuild(ctx, subArgs)
 	case "clone":
 		return c.runClone(ctx, subArgs)
+	case "ps":
+		return c.ps.RunWithCommandPath(ctx, subArgs, "app ps")
 	case "run":
 		return c.run.RunWithCommandPath(ctx, subArgs, "app run")
+	case "stop":
+		return c.stop.RunWithCommandPath(ctx, subArgs, "app stop")
 	case "update":
 		return c.runUpdate(ctx, subArgs)
 	case "-h", flagHelp, helpSubcmd:

--- a/src/cli/internal/cmd/app_manager_access.go
+++ b/src/cli/internal/cmd/app_manager_access.go
@@ -124,13 +124,6 @@ func shortContainerID(containerID string) string {
 	return containerID[:shortContainerIDLength]
 }
 
-func appName(app appmanager.DiscoveredApp) string {
-	if app.Name != "" {
-		return app.Name
-	}
-	return "-"
-}
-
 func appPortNumber(app appmanager.DiscoveredApp) int {
 	if app.HostPort != nil && *app.HostPort > 0 {
 		return *app.HostPort

--- a/src/cli/internal/cmd/app_manager_access.go
+++ b/src/cli/internal/cmd/app_manager_access.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 	"sort"
@@ -36,15 +35,6 @@ func newAppManagerAccess(cfg *config.Config) appManagerAccess {
 }
 
 func (a appManagerAccess) ensure(ctx context.Context) error {
-	if a.client != nil {
-		_, err := a.client.Status(ctx)
-		if err == nil {
-			return nil
-		}
-		if !errors.Is(err, appmanager.ErrNotRunning) {
-			return fmt.Errorf("get app-manager status: %w", err)
-		}
-	}
 	if a.ensureStarted == nil {
 		return nil
 	}

--- a/src/cli/internal/cmd/app_manager_access.go
+++ b/src/cli/internal/cmd/app_manager_access.go
@@ -1,0 +1,162 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+
+	"altinn.studio/studioctl/internal/appmanager"
+	envlocaltest "altinn.studio/studioctl/internal/cmd/env/localtest"
+	"altinn.studio/studioctl/internal/config"
+)
+
+type appRuntimeClient interface {
+	Status(ctx context.Context) (*appmanager.Status, error)
+	UnregisterApp(ctx context.Context, appID string) error
+}
+
+type appManagerAccess struct {
+	cfg           *config.Config
+	client        appRuntimeClient
+	ensureStarted ensureStartedFunc
+}
+
+const shortContainerIDLength = 12
+
+func newAppManagerAccess(cfg *config.Config) appManagerAccess {
+	return appManagerAccess{
+		cfg:           cfg,
+		client:        appmanager.NewClient(cfg),
+		ensureStarted: appmanager.EnsureStarted,
+	}
+}
+
+func (a appManagerAccess) ensure(ctx context.Context) error {
+	if a.client != nil {
+		_, err := a.client.Status(ctx)
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, appmanager.ErrNotRunning) {
+			return fmt.Errorf("get app-manager status: %w", err)
+		}
+	}
+	if a.ensureStarted == nil {
+		return nil
+	}
+	if a.cfg == nil {
+		return errStudioctlConfigRequired
+	}
+	return a.ensureStarted(ctx, a.cfg, envlocaltest.DefaultLoadBalancerPortString())
+}
+
+func filterApps(apps []appmanager.DiscoveredApp, appID string, managedOnly bool) []appmanager.DiscoveredApp {
+	filtered := make([]appmanager.DiscoveredApp, 0, len(apps))
+	for _, app := range apps {
+		if appID != "" && !strings.EqualFold(app.AppID, appID) {
+			continue
+		}
+		if managedOnly && !hasStopHandle(app) {
+			continue
+		}
+		filtered = append(filtered, app)
+	}
+	return filtered
+}
+
+func sortDiscoveredApps(apps []appmanager.DiscoveredApp) []appmanager.DiscoveredApp {
+	sort.Slice(apps, func(i, j int) bool {
+		if apps[i].AppID != apps[j].AppID {
+			return apps[i].AppID < apps[j].AppID
+		}
+		return apps[i].BaseURL < apps[j].BaseURL
+	})
+	return apps
+}
+
+func hasStopHandle(app appmanager.DiscoveredApp) bool {
+	return appProcessID(app) > 0 || app.ContainerID != "" || app.Name != ""
+}
+
+func appMode(app appmanager.DiscoveredApp) string {
+	if appHasContainerHandle(app) {
+		return runModeContainer
+	}
+	if appProcessID(app) > 0 {
+		return runModeProcess
+	}
+	return app.Source
+}
+
+func appStopMode(app appmanager.DiscoveredApp) string {
+	if appHasContainerHandle(app) {
+		return runModeContainer
+	}
+	if appProcessID(app) > 0 {
+		return runModeProcess
+	}
+	return app.Source
+}
+
+func appHasContainerHandle(app appmanager.DiscoveredApp) bool {
+	return app.ContainerID != "" || (app.Name != "" && appProcessID(app) == 0)
+}
+
+func appProcessID(app appmanager.DiscoveredApp) int {
+	if app.ProcessID != nil {
+		return *app.ProcessID
+	}
+	return 0
+}
+
+func pidString(pid int) string {
+	if pid <= 0 {
+		return "-"
+	}
+	return strconv.Itoa(pid)
+}
+
+func appRuntimeID(app appmanager.DiscoveredApp) string {
+	if app.ContainerID != "" {
+		return shortContainerID(app.ContainerID)
+	}
+	return pidString(appProcessID(app))
+}
+
+func shortContainerID(containerID string) string {
+	if len(containerID) <= shortContainerIDLength {
+		return containerID
+	}
+	return containerID[:shortContainerIDLength]
+}
+
+func appName(app appmanager.DiscoveredApp) string {
+	if app.Name != "" {
+		return app.Name
+	}
+	return "-"
+}
+
+func appPortNumber(app appmanager.DiscoveredApp) int {
+	if app.HostPort != nil && *app.HostPort > 0 {
+		return *app.HostPort
+	}
+	if app.BaseURL != "" {
+		baseURL, err := url.Parse(app.BaseURL)
+		if err == nil && baseURL.Port() != "" {
+			port, parseErr := strconv.Atoi(baseURL.Port())
+			if parseErr == nil {
+				return port
+			}
+		}
+	}
+	return 0
+}
+
+func startAppManagerError(err error) error {
+	return fmt.Errorf("start app-manager: %w", err)
+}

--- a/src/cli/internal/cmd/ps.go
+++ b/src/cli/internal/cmd/ps.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"strconv"
 
 	"altinn.studio/studioctl/internal/appmanager"
 	appsvc "altinn.studio/studioctl/internal/cmd/app"
@@ -79,7 +80,7 @@ func (c *AppPsCommand) RunWithCommandPath(ctx context.Context, args []string, co
 	status, err := c.manager.client.Status(ctx)
 	if err != nil {
 		if errors.Is(err, appmanager.ErrNotRunning) {
-			return appPsOutput{Running: false, JSONOutput: flags.jsonOutput}.Print(c.out)
+			return appPsOutput{Apps: nil, Running: false, JSONOutput: flags.jsonOutput}.Print(c.out)
 		}
 		return fmt.Errorf("get app-manager status: %w", err)
 	}
@@ -184,5 +185,5 @@ func tablePort(port int) string {
 	if port <= 0 {
 		return "-"
 	}
-	return fmt.Sprint(port)
+	return strconv.Itoa(port)
 }

--- a/src/cli/internal/cmd/ps.go
+++ b/src/cli/internal/cmd/ps.go
@@ -1,0 +1,188 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+
+	"altinn.studio/studioctl/internal/appmanager"
+	appsvc "altinn.studio/studioctl/internal/cmd/app"
+	"altinn.studio/studioctl/internal/config"
+	repocontext "altinn.studio/studioctl/internal/context"
+	"altinn.studio/studioctl/internal/osutil"
+	"altinn.studio/studioctl/internal/ui"
+)
+
+// AppPsCommand implements `studioctl app ps`.
+type AppPsCommand struct {
+	out     *ui.Output
+	manager appManagerAccess
+	service *appsvc.Service
+}
+
+type appPsFlags struct {
+	appPath    string
+	jsonOutput bool
+}
+
+type appPsOutput struct {
+	Apps       []appPsAppOutput `json:"apps"`
+	Running    bool             `json:"running"`
+	JSONOutput bool             `json:"-"`
+}
+
+type appPsAppOutput struct {
+	AppID string `json:"appId"`
+	Mode  string `json:"mode"`
+	ID    string `json:"id,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Port  int    `json:"port,omitempty"`
+}
+
+func newAppPsCommand(cfg *config.Config, out *ui.Output, service *appsvc.Service) *AppPsCommand {
+	return &AppPsCommand{
+		out:     out,
+		manager: newAppManagerAccess(cfg),
+		service: service,
+	}
+}
+
+// RunWithCommandPath executes ps with usage text bound to commandPath.
+func (c *AppPsCommand) RunWithCommandPath(ctx context.Context, args []string, commandPath string) error {
+	flags, help, err := c.parseFlags(args, commandPath)
+	if err != nil {
+		return err
+	}
+	if help {
+		c.out.Print(c.UsageFor(commandPath))
+		return nil
+	}
+
+	var appID string
+	if flags.appPath != "" {
+		target, targetErr := c.service.ResolveRunTarget(ctx, flags.appPath)
+		if targetErr != nil {
+			if errors.Is(targetErr, repocontext.ErrAppNotFound) {
+				return fmt.Errorf("%w: use a valid app directory with -p", ErrNoAppFound)
+			}
+			return fmt.Errorf("resolve app: %w", targetErr)
+		}
+		appID = target.AppID
+	}
+
+	if ensureErr := c.manager.ensure(ctx); ensureErr != nil {
+		return startAppManagerError(ensureErr)
+	}
+
+	status, err := c.manager.client.Status(ctx)
+	if err != nil {
+		if errors.Is(err, appmanager.ErrNotRunning) {
+			return appPsOutput{Running: false, JSONOutput: flags.jsonOutput}.Print(c.out)
+		}
+		return fmt.Errorf("get app-manager status: %w", err)
+	}
+
+	return appPsOutput{
+		Running:    true,
+		Apps:       appPsAppsOutput(sortDiscoveredApps(filterApps(status.Apps, appID, false))),
+		JSONOutput: flags.jsonOutput,
+	}.Print(c.out)
+}
+
+// UsageFor returns usage text for the supplied command path.
+func (c *AppPsCommand) UsageFor(commandPath string) string {
+	return joinLines(
+		fmt.Sprintf("Usage: %s %s [-p PATH]", osutil.CurrentBin(), commandPath),
+		"",
+		"Lists app endpoints discovered by app-manager.",
+		"",
+		"Options:",
+		"  -p, --path PATH       Filter by app directory",
+		"  --json               Output as JSON",
+		"  -h, --help           Show this help",
+	)
+}
+
+func (c *AppPsCommand) parseFlags(args []string, commandPath string) (appPsFlags, bool, error) {
+	fs := flag.NewFlagSet(commandPath, flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	var flags appPsFlags
+	fs.StringVar(&flags.appPath, "p", "", "App directory path")
+	fs.StringVar(&flags.appPath, "path", "", "App directory path")
+	fs.BoolVar(&flags.jsonOutput, "json", false, "Output as JSON")
+
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return flags, true, nil
+		}
+		return flags, false, fmt.Errorf("parsing flags: %w", err)
+	}
+	return flags, false, nil
+}
+
+func appPsAppsOutput(apps []appmanager.DiscoveredApp) []appPsAppOutput {
+	output := make([]appPsAppOutput, 0, len(apps))
+	for _, app := range apps {
+		id := appRuntimeID(app)
+		if id == "-" {
+			id = ""
+		}
+		output = append(output, appPsAppOutput{
+			AppID: app.AppID,
+			Mode:  appMode(app),
+			ID:    id,
+			Name:  app.Name,
+			Port:  appPortNumber(app),
+		})
+	}
+	return output
+}
+
+func (o appPsOutput) Print(out *ui.Output) error {
+	if o.JSONOutput {
+		return printJSONOutput(out, "app ps", o)
+	}
+	if !o.Running {
+		out.Println("app-manager is not running.")
+		return nil
+	}
+	if len(o.Apps) == 0 {
+		out.Println("No apps running.")
+		return nil
+	}
+
+	table := ui.NewTable(
+		ui.NewColumn("APP ID"),
+		ui.NewColumn("MODE"),
+		ui.NewColumn("ID").WithAlign(ui.AlignRight),
+		ui.NewColumn("NAME"),
+		ui.NewColumn("PORT").WithAlign(ui.AlignRight),
+	)
+	for _, app := range o.Apps {
+		table.TextRow(
+			app.AppID,
+			app.Mode,
+			tableDash(app.ID),
+			tableDash(app.Name),
+			tablePort(app.Port),
+		)
+	}
+	out.RenderTable(table)
+	return nil
+}
+
+func tableDash(value string) string {
+	if value == "" {
+		return "-"
+	}
+	return value
+}
+
+func tablePort(port int) string {
+	if port <= 0 {
+		return "-"
+	}
+	return fmt.Sprint(port)
+}

--- a/src/cli/internal/cmd/root.go
+++ b/src/cli/internal/cmd/root.go
@@ -55,8 +55,8 @@ func NewCLI(cfg *config.Config) *CLI {
 		commands: make(map[string]Command),
 	}
 
-	// TODO: stop command as well?
 	cli.Register(NewRunCommand(cfg, out))
+	cli.Register(NewStopCommand(cfg, out))
 	cli.Register(NewEnvCommand(cfg, out))
 	cli.Register(NewAuthCommand(cfg, out))
 	cli.Register(NewDoctorCommand(cfg, out))
@@ -123,7 +123,7 @@ func (c *CLI) printUsage() {
 		}
 	}
 
-	order := []string{"run", "env", "auth", "app", "install", "doctor", "self", "servers", "shell"}
+	order := []string{"run", "stop", "env", "auth", "app", "install", "doctor", "self", "servers", "shell"}
 	for _, name := range order {
 		if cmd, ok := c.commands[name]; ok {
 			c.out.Printlnf("  %-*s  %s", maxLen+2, name, cmd.Synopsis())

--- a/src/cli/internal/cmd/root_test.go
+++ b/src/cli/internal/cmd/root_test.go
@@ -203,8 +203,23 @@ func TestCLI_Run(t *testing.T) {
 			wantCode: 0,
 		},
 		{
+			name:     "stop alias exists",
+			args:     []string{"stop", "--help"},
+			wantCode: 0,
+		},
+		{
 			name:     "app run command exists",
 			args:     []string{"app", "run", "--help"},
+			wantCode: 0,
+		},
+		{
+			name:     "app ps command exists",
+			args:     []string{"app", "ps", "--help"},
+			wantCode: 0,
+		},
+		{
+			name:     "app stop command exists",
+			args:     []string{"app", "stop", "--help"},
 			wantCode: 0,
 		},
 	}

--- a/src/cli/internal/cmd/run.go
+++ b/src/cli/internal/cmd/run.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	runModeNative                     = "native"
+	runModeProcess                    = "process"
 	runModeContainer                  = "container"
 	foregroundContainerCleanupTimeout = 15 * time.Second
 	dotnetShutdownTimeout             = 10 * time.Second
@@ -90,7 +90,7 @@ func (c *RunCommand) UsageFor(commandPath string) string {
 		"",
 		"Options:",
 		"  -p, --path PATH       Specify app directory (overrides auto-detect)",
-		"  -m, --mode MODE       Run mode: native or container (default: native)",
+		"  -m, --mode MODE       Run mode: process or container (default: process)",
 		"  -d, --detach          Run app in background",
 		"  --random-host-port    Use a random host port",
 		"  --image-tag IMAGE     Use a specific app container image tag (container mode)",
@@ -113,22 +113,22 @@ type runFlags struct {
 }
 
 type runDetachedOutput struct {
-	AppID         string `json:"appId"`
-	Mode          string `json:"mode"`
-	URL           string `json:"url"`
-	LogPath       string `json:"logPath,omitempty"`
-	ContainerID   string `json:"containerId,omitempty"`
-	ContainerName string `json:"containerName,omitempty"`
-	ProcessID     int    `json:"processId,omitempty"`
-	HostPort      int    `json:"hostPort,omitempty"`
-	JSONOutput    bool   `json:"-"`
+	AppID       string `json:"appId"`
+	Mode        string `json:"mode"`
+	URL         string `json:"url"`
+	LogPath     string `json:"logPath,omitempty"`
+	ContainerID string `json:"containerId,omitempty"`
+	Name        string `json:"name,omitempty"`
+	ProcessID   int    `json:"processId,omitempty"`
+	HostPort    int    `json:"hostPort,omitempty"`
+	JSONOutput  bool   `json:"-"`
 }
 
 func (o runDetachedOutput) Print(out *ui.Output) error {
 	if o.JSONOutput {
 		return printJSONOutput(out, "run", o)
 	}
-	if o.Mode != runModeNative {
+	if o.Mode != runModeProcess {
 		return nil
 	}
 	out.Printlnf("App running in background.")
@@ -179,8 +179,8 @@ func (c *RunCommand) parseRunFlags(args []string, commandPath string) (runFlags,
 	var flags runFlags
 	fs.StringVar(&flags.appPath, "p", "", "App directory path")
 	fs.StringVar(&flags.appPath, "path", "", "App directory path")
-	fs.StringVar(&flags.mode, "m", runModeNative, "Run mode")
-	fs.StringVar(&flags.mode, "mode", runModeNative, "Run mode")
+	fs.StringVar(&flags.mode, "m", runModeProcess, "Run mode")
+	fs.StringVar(&flags.mode, "mode", runModeProcess, "Run mode")
 	fs.StringVar(&flags.imageTag, "image-tag", "", "App container image tag")
 	fs.BoolVar(&flags.detach, "d", false, "Run app in background")
 	fs.BoolVar(&flags.detach, "detach", false, "Run app in background")
@@ -214,7 +214,7 @@ func (c *RunCommand) parseRunFlags(args []string, commandPath string) (runFlags,
 }
 
 func validateRunFlags(flags runFlags) error {
-	if flags.mode != runModeNative && flags.mode != runModeContainer {
+	if flags.mode != runModeProcess && flags.mode != runModeContainer {
 		return fmt.Errorf("%w: %s", ErrUnsupportedRuntime, flags.mode)
 	}
 	if flags.jsonOutput && !flags.detach {
@@ -241,7 +241,7 @@ func (c *RunCommand) runTarget(
 	flags runFlags,
 ) error {
 	switch flags.mode {
-	case runModeNative:
+	case runModeProcess:
 		return c.runDotnet(ctx, target, dotnetArgs, flags)
 	case runModeContainer:
 		return c.runDocker(ctx, target, dotnetArgs, flags)
@@ -260,7 +260,7 @@ func (c *RunCommand) runDotnet(ctx context.Context, target appsvc.RunTarget, arg
 		appsvc.DotnetRunOptions{RandomHostPort: flags.randomHostPort},
 	)
 	if specErr != nil {
-		return fmt.Errorf("build native run spec: %w", specErr)
+		return fmt.Errorf("build process run spec: %w", specErr)
 	}
 
 	if err := c.buildDotnetApp(ctx, spec, flags.jsonOutput); err != nil {
@@ -292,24 +292,25 @@ func (c *RunCommand) runDotnet(ctx context.Context, target appsvc.RunTarget, arg
 		waitErr <- cmd.Wait()
 	}()
 
-	baseURL, err := c.registerStartedDotnetApp(ctx, target, spec, cmd, waitErr, flags)
+	processName := filepath.Base(targetPath)
+	baseURL, err := c.registerStartedDotnetApp(ctx, target, spec, cmd, waitErr, processName, logPath, flags)
 	if err != nil {
 		return err
 	}
 	if flags.detach {
 		return runDetachedOutput{
-			AppID:         target.AppID,
-			Mode:          runModeNative,
-			URL:           baseURL,
-			LogPath:       logPath,
-			ContainerID:   "",
-			ContainerName: "",
-			ProcessID:     cmd.Process.Pid,
-			HostPort:      0,
-			JSONOutput:    flags.jsonOutput,
+			AppID:       target.AppID,
+			Mode:        runModeProcess,
+			URL:         baseURL,
+			LogPath:     logPath,
+			ContainerID: "",
+			Name:        processName,
+			ProcessID:   cmd.Process.Pid,
+			HostPort:    0,
+			JSONOutput:  flags.jsonOutput,
 		}.Print(c.out)
 	}
-	defer c.unregisterAppBestEffort(ctx, target.AppID, baseURL)
+	defer c.unregisterAppBestEffort(ctx, target.AppID)
 
 	select {
 	case err := <-waitErr:
@@ -360,9 +361,25 @@ func (c *RunCommand) registerStartedDotnetApp(
 	spec appsvc.DotnetRunSpec,
 	cmd *exec.Cmd,
 	waitErr chan error,
+	processName string,
+	logPath string,
 	flags runFlags,
 ) (string, error) {
 	monitor := processReadinessMonitor(waitErr)
+	runInfo := nativeAppRunInfo(cmd.Process.Pid)
+	return c.registerStartedDotnetAppWithRunInfo(ctx, target, spec, cmd, waitErr, monitor, runInfo, flags)
+}
+
+func (c *RunCommand) registerStartedDotnetAppWithRunInfo(
+	ctx context.Context,
+	target appsvc.RunTarget,
+	spec appsvc.DotnetRunSpec,
+	cmd *exec.Cmd,
+	waitErr chan error,
+	monitor readinessMonitor,
+	runInfo appmanager.AppRegistration,
+	flags runFlags,
+) (string, error) {
 	var baseURL string
 	var registerErr error
 	if flags.randomHostPort {
@@ -370,11 +387,19 @@ func (c *RunCommand) registerStartedDotnetApp(
 			ctx,
 			target.AppID,
 			cmd.Process.Pid,
+			runInfo,
 			monitor,
 			flags.jsonOutput,
 		)
 	} else {
-		baseURL, registerErr = c.registerPortAndWaitForApp(ctx, target.AppID, spec.Port, monitor, flags.jsonOutput)
+		baseURL, registerErr = c.registerPortAndWaitForApp(
+			ctx,
+			target.AppID,
+			spec.Port,
+			runInfo,
+			monitor,
+			flags.jsonOutput,
+		)
 	}
 	if registerErr != nil {
 		stopDotnetProcess(cmd.Process, waitErr)
@@ -472,6 +497,16 @@ func closeDetachedAppLog(out *ui.Output, logFile *os.File) {
 	}
 }
 
+func nativeAppRunInfo(processID int) appmanager.AppRegistration {
+	return appmanager.AppRegistration{
+		AppID:          "",
+		ContainerID:    "",
+		HostPort:       0,
+		ProcessID:      processID,
+		TimeoutSeconds: 0,
+	}
+}
+
 func stopDotnetProcess(process *os.Process, waitErr <-chan error) {
 	signalProcessBestEffort(process, os.Interrupt)
 	select {
@@ -538,6 +573,7 @@ func (c *RunCommand) registerPortAndWaitForApp(
 	ctx context.Context,
 	appID string,
 	port int,
+	runInfo appmanager.AppRegistration,
 	monitor readinessMonitor,
 	jsonOutput bool,
 ) (string, error) {
@@ -549,7 +585,7 @@ func (c *RunCommand) registerPortAndWaitForApp(
 	}
 
 	client := appmanager.NewClient(c.cfg)
-	baseURL, err := registerPortAppWithStartupMonitor(ctx, client, appID, port, monitor)
+	baseURL, err := registerPortAppWithStartupMonitor(ctx, client, appID, port, runInfo, monitor)
 	if err != nil {
 		return "", err
 	}
@@ -565,18 +601,21 @@ func registerPortAppWithStartupMonitor(
 	client *appmanager.Client,
 	appID string,
 	port int,
+	runInfo appmanager.AppRegistration,
 	monitor readinessMonitor,
 ) (string, error) {
+	registration := appmanager.AppRegistration{
+		AppID:          appID,
+		ContainerID:    "",
+		HostPort:       port,
+		ProcessID:      0,
+		TimeoutSeconds: int(appStartupTimeout.Seconds()),
+	}
+	applyAppRunInfo(&registration, runInfo)
 	return registerAppWithStartupMonitor(
 		ctx,
 		client,
-		appmanager.AppRegistration{
-			AppID:              appID,
-			Port:               port,
-			ProcessID:          0,
-			GracePeriodSeconds: int(appStartupTimeout.Seconds()),
-			Description:        "studioctl run " + appID,
-		},
+		registration,
 		monitor,
 		portAppRegistrationTimeoutError(appID, port),
 	)
@@ -596,6 +635,7 @@ func (c *RunCommand) registerContainerAndWaitForApp(
 	ctx context.Context,
 	appID string,
 	hostPort int,
+	runInfo appmanager.AppRegistration,
 	monitor readinessMonitor,
 	jsonOutput bool,
 ) (string, error) {
@@ -607,7 +647,7 @@ func (c *RunCommand) registerContainerAndWaitForApp(
 	}
 
 	client := appmanager.NewClient(c.cfg)
-	baseURL, err := registerPortAppWithStartupMonitor(ctx, client, appID, hostPort, monitor)
+	baseURL, err := registerPortAppWithStartupMonitor(ctx, client, appID, hostPort, runInfo, monitor)
 	if err != nil {
 		return "", err
 	}
@@ -622,6 +662,7 @@ func (c *RunCommand) registerProcessAndWaitForApp(
 	ctx context.Context,
 	appID string,
 	processID int,
+	runInfo appmanager.AppRegistration,
 	monitor readinessMonitor,
 	jsonOutput bool,
 ) (string, error) {
@@ -633,7 +674,7 @@ func (c *RunCommand) registerProcessAndWaitForApp(
 	}
 
 	client := appmanager.NewClient(c.cfg)
-	baseURL, err := registerProcessAppWithStartupMonitor(ctx, client, appID, processID, monitor)
+	baseURL, err := registerProcessAppWithStartupMonitor(ctx, client, appID, processID, runInfo, monitor)
 	if err != nil {
 		return "", err
 	}
@@ -649,21 +690,34 @@ func registerProcessAppWithStartupMonitor(
 	client *appmanager.Client,
 	appID string,
 	processID int,
+	runInfo appmanager.AppRegistration,
 	monitor readinessMonitor,
 ) (string, error) {
+	registration := appmanager.AppRegistration{
+		AppID:          appID,
+		ContainerID:    "",
+		HostPort:       0,
+		ProcessID:      processID,
+		TimeoutSeconds: int(appStartupTimeout.Seconds()),
+	}
+	applyAppRunInfo(&registration, runInfo)
 	return registerAppWithStartupMonitor(
 		ctx,
 		client,
-		appmanager.AppRegistration{
-			AppID:              appID,
-			Port:               0,
-			ProcessID:          processID,
-			GracePeriodSeconds: int(appStartupTimeout.Seconds()),
-			Description:        "studioctl run " + appID,
-		},
+		registration,
 		monitor,
 		processAppRegistrationTimeoutError(appID, processID),
 	)
+}
+
+func applyAppRunInfo(registration *appmanager.AppRegistration, runInfo appmanager.AppRegistration) {
+	if runInfo.ProcessID > 0 {
+		registration.ProcessID = runInfo.ProcessID
+	}
+	registration.ContainerID = runInfo.ContainerID
+	if runInfo.HostPort > 0 {
+		registration.HostPort = runInfo.HostPort
+	}
 }
 
 func registerAppWithStartupMonitor(
@@ -762,7 +816,7 @@ func startupOperationError(ctx context.Context, operation string, err error) err
 	return fmt.Errorf("%s: %w", operation, err)
 }
 
-func (c *RunCommand) unregisterAppBestEffort(ctx context.Context, appID, baseURL string) {
+func (c *RunCommand) unregisterAppBestEffort(ctx context.Context, appID string) {
 	if c.cfg == nil {
 		return
 	}
@@ -770,7 +824,7 @@ func (c *RunCommand) unregisterAppBestEffort(ctx context.Context, appID, baseURL
 	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), appManagerCleanupTimeout)
 	defer cancel()
 
-	if err := appmanager.NewClient(c.cfg).UnregisterApp(cleanupCtx, appID, baseURL); err != nil {
+	if err := appmanager.NewClient(c.cfg).UnregisterApp(cleanupCtx, appID); err != nil {
 		c.out.Verbosef("failed to unregister app %s from app-manager: %v", appID, err)
 	}
 }
@@ -826,7 +880,8 @@ func (c *RunCommand) runDocker(ctx context.Context, target appsvc.RunTarget, arg
 		c.printDockerRunInfo(info)
 	}
 
-	baseURL, err := c.waitForDockerAppReady(ctx, client, containerID, info, target.AppID, flags.jsonOutput)
+	runInfo := containerAppRunInfo(containerID, info)
+	baseURL, err := c.waitForDockerAppReady(ctx, client, containerID, info, target.AppID, runInfo, flags.jsonOutput)
 	if err != nil {
 		return c.withAppContainerCleanup(ctx, client, containerID, err)
 	}
@@ -834,7 +889,7 @@ func (c *RunCommand) runDocker(ctx context.Context, target appsvc.RunTarget, arg
 	if flags.detach {
 		return c.detachedDockerOutput(target.AppID, containerID, info, baseURL, flags).Print(c.out)
 	}
-	defer c.unregisterAppBestEffort(ctx, target.AppID, baseURL)
+	defer c.unregisterAppBestEffort(ctx, target.AppID)
 
 	runErr := c.followContainer(ctx, client, containerID)
 	removeErr := c.removeForegroundContainer(ctx, client, containerID)
@@ -869,6 +924,7 @@ func (c *RunCommand) waitForDockerAppReady(
 	containerID string,
 	info containerruntime.ContainerInfo,
 	appID string,
+	runInfo appmanager.AppRegistration,
 	jsonOutput bool,
 ) (string, error) {
 	candidate, ok := appcontainers.CandidateFromContainer(info)
@@ -880,6 +936,7 @@ func (c *RunCommand) waitForDockerAppReady(
 		ctx,
 		appID,
 		candidate.HostPort,
+		runInfo,
 		containerReadinessMonitor(client, containerID),
 		jsonOutput,
 	)
@@ -897,20 +954,34 @@ func (c *RunCommand) detachedDockerOutput(
 	flags runFlags,
 ) runDetachedOutput {
 	output := runDetachedOutput{
-		AppID:         appID,
-		Mode:          runModeContainer,
-		URL:           baseURL,
-		LogPath:       "",
-		ContainerID:   containerID,
-		ContainerName: info.Name,
-		ProcessID:     0,
-		HostPort:      0,
-		JSONOutput:    flags.jsonOutput,
+		AppID:       appID,
+		Mode:        runModeContainer,
+		URL:         baseURL,
+		LogPath:     "",
+		ContainerID: containerID,
+		Name:        info.Name,
+		ProcessID:   0,
+		HostPort:    0,
+		JSONOutput:  flags.jsonOutput,
 	}
 	if candidate, ok := appcontainers.CandidateFromContainer(info); ok {
 		output.HostPort = candidate.HostPort
 	}
 	return output
+}
+
+func containerAppRunInfo(containerID string, info containerruntime.ContainerInfo) appmanager.AppRegistration {
+	runInfo := appmanager.AppRegistration{
+		AppID:          "",
+		ContainerID:    containerID,
+		HostPort:       0,
+		ProcessID:      0,
+		TimeoutSeconds: 0,
+	}
+	if candidate, ok := appcontainers.CandidateFromContainer(info); ok {
+		runInfo.HostPort = candidate.HostPort
+	}
+	return runInfo
 }
 
 func (c *RunCommand) removeForegroundContainer(

--- a/src/cli/internal/cmd/run.go
+++ b/src/cli/internal/cmd/run.go
@@ -293,7 +293,7 @@ func (c *RunCommand) runDotnet(ctx context.Context, target appsvc.RunTarget, arg
 	}()
 
 	processName := filepath.Base(targetPath)
-	baseURL, err := c.registerStartedDotnetApp(ctx, target, spec, cmd, waitErr, processName, logPath, flags)
+	baseURL, err := c.registerStartedDotnetApp(ctx, target, spec, cmd, waitErr, flags)
 	if err != nil {
 		return err
 	}
@@ -361,8 +361,6 @@ func (c *RunCommand) registerStartedDotnetApp(
 	spec appsvc.DotnetRunSpec,
 	cmd *exec.Cmd,
 	waitErr chan error,
-	processName string,
-	logPath string,
 	flags runFlags,
 ) (string, error) {
 	monitor := processReadinessMonitor(waitErr)

--- a/src/cli/internal/cmd/run_internal_test.go
+++ b/src/cli/internal/cmd/run_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	containermock "altinn.studio/devenv/pkg/container/mock"
+	"altinn.studio/devenv/pkg/container/types"
 	"altinn.studio/studioctl/internal/ui"
 )
 
@@ -101,13 +102,26 @@ func TestAppRunJSONRequiresDetach(t *testing.T) {
 	}
 }
 
+func TestParseRunFlagsUsesProcessMode(t *testing.T) {
+	t.Parallel()
+
+	cmd := &RunCommand{out: ui.NewOutput(io.Discard, io.Discard, false)}
+	flags, _, _, err := cmd.parseRunFlags([]string{"--mode", "process"}, "run")
+	if err != nil {
+		t.Fatalf("parseRunFlags() error = %v", err)
+	}
+	if flags.mode != runModeProcess {
+		t.Fatalf("mode = %q, want %q", flags.mode, runModeProcess)
+	}
+}
+
 func TestRunDetachedOutputPrintJSON(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
 	result := runDetachedOutput{
 		AppID:      "ttd/app",
-		Mode:       runModeNative,
+		Mode:       runModeProcess,
 		URL:        "http://localtest.localhost/app",
 		LogPath:    "/tmp/app.log",
 		ProcessID:  123,
@@ -124,5 +138,25 @@ func TestRunDetachedOutputPrintJSON(t *testing.T) {
 	if got.AppID != result.AppID || got.Mode != result.Mode || got.URL != result.URL ||
 		got.LogPath != result.LogPath || got.ProcessID != result.ProcessID {
 		t.Fatalf("output = %+v, want %+v", got, result)
+	}
+}
+
+func TestContainerAppRunInfoIncludesContainerHandle(t *testing.T) {
+	t.Parallel()
+
+	got := containerAppRunInfo("container-id", types.ContainerInfo{
+		ID:    "container-id",
+		Name:  "container-name",
+		State: types.ContainerState{Running: true},
+		Ports: []types.PublishedPort{
+			{
+				ContainerPort: "5005",
+				HostPort:      "5006",
+			},
+		},
+	})
+
+	if got.ContainerID != "container-id" || got.HostPort != 5006 {
+		t.Fatalf("containerAppRunInfo() = %+v, want container handle and host port", got)
 	}
 }

--- a/src/cli/internal/cmd/stop.go
+++ b/src/cli/internal/cmd/stop.go
@@ -1,0 +1,297 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+
+	containerruntime "altinn.studio/devenv/pkg/container"
+	"altinn.studio/studioctl/internal/appmanager"
+	appsvc "altinn.studio/studioctl/internal/cmd/app"
+	"altinn.studio/studioctl/internal/config"
+	repocontext "altinn.studio/studioctl/internal/context"
+	"altinn.studio/studioctl/internal/osutil"
+	"altinn.studio/studioctl/internal/ui"
+)
+
+type containerClientFactory func(context.Context) (containerruntime.ContainerClient, error)
+type stopProcessFunc func(context.Context, int) error
+
+var (
+	errAppContainerIDMissing = errors.New("app container id or name missing")
+	errAppProcessIDMissing   = errors.New("app process id missing")
+)
+
+// StopCommand implements `studioctl stop` and `studioctl app stop`.
+type StopCommand struct {
+	out             *ui.Output
+	manager         appManagerAccess
+	service         *appsvc.Service
+	containerClient containerClientFactory
+	stopProcess     stopProcessFunc
+}
+
+type appStopFlags struct {
+	appPath    string
+	all        bool
+	jsonOutput bool
+}
+
+type stoppedAppOutput struct {
+	AppID       string `json:"appId"`
+	Mode        string `json:"mode"`
+	URL         string `json:"url"`
+	ContainerID string `json:"containerId,omitempty"`
+	Name        string `json:"name,omitempty"`
+	ProcessID   int    `json:"processId,omitempty"`
+	HostPort    int    `json:"hostPort,omitempty"`
+}
+
+type appStopOutput struct {
+	Stopped    []stoppedAppOutput `json:"stopped"`
+	Running    bool               `json:"running"`
+	JSONOutput bool               `json:"-"`
+}
+
+// NewStopCommand creates a new top-level stop alias command.
+func NewStopCommand(cfg *config.Config, out *ui.Output) *StopCommand {
+	return newStopCommand(cfg, out, appsvc.NewService(cfg.Home))
+}
+
+func newStopCommand(cfg *config.Config, out *ui.Output, service *appsvc.Service) *StopCommand {
+	return &StopCommand{
+		out:             out,
+		manager:         newAppManagerAccess(cfg),
+		service:         service,
+		containerClient: containerruntime.Detect,
+		stopProcess: func(ctx context.Context, pid int) error {
+			return osutil.StopProcess(ctx, pid, dotnetShutdownTimeout)
+		},
+	}
+}
+
+// Name returns the command name.
+func (c *StopCommand) Name() string { return "stop" }
+
+// Synopsis returns a short description.
+func (c *StopCommand) Synopsis() string { return "Stop app (alias for 'app stop')" }
+
+// Usage returns the top-level stop command usage.
+func (c *StopCommand) Usage() string {
+	return c.UsageFor("stop")
+}
+
+// UsageFor returns usage text for the supplied command path.
+func (c *StopCommand) UsageFor(commandPath string) string {
+	return joinLines(
+		fmt.Sprintf("Usage: %s %s [-p PATH] [--all]", osutil.CurrentBin(), commandPath),
+		"",
+		"Stops detached Studio apps discovered by app-manager.",
+		"",
+		"Options:",
+		"  -p, --path PATH       Specify app directory (overrides auto-detect)",
+		"  --all                Stop all discovered app runs with stop handles",
+		"  --json               Output as JSON",
+		"  -h, --help           Show this help",
+	)
+}
+
+// Run executes the top-level stop alias.
+func (c *StopCommand) Run(ctx context.Context, args []string) error {
+	return c.RunWithCommandPath(ctx, args, "stop")
+}
+
+// RunWithCommandPath executes stop with usage text bound to commandPath.
+func (c *StopCommand) RunWithCommandPath(ctx context.Context, args []string, commandPath string) error {
+	flags, help, err := c.parseStopFlags(args, commandPath)
+	if err != nil {
+		return err
+	}
+	if help {
+		c.out.Print(c.UsageFor(commandPath))
+		return nil
+	}
+
+	var appID string
+	if !flags.all {
+		target, err := c.service.ResolveRunTarget(ctx, flags.appPath)
+		if err != nil {
+			if errors.Is(err, repocontext.ErrAppNotFound) {
+				return fmt.Errorf("%w: run from an app directory, use -p, or use --all", ErrNoAppFound)
+			}
+			return fmt.Errorf("resolve app: %w", err)
+		}
+		appID = target.AppID
+	}
+
+	return c.stopApps(ctx, appID, flags)
+}
+
+func (c *StopCommand) parseStopFlags(args []string, commandPath string) (appStopFlags, bool, error) {
+	fs := flag.NewFlagSet(commandPath, flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	var flags appStopFlags
+	fs.StringVar(&flags.appPath, "p", "", "App directory path")
+	fs.StringVar(&flags.appPath, "path", "", "App directory path")
+	fs.BoolVar(&flags.all, "all", false, "Stop all discovered app runs with stop handles")
+	fs.BoolVar(&flags.jsonOutput, "json", false, "Output as JSON")
+
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return flags, true, nil
+		}
+		return flags, false, fmt.Errorf("parsing flags: %w", err)
+	}
+	if flags.all && flags.appPath != "" {
+		return flags, false, fmt.Errorf("%w: --all cannot be combined with --path", ErrInvalidFlagValue)
+	}
+	return flags, false, nil
+}
+
+func (c *StopCommand) stopApps(ctx context.Context, appID string, flags appStopFlags) error {
+	if err := c.manager.ensure(ctx); err != nil {
+		return startAppManagerError(err)
+	}
+
+	status, err := c.manager.client.Status(ctx)
+	if err != nil {
+		if errors.Is(err, appmanager.ErrNotRunning) {
+			return appStopOutput{Stopped: nil, Running: false, JSONOutput: flags.jsonOutput}.Print(c.out)
+		}
+		return fmt.Errorf("get app-manager status: %w", err)
+	}
+
+	apps := sortDiscoveredApps(filterApps(status.Apps, appID, true))
+	if len(apps) == 0 {
+		return appStopOutput{Stopped: nil, Running: true, JSONOutput: flags.jsonOutput}.Print(c.out)
+	}
+
+	var containerClient containerruntime.ContainerClient
+	defer func() {
+		if containerClient != nil {
+			if err := containerClient.Close(); err != nil {
+				c.out.Verbosef("failed to close container client: %v", err)
+			}
+		}
+	}()
+
+	var stopped []stoppedAppOutput
+	for _, app := range apps {
+		output, err := c.stopApp(ctx, app, &containerClient)
+		if err != nil {
+			return err
+		}
+		c.unregisterBestEffort(ctx, app)
+		stopped = append(stopped, output)
+	}
+
+	return appStopOutput{Running: true, Stopped: stopped, JSONOutput: flags.jsonOutput}.Print(c.out)
+}
+
+func (c *StopCommand) stopApp(
+	ctx context.Context,
+	app appmanager.DiscoveredApp,
+	containerClient *containerruntime.ContainerClient,
+) (stoppedAppOutput, error) {
+	output := stoppedAppOutput{
+		AppID:       app.AppID,
+		Mode:        appMode(app),
+		URL:         app.BaseURL,
+		ContainerID: app.ContainerID,
+		Name:        app.Name,
+		ProcessID:   0,
+		HostPort:    0,
+	}
+	if app.HostPort != nil {
+		output.HostPort = *app.HostPort
+	}
+
+	stopMode := appStopMode(app)
+	switch stopMode {
+	case runModeProcess:
+		pid := appProcessID(app)
+		if pid <= 0 {
+			return stoppedAppOutput{}, fmt.Errorf("%w: %s", errAppProcessIDMissing, app.AppID)
+		}
+		stopProcess := c.stopProcess
+		if stopProcess == nil {
+			stopProcess = func(ctx context.Context, pid int) error {
+				return osutil.StopProcess(ctx, pid, dotnetShutdownTimeout)
+			}
+		}
+		if err := stopProcess(ctx, pid); err != nil {
+			return stoppedAppOutput{}, fmt.Errorf("stop app process %d: %w", pid, err)
+		}
+		output.ProcessID = pid
+	case runModeContainer:
+		if err := c.ensureContainerRuntime(ctx, containerClient); err != nil {
+			return stoppedAppOutput{}, err
+		}
+		client := *containerClient
+		nameOrID := app.ContainerID
+		if nameOrID == "" {
+			nameOrID = app.Name
+		}
+		if nameOrID == "" {
+			return stoppedAppOutput{}, fmt.Errorf("%w: %s", errAppContainerIDMissing, app.AppID)
+		}
+		if err := client.ContainerStop(ctx, nameOrID, nil); err != nil &&
+			!errors.Is(err, containerruntime.ErrContainerNotFound) {
+			return stoppedAppOutput{}, fmt.Errorf("stop app container %s: %w", nameOrID, err)
+		}
+		if err := client.ContainerRemove(ctx, nameOrID, true); err != nil &&
+			!errors.Is(err, containerruntime.ErrContainerNotFound) {
+			return stoppedAppOutput{}, fmt.Errorf("remove app container %s: %w", nameOrID, err)
+		}
+	default:
+		return stoppedAppOutput{}, fmt.Errorf("%w: %s", ErrUnsupportedRuntime, stopMode)
+	}
+
+	return output, nil
+}
+
+func (c *StopCommand) ensureContainerRuntime(
+	ctx context.Context,
+	containerClient *containerruntime.ContainerClient,
+) error {
+	if *containerClient != nil {
+		return nil
+	}
+
+	containerClientFactory := c.containerClient
+	if containerClientFactory == nil {
+		containerClientFactory = containerruntime.Detect
+	}
+	client, err := containerClientFactory(ctx)
+	if err != nil {
+		return fmt.Errorf("connect to container runtime: %w", err)
+	}
+	*containerClient = client
+	return nil
+}
+
+func (c *StopCommand) unregisterBestEffort(ctx context.Context, app appmanager.DiscoveredApp) {
+	if err := c.manager.client.UnregisterApp(ctx, app.AppID); err != nil {
+		c.out.Verbosef("failed to unregister app %s from app-manager: %v", app.AppID, err)
+	}
+}
+
+func (o appStopOutput) Print(out *ui.Output) error {
+	if o.JSONOutput {
+		return printJSONOutput(out, "app stop", o)
+	}
+	if !o.Running {
+		out.Println("app-manager is not running.")
+		return nil
+	}
+	if len(o.Stopped) == 0 {
+		out.Println("No matching apps running.")
+		return nil
+	}
+	for _, app := range o.Stopped {
+		out.Printlnf("Stopped %s (%s).", app.AppID, app.Mode)
+	}
+	return nil
+}

--- a/src/cli/internal/cmd/stop.go
+++ b/src/cli/internal/cmd/stop.go
@@ -178,16 +178,21 @@ func (c *StopCommand) stopApps(ctx context.Context, appID string, flags appStopF
 	}()
 
 	var stopped []stoppedAppOutput
+	var stopErrors []error
 	for _, app := range apps {
 		output, err := c.stopApp(ctx, app, &containerClient)
 		if err != nil {
-			return err
+			stopErrors = append(stopErrors, fmt.Errorf("%s: %w", app.AppID, err))
+			continue
 		}
 		c.unregisterBestEffort(ctx, app)
 		stopped = append(stopped, output)
 	}
 
-	return appStopOutput{Running: true, Stopped: stopped, JSONOutput: flags.jsonOutput}.Print(c.out)
+	if err := (appStopOutput{Running: true, Stopped: stopped, JSONOutput: flags.jsonOutput}).Print(c.out); err != nil {
+		return err
+	}
+	return errors.Join(stopErrors...)
 }
 
 func (c *StopCommand) stopApp(

--- a/src/cli/internal/cmd/stop_internal_test.go
+++ b/src/cli/internal/cmd/stop_internal_test.go
@@ -1,0 +1,307 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+
+	containerruntime "altinn.studio/devenv/pkg/container"
+	containermock "altinn.studio/devenv/pkg/container/mock"
+	"altinn.studio/studioctl/internal/appmanager"
+	"altinn.studio/studioctl/internal/config"
+	"altinn.studio/studioctl/internal/ui"
+)
+
+const testAppID = "ttd/app"
+
+func TestAppPsJSONListsApps(t *testing.T) {
+	t.Parallel()
+
+	processID := 123
+	var out bytes.Buffer
+	command := &AppPsCommand{
+		out: ui.NewOutput(&out, io.Discard, false),
+		manager: appManagerAccess{
+			client: &fakeAppRuntimeClient{
+				status: &appmanager.Status{
+					Apps: []appmanager.DiscoveredApp{
+						{
+							ProcessID:   &processID,
+							AppID:       testAppID,
+							BaseURL:     "http://localhost:5005",
+							Source:      "studioctl",
+							Description: "test app",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := command.RunWithCommandPath(t.Context(), []string{"--json"}, "app ps"); err != nil {
+		t.Fatalf("RunWithCommandPath() error = %v", err)
+	}
+
+	var got appPsOutput
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out.String())), &got); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if !got.Running || len(got.Apps) != 1 || got.Apps[0].AppID != testAppID {
+		t.Fatalf("output = %+v, want one running app", got)
+	}
+}
+
+func TestAppPsTableUsesProcessModeAndRuntimeID(t *testing.T) {
+	t.Parallel()
+
+	processID := 123
+	var out bytes.Buffer
+	command := &AppPsCommand{
+		out: ui.NewOutput(&out, io.Discard, false),
+		manager: appManagerAccess{
+			client: &fakeAppRuntimeClient{
+				status: &appmanager.Status{
+					Apps: []appmanager.DiscoveredApp{
+						{
+							ProcessID: &processID,
+							AppID:     testAppID,
+							BaseURL:   "http://localhost:5005",
+							Name:      "Altinn.Application.dll",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := command.RunWithCommandPath(t.Context(), nil, "app ps"); err != nil {
+		t.Fatalf("RunWithCommandPath() error = %v", err)
+	}
+
+	output := out.String()
+	for _, want := range []string{"APP ID", "MODE", "ID", "NAME", "process", "123", "Altinn.Application.dll"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output = %q, want %q", output, want)
+		}
+	}
+	if strings.Contains(output, "PID") {
+		t.Fatalf("output = %q, did not want PID header", output)
+	}
+}
+
+func TestAppPsTableShortensContainerID(t *testing.T) {
+	t.Parallel()
+
+	const containerID = "1234567890abcdef"
+	var out bytes.Buffer
+	command := &AppPsCommand{
+		out: ui.NewOutput(&out, io.Discard, false),
+		manager: appManagerAccess{
+			client: &fakeAppRuntimeClient{
+				status: &appmanager.Status{
+					Apps: []appmanager.DiscoveredApp{
+						{
+							ContainerID: containerID,
+							AppID:       testAppID,
+							BaseURL:     "http://localhost:5005",
+							Name:        "container-name",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := command.RunWithCommandPath(t.Context(), nil, "app ps"); err != nil {
+		t.Fatalf("RunWithCommandPath() error = %v", err)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, containerID[:shortContainerIDLength]) {
+		t.Fatalf("output = %q, want short container id", output)
+	}
+	if strings.Contains(output, containerID) {
+		t.Fatalf("output = %q, did not want full container id", output)
+	}
+}
+
+func TestAppPsStartsAppManagerBeforeStatus(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig(t)
+	var out bytes.Buffer
+	var started bool
+	command := &AppPsCommand{
+		out: ui.NewOutput(&out, io.Discard, false),
+		manager: appManagerAccess{
+			cfg: cfg,
+			client: &fakeAppRuntimeClient{
+				statusErrs: []error{appmanager.ErrNotRunning, nil},
+				status:     &appmanager.Status{},
+			},
+			ensureStarted: func(context.Context, *config.Config, string) error {
+				started = true
+				return nil
+			},
+		},
+	}
+
+	if err := command.RunWithCommandPath(t.Context(), []string{"--json"}, "app ps"); err != nil {
+		t.Fatalf("RunWithCommandPath() error = %v", err)
+	}
+	if !started {
+		t.Fatal("ensureStarted was not called")
+	}
+}
+
+func TestAppPsDoesNotRestartRunningAppManager(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig(t)
+	var out bytes.Buffer
+	var started bool
+	command := &AppPsCommand{
+		out: ui.NewOutput(&out, io.Discard, false),
+		manager: appManagerAccess{
+			cfg:    cfg,
+			client: &fakeAppRuntimeClient{status: &appmanager.Status{}},
+			ensureStarted: func(context.Context, *config.Config, string) error {
+				started = true
+				return nil
+			},
+		},
+	}
+
+	if err := command.RunWithCommandPath(t.Context(), []string{"--json"}, "app ps"); err != nil {
+		t.Fatalf("RunWithCommandPath() error = %v", err)
+	}
+	if started {
+		t.Fatal("ensureStarted was called")
+	}
+}
+
+func TestAppStopJSONStopsNativeAppsWithProcessID(t *testing.T) {
+	t.Parallel()
+
+	processID := 123
+	var stoppedPID int
+	var out bytes.Buffer
+	client := &fakeAppRuntimeClient{
+		status: &appmanager.Status{
+			Apps: []appmanager.DiscoveredApp{
+				{
+					ProcessID: &processID,
+					AppID:     testAppID,
+					BaseURL:   "http://localhost:5005",
+				},
+				{
+					AppID:   "ttd/no-handle",
+					BaseURL: "http://localhost:5006",
+				},
+			},
+		},
+	}
+	command := &StopCommand{
+		out: ui.NewOutput(&out, io.Discard, false),
+		manager: appManagerAccess{
+			client: client,
+		},
+		stopProcess: func(_ context.Context, pid int) error {
+			stoppedPID = pid
+			return nil
+		},
+	}
+
+	if err := command.RunWithCommandPath(t.Context(), []string{"--all", "--json"}, "app stop"); err != nil {
+		t.Fatalf("RunWithCommandPath() error = %v", err)
+	}
+
+	var got appStopOutput
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out.String())), &got); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if stoppedPID != processID {
+		t.Fatalf("stopped pid = %d, want %d", stoppedPID, processID)
+	}
+	if len(got.Stopped) != 1 || got.Stopped[0].AppID != testAppID {
+		t.Fatalf("stopped = %+v, want one app", got.Stopped)
+	}
+	if got.Stopped[0].Mode != runModeProcess || got.Stopped[0].ProcessID != processID {
+		t.Fatalf("stopped = %+v, want process mode and pid %d", got.Stopped[0], processID)
+	}
+	if len(client.unregistered) != 1 || client.unregistered[0] != testAppID {
+		t.Fatalf("unregistered = %+v, want %s", client.unregistered, testAppID)
+	}
+}
+
+func TestAppStopJSONStopsManagedContainerApps(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	runtime := containermock.New()
+	command := &StopCommand{
+		out: ui.NewOutput(&out, io.Discard, false),
+		manager: appManagerAccess{
+			client: &fakeAppRuntimeClient{
+				status: &appmanager.Status{
+					Apps: []appmanager.DiscoveredApp{
+						{
+							AppID:       testAppID,
+							BaseURL:     "http://localhost:5005",
+							ContainerID: "container-id",
+							Name:        "container-name",
+						},
+					},
+				},
+			},
+		},
+		containerClient: func(context.Context) (containerruntime.ContainerClient, error) {
+			return runtime, nil
+		},
+	}
+
+	if err := command.RunWithCommandPath(t.Context(), []string{"--all", "--json"}, "app stop"); err != nil {
+		t.Fatalf("RunWithCommandPath() error = %v", err)
+	}
+
+	if len(runtime.Calls) < 2 {
+		t.Fatalf("container calls = %+v, want stop and remove", runtime.Calls)
+	}
+	if runtime.Calls[0].Method != "ContainerStop" || runtime.Calls[1].Method != "ContainerRemove" {
+		t.Fatalf("container calls = %+v, want stop then remove", runtime.Calls)
+	}
+}
+
+type fakeAppRuntimeClient struct {
+	status       *appmanager.Status
+	statusErr    error
+	statusErrs   []error
+	unregistered []string
+}
+
+func (f *fakeAppRuntimeClient) Status(context.Context) (*appmanager.Status, error) {
+	if len(f.statusErrs) > 0 {
+		err := f.statusErrs[0]
+		f.statusErrs = f.statusErrs[1:]
+		return f.status, err
+	}
+	return f.status, f.statusErr
+}
+
+func (f *fakeAppRuntimeClient) UnregisterApp(_ context.Context, appID string) error {
+	f.unregistered = append(f.unregistered, appID)
+	return nil
+}
+
+func testConfig(t *testing.T) *config.Config {
+	t.Helper()
+
+	cfg, err := config.New(config.Flags{Home: t.TempDir(), SocketDir: "", Verbose: false}, "test-version")
+	if err != nil {
+		t.Fatalf("config.New() error = %v", err)
+	}
+	return cfg
+}

--- a/src/cli/internal/cmd/stop_internal_test.go
+++ b/src/cli/internal/cmd/stop_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -16,6 +17,8 @@ import (
 )
 
 const testAppID = "ttd/app"
+
+var errStopFailed = errors.New("stop failed")
 
 func TestAppPsJSONListsApps(t *testing.T) {
 	t.Parallel()
@@ -234,6 +237,63 @@ func TestAppStopJSONStopsNativeAppsWithProcessID(t *testing.T) {
 	}
 	if len(client.unregistered) != 1 || client.unregistered[0] != testAppID {
 		t.Fatalf("unregistered = %+v, want %s", client.unregistered, testAppID)
+	}
+}
+
+func TestAppStopContinuesAfterStopError(t *testing.T) {
+	t.Parallel()
+
+	firstProcessID := 123
+	secondProcessID := 456
+	var stoppedPIDs []int
+	var out bytes.Buffer
+	client := &fakeAppRuntimeClient{
+		status: &appmanager.Status{
+			Apps: []appmanager.DiscoveredApp{
+				{
+					ProcessID: &firstProcessID,
+					AppID:     "ttd/fails",
+					BaseURL:   "http://localhost:5005",
+				},
+				{
+					ProcessID: &secondProcessID,
+					AppID:     "ttd/stops",
+					BaseURL:   "http://localhost:5006",
+				},
+			},
+		},
+	}
+	command := &StopCommand{
+		out: ui.NewOutput(&out, io.Discard, false),
+		manager: appManagerAccess{
+			client: client,
+		},
+		stopProcess: func(_ context.Context, pid int) error {
+			stoppedPIDs = append(stoppedPIDs, pid)
+			if pid == firstProcessID {
+				return errStopFailed
+			}
+			return nil
+		},
+	}
+
+	err := command.RunWithCommandPath(t.Context(), []string{"--all", "--json"}, "app stop")
+	if err == nil || !strings.Contains(err.Error(), "ttd/fails") {
+		t.Fatalf("RunWithCommandPath() error = %v, want failed app id", err)
+	}
+
+	var got appStopOutput
+	if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(out.String())), &got); jsonErr != nil {
+		t.Fatalf("json.Unmarshal() error = %v", jsonErr)
+	}
+	if len(stoppedPIDs) != 2 {
+		t.Fatalf("stopped pids = %+v, want both apps attempted", stoppedPIDs)
+	}
+	if len(got.Stopped) != 1 || got.Stopped[0].AppID != "ttd/stops" {
+		t.Fatalf("stopped = %+v, want successful app output", got.Stopped)
+	}
+	if len(client.unregistered) != 1 || client.unregistered[0] != "ttd/stops" {
+		t.Fatalf("unregistered = %+v, want successful app only", client.unregistered)
 	}
 }
 

--- a/src/cli/internal/cmd/stop_internal_test.go
+++ b/src/cli/internal/cmd/stop_internal_test.go
@@ -157,7 +157,7 @@ func TestAppPsStartsAppManagerBeforeStatus(t *testing.T) {
 	}
 }
 
-func TestAppPsDoesNotRestartRunningAppManager(t *testing.T) {
+func TestAppPsReconcilesRunningAppManager(t *testing.T) {
 	t.Parallel()
 
 	cfg := testConfig(t)
@@ -178,8 +178,8 @@ func TestAppPsDoesNotRestartRunningAppManager(t *testing.T) {
 	if err := command.RunWithCommandPath(t.Context(), []string{"--json"}, "app ps"); err != nil {
 		t.Fatalf("RunWithCommandPath() error = %v", err)
 	}
-	if started {
-		t.Fatal("ensureStarted was called")
+	if !started {
+		t.Fatal("ensureStarted was not called")
 	}
 }
 

--- a/src/cli/internal/osutil/process.go
+++ b/src/cli/internal/osutil/process.go
@@ -1,0 +1,68 @@
+package osutil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+)
+
+const processPollInterval = 100 * time.Millisecond
+
+// StopProcess asks a process to stop, then kills it if it is still running after timeout.
+func StopProcess(ctx context.Context, pid int, timeout time.Duration) error {
+	if pid <= 0 {
+		return nil
+	}
+
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("find process: %w", err)
+	}
+
+	interruptErr := interruptProcess(process, pid)
+	if errors.Is(interruptErr, os.ErrProcessDone) {
+		return nil
+	}
+	if interruptErr != nil {
+		return KillProcess(pid)
+	}
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		running, runningErr := ProcessRunning(pid)
+		if runningErr != nil {
+			return runningErr
+		}
+		if !running {
+			return nil
+		}
+
+		timer := time.NewTimer(processPollInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return fmt.Errorf("stop process: %w", ctx.Err())
+		case <-timer.C:
+		}
+	}
+
+	return KillProcess(pid)
+}
+
+// KillProcess kills a process.
+func KillProcess(pid int) error {
+	if pid <= 0 {
+		return nil
+	}
+
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("find process: %w", err)
+	}
+	if err := process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return fmt.Errorf("kill process: %w", err)
+	}
+	return nil
+}

--- a/src/cli/internal/osutil/process_unix.go
+++ b/src/cli/internal/osutil/process_unix.go
@@ -1,6 +1,6 @@
 //go:build !windows
 
-package appmanager
+package osutil
 
 import (
 	"errors"
@@ -9,7 +9,15 @@ import (
 	"syscall"
 )
 
-func isProcessRunning(pid int) (bool, error) {
+func interruptProcess(process *os.Process, _ int) error {
+	if err := process.Signal(os.Interrupt); err != nil {
+		return fmt.Errorf("interrupt process: %w", err)
+	}
+	return nil
+}
+
+// ProcessRunning reports whether pid is still running.
+func ProcessRunning(pid int) (bool, error) {
 	if pid <= 0 {
 		return false, nil
 	}

--- a/src/cli/internal/osutil/process_windows.go
+++ b/src/cli/internal/osutil/process_windows.go
@@ -5,6 +5,7 @@ package osutil
 import (
 	"errors"
 	"fmt"
+	"math"
 	"os"
 
 	"golang.org/x/sys/windows"
@@ -15,10 +16,11 @@ const stillActiveExitCode = 259
 var errPIDExceedsWindowsLimit = errors.New("pid exceeds windows limit")
 
 func interruptProcess(_ *os.Process, pid int) error {
-	if pid > int(^uint32(0)) {
-		return fmt.Errorf("%w: %d", errPIDExceedsWindowsLimit, pid)
+	processID, err := windowsProcessID(pid)
+	if err != nil {
+		return err
 	}
-	if err := windows.GenerateConsoleCtrlEvent(windows.CTRL_BREAK_EVENT, uint32(pid)); err != nil {
+	if err := windows.GenerateConsoleCtrlEvent(windows.CTRL_BREAK_EVENT, processID); err != nil {
 		return fmt.Errorf("send ctrl-break: %w", err)
 	}
 	return nil
@@ -29,11 +31,12 @@ func ProcessRunning(pid int) (bool, error) {
 	if pid <= 0 {
 		return false, nil
 	}
-	if pid > int(^uint32(0)) {
-		return false, fmt.Errorf("%w: %d", errPIDExceedsWindowsLimit, pid)
+	processID, err := windowsProcessID(pid)
+	if err != nil {
+		return false, err
 	}
 
-	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, processID)
 	switch {
 	case err == nil:
 	case errors.Is(err, windows.ERROR_INVALID_PARAMETER):
@@ -60,4 +63,11 @@ func ProcessRunning(pid int) (bool, error) {
 	}
 
 	return exitCode == stillActiveExitCode, nil
+}
+
+func windowsProcessID(pid int) (uint32, error) {
+	if pid < 0 || uint64(pid) > math.MaxUint32 {
+		return 0, fmt.Errorf("%w: %d", errPIDExceedsWindowsLimit, pid)
+	}
+	return uint32(pid), nil
 }

--- a/src/cli/internal/osutil/process_windows.go
+++ b/src/cli/internal/osutil/process_windows.go
@@ -1,10 +1,11 @@
 //go:build windows
 
-package appmanager
+package osutil
 
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	"golang.org/x/sys/windows"
 )
@@ -13,7 +14,18 @@ const stillActiveExitCode = 259
 
 var errPIDExceedsWindowsLimit = errors.New("pid exceeds windows limit")
 
-func isProcessRunning(pid int) (bool, error) {
+func interruptProcess(_ *os.Process, pid int) error {
+	if pid > int(^uint32(0)) {
+		return fmt.Errorf("%w: %d", errPIDExceedsWindowsLimit, pid)
+	}
+	if err := windows.GenerateConsoleCtrlEvent(windows.CTRL_BREAK_EVENT, uint32(pid)); err != nil {
+		return fmt.Errorf("send ctrl-break: %w", err)
+	}
+	return nil
+}
+
+// ProcessRunning reports whether pid is still running.
+func ProcessRunning(pid int) (bool, error) {
 	if pid <= 0 {
 		return false, nil
 	}


### PR DESCRIPTION
## Description

- refactored discovery and tunneling a bit 
  - app register/unregister are only notifications, doesnt contribute data
to the registry, felt very "2 sources of truth" which led to some weird states
  - appregistry supports multiple uris for an app id
  - tunnel does round robin load balancing towards apps to match real envs
- add `app ps` and `[app] stop` command since one can now run detached both as process and contaienr
- rename `native` to `process` for `studioctl run --mode` 

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `app ps` command to list running app processes and containers.
  * Added `app stop` command to stop running applications.
  * Enabled support for running multiple instances of the same app with automatic load balancing.
  * Extended app discovery to track container identifiers and host port information.

* **Changed**
  * Renamed app run mode from "native" to "process".
  * Updated app registration to use timeout configuration instead of grace period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->