### PR TITLE
chore: studioctl - simplify servers logs logic

### DIFF
--- a/src/cli/app-manager/Platform/FileLoggerProvider.cs
+++ b/src/cli/app-manager/Platform/FileLoggerProvider.cs
@@ -10,6 +10,7 @@ internal sealed class FileLoggerProvider : ILoggerProvider
     private const int Capacity = 1024;
     private readonly Channel<LogEntry> _channel;
     private readonly string _directory;
+    private readonly string _logId;
     private readonly Task _writerTask;
     private StreamWriter _writer;
     private string _currentDate;
@@ -22,6 +23,7 @@ internal sealed class FileLoggerProvider : ILoggerProvider
 
         Directory.CreateDirectory(directory);
         _directory = directory;
+        _logId = NextLogId(directory);
         _currentDate = UtcDate();
         _writer = OpenWriter(_currentDate);
         _channel = Channel.CreateBounded<LogEntry>(
@@ -95,7 +97,50 @@ internal sealed class FileLoggerProvider : ILoggerProvider
     }
 
     private string LogPath(string date) =>
-        Path.Combine(_directory, string.Create(CultureInfo.InvariantCulture, $"{date}-{Environment.ProcessId}.log"));
+        Path.Combine(_directory, string.Create(CultureInfo.InvariantCulture, $"{date}-{_logId}.log"));
+
+    private static string NextLogId(string directory)
+    {
+        var maxId = 0;
+        foreach (var path in Directory.EnumerateFiles(directory, "*" + ".log"))
+        {
+            if (TryParseLogId(Path.GetFileName(path), out var id) && id > maxId)
+                maxId = id;
+        }
+
+        return (maxId + 1).ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static bool TryParseLogId(string? fileName, out int id)
+    {
+        id = 0;
+        const int dateLength = 10;
+        if (
+            string.IsNullOrWhiteSpace(fileName)
+            || !fileName.EndsWith(".log", StringComparison.Ordinal)
+            || fileName.Length < dateLength + "-1.log".Length
+            || fileName[dateLength] != '-'
+        )
+        {
+            return false;
+        }
+
+        if (
+            !DateTime.TryParseExact(
+                fileName[..dateLength],
+                "yyyy-MM-dd",
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out _
+            )
+        )
+        {
+            return false;
+        }
+
+        var idValue = fileName[(dateLength + 1)..^".log".Length];
+        return int.TryParse(idValue, NumberStyles.None, CultureInfo.InvariantCulture, out id) && id > 0;
+    }
 
     private static string UtcDate() => DateTimeOffset.UtcNow.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
 

--- a/src/cli/internal/appmanager/client.go
+++ b/src/cli/internal/appmanager/client.go
@@ -385,7 +385,10 @@ func EnsureStartedWithStudioctlPath(
 	switch {
 	case err == nil:
 		if liveConfig(cfg, status) == desired {
-			return writeAppManagerState(cfg, runtimeState{PID: status.ProcessID, Start: desired})
+			return writeAppManagerState(cfg, runtimeState{
+				PID:   status.ProcessID,
+				Start: desired,
+			})
 		}
 		return restartManagedProcess(ctx, cfg, client, status.ProcessID, desired)
 	case !errors.Is(err, ErrNotRunning):
@@ -429,9 +432,12 @@ func reconcilePersistedProcess(
 	}
 
 	if state.Start == desired {
-		status, waitErr := waitForHealthy(ctx, cfg, client, state.PID)
+		status, waitErr := waitForHealthy(ctx, cfg, client, time.Now())
 		if waitErr == nil {
-			return writeAppManagerState(cfg, runtimeState{PID: status.ProcessID, Start: desired})
+			return writeAppManagerState(cfg, runtimeState{
+				PID:   status.ProcessID,
+				Start: desired,
+			})
 		}
 	}
 
@@ -497,6 +503,7 @@ func startProcess(ctx context.Context, cfg *config.Config, startConfig startConf
 	if err := removeAppManagerState(cfg); err != nil {
 		return fmt.Errorf("remove stale app-manager pid file: %w", err)
 	}
+	startedAt := time.Now()
 
 	//nolint:gosec // G204: binary path comes from resolved studioctl config.
 	cmd := exec.CommandContext(context.WithoutCancel(ctx), cfg.AppManagerBinaryPath())
@@ -526,7 +533,10 @@ func startProcess(ctx context.Context, cfg *config.Config, startConfig startConf
 	if err != nil {
 		return fmt.Errorf("start app-manager: %w", err)
 	}
-	err = writeAppManagerState(cfg, runtimeState{PID: cmd.Process.Pid, Start: startConfig})
+	err = writeAppManagerState(cfg, runtimeState{
+		PID:   cmd.Process.Pid,
+		Start: startConfig,
+	})
 	if err != nil {
 		ignoreError(cmd.Process.Kill())
 		return fmt.Errorf("write app-manager pid file: %w", err)
@@ -538,9 +548,12 @@ func startProcess(ctx context.Context, cfg *config.Config, startConfig startConf
 	}
 
 	client := NewClient(cfg)
-	status, err := waitForHealthy(ctx, cfg, client, cmd.Process.Pid)
+	status, err := waitForHealthy(ctx, cfg, client, startedAt)
 	if err == nil {
-		return writeAppManagerState(cfg, runtimeState{PID: status.ProcessID, Start: startConfig})
+		return writeAppManagerState(cfg, runtimeState{
+			PID:   status.ProcessID,
+			Start: startConfig,
+		})
 	}
 
 	ignoreError(osutil.KillProcess(cmd.Process.Pid))
@@ -548,7 +561,7 @@ func startProcess(ctx context.Context, cfg *config.Config, startConfig startConf
 	return err
 }
 
-func waitForHealthy(ctx context.Context, cfg *config.Config, client *Client, logPID int) (*Status, error) {
+func waitForHealthy(ctx context.Context, cfg *config.Config, client *Client, logSince time.Time) (*Status, error) {
 	deadline := time.Now().Add(appManagerStartTimeout)
 	var lastErr error
 	for time.Now().Before(deadline) {
@@ -567,7 +580,7 @@ func waitForHealthy(ctx context.Context, cfg *config.Config, client *Client, log
 			errAppManagerStartTimedOut,
 			appManagerStartTimeout,
 			lastErr,
-			readAppManagerLogTailForPID(cfg.AppManagerLogDir(), logPID),
+			readLatestAppManagerLogTailSince(cfg.AppManagerLogDir(), logSince),
 		)
 	}
 
@@ -575,7 +588,7 @@ func waitForHealthy(ctx context.Context, cfg *config.Config, client *Client, log
 		"%w: %s%s",
 		errAppManagerStartTimedOut,
 		appManagerStartTimeout,
-		readAppManagerLogTailForPID(cfg.AppManagerLogDir(), logPID),
+		readLatestAppManagerLogTailSince(cfg.AppManagerLogDir(), logSince),
 	)
 }
 
@@ -776,16 +789,17 @@ func readLatestAppManagerLogTail(dir string) string {
 	return readAppManagerLogTail(path)
 }
 
-func readAppManagerLogTailForPID(dir string, pid int) string {
-	if pid <= 0 {
-		return readLatestAppManagerLogTail(dir)
-	}
-
-	paths, err := LogPathsForPID(dir, pid)
-	if err != nil || len(paths) == 0 {
+func readLatestAppManagerLogTailSince(dir string, since time.Time) string {
+	files, err := LogFiles(dir)
+	if err != nil {
 		return ""
 	}
-	return readAppManagerLogTail(paths[len(paths)-1])
+	for i := len(files) - 1; i >= 0; i-- {
+		if !files[i].ModTime.Before(since) {
+			return readAppManagerLogTail(files[i].Path)
+		}
+	}
+	return ""
 }
 
 func readAppManagerLogTail(path string) string {
@@ -868,61 +882,30 @@ func LogFiles(dir string) ([]LogFile, error) {
 	return files, nil
 }
 
-// LogPathsForPID returns app-manager logs for a process id in filename order.
-func LogPathsForPID(dir string, pid int) ([]string, error) {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("read app-manager log directory: %w", err)
-	}
-
-	paths := make([]string, 0, len(entries))
-	for _, entry := range entries {
-		if entry.IsDir() || !isAppManagerLogNameForPID(entry.Name(), pid) {
-			continue
-		}
-		paths = append(paths, filepath.Join(dir, entry.Name()))
-	}
-	sort.Strings(paths)
-
-	return paths, nil
-}
-
 func isAppManagerLogName(name string) bool {
-	_, ok := logPIDFromName(name)
-	return ok
+	return logIDFromName(name) != ""
 }
 
-func logPIDFromName(name string) (int, bool) {
+func logIDFromName(name string) string {
 	const dateLength = len("2006-01-02")
 	if len(name) <= dateLength+len("-")+len(appManagerLogSuffix) {
-		return 0, false
-	}
-	if !isUTCDatePrefix(name[:dateLength]) {
-		return 0, false
-	}
-	if name[dateLength] != '-' {
-		return 0, false
+		return ""
 	}
 	if !strings.HasSuffix(name, appManagerLogSuffix) {
-		return 0, false
+		return ""
 	}
-
-	value, err := strconv.Atoi(name[dateLength+1 : len(name)-len(appManagerLogSuffix)])
+	if !isUTCDatePrefix(name[:dateLength]) {
+		return ""
+	}
+	if name[dateLength] != '-' {
+		return ""
+	}
+	id := name[dateLength+1 : len(name)-len(appManagerLogSuffix)]
+	value, err := strconv.Atoi(id)
 	if err != nil || value <= 0 {
-		return 0, false
+		return ""
 	}
-	return value, true
-}
-
-func isAppManagerLogNameForPID(name string, pid int) bool {
-	if pid <= 0 {
-		return false
-	}
-	logPID, ok := logPIDFromName(name)
-	return ok && logPID == pid
+	return id
 }
 
 func isUTCDatePrefix(value string) bool {

--- a/src/cli/internal/appmanager/client_internal_test.go
+++ b/src/cli/internal/appmanager/client_internal_test.go
@@ -12,8 +12,8 @@ func TestLatestAppManagerLogPath_ReturnsNewestMatchingFile(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	oldPath := writeTestLog(t, dir, "2026-04-18-100.log", "old\n")
-	newPath := writeTestLog(t, dir, "2026-04-19-200.log", "new\n")
+	oldPath := writeTestLog(t, dir, "2026-04-18-1.log", "old\n")
+	newPath := writeTestLog(t, dir, "2026-04-19-2.log", "new\n")
 	_ = writeTestLog(t, dir, "legacy.log", "legacy\n")
 	setModTime(t, oldPath, time.Date(2026, 4, 18, 1, 0, 0, 0, time.UTC))
 	setModTime(t, newPath, time.Date(2026, 4, 19, 1, 0, 0, 0, time.UTC))
@@ -31,8 +31,8 @@ func TestReadLatestAppManagerLogTail_ReadsOnlyNewestMatchingFile(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	oldPath := writeTestLog(t, dir, "2026-04-18-100.log", "old\n")
-	newPath := writeTestLog(t, dir, "2026-04-19-200.log", "new\n")
+	oldPath := writeTestLog(t, dir, "2026-04-18-1.log", "old\n")
+	newPath := writeTestLog(t, dir, "2026-04-19-2.log", "new\n")
 	setModTime(t, oldPath, time.Date(2026, 4, 18, 1, 0, 0, 0, time.UTC))
 	setModTime(t, newPath, time.Date(2026, 4, 19, 1, 0, 0, 0, time.UTC))
 
@@ -55,7 +55,7 @@ func TestReadLatestAppManagerLogTail_LimitsOutput(t *testing.T) {
 		content.WriteString("line\n")
 	}
 	content.WriteString("last\n")
-	path := writeTestLog(t, dir, "2026-04-19-200.log", content.String())
+	path := writeTestLog(t, dir, "2026-04-19-2.log", content.String())
 
 	assertLatestLogPath(t, dir, path)
 	got := readLatestAppManagerLogTail(dir)
@@ -67,50 +67,21 @@ func TestReadLatestAppManagerLogTail_LimitsOutput(t *testing.T) {
 	}
 }
 
-func TestReadAppManagerLogTailForPID_IgnoresOtherProcessLogs(t *testing.T) {
+func TestReadLatestAppManagerLogTailSince_IgnoresOlderLogs(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	targetPath := writeTestLog(t, dir, "2026-04-19-100.log", "target\n")
-	stalePath := writeTestLog(t, dir, "2026-04-19-200.log", "stale\n")
-	setModTime(t, targetPath, time.Date(2026, 4, 19, 1, 0, 0, 0, time.UTC))
-	setModTime(t, stalePath, time.Date(2026, 4, 19, 2, 0, 0, 0, time.UTC))
+	oldPath := writeTestLog(t, dir, "2026-04-19-1.log", "old\n")
+	newPath := writeTestLog(t, dir, "2026-04-19-2.log", "new\n")
+	setModTime(t, oldPath, time.Date(2026, 4, 19, 1, 0, 0, 0, time.UTC))
+	setModTime(t, newPath, time.Date(2026, 4, 19, 3, 0, 0, 0, time.UTC))
 
-	got := readAppManagerLogTailForPID(dir, 100)
-	if !strings.Contains(got, "target") {
-		t.Fatalf("readAppManagerLogTailForPID() = %q, want target log", got)
+	got := readLatestAppManagerLogTailSince(dir, time.Date(2026, 4, 19, 2, 0, 0, 0, time.UTC))
+	if !strings.Contains(got, "new") {
+		t.Fatalf("readLatestAppManagerLogTailSince() = %q, want new log", got)
 	}
-	if strings.Contains(got, "stale") {
-		t.Fatalf("readAppManagerLogTailForPID() = %q, want no stale log", got)
-	}
-}
-
-func TestLogPathsForPID_ReturnsOnlyMatchingPIDInOrder(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	first := writeTestLog(t, dir, "2026-04-18-100.log", "first\n")
-	second := writeTestLog(t, dir, "2026-04-19-100.log", "second\n")
-	singleDigit := writeTestLog(t, dir, "2026-04-19-1.log", "single\n")
-	_ = writeTestLog(t, dir, "2026-04-19-200.log", "other\n")
-	_ = writeTestLog(t, dir, "legacy.log", "legacy\n")
-
-	got, err := LogPathsForPID(dir, 100)
-	if err != nil {
-		t.Fatalf("LogPathsForPID() error = %v", err)
-	}
-
-	want := []string{first, second}
-	if strings.Join(got, "\n") != strings.Join(want, "\n") {
-		t.Fatalf("LogPathsForPID() = %v, want %v", got, want)
-	}
-
-	got, err = LogPathsForPID(dir, 1)
-	if err != nil {
-		t.Fatalf("LogPathsForPID(single digit) error = %v", err)
-	}
-	if len(got) != 1 || got[0] != singleDigit {
-		t.Fatalf("LogPathsForPID(single digit) = %v, want %v", got, []string{singleDigit})
+	if strings.Contains(got, "old") {
+		t.Fatalf("readLatestAppManagerLogTailSince() = %q, want no old log", got)
 	}
 }
 
@@ -118,8 +89,8 @@ func TestLogFiles_ReturnsMatchingFilesByModTime(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	first := writeTestLog(t, dir, "2026-04-19-200.log", "first\n")
-	second := writeTestLog(t, dir, "2026-04-18-100.log", "second\n")
+	first := writeTestLog(t, dir, "2026-04-19-2.log", "first\n")
+	second := writeTestLog(t, dir, "2026-04-18-1.log", "second\n")
 	_ = writeTestLog(t, dir, "legacy.log", "legacy\n")
 	setModTime(t, first, time.Date(2026, 4, 19, 1, 0, 0, 0, time.UTC))
 	setModTime(t, second, time.Date(2026, 4, 19, 2, 0, 0, 0, time.UTC))
@@ -145,9 +116,9 @@ func TestLogLookup_HandlesDirectoryWithGlobMetacharacters(t *testing.T) {
 	if err := os.Mkdir(dir, 0o700); err != nil {
 		t.Fatalf("create log dir: %v", err)
 	}
-	oldPath := writeTestLog(t, dir, "2026-04-18-100.log", "first\n")
-	newPath := writeTestLog(t, dir, "2026-04-19-100.log", "second\n")
-	otherPath := writeTestLog(t, dir, "2026-04-19-200.log", "other\n")
+	oldPath := writeTestLog(t, dir, "2026-04-18-1.log", "first\n")
+	newPath := writeTestLog(t, dir, "2026-04-19-1.log", "second\n")
+	otherPath := writeTestLog(t, dir, "2026-04-19-2.log", "other\n")
 	setModTime(t, oldPath, time.Date(2026, 4, 18, 1, 0, 0, 0, time.UTC))
 	setModTime(t, newPath, time.Date(2026, 4, 19, 1, 0, 0, 0, time.UTC))
 	setModTime(t, otherPath, time.Date(2026, 4, 18, 2, 0, 0, 0, time.UTC))
@@ -160,13 +131,17 @@ func TestLogLookup_HandlesDirectoryWithGlobMetacharacters(t *testing.T) {
 		t.Fatalf("LatestLogPath() = %q, want %q", latest, newPath)
 	}
 
-	paths, err := LogPathsForPID(dir, 100)
+	files, err := LogFiles(dir)
 	if err != nil {
-		t.Fatalf("LogPathsForPID() error = %v", err)
+		t.Fatalf("LogFiles() error = %v", err)
 	}
-	want := []string{oldPath, newPath}
-	if strings.Join(paths, "\n") != strings.Join(want, "\n") {
-		t.Fatalf("LogPathsForPID() = %v, want %v", paths, want)
+	want := []string{oldPath, otherPath, newPath}
+	got := make([]string, 0, len(files))
+	for _, file := range files {
+		got = append(got, file.Path)
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("LogFiles() = %v, want %v", got, want)
 	}
 }
 

--- a/src/cli/internal/cmd/servers/logs_internal_test.go
+++ b/src/cli/internal/cmd/servers/logs_internal_test.go
@@ -98,8 +98,8 @@ func TestReadTailSnapshot_ReadsOlderFilesOnlyWhenNeeded(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	oldPath := writeNamedLog(t, dir, "2026-04-18-100.log", "one\n")
-	newPath := writeNamedLog(t, dir, "2026-04-19-100.log", "two\n")
+	oldPath := writeNamedLog(t, dir, "2026-04-18-1.log", "one\n")
+	newPath := writeNamedLog(t, dir, "2026-04-19-1.log", "two\n")
 
 	snapshot, err := readTailSnapshot([]string{oldPath, newPath}, 2)
 	if err != nil {
@@ -114,8 +114,8 @@ func TestReadTailSnapshot_DoesNotReadOldFilesWhenNewerFileSatisfiesTail(t *testi
 	t.Parallel()
 
 	dir := t.TempDir()
-	oldPath := writeNamedLog(t, dir, "2026-04-18-100.log", strings.Repeat("x", logScannerMaxSize+1))
-	newPath := writeNamedLog(t, dir, "2026-04-19-100.log", "new\n")
+	oldPath := writeNamedLog(t, dir, "2026-04-18-1.log", strings.Repeat("x", logScannerMaxSize+1))
+	newPath := writeNamedLog(t, dir, "2026-04-19-1.log", "new\n")
 
 	snapshot, err := readTailSnapshot([]string{oldPath, newPath}, 1)
 	if err != nil {
@@ -167,8 +167,8 @@ func TestStreamLogs_WithoutPIDReadsLatestLog(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	oldPath := writeNamedLog(t, dir, "2026-04-18-100.log", "old\n")
-	newPath := writeNamedLog(t, dir, "2026-04-19-200.log", "new\n")
+	oldPath := writeNamedLog(t, dir, "2026-04-18-1.log", "old\n")
+	newPath := writeNamedLog(t, dir, "2026-04-19-2.log", "new\n")
 	setLogModTime(t, oldPath, time.Date(2026, 4, 18, 1, 0, 0, 0, time.UTC))
 	setLogModTime(t, newPath, time.Date(2026, 4, 19, 1, 0, 0, 0, time.UTC))
 
@@ -188,9 +188,9 @@ func TestPrintChangedFiles_ReadsNewFilesFromBeginning(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	oldPath := writeNamedLog(t, dir, "2026-04-18-100.log", "old\n")
+	oldPath := writeNamedLog(t, dir, "2026-04-18-1.log", "old\n")
 	offsets := map[string]int64{oldPath: int64(len("old\n"))}
-	newPath := writeNamedLog(t, dir, "2026-04-19-200.log", "new\n")
+	newPath := writeNamedLog(t, dir, "2026-04-19-2.log", "new\n")
 	setLogModTime(t, oldPath, time.Date(2026, 4, 18, 1, 0, 0, 0, time.UTC))
 	setLogModTime(t, newPath, time.Date(2026, 4, 19, 1, 0, 0, 0, time.UTC))
 
@@ -228,7 +228,7 @@ func TestFollowDiscoversNewLogFile(t *testing.T) {
 		errCh <- streamer.follow(ctx, map[string]int64{}, false)
 	}()
 
-	writeNamedLog(t, dir, "2026-04-19-200.log", "new\n")
+	writeNamedLog(t, dir, "2026-04-19-2.log", "new\n")
 	waitForOutput(t, &out, "new"+osutil.LineBreak)
 	cancel()
 
@@ -240,7 +240,7 @@ func TestFollowDiscoversNewLogFile(t *testing.T) {
 func writeLog(t *testing.T, dir, content string) string {
 	t.Helper()
 
-	return writeNamedLog(t, dir, "2026-04-19-100.log", content)
+	return writeNamedLog(t, dir, "2026-04-19-1.log", content)
 }
 
 func writeNamedLog(t *testing.T, dir, name, content string) string {

--- a/src/cli/internal/cmd/servers_internal_test.go
+++ b/src/cli/internal/cmd/servers_internal_test.go
@@ -243,9 +243,9 @@ func TestServersLogsJSON_TailsMatchingPIDAcrossFiles(t *testing.T) {
 
 	logDir := t.TempDir()
 	appManagerLogDir := filepath.Join(logDir, "app-manager")
-	oldPath := writeServerLog(t, appManagerLogDir, "2026-04-18-100.log", "one\n")
-	newPath := writeServerLog(t, appManagerLogDir, "2026-04-19-100.log", "two\nthree\n")
-	otherPath := writeServerLog(t, appManagerLogDir, "2026-04-19-200.log", "other\n")
+	oldPath := writeServerLog(t, appManagerLogDir, "2026-04-18-1.log", "one\n")
+	newPath := writeServerLog(t, appManagerLogDir, "2026-04-19-1.log", "two\nthree\n")
+	otherPath := writeServerLog(t, appManagerLogDir, "2026-04-19-2.log", "other\n")
 	setServerLogModTime(t, oldPath, time.Date(2026, 4, 18, 1, 0, 0, 0, time.UTC))
 	setServerLogModTime(t, newPath, time.Date(2026, 4, 19, 2, 0, 0, 0, time.UTC))
 	setServerLogModTime(t, otherPath, time.Date(2026, 4, 19, 1, 0, 0, 0, time.UTC))
@@ -334,8 +334,8 @@ func TestServersLogs_ReadsLatestLogWithoutStatus(t *testing.T) {
 
 	logDir := t.TempDir()
 	appManagerLogDir := filepath.Join(logDir, "app-manager")
-	oldPath := writeServerLog(t, appManagerLogDir, "2026-04-18-100.log", "old\n")
-	newPath := writeServerLog(t, appManagerLogDir, "2026-04-19-200.log", "new\n")
+	oldPath := writeServerLog(t, appManagerLogDir, "2026-04-18-1.log", "old\n")
+	newPath := writeServerLog(t, appManagerLogDir, "2026-04-19-2.log", "new\n")
 	setServerLogModTime(t, oldPath, time.Date(2026, 4, 18, 1, 0, 0, 0, time.UTC))
 	setServerLogModTime(t, newPath, time.Date(2026, 4, 19, 1, 0, 0, 0, time.UTC))
 


### PR DESCRIPTION
## Description

use integers instead of pid in the log file name, will align with apps logs

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log file selection for startup health checks using timestamp-based filtering instead of process-based identification, ensuring accurate log retrieval in timeout scenarios.

* **Changes**
  * Log files now use sequential numeric identifiers in filenames rather than process IDs for improved organisation and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->