### PR TITLE
feat: studioctl - app logs

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `--json` output for detached `run` and `app run`.
 - Add `app ps` for listing running app processes and containers.
 - Add `app stop` and top-level `stop` for stopping discovered app processes and containers.
-- Support for multiple instances of the same app and round robin loadbalancing similar to deployed environments.
+- Add `app logs` for reading app process and container logs.
+- Support for multiple instances of the same app and roundrobin loadbalancing similar to deployed environments.
 
 ### Changed
 

--- a/src/cli/internal/cmd/app.go
+++ b/src/cli/internal/cmd/app.go
@@ -24,11 +24,14 @@ import (
 // AppCommand implements the 'app' subcommand.
 type AppCommand struct {
 	out     *ui.Output
+	logs    *appLogsCommand
 	ps      *AppPsCommand
 	run     *RunCommand
 	stop    *StopCommand
 	service *appsvc.Service
 }
+
+const appLogsSubcommand = "logs"
 
 type appBuildOutput struct {
 	ImageTag   string `json:"imageTag"`
@@ -67,6 +70,7 @@ func NewAppCommand(cfg *config.Config, out *ui.Output) *AppCommand {
 	service := appsvc.NewService(cfg.Home)
 	return &AppCommand{
 		out:     out,
+		logs:    newAppLogsCommand(cfg, out, service),
 		ps:      newAppPsCommand(cfg, out, service),
 		run:     newRunCommand(cfg, out, service),
 		stop:    newStopCommand(cfg, out, service),
@@ -90,6 +94,7 @@ func (c *AppCommand) Usage() string {
 		"Subcommands:",
 		"  build     Build an app container image",
 		"  clone     Clone an app repository from Altinn Studio",
+		"  logs      Stream app logs",
 		"  ps        List running apps",
 		"  run       Run app locally",
 		"  stop      Stop running apps",
@@ -114,6 +119,8 @@ func (c *AppCommand) Run(ctx context.Context, args []string) error {
 		return c.runBuild(ctx, subArgs)
 	case "clone":
 		return c.runClone(ctx, subArgs)
+	case appLogsSubcommand:
+		return c.logs.run(ctx, subArgs)
 	case "ps":
 		return c.ps.RunWithCommandPath(ctx, subArgs, "app ps")
 	case "run":

--- a/src/cli/internal/cmd/apps/logs.go
+++ b/src/cli/internal/cmd/apps/logs.go
@@ -1,0 +1,249 @@
+// Package apps contains app command support code.
+package apps
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"altinn.studio/studioctl/internal/logstream"
+	"altinn.studio/studioctl/internal/osutil"
+)
+
+const (
+	dateFormat = "2006-01-02"
+	logSuffix  = ".log"
+	metaSuffix = ".json"
+)
+
+// RunMetadata describes the studioctl run that produced one app log file.
+type RunMetadata struct {
+	StartedAt time.Time `json:"startedAt"`
+	AppID     string    `json:"appId"`
+	Mode      string    `json:"mode"`
+	ID        string    `json:"id"`
+	Name      string    `json:"name,omitempty"`
+	LogPath   string    `json:"logPath"`
+	ProcessID int       `json:"processId,omitempty"`
+	HostPort  int       `json:"hostPort,omitempty"`
+}
+
+// SanitizeAppID returns the directory-safe app id used for app log folders.
+func SanitizeAppID(appID string) string {
+	return strings.ReplaceAll(appID, "/", "-")
+}
+
+// NextLogPath returns the next auto-incremented app log path for the given date.
+func NextLogPath(dir string, now time.Time) (string, error) {
+	date := now.Format(dateFormat)
+	nextRunID, err := nextRunID(dir, date)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, date+"-"+strconv.Itoa(nextRunID)+logSuffix), nil
+}
+
+// WriteRunMetadata writes sidecar metadata for an app log file.
+func WriteRunMetadata(logPath string, metadata RunMetadata) error {
+	metadata.LogPath = logPath
+	data, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode app log metadata: %w", err)
+	}
+	if err := os.WriteFile(MetadataPath(logPath), append(data, '\n'), osutil.FilePermOwnerOnly); err != nil {
+		return fmt.Errorf("write app log metadata: %w", err)
+	}
+	return nil
+}
+
+// MetadataPath returns the sidecar metadata path for an app log path.
+func MetadataPath(logPath string) string {
+	return strings.TrimSuffix(logPath, filepath.Ext(logPath)) + metaSuffix
+}
+
+// LatestLogPath returns the most recently modified app log path.
+func LatestLogPath(dir string) (string, bool, error) {
+	files, err := LogFiles(dir)
+	if err != nil || len(files) == 0 {
+		return "", false, err
+	}
+	return files[len(files)-1].Path, true, nil
+}
+
+// LogFiles returns app log files ordered by modification time.
+func LogFiles(dir string) ([]logstream.File, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read app log directory: %w", err)
+	}
+
+	files := make([]logstream.File, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !IsLogName(entry.Name()) {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		files = append(files, logstream.File{
+			Path:    filepath.Join(dir, entry.Name()),
+			ModTime: info.ModTime(),
+			Size:    info.Size(),
+		})
+	}
+	sort.Slice(files, func(i, j int) bool {
+		if files[i].ModTime.Equal(files[j].ModTime) {
+			return files[i].Path < files[j].Path
+		}
+		return files[i].ModTime.Before(files[j].ModTime)
+	})
+
+	return files, nil
+}
+
+// FindMetadataByID returns the newest app log metadata matching a runtime id.
+func FindMetadataByID(dir string, id string) (RunMetadata, bool, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return zeroRunMetadata(), false, nil
+		}
+		return zeroRunMetadata(), false, fmt.Errorf("read app log directory: %w", err)
+	}
+
+	var found RunMetadata
+	foundModTime := time.Time{}
+	for _, entry := range entries {
+		if entry.IsDir() || !IsMetadataName(entry.Name()) {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		metadata, err := readMetadata(path)
+		if err != nil || !metadataMatchesID(metadata, id) {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		if found.LogPath == "" || info.ModTime().After(foundModTime) {
+			found = metadata
+			foundModTime = info.ModTime()
+		}
+	}
+	return found, found.LogPath != "", nil
+}
+
+// IsLogName reports whether name matches the app log file naming format.
+func IsLogName(name string) bool {
+	return runIDFromName(name, logSuffix)
+}
+
+// IsMetadataName reports whether name matches the app log metadata naming format.
+func IsMetadataName(name string) bool {
+	return runIDFromName(name, metaSuffix)
+}
+
+func nextRunID(dir string, date string) (int, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0, fmt.Errorf("read app log directory: %w", err)
+	}
+
+	maxRunID := 0
+	prefix := date + "-"
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, logSuffix) {
+			continue
+		}
+		runIDText := strings.TrimSuffix(strings.TrimPrefix(name, prefix), logSuffix)
+		runID, parseErr := strconv.Atoi(runIDText)
+		if parseErr == nil && runID > maxRunID {
+			maxRunID = runID
+		}
+	}
+	return maxRunID + 1, nil
+}
+
+func readMetadata(path string) (RunMetadata, error) {
+	//nolint:gosec // G304: path comes from the configured app log directory and metadata filename pattern.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return zeroRunMetadata(), fmt.Errorf("read app log metadata: %w", err)
+	}
+	var metadata RunMetadata
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		return zeroRunMetadata(), fmt.Errorf("decode app log metadata: %w", err)
+	}
+	return metadata, nil
+}
+
+func zeroRunMetadata() RunMetadata {
+	return RunMetadata{
+		StartedAt: time.Time{},
+		AppID:     "",
+		Mode:      "",
+		ID:        "",
+		Name:      "",
+		LogPath:   "",
+		ProcessID: 0,
+		HostPort:  0,
+	}
+}
+
+func metadataMatchesID(metadata RunMetadata, id string) bool {
+	if metadata.ID == id {
+		return true
+	}
+	if metadata.ProcessID > 0 && strconv.Itoa(metadata.ProcessID) == id {
+		return true
+	}
+	return false
+}
+
+func runIDFromName(name string, suffix string) bool {
+	const dateLength = len("2006-01-02")
+	if len(name) <= dateLength+len("-")+len(suffix) {
+		return false
+	}
+	if !isUTCDatePrefix(name[:dateLength]) {
+		return false
+	}
+	if name[dateLength] != '-' {
+		return false
+	}
+	if !strings.HasSuffix(name, suffix) {
+		return false
+	}
+
+	value, err := strconv.Atoi(name[dateLength+1 : len(name)-len(suffix)])
+	return err == nil && value > 0
+}
+
+func isUTCDatePrefix(value string) bool {
+	if len(value) != len("2006-01-02") || value[4] != '-' || value[7] != '-' {
+		return false
+	}
+	for i, r := range value {
+		if i == 4 || i == 7 {
+			continue
+		}
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/src/cli/internal/cmd/apps/logs.go
+++ b/src/cli/internal/cmd/apps/logs.go
@@ -92,7 +92,7 @@ func LogFiles(dir string) ([]logstream.File, error) {
 		}
 		info, err := entry.Info()
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("stat app log %s: %w", entry.Name(), err)
 		}
 		files = append(files, logstream.File{
 			Path:    filepath.Join(dir, entry.Name()),
@@ -128,12 +128,15 @@ func FindMetadataByID(dir string, id string) (RunMetadata, bool, error) {
 		}
 		path := filepath.Join(dir, entry.Name())
 		metadata, err := readMetadata(path)
-		if err != nil || !metadataMatchesID(metadata, id) {
+		if err != nil {
+			return zeroRunMetadata(), false, err
+		}
+		if !metadataMatchesID(metadata, id) {
 			continue
 		}
 		info, err := entry.Info()
 		if err != nil {
-			continue
+			return zeroRunMetadata(), false, fmt.Errorf("stat app log metadata %s: %w", entry.Name(), err)
 		}
 		if found.LogPath == "" || info.ModTime().After(foundModTime) {
 			found = metadata

--- a/src/cli/internal/cmd/apps/logs_test.go
+++ b/src/cli/internal/cmd/apps/logs_test.go
@@ -1,0 +1,46 @@
+package apps_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"altinn.studio/studioctl/internal/cmd/apps"
+	"altinn.studio/studioctl/internal/osutil"
+)
+
+func TestFindMetadataByIDReturnsDecodeError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "2026-04-20-1.json"), []byte("{"), osutil.FilePermOwnerOnly); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+
+	_, _, err := apps.FindMetadataByID(dir, "123")
+	if err == nil {
+		t.Fatal("FindMetadataByID() error = nil, want decode error")
+	}
+	if !strings.Contains(err.Error(), "decode app log metadata") {
+		t.Fatalf("FindMetadataByID() error = %v, want decode error", err)
+	}
+}
+
+func TestLogFilesReturnsReadDirError(t *testing.T) {
+	t.Parallel()
+
+	file := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(file, []byte("log"), osutil.FilePermOwnerOnly); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	_, err := apps.LogFiles(file)
+	if err == nil {
+		t.Fatal("LogFiles() error = nil, want error")
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("LogFiles() error = %v, want read dir error", err)
+	}
+}

--- a/src/cli/internal/cmd/apps/logs_test.go
+++ b/src/cli/internal/cmd/apps/logs_test.go
@@ -1,7 +1,6 @@
 package apps_test
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,22 +24,5 @@ func TestFindMetadataByIDReturnsDecodeError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "decode app log metadata") {
 		t.Fatalf("FindMetadataByID() error = %v, want decode error", err)
-	}
-}
-
-func TestLogFilesReturnsReadDirError(t *testing.T) {
-	t.Parallel()
-
-	file := filepath.Join(t.TempDir(), "not-a-directory")
-	if err := os.WriteFile(file, []byte("log"), osutil.FilePermOwnerOnly); err != nil {
-		t.Fatalf("write file: %v", err)
-	}
-
-	_, err := apps.LogFiles(file)
-	if err == nil {
-		t.Fatal("LogFiles() error = nil, want error")
-	}
-	if errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("LogFiles() error = %v, want read dir error", err)
 	}
 }

--- a/src/cli/internal/cmd/logs.go
+++ b/src/cli/internal/cmd/logs.go
@@ -306,8 +306,11 @@ func (c *appLogsCommand) streamLogFile(
 	streamer := logstream.Streamer{
 		ListFiles: func() ([]logstream.File, error) {
 			file, ok, err := logFile(logPath)
-			if err != nil || !ok {
+			if err != nil {
 				return nil, err
+			}
+			if !ok {
+				return nil, logstream.ErrNoLogFiles
 			}
 			return []logstream.File{file}, nil
 		},

--- a/src/cli/internal/cmd/logs.go
+++ b/src/cli/internal/cmd/logs.go
@@ -1,0 +1,496 @@
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	containerruntime "altinn.studio/devenv/pkg/container"
+	"altinn.studio/studioctl/internal/appmanager"
+	appsvc "altinn.studio/studioctl/internal/cmd/app"
+	appsupport "altinn.studio/studioctl/internal/cmd/apps"
+	"altinn.studio/studioctl/internal/config"
+	repocontext "altinn.studio/studioctl/internal/context"
+	"altinn.studio/studioctl/internal/logstream"
+	"altinn.studio/studioctl/internal/osutil"
+	"altinn.studio/studioctl/internal/ui"
+)
+
+var (
+	errAppLogsNotFound    = errors.New("app logs not found")
+	errAppLogsUnavailable = errors.New("app logs unavailable")
+)
+
+const appLogsTailAllValue = "all"
+
+type appLogsCommand struct {
+	out             *ui.Output
+	manager         appManagerAccess
+	service         *appsvc.Service
+	cfg             *config.Config
+	containerClient containerClientFactory
+}
+
+type appLogsFlags struct {
+	appPath    string
+	id         string
+	tail       int
+	tailAll    bool
+	follow     bool
+	jsonOutput bool
+}
+
+type appLogsTailFlag struct {
+	all   *bool
+	value *int
+}
+
+type appLogLine struct {
+	AppID   string `json:"appId"`
+	Mode    string `json:"mode,omitempty"`
+	ID      string `json:"id,omitempty"`
+	Name    string `json:"name,omitempty"`
+	LogPath string `json:"logPath,omitempty"`
+	Line    string `json:"line"`
+	Port    int    `json:"port,omitempty"`
+	JSON    bool   `json:"-"`
+}
+
+func newAppLogsCommand(cfg *config.Config, out *ui.Output, service *appsvc.Service) *appLogsCommand {
+	return &appLogsCommand{
+		out:             out,
+		cfg:             cfg,
+		manager:         newAppManagerAccess(cfg),
+		service:         service,
+		containerClient: containerruntime.Detect,
+	}
+}
+
+func (c *appLogsCommand) usageFor(commandPath string) string {
+	return joinLines(
+		fmt.Sprintf("Usage: %s %s [-p PATH] [--id ID]", osutil.CurrentBin(), commandPath),
+		"",
+		"Streams logs for a Studio app.",
+		"",
+		"Options:",
+		"  -p, --path PATH       Specify app directory (overrides auto-detect)",
+		"  --id ID              Select process ID or container ID from 'app ps'",
+		"  -f, --follow         Follow log output (default: true)",
+		fmt.Sprintf("  --tail N|all        Number of log lines to show (default: %d)", defaultServersLogTailLines),
+		"  --json              Output as newline-delimited JSON",
+		"  -h, --help          Show this help",
+	)
+}
+
+func (c *appLogsCommand) run(ctx context.Context, args []string) error {
+	const commandPath = "app logs"
+
+	flags, help, err := c.parseFlags(args, commandPath)
+	if err != nil {
+		return err
+	}
+	if help {
+		c.out.Print(c.usageFor(commandPath))
+		return nil
+	}
+	if c.cfg == nil {
+		return errStudioctlConfigRequired
+	}
+
+	appID, err := c.resolveAppID(ctx, flags)
+	if err != nil {
+		return err
+	}
+	if flags.tailAll && appID == "" && flags.id == "" {
+		return fmt.Errorf("%w: --tail all requires an app directory, -p, or --id", ErrInvalidFlagValue)
+	}
+
+	apps, err := c.matchingRunningApps(ctx, appID, flags.id)
+	if err != nil {
+		return err
+	}
+	if len(apps) > 1 {
+		return fmt.Errorf(
+			"%w: multiple app runs match; use --id from '%s app ps'",
+			ErrInvalidFlagValue,
+			osutil.CurrentBin(),
+		)
+	}
+	if len(apps) == 1 {
+		return c.streamRunningApp(ctx, apps[0], flags)
+	}
+
+	if appID == "" {
+		return fmt.Errorf("%w: run from an app directory, use -p, or use --id for a running app", ErrNoAppFound)
+	}
+	return c.streamStoredAppLog(ctx, appID, flags)
+}
+
+func (c *appLogsCommand) parseFlags(args []string, commandPath string) (appLogsFlags, bool, error) {
+	fs := flag.NewFlagSet(commandPath, flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	flags := appLogsFlags{
+		appPath:    "",
+		id:         "",
+		tail:       defaultServersLogTailLines,
+		tailAll:    false,
+		follow:     true,
+		jsonOutput: false,
+	}
+	fs.StringVar(&flags.appPath, "p", "", "App directory path")
+	fs.StringVar(&flags.appPath, "path", "", "App directory path")
+	fs.StringVar(&flags.id, "id", "", "Process ID or container ID from app ps")
+	fs.BoolVar(&flags.follow, "f", true, "Follow log output")
+	fs.BoolVar(&flags.follow, "follow", true, "Follow log output")
+	fs.Var(appLogsTailFlag{all: &flags.tailAll, value: &flags.tail}, "tail", "Number of log lines to show")
+	fs.BoolVar(&flags.jsonOutput, "json", false, "Output as newline-delimited JSON")
+
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return flags, true, nil
+		}
+		return flags, false, fmt.Errorf("parsing flags: %w", err)
+	}
+	if flags.tail < 0 {
+		return flags, false, fmt.Errorf("%w: --tail must be greater than or equal to 0", ErrInvalidFlagValue)
+	}
+	if flags.tail > maxServersLogTailLines {
+		return flags, false, fmt.Errorf(
+			"%w: --tail must be less than or equal to %d",
+			ErrInvalidFlagValue,
+			maxServersLogTailLines,
+		)
+	}
+	return flags, false, nil
+}
+
+func (c *appLogsCommand) resolveAppID(ctx context.Context, flags appLogsFlags) (string, error) {
+	if c.service == nil {
+		return "", nil
+	}
+
+	target, err := c.service.ResolveRunTarget(ctx, flags.appPath)
+	if err == nil {
+		return target.AppID, nil
+	}
+	if flags.appPath == "" && errors.Is(err, repocontext.ErrAppNotFound) {
+		return "", nil
+	}
+	if errors.Is(err, repocontext.ErrAppNotFound) {
+		return "", fmt.Errorf("%w: use a valid app directory with -p", ErrNoAppFound)
+	}
+	return "", fmt.Errorf("resolve app: %w", err)
+}
+
+func (c *appLogsCommand) matchingRunningApps(
+	ctx context.Context,
+	appID string,
+	id string,
+) ([]appmanager.DiscoveredApp, error) {
+	if err := c.manager.ensure(ctx); err != nil {
+		return nil, startAppManagerError(err)
+	}
+
+	status, err := c.manager.client.Status(ctx)
+	if err != nil {
+		if errors.Is(err, appmanager.ErrNotRunning) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get app-manager status: %w", err)
+	}
+
+	apps := filterApps(status.Apps, appID, false)
+	if id == "" {
+		return sortDiscoveredApps(apps), nil
+	}
+
+	filtered := make([]appmanager.DiscoveredApp, 0, len(apps))
+	for _, app := range apps {
+		if appMatchesRuntimeID(app, id) {
+			filtered = append(filtered, app)
+		}
+	}
+	return sortDiscoveredApps(filtered), nil
+}
+
+func (c *appLogsCommand) streamRunningApp(ctx context.Context, app appmanager.DiscoveredApp, flags appLogsFlags) error {
+	if appHasContainerHandle(app) {
+		return c.streamContainerLogs(ctx, app, flags)
+	}
+
+	processID := appProcessID(app)
+	if processID <= 0 {
+		return fmt.Errorf("%w: no log source for %s", errAppLogsUnavailable, app.AppID)
+	}
+
+	logDir := c.appLogDir(app.AppID)
+	metadata, ok, err := appsupport.FindMetadataByID(logDir, strconv.Itoa(processID))
+	if err != nil {
+		return fmt.Errorf("find app log metadata: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf(
+			"%w: logs are not available for process %d; start the app with '%s run' to capture logs",
+			errAppLogsUnavailable,
+			processID,
+			osutil.CurrentBin(),
+		)
+	}
+	return c.streamLogFile(ctx, appLogLine{
+		AppID:   app.AppID,
+		Mode:    runModeProcess,
+		ID:      strconv.Itoa(processID),
+		Name:    app.Name,
+		Port:    appPortNumber(app),
+		LogPath: metadata.LogPath,
+		Line:    "",
+		JSON:    flags.jsonOutput,
+	}, metadata.LogPath, flags)
+}
+
+func (c *appLogsCommand) streamStoredAppLog(ctx context.Context, appID string, flags appLogsFlags) error {
+	logDir := c.appLogDir(appID)
+	if flags.id != "" {
+		metadata, ok, err := appsupport.FindMetadataByID(logDir, flags.id)
+		if err != nil {
+			return fmt.Errorf("find app log metadata: %w", err)
+		}
+		if !ok {
+			return fmt.Errorf("%w: no log metadata matches id %s", errAppLogsNotFound, flags.id)
+		}
+		return c.streamLogFile(ctx, appLogLine{
+			AppID:   metadata.AppID,
+			Mode:    metadata.Mode,
+			ID:      metadata.ID,
+			Name:    metadata.Name,
+			Port:    metadata.HostPort,
+			LogPath: metadata.LogPath,
+			Line:    "",
+			JSON:    flags.jsonOutput,
+		}, metadata.LogPath, flags)
+	}
+
+	logPath, ok, err := appsupport.LatestLogPath(logDir)
+	if err != nil {
+		return fmt.Errorf("find latest app log: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("%w: %s", errAppLogsNotFound, appID)
+	}
+	return c.streamLogFile(ctx, appLogLine{
+		AppID:   appID,
+		Mode:    "",
+		ID:      "",
+		Name:    "",
+		Port:    0,
+		LogPath: logPath,
+		Line:    "",
+		JSON:    flags.jsonOutput,
+	}, logPath, flags)
+}
+
+func (c *appLogsCommand) streamLogFile(
+	ctx context.Context,
+	line appLogLine,
+	logPath string,
+	flags appLogsFlags,
+) error {
+	streamer := logstream.Streamer{
+		ListFiles: func() ([]logstream.File, error) {
+			file, ok, err := logFile(logPath)
+			if err != nil || !ok {
+				return nil, err
+			}
+			return []logstream.File{file}, nil
+		},
+		Emit: func(_ string, text string) error {
+			line.Line = strings.TrimSuffix(text, "\r")
+			return line.Print(c.out)
+		},
+	}
+	if err := streamer.Stream(ctx, logstream.Options{
+		Tail:    flags.tail,
+		TailAll: flags.tailAll,
+		Follow:  flags.follow,
+	}); err != nil {
+		if errors.Is(err, logstream.ErrNoLogFiles) {
+			return errAppLogsNotFound
+		}
+		if errors.Is(err, logstream.ErrLineTooLong) {
+			return fmt.Errorf("%w: app log line exceeds max size", errAppLogsUnavailable)
+		}
+		return fmt.Errorf("stream app log: %w", err)
+	}
+	return nil
+}
+
+func (c *appLogsCommand) streamContainerLogs(
+	ctx context.Context,
+	app appmanager.DiscoveredApp,
+	flags appLogsFlags,
+) error {
+	clientFactory := c.containerClient
+	if clientFactory == nil {
+		clientFactory = containerruntime.Detect
+	}
+	client, err := clientFactory(ctx)
+	if err != nil {
+		return fmt.Errorf("connect to container runtime: %w", err)
+	}
+	defer func() {
+		if closeErr := client.Close(); closeErr != nil {
+			c.out.Verbosef("failed to close container client: %v", closeErr)
+		}
+	}()
+
+	nameOrID := app.ContainerID
+	if nameOrID == "" {
+		nameOrID = app.Name
+	}
+	if nameOrID == "" {
+		return fmt.Errorf("%w: app container id or name missing", errAppLogsUnavailable)
+	}
+
+	logs, err := client.ContainerLogs(ctx, nameOrID, flags.follow, appLogsTailValue(flags))
+	if err != nil {
+		return fmt.Errorf("stream app container logs: %w", err)
+	}
+	defer func() {
+		if closeErr := logs.Close(); closeErr != nil {
+			c.out.Verbosef("failed to close app container logs: %v", closeErr)
+		}
+	}()
+
+	line := appLogLine{
+		AppID:   app.AppID,
+		Mode:    runModeContainer,
+		ID:      appRuntimeID(app),
+		Name:    app.Name,
+		LogPath: "",
+		Line:    "",
+		Port:    appPortNumber(app),
+		JSON:    flags.jsonOutput,
+	}
+	return c.streamContainerLogReader(ctx, logs, line)
+}
+
+func (c *appLogsCommand) streamContainerLogReader(ctx context.Context, logs io.Reader, line appLogLine) error {
+	scanner := bufio.NewScanner(logs)
+	buf := make([]byte, logstream.ScannerBufSize)
+	scanner.Buffer(buf, logstream.ScannerMaxSize)
+	for scanner.Scan() {
+		line.Line = strings.TrimSuffix(scanner.Text(), "\r")
+		if err := line.Print(c.out); err != nil {
+			return err
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		if ctx.Err() != nil {
+			return canceledContainerLogRead()
+		}
+		return fmt.Errorf("read app container logs: %w", err)
+	}
+	return nil
+}
+
+func canceledContainerLogRead() error {
+	return nil
+}
+
+func (c *appLogsCommand) appLogDir(appID string) string {
+	return c.cfg.AppLogDir(appsupport.SanitizeAppID(appID))
+}
+
+func (l appLogLine) Print(out *ui.Output) error {
+	if !l.JSON {
+		out.Println(l.Line)
+		return nil
+	}
+
+	payload, err := json.Marshal(l)
+	if err != nil {
+		return fmt.Errorf("marshal app log line: %w", err)
+	}
+	out.Println(string(payload))
+	return nil
+}
+
+func appMatchesRuntimeID(app appmanager.DiscoveredApp, id string) bool {
+	if id == "" {
+		return true
+	}
+	if appRuntimeID(app) == id {
+		return true
+	}
+	if processID := appProcessID(app); processID > 0 && strconv.Itoa(processID) == id {
+		return true
+	}
+	return app.ContainerID != "" && strings.HasPrefix(app.ContainerID, id)
+}
+
+func logFile(path string) (logstream.File, bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return zeroLogFile(), false, nil
+		}
+		return zeroLogFile(), false, fmt.Errorf("stat app log: %w", err)
+	}
+	if info.IsDir() {
+		return zeroLogFile(), false, nil
+	}
+	return logstream.File{
+		ModTime: info.ModTime(),
+		Path:    path,
+		Size:    info.Size(),
+	}, true, nil
+}
+
+func zeroLogFile() logstream.File {
+	return logstream.File{
+		ModTime: time.Time{},
+		Path:    "",
+		Size:    0,
+	}
+}
+
+func (f appLogsTailFlag) String() string {
+	if f.all != nil && *f.all {
+		return appLogsTailAllValue
+	}
+	if f.value == nil {
+		return ""
+	}
+	return strconv.Itoa(*f.value)
+}
+
+func (f appLogsTailFlag) Set(value string) error {
+	if strings.EqualFold(value, appLogsTailAllValue) {
+		*f.all = true
+		*f.value = 0
+		return nil
+	}
+
+	tail, err := strconv.Atoi(value)
+	if err != nil {
+		return fmt.Errorf("%w: %q", ErrInvalidFlagValue, value)
+	}
+	*f.all = false
+	*f.value = tail
+	return nil
+}
+
+func appLogsTailValue(flags appLogsFlags) string {
+	if flags.tailAll {
+		return appLogsTailAllValue
+	}
+	return strconv.Itoa(flags.tail)
+}

--- a/src/cli/internal/cmd/logs_internal_test.go
+++ b/src/cli/internal/cmd/logs_internal_test.go
@@ -229,6 +229,23 @@ func TestAppLogsStoredLatestFileWithoutRunningApp(t *testing.T) {
 	}
 }
 
+func TestAppLogsSelectedMissingFileReturnsNotFound(t *testing.T) {
+	t.Parallel()
+
+	command := &appLogsCommand{
+		out: ioDiscardOutput(),
+		cfg: testConfig(t),
+	}
+
+	err := command.streamLogFile(t.Context(), appLogLine{AppID: testAppID}, "/does/not/exist.log", appLogsFlags{
+		tail:   1,
+		follow: true,
+	})
+	if !errors.Is(err, errAppLogsNotFound) {
+		t.Fatalf("streamLogFile() error = %v, want errAppLogsNotFound", err)
+	}
+}
+
 func TestAppLogsStoredIDUsesCurrentAppDirectory(t *testing.T) {
 	cfg := testConfig(t)
 	appRoot := t.TempDir()

--- a/src/cli/internal/cmd/logs_internal_test.go
+++ b/src/cli/internal/cmd/logs_internal_test.go
@@ -1,0 +1,364 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	containerruntime "altinn.studio/devenv/pkg/container"
+	containermock "altinn.studio/devenv/pkg/container/mock"
+	"altinn.studio/studioctl/internal/appmanager"
+	appsvc "altinn.studio/studioctl/internal/cmd/app"
+	appsupport "altinn.studio/studioctl/internal/cmd/apps"
+	"altinn.studio/studioctl/internal/osutil"
+	"altinn.studio/studioctl/internal/ui"
+)
+
+func TestAppLogsStreamsProcessLogByPID(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig(t)
+	processID := 123
+	logDir := cfg.AppLogDir(appsupport.SanitizeAppID(testAppID))
+	logPath := writeAppLog(t, logDir, "2026-04-20-1.log", "one\ntwo\n")
+	writeAppLogMetadata(t, logPath, appsupport.RunMetadata{
+		StartedAt: time.Now().UTC(),
+		AppID:     testAppID,
+		Mode:      runModeProcess,
+		ID:        "123",
+		LogPath:   logPath,
+		ProcessID: processID,
+	})
+
+	var out bytes.Buffer
+	command := &appLogsCommand{
+		out: ui.NewOutput(&out, io.Discard, false),
+		cfg: cfg,
+		manager: appManagerAccess{
+			client: &fakeAppRuntimeClient{
+				status: &appmanager.Status{
+					Apps: []appmanager.DiscoveredApp{
+						{
+							ProcessID: &processID,
+							AppID:     testAppID,
+							BaseURL:   "http://127.0.0.1:5005",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := command.run(
+		t.Context(),
+		[]string{"--id", "123", "--tail", "1", "--follow=false"},
+	); err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	if out.String() != "two"+osutil.LineBreak {
+		t.Fatalf("output = %q, want tail line", out.String())
+	}
+}
+
+func TestAppLogsJSONIncludesMetadata(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig(t)
+	processID := 123
+	logDir := cfg.AppLogDir(appsupport.SanitizeAppID(testAppID))
+	logPath := writeAppLog(t, logDir, "2026-04-20-1.log", "one\n")
+	writeAppLogMetadata(t, logPath, appsupport.RunMetadata{
+		StartedAt: time.Now().UTC(),
+		AppID:     testAppID,
+		Mode:      runModeProcess,
+		ID:        "123",
+		Name:      "Altinn.Application.dll",
+		LogPath:   logPath,
+		ProcessID: processID,
+	})
+
+	var out bytes.Buffer
+	command := &appLogsCommand{
+		out: ui.NewOutput(&out, io.Discard, false),
+		cfg: cfg,
+		manager: appManagerAccess{
+			client: &fakeAppRuntimeClient{
+				status: &appmanager.Status{
+					Apps: []appmanager.DiscoveredApp{
+						{
+							ProcessID: &processID,
+							AppID:     testAppID,
+							BaseURL:   "http://127.0.0.1:5005",
+							Name:      "Altinn.Application.dll",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := command.run(
+		t.Context(),
+		[]string{"--id", "123", "--follow=false", "--json"},
+	); err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+
+	var got appLogLine
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out.String())), &got); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if got.AppID != testAppID || got.ID != "123" || got.Mode != runModeProcess || got.Line != "one" {
+		t.Fatalf("output = %+v, want process log metadata", got)
+	}
+}
+
+func TestAppLogsReturnsUnavailableForManualProcess(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig(t)
+	processID := 123
+	command := &appLogsCommand{
+		out: ioDiscardOutput(),
+		cfg: cfg,
+		manager: appManagerAccess{
+			client: &fakeAppRuntimeClient{
+				status: &appmanager.Status{
+					Apps: []appmanager.DiscoveredApp{
+						{
+							ProcessID: &processID,
+							AppID:     testAppID,
+							BaseURL:   "http://127.0.0.1:5005",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := command.run(t.Context(), []string{"--id", "123", "--follow=false"})
+	if !errors.Is(err, errAppLogsUnavailable) {
+		t.Fatalf("run() error = %v, want errAppLogsUnavailable", err)
+	}
+	if !strings.Contains(err.Error(), "run") {
+		t.Fatalf("run() error = %v, want run hint", err)
+	}
+}
+
+func TestAppLogsStreamsContainerLogs(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig(t)
+	const containerID = "1234567890abcdef"
+	var gotName string
+	var gotFollow bool
+	var gotTail string
+	client := containermock.New()
+	client.ContainerLogsFunc = func(_ context.Context, nameOrID string, follow bool, tail string) (io.ReadCloser, error) {
+		gotName = nameOrID
+		gotFollow = follow
+		gotTail = tail
+		return io.NopCloser(strings.NewReader("container line\n")), nil
+	}
+
+	var out bytes.Buffer
+	command := &appLogsCommand{
+		out: ui.NewOutput(&out, io.Discard, false),
+		cfg: cfg,
+		manager: appManagerAccess{
+			client: &fakeAppRuntimeClient{
+				status: &appmanager.Status{
+					Apps: []appmanager.DiscoveredApp{
+						{
+							ContainerID: containerID,
+							AppID:       testAppID,
+							BaseURL:     "http://127.0.0.1:5005",
+							Name:        "app-container",
+						},
+					},
+				},
+			},
+		},
+		containerClient: func(context.Context) (containerruntime.ContainerClient, error) {
+			return client, nil
+		},
+	}
+
+	if err := command.run(
+		t.Context(),
+		[]string{"--id", containerID[:12], "--tail", appLogsTailAllValue, "--follow=false"},
+	); err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	if gotName != containerID || gotFollow || gotTail != appLogsTailAllValue {
+		t.Fatalf("ContainerLogs args = %q %v %q, want container id, false, all", gotName, gotFollow, gotTail)
+	}
+	if out.String() != "container line"+osutil.LineBreak {
+		t.Fatalf("output = %q, want container log line", out.String())
+	}
+}
+
+func TestAppLogsStoredLatestFileWithoutRunningApp(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig(t)
+	logDir := cfg.AppLogDir(appsupport.SanitizeAppID(testAppID))
+	oldPath := writeAppLog(t, logDir, "2026-04-19-1.log", "old\n")
+	newPath := writeAppLog(t, logDir, "2026-04-20-1.log", "new\n")
+	setAppLogModTime(t, oldPath, time.Date(2026, 4, 19, 1, 0, 0, 0, time.UTC))
+	setAppLogModTime(t, newPath, time.Date(2026, 4, 20, 1, 0, 0, 0, time.UTC))
+
+	var out bytes.Buffer
+	command := &appLogsCommand{
+		out: ui.NewOutput(&out, io.Discard, false),
+		cfg: cfg,
+	}
+
+	if err := command.streamStoredAppLog(t.Context(), testAppID, appLogsFlags{tail: 100, follow: false}); err != nil {
+		t.Fatalf("streamStoredAppLog() error = %v", err)
+	}
+	if out.String() != "new"+osutil.LineBreak {
+		t.Fatalf("output = %q, want latest stored log", out.String())
+	}
+}
+
+func TestAppLogsStoredIDUsesCurrentAppDirectory(t *testing.T) {
+	cfg := testConfig(t)
+	appRoot := t.TempDir()
+	writeTestAppMetadata(t, appRoot, testAppID)
+	t.Chdir(appRoot)
+
+	const processID = 123
+	logDir := cfg.AppLogDir(appsupport.SanitizeAppID(testAppID))
+	logPath := writeAppLog(t, logDir, "2026-04-20-1.log", "one\ntwo\nthree\n")
+	writeAppLogMetadata(t, logPath, appsupport.RunMetadata{
+		StartedAt: time.Now().UTC(),
+		AppID:     testAppID,
+		Mode:      runModeProcess,
+		ID:        "123",
+		LogPath:   logPath,
+		ProcessID: processID,
+	})
+
+	var out bytes.Buffer
+	command := &appLogsCommand{
+		out:     ui.NewOutput(&out, io.Discard, false),
+		cfg:     cfg,
+		service: appsvc.NewService(""),
+		manager: appManagerAccess{
+			client: &fakeAppRuntimeClient{status: &appmanager.Status{}},
+		},
+	}
+
+	if err := command.run(
+		t.Context(),
+		[]string{"--id", "123", "--tail", appLogsTailAllValue, "--follow=false"},
+	); err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	want := "one" + osutil.LineBreak + "two" + osutil.LineBreak + "three" + osutil.LineBreak
+	if out.String() != want {
+		t.Fatalf("output = %q, want all stored lines", out.String())
+	}
+}
+
+func TestAppLogsTailAllRequiresScope(t *testing.T) {
+	t.Parallel()
+
+	command := &appLogsCommand{
+		out: ioDiscardOutput(),
+		cfg: testConfig(t),
+	}
+
+	err := command.run(t.Context(), []string{"--tail", appLogsTailAllValue, "--follow=false"})
+	if !errors.Is(err, ErrInvalidFlagValue) {
+		t.Fatalf("run() error = %v, want ErrInvalidFlagValue", err)
+	}
+}
+
+func TestAppLogsContainerReaderIgnoresCanceledContextError(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	command := &appLogsCommand{out: ioDiscardOutput()}
+	err := command.streamContainerLogReader(ctx, errReader{err: context.Canceled}, appLogLine{
+		AppID:   testAppID,
+		Mode:    runModeContainer,
+		ID:      "container-id",
+		Name:    "container-name",
+		LogPath: "",
+		Line:    "",
+		Port:    5005,
+		JSON:    false,
+	})
+	if err != nil {
+		t.Fatalf("streamContainerLogReader() error = %v, want nil", err)
+	}
+}
+
+func writeAppLog(t *testing.T, dir string, name string, content string) string {
+	t.Helper()
+
+	if err := os.MkdirAll(dir, osutil.DirPermOwnerOnly); err != nil {
+		t.Fatalf("create app log dir: %v", err)
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), osutil.FilePermOwnerOnly); err != nil {
+		t.Fatalf("write app log: %v", err)
+	}
+	return path
+}
+
+func writeAppLogMetadata(t *testing.T, logPath string, metadata appsupport.RunMetadata) {
+	t.Helper()
+
+	if err := appsupport.WriteRunMetadata(logPath, metadata); err != nil {
+		t.Fatalf("write app log metadata: %v", err)
+	}
+}
+
+func writeTestAppMetadata(t *testing.T, appPath string, appID string) {
+	t.Helper()
+
+	configDir := filepath.Join(appPath, "App", "config")
+	if err := os.MkdirAll(configDir, osutil.DirPermOwnerOnly); err != nil {
+		t.Fatalf("create app config dir: %v", err)
+	}
+	content := []byte(`{"id":"` + appID + `"}`)
+	if err := os.WriteFile(
+		filepath.Join(configDir, "applicationmetadata.json"),
+		content,
+		osutil.FilePermOwnerOnly,
+	); err != nil {
+		t.Fatalf("write app metadata: %v", err)
+	}
+}
+
+func setAppLogModTime(t *testing.T, path string, modTime time.Time) {
+	t.Helper()
+
+	if err := os.Chtimes(path, modTime, modTime); err != nil {
+		t.Fatalf("chtimes %q: %v", path, err)
+	}
+}
+
+func ioDiscardOutput() *ui.Output {
+	return ui.NewOutput(io.Discard, io.Discard, false)
+}
+
+type errReader struct {
+	err error
+}
+
+func (r errReader) Read([]byte) (int, error) {
+	return 0, r.err
+}

--- a/src/cli/internal/cmd/root_test.go
+++ b/src/cli/internal/cmd/root_test.go
@@ -213,6 +213,11 @@ func TestCLI_Run(t *testing.T) {
 			wantCode: 0,
 		},
 		{
+			name:     "app logs command exists",
+			args:     []string{"app", "logs", "--help"},
+			wantCode: 0,
+		},
+		{
 			name:     "app ps command exists",
 			args:     []string{"app", "ps", "--help"},
 			wantCode: 0,

--- a/src/cli/internal/cmd/run.go
+++ b/src/cli/internal/cmd/run.go
@@ -20,6 +20,7 @@ import (
 	"altinn.studio/studioctl/internal/appimage"
 	"altinn.studio/studioctl/internal/appmanager"
 	appsvc "altinn.studio/studioctl/internal/cmd/app"
+	appsupport "altinn.studio/studioctl/internal/cmd/apps"
 	envlocaltest "altinn.studio/studioctl/internal/cmd/env/localtest"
 	"altinn.studio/studioctl/internal/config"
 	repocontext "altinn.studio/studioctl/internal/context"
@@ -35,7 +36,6 @@ const (
 	appManagerCleanupTimeout          = 2 * time.Second
 	appStartupTimeout                 = 15 * time.Second
 	appStartupPollInterval            = 500 * time.Millisecond
-	appLogDateFormat                  = "2006-01-02"
 	maxAppLogCreateAttempts           = 3
 )
 
@@ -283,20 +283,21 @@ func (c *RunCommand) runDotnet(ctx context.Context, target appsvc.RunTarget, arg
 	if err != nil {
 		return err
 	}
-	if cleanupLog != nil {
-		defer cleanupLog()
-	}
+	defer cleanupLog()
 
 	if startErr := cmd.Start(); startErr != nil {
 		return fmt.Errorf("start dotnet: %w", startErr)
 	}
 
-	waitErr := make(chan error, 1)
-	go func() {
-		waitErr <- cmd.Wait()
-	}()
+	waitErr := waitForCommand(cmd)
 
 	processName := filepath.Base(targetPath)
+	metadataErr := c.writeProcessLogMetadata(target.AppID, cmd.Process.Pid, processName, logPath)
+	if metadataErr != nil {
+		stopDotnetProcess(cmd.Process, waitErr)
+		return metadataErr
+	}
+
 	baseURL, err := c.registerStartedDotnetApp(ctx, target, spec, cmd, waitErr, flags)
 	if err != nil {
 		return err
@@ -357,6 +358,14 @@ func (c *RunCommand) configureDotnetRunCommand(
 	cmd.Stderr = logFile
 	osutil.ApplyDetachedAttrs(cmd)
 	return logPath, func() { closeAppLog(c.out, logFile) }, nil
+}
+
+func waitForCommand(cmd *exec.Cmd) chan error {
+	waitErr := make(chan error, 1)
+	go func() {
+		waitErr <- cmd.Wait()
+	}()
+	return waitErr
 }
 
 func (c *RunCommand) registerStartedDotnetApp(
@@ -473,14 +482,14 @@ func (c *RunCommand) openAppLog(appID string, jsonOutput bool) (*os.File, string
 	if c.cfg == nil {
 		return nil, "", errStudioctlConfigRequired
 	}
-	logDir := c.cfg.AppLogDir(sanitizeAppIDForPath(appID))
+	logDir := c.cfg.AppLogDir(appsupport.SanitizeAppID(appID))
 	if err := os.MkdirAll(logDir, osutil.DirPermOwnerOnly); err != nil {
 		return nil, "", fmt.Errorf("create app log directory: %w", err)
 	}
 	for range maxAppLogCreateAttempts {
-		logPath, err := nextAppLogPath(logDir, time.Now().UTC())
+		logPath, err := appsupport.NextLogPath(logDir, time.Now().UTC())
 		if err != nil {
-			return nil, "", err
+			return nil, "", fmt.Errorf("resolve app log path: %w", err)
 		}
 		//nolint:gosec // G304: log path stays under the configured studioctl log directory; app ID is path-sanitized.
 		logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, osutil.FilePermOwnerOnly)
@@ -499,49 +508,26 @@ func (c *RunCommand) openAppLog(appID string, jsonOutput bool) (*os.File, string
 	return nil, "", fmt.Errorf("create app log: %w", errAppLogCreateCollision)
 }
 
-func nextAppLogPath(dir string, now time.Time) (string, error) {
-	date := now.Format(appLogDateFormat)
-	nextRunID, err := nextAppLogRunID(dir, date)
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, date+"-"+strconv.Itoa(nextRunID)+".log"), nil
-}
-
-func nextAppLogRunID(dir string, date string) (int, error) {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return 0, fmt.Errorf("read app log directory: %w", err)
-	}
-
-	maxRunID := 0
-	prefix := date + "-"
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		name := entry.Name()
-		if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, ".log") {
-			continue
-		}
-		runIDText := strings.TrimSuffix(strings.TrimPrefix(name, prefix), ".log")
-		runID, parseErr := strconv.Atoi(runIDText)
-		if parseErr == nil && runID > maxRunID {
-			maxRunID = runID
-		}
-	}
-	return maxRunID + 1, nil
-}
-
-func sanitizeAppIDForPath(appID string) string {
-	replacer := strings.NewReplacer("/", "-", "\\", "-", ":", "-")
-	return replacer.Replace(strings.Trim(appID, "/"))
-}
-
 func closeAppLog(out *ui.Output, logFile *os.File) {
 	if err := logFile.Close(); err != nil {
 		out.Verbosef("failed to close app log: %v", err)
 	}
+}
+
+func (c *RunCommand) writeProcessLogMetadata(appID string, processID int, processName string, logPath string) error {
+	if err := appsupport.WriteRunMetadata(logPath, appsupport.RunMetadata{
+		StartedAt: time.Now().UTC(),
+		AppID:     appID,
+		Mode:      runModeProcess,
+		ID:        strconv.Itoa(processID),
+		Name:      processName,
+		LogPath:   logPath,
+		ProcessID: processID,
+		HostPort:  0,
+	}); err != nil {
+		return fmt.Errorf("write app log metadata: %w", err)
+	}
+	return nil
 }
 
 func nativeAppRunInfo(processID int) appmanager.AppRegistration {

--- a/src/cli/internal/cmd/run.go
+++ b/src/cli/internal/cmd/run.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -34,6 +35,8 @@ const (
 	appManagerCleanupTimeout          = 2 * time.Second
 	appStartupTimeout                 = 15 * time.Second
 	appStartupPollInterval            = 500 * time.Millisecond
+	appLogDateFormat                  = "2006-01-02"
+	maxAppLogCreateAttempts           = 3
 )
 
 var (
@@ -41,6 +44,7 @@ var (
 	errAppContainerExited              = errors.New("app container exited")
 	errAppContainerStoppedBeforeReady  = errors.New("app container stopped before becoming reachable through localtest")
 	errAppExitedBeforeReady            = errors.New("app exited before becoming reachable through localtest")
+	errAppLogCreateCollision           = errors.New("too many app log files created concurrently")
 	errAppRunStopped                   = errors.New("app run stopped")
 	errAppStartupTimedOut              = errors.New("app did not become reachable through localtest")
 	errDotnetTargetPathEmpty           = errors.New("dotnet TargetPath is empty")
@@ -469,19 +473,64 @@ func (c *RunCommand) openDetachedAppLog(appID string, jsonOutput bool) (*os.File
 	if c.cfg == nil {
 		return nil, "", errStudioctlConfigRequired
 	}
-	if err := os.MkdirAll(c.cfg.LogDir, osutil.DirPermOwnerOnly); err != nil {
-		return nil, "", fmt.Errorf("create log directory: %w", err)
+	logDir := c.cfg.AppLogDir(sanitizeAppIDForPath(appID))
+	if err := os.MkdirAll(logDir, osutil.DirPermOwnerOnly); err != nil {
+		return nil, "", fmt.Errorf("create app log directory: %w", err)
 	}
-	logPath := filepath.Join(c.cfg.LogDir, "app-"+sanitizeAppIDForPath(appID)+".log")
-	//nolint:gosec // G304: log path stays under the configured studioctl log directory; app ID is path-sanitized.
-	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, osutil.FilePermOwnerOnly)
+	for range maxAppLogCreateAttempts {
+		logPath, err := nextAppLogPath(logDir, time.Now().UTC())
+		if err != nil {
+			return nil, "", err
+		}
+		//nolint:gosec // G304: log path stays under the configured studioctl log directory; app ID is path-sanitized.
+		logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, osutil.FilePermOwnerOnly)
+		if errors.Is(err, os.ErrExist) {
+			continue
+		}
+		if err != nil {
+			return nil, "", fmt.Errorf("open app log: %w", err)
+		}
+		if !jsonOutput {
+			c.out.Printlnf("Log: %s", logPath)
+		}
+		return logFile, logPath, nil
+	}
+
+	return nil, "", fmt.Errorf("create app log: %w", errAppLogCreateCollision)
+}
+
+func nextAppLogPath(dir string, now time.Time) (string, error) {
+	date := now.Format(appLogDateFormat)
+	nextRunID, err := nextAppLogRunID(dir, date)
 	if err != nil {
-		return nil, "", fmt.Errorf("open app log: %w", err)
+		return "", err
 	}
-	if !jsonOutput {
-		c.out.Printlnf("Log: %s", logPath)
+	return filepath.Join(dir, date+"-"+strconv.Itoa(nextRunID)+".log"), nil
+}
+
+func nextAppLogRunID(dir string, date string) (int, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0, fmt.Errorf("read app log directory: %w", err)
 	}
-	return logFile, logPath, nil
+
+	maxRunID := 0
+	prefix := date + "-"
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, ".log") {
+			continue
+		}
+		runIDText := strings.TrimSuffix(strings.TrimPrefix(name, prefix), ".log")
+		runID, parseErr := strconv.Atoi(runIDText)
+		if parseErr == nil && runID > maxRunID {
+			maxRunID = runID
+		}
+	}
+	return maxRunID + 1, nil
 }
 
 func sanitizeAppIDForPath(appID string) string {

--- a/src/cli/internal/cmd/run.go
+++ b/src/cli/internal/cmd/run.go
@@ -342,21 +342,21 @@ func (c *RunCommand) configureDotnetRunCommand(
 ) (string, func(), error) {
 	cmd.Dir = spec.Dir
 	cmd.Env = spec.Env
-	if !flags.detach {
-		cmd.Stdin = os.Stdin
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		return "", nil, nil
-	}
-
-	logFile, logPath, err := c.openDetachedAppLog(target.AppID, flags.jsonOutput)
+	logFile, logPath, err := c.openAppLog(target.AppID, flags.jsonOutput)
 	if err != nil {
 		return "", nil, err
 	}
+	if !flags.detach {
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = io.MultiWriter(os.Stdout, logFile)
+		cmd.Stderr = io.MultiWriter(os.Stderr, logFile)
+		return logPath, func() { closeAppLog(c.out, logFile) }, nil
+	}
+
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
 	osutil.ApplyDetachedAttrs(cmd)
-	return logPath, func() { closeDetachedAppLog(c.out, logFile) }, nil
+	return logPath, func() { closeAppLog(c.out, logFile) }, nil
 }
 
 func (c *RunCommand) registerStartedDotnetApp(
@@ -469,7 +469,7 @@ func lastNonEmptyLine(output []byte) string {
 	return ""
 }
 
-func (c *RunCommand) openDetachedAppLog(appID string, jsonOutput bool) (*os.File, string, error) {
+func (c *RunCommand) openAppLog(appID string, jsonOutput bool) (*os.File, string, error) {
 	if c.cfg == nil {
 		return nil, "", errStudioctlConfigRequired
 	}
@@ -538,7 +538,7 @@ func sanitizeAppIDForPath(appID string) string {
 	return replacer.Replace(strings.Trim(appID, "/"))
 }
 
-func closeDetachedAppLog(out *ui.Output, logFile *os.File) {
+func closeAppLog(out *ui.Output, logFile *os.File) {
 	if err := logFile.Close(); err != nil {
 		out.Verbosef("failed to close app log: %v", err)
 	}

--- a/src/cli/internal/cmd/run_internal_test.go
+++ b/src/cli/internal/cmd/run_internal_test.go
@@ -7,11 +7,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	containermock "altinn.studio/devenv/pkg/container/mock"
 	"altinn.studio/devenv/pkg/container/types"
+	"altinn.studio/studioctl/internal/osutil"
 	"altinn.studio/studioctl/internal/ui"
 )
 
@@ -138,6 +142,32 @@ func TestRunDetachedOutputPrintJSON(t *testing.T) {
 	if got.AppID != result.AppID || got.Mode != result.Mode || got.URL != result.URL ||
 		got.LogPath != result.LogPath || got.ProcessID != result.ProcessID {
 		t.Fatalf("output = %+v, want %+v", got, result)
+	}
+}
+
+func TestNextAppLogPathUsesNextRunIDForDate(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	for _, name := range []string{
+		"2026-04-20-1.log",
+		"2026-04-20-3.log",
+		"2026-04-19-10.log",
+		"2026-04-20-not-a-number.log",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), nil, osutil.FilePermOwnerOnly); err != nil {
+			t.Fatalf("write log file: %v", err)
+		}
+	}
+
+	got, err := nextAppLogPath(dir, time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("nextAppLogPath() error = %v", err)
+	}
+
+	want := filepath.Join(dir, "2026-04-20-4.log")
+	if got != want {
+		t.Fatalf("nextAppLogPath() = %q, want %q", got, want)
 	}
 }
 

--- a/src/cli/internal/cmd/run_internal_test.go
+++ b/src/cli/internal/cmd/run_internal_test.go
@@ -15,6 +15,7 @@ import (
 
 	containermock "altinn.studio/devenv/pkg/container/mock"
 	"altinn.studio/devenv/pkg/container/types"
+	appsupport "altinn.studio/studioctl/internal/cmd/apps"
 	"altinn.studio/studioctl/internal/osutil"
 	"altinn.studio/studioctl/internal/ui"
 )
@@ -160,14 +161,14 @@ func TestNextAppLogPathUsesNextRunIDForDate(t *testing.T) {
 		}
 	}
 
-	got, err := nextAppLogPath(dir, time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC))
+	got, err := appsupport.NextLogPath(dir, time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC))
 	if err != nil {
-		t.Fatalf("nextAppLogPath() error = %v", err)
+		t.Fatalf("NextLogPath() error = %v", err)
 	}
 
 	want := filepath.Join(dir, "2026-04-20-4.log")
 	if got != want {
-		t.Fatalf("nextAppLogPath() = %q, want %q", got, want)
+		t.Fatalf("NextLogPath() = %q, want %q", got, want)
 	}
 }
 

--- a/src/cli/internal/cmd/servers/logs.go
+++ b/src/cli/internal/cmd/servers/logs.go
@@ -2,25 +2,15 @@
 package servers
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"os"
 	"strings"
-	"time"
 
 	"altinn.studio/studioctl/internal/appmanager"
+	"altinn.studio/studioctl/internal/logstream"
 	"altinn.studio/studioctl/internal/ui"
-)
-
-const (
-	logScannerBufSize = 64 * 1024
-	logScannerMaxSize = 1024 * 1024
-	logPollInterval   = 200 * time.Millisecond
 )
 
 var (
@@ -33,21 +23,6 @@ type LogOptions struct {
 	Tail   int
 	Follow bool
 	JSON   bool
-}
-
-type logStreamer struct {
-	out    *ui.Output
-	logDir string
-}
-
-type tailSnapshot struct {
-	nextOffsetByPath map[string]int64
-	lines            []string
-}
-
-type tailFileSnapshot struct {
-	lines      []string
-	nextOffset int64
 }
 
 type serverLogLine struct {
@@ -72,306 +47,45 @@ func (l serverLogLine) Print(out *ui.Output) error {
 
 // StreamLogs writes app-manager log lines to the configured output.
 func StreamLogs(ctx context.Context, logDir string, out *ui.Output, opts LogOptions) error {
-	streamer := logStreamer{
-		logDir: logDir,
-		out:    out,
-	}
-	return streamer.stream(ctx, opts)
-}
-
-func (s *logStreamer) stream(ctx context.Context, opts LogOptions) error {
-	files, err := appmanager.LogFiles(s.logDir)
-	if err != nil {
-		return fmt.Errorf("find app-manager logs: %w", err)
-	}
-	if len(files) == 0 && !opts.Follow {
-		return errAppManagerLogsNotFound
-	}
-
-	snapshot, err := readTailSnapshot(logFilePaths(files), opts.Tail)
-	if err != nil {
-		return err
-	}
-	offsets := initialOffsets(files, snapshot)
-	for _, line := range snapshot.lines {
-		if err := printServerLogLine(s.out, line, opts.JSON); err != nil {
-			return err
-		}
-	}
-
-	if !opts.Follow {
-		return nil
-	}
-	return s.follow(ctx, offsets, opts.JSON)
-}
-
-func (s *logStreamer) follow(
-	ctx context.Context,
-	offsetByPath map[string]int64,
-	jsonOutput bool,
-) error {
-	ticker := time.NewTicker(logPollInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case <-ticker.C:
-			if err := s.printChangedFiles(offsetByPath, jsonOutput); err != nil {
-				return err
+	streamer := logstream.Streamer{
+		ListFiles: func() ([]logstream.File, error) {
+			files, err := appmanager.LogFiles(logDir)
+			if err != nil {
+				return nil, fmt.Errorf("find app-manager logs: %w", err)
 			}
+			return appManagerLogFiles(files), nil
+		},
+		Emit: func(_ string, line string) error {
+			return printServerLogLine(out, line, opts.JSON)
+		},
+	}
+	if err := streamer.Stream(ctx, logstream.Options{
+		Tail:    opts.Tail,
+		TailAll: false,
+		Follow:  opts.Follow,
+	}); err != nil {
+		switch {
+		case errors.Is(err, logstream.ErrNoLogFiles):
+			return errAppManagerLogsNotFound
+		case errors.Is(err, logstream.ErrLineTooLong):
+			return errLogLineTooLong
+		default:
+			return fmt.Errorf("stream app-manager logs: %w", err)
 		}
-	}
-}
-
-func logFilePaths(files []appmanager.LogFile) []string {
-	paths := make([]string, 0, len(files))
-	for _, file := range files {
-		paths = append(paths, file.Path)
-	}
-	return paths
-}
-
-func initialOffsets(files []appmanager.LogFile, snapshot tailSnapshot) map[string]int64 {
-	offsetByPath := make(map[string]int64, len(files))
-	for _, file := range files {
-		offset, ok := snapshot.nextOffsetByPath[file.Path]
-		if !ok {
-			offset = file.Size
-		}
-		offsetByPath[file.Path] = offset
-	}
-	return offsetByPath
-}
-
-func (s *logStreamer) printChangedFiles(offsetByPath map[string]int64, jsonOutput bool) error {
-	files, err := appmanager.LogFiles(s.logDir)
-	if err != nil {
-		return fmt.Errorf("find app-manager logs: %w", err)
-	}
-
-	for _, file := range files {
-		offset := offsetByPath[file.Path]
-		nextOffset, err := s.printAppended(file.Path, offset, jsonOutput)
-		if err != nil {
-			return err
-		}
-		offsetByPath[file.Path] = nextOffset
 	}
 	return nil
 }
 
-func (s *logStreamer) printAppended(path string, offset int64, jsonOutput bool) (int64, error) {
-	if size := fileSize(path); size < offset {
-		offset = 0
-	} else if size == offset {
-		return offset, nil
+func appManagerLogFiles(files []appmanager.LogFile) []logstream.File {
+	result := make([]logstream.File, 0, len(files))
+	for _, file := range files {
+		result = append(result, logstream.File{
+			ModTime: file.ModTime,
+			Path:    file.Path,
+			Size:    file.Size,
+		})
 	}
-
-	//nolint:gosec // G304: path comes from the configured log directory and app-manager log filename pattern.
-	file, err := os.Open(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return offset, nil
-		}
-		return offset, fmt.Errorf("open app-manager log: %w", err)
-	}
-	defer func() {
-		if closeErr := file.Close(); closeErr != nil {
-			s.out.Verbosef("failed to close app-manager log: %v", closeErr)
-		}
-	}()
-
-	nextOffset, err := scanCompleteLines(file, offset, func(line string) error {
-		return printServerLogLine(s.out, line, jsonOutput)
-	})
-	if err != nil {
-		return offset, err
-	}
-	return nextOffset, nil
-}
-
-func readTailSnapshot(paths []string, tail int) (tailSnapshot, error) {
-	snapshot := tailSnapshot{
-		nextOffsetByPath: make(map[string]int64, len(paths)),
-		lines:            nil,
-	}
-	if tail == 0 {
-		return snapshot, nil
-	}
-
-	chunks := make([][]string, 0, len(paths))
-	remaining := tail
-	for i := len(paths) - 1; i >= 0 && remaining > 0; i-- {
-		path := paths[i]
-		fileTail, err := readFileTail(path, remaining)
-		if err != nil {
-			return tailSnapshot{}, err
-		}
-		snapshot.nextOffsetByPath[path] = fileTail.nextOffset
-		if len(fileTail.lines) == 0 {
-			continue
-		}
-		chunks = append(chunks, fileTail.lines)
-		remaining -= len(fileTail.lines)
-	}
-
-	for i := len(chunks) - 1; i >= 0; i-- {
-		snapshot.lines = append(snapshot.lines, chunks[i]...)
-	}
-	return snapshot, nil
-}
-
-func readFileTail(path string, maxLines int) (snapshot tailFileSnapshot, err error) {
-	//nolint:gosec // G304: path comes from the configured log directory and app-manager log filename pattern.
-	file, err := os.Open(path)
-	if err != nil {
-		return tailFileSnapshot{}, fmt.Errorf("open app-manager log: %w", err)
-	}
-	defer func() {
-		if closeErr := file.Close(); err == nil && closeErr != nil {
-			err = fmt.Errorf("close app-manager log: %w", closeErr)
-		}
-	}()
-
-	info, err := file.Stat()
-	if err != nil {
-		return tailFileSnapshot{}, fmt.Errorf("stat app-manager log: %w", err)
-	}
-	if info.IsDir() {
-		return tailFileSnapshot{lines: nil, nextOffset: 0}, nil
-	}
-
-	return readFileTailFrom(file, info.Size(), maxLines)
-}
-
-func readFileTailFrom(file *os.File, size int64, maxLines int) (tailFileSnapshot, error) {
-	if size == 0 {
-		return tailFileSnapshot{lines: nil, nextOffset: 0}, nil
-	}
-
-	buf := make([]byte, 0, logScannerBufSize)
-	chunk := make([]byte, logScannerBufSize)
-	for start := size; start > 0; {
-		nextStart, nextBuf, err := prependPreviousChunk(file, start, chunk, buf)
-		if err != nil {
-			return tailFileSnapshot{}, err
-		}
-		start = nextStart
-		buf = nextBuf
-
-		snapshot, done, err := tailSnapshotFromBuffer(buf, start, maxLines)
-		if err != nil || done {
-			return snapshot, err
-		}
-	}
-
-	return tailFileSnapshot{lines: nil, nextOffset: 0}, nil
-}
-
-func prependPreviousChunk(file *os.File, start int64, chunk, buf []byte) (int64, []byte, error) {
-	readSize := min(int64(len(chunk)), start)
-	readLen := int(readSize)
-	nextStart := start - readSize
-	if _, err := file.ReadAt(chunk[:readLen], nextStart); err != nil && !errors.Is(err, io.EOF) {
-		return 0, nil, fmt.Errorf("read app-manager log tail: %w", err)
-	}
-
-	nextBuf := make([]byte, readLen+len(buf))
-	copy(nextBuf, chunk[:readLen])
-	copy(nextBuf[readLen:], buf)
-	return nextStart, nextBuf, nil
-}
-
-func tailSnapshotFromBuffer(buf []byte, start int64, maxLines int) (tailFileSnapshot, bool, error) {
-	completeEnd := bytes.LastIndexByte(buf, '\n') + 1
-	if completeEnd == 0 {
-		if len(buf) > logScannerMaxSize {
-			return tailFileSnapshot{}, false, errLogLineTooLong
-		}
-		return tailFileSnapshot{lines: nil, nextOffset: 0}, false, nil
-	}
-
-	complete := buf[:completeEnd]
-	newlineCount := bytes.Count(complete, []byte{'\n'})
-	if newlineCount <= maxLines && start > 0 {
-		return tailFileSnapshot{lines: nil, nextOffset: 0}, false, nil
-	}
-
-	lines, err := tailLinesFromCompleteBytes(complete, maxLines)
-	if err != nil {
-		return tailFileSnapshot{}, false, err
-	}
-	return tailFileSnapshot{
-		lines:      lines,
-		nextOffset: start + int64(completeEnd),
-	}, true, nil
-}
-
-func tailLinesFromCompleteBytes(data []byte, maxLines int) ([]string, error) {
-	parts := bytes.Split(data, []byte{'\n'})
-	if len(parts) == 0 {
-		return nil, nil
-	}
-	parts = parts[:len(parts)-1]
-	if len(parts) > maxLines {
-		parts = parts[len(parts)-maxLines:]
-	}
-
-	lines := make([]string, 0, len(parts))
-	for _, part := range parts {
-		if len(part) > logScannerMaxSize {
-			return nil, errLogLineTooLong
-		}
-		lines = append(lines, string(part))
-	}
-	return lines, nil
-}
-
-func scanCompleteLines(file *os.File, offset int64, emit func(string) error) (int64, error) {
-	if _, err := file.Seek(offset, io.SeekStart); err != nil {
-		return offset, fmt.Errorf("seek app-manager log: %w", err)
-	}
-
-	reader := bufio.NewReaderSize(file, logScannerBufSize)
-	// nextOffset is always the byte after the last emitted newline. EOF without
-	// a newline leaves the offset unchanged, so follow mode retries the partial
-	// line and emits it only when it becomes complete.
-	nextOffset := offset
-	line := make([]byte, 0, logScannerBufSize)
-
-	for {
-		fragment, err := reader.ReadSlice('\n')
-		if len(line)+len(fragment) > logScannerMaxSize {
-			return nextOffset, errLogLineTooLong
-		}
-		line = append(line, fragment...)
-
-		switch {
-		case errors.Is(err, bufio.ErrBufferFull):
-			continue
-		case errors.Is(err, io.EOF):
-			return nextOffset, nil
-		case err != nil:
-			return nextOffset, fmt.Errorf("read app-manager log: %w", err)
-		}
-
-		nextOffset += int64(len(line))
-		text := strings.TrimSuffix(string(line), "\n")
-		if err := emit(text); err != nil {
-			return nextOffset, err
-		}
-		line = line[:0]
-	}
-}
-
-func fileSize(path string) int64 {
-	info, err := os.Stat(path)
-	if err != nil || info.IsDir() {
-		return 0
-	}
-	return info.Size()
+	return result
 }
 
 func printServerLogLine(out *ui.Output, line string, jsonOutput bool) error {

--- a/src/cli/internal/cmd/servers/logs_internal_test.go
+++ b/src/cli/internal/cmd/servers/logs_internal_test.go
@@ -3,12 +3,11 @@ package servers
 import (
 	"bytes"
 	"context"
-	"fmt"
+	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -16,165 +15,20 @@ import (
 	"altinn.studio/studioctl/internal/ui"
 )
 
-func TestReadTailSnapshot_ReturnsOffsetAtScanEnd(t *testing.T) {
-	t.Parallel()
-
-	path := writeLog(t, t.TempDir(), "one\n")
-
-	snapshot, err := readTailSnapshot([]string{path}, 100)
-	if err != nil {
-		t.Fatalf("readTailSnapshot() error = %v", err)
-	}
-	if strings.Join(snapshot.lines, "\n") != "one" {
-		t.Fatalf("lines = %v, want one", snapshot.lines)
-	}
-
-	appendLog(t, path, "two\n")
-	if snapshot.nextOffsetByPath[path] != int64(len("one\n")) {
-		t.Fatalf("offset = %d, want %d", snapshot.nextOffsetByPath[path], len("one\n"))
-	}
-}
-
-func TestTailThenPrintAppended_EmitsEachCompleteLineOnce(t *testing.T) {
-	t.Parallel()
-
-	path := writeLog(t, t.TempDir(), "one\n")
-	var out bytes.Buffer
-	streamer := logStreamer{
-		logDir: filepath.Dir(path),
-		out:    ui.NewOutput(&out, io.Discard, false),
-	}
-
-	snapshot, err := readTailSnapshot([]string{path}, 100)
-	if err != nil {
-		t.Fatalf("readTailSnapshot() error = %v", err)
-	}
-	for _, line := range snapshot.lines {
-		if printErr := printServerLogLine(streamer.out, line, false); printErr != nil {
-			t.Fatalf("printServerLogLine() error = %v", printErr)
-		}
-	}
-
-	appendLog(t, path, "two\n")
-	offset, err := streamer.printAppended(path, snapshot.nextOffsetByPath[path], false)
-	if err != nil {
-		t.Fatalf("printAppended() error = %v", err)
-	}
-	if out.String() != "one"+osutil.LineBreak+"two"+osutil.LineBreak {
-		t.Fatalf("output = %q, want one and two once", out.String())
-	}
-	if offset != int64(len("one\ntwo\n")) {
-		t.Fatalf("offset = %d, want %d", offset, len("one\ntwo\n"))
-	}
-
-	out.Reset()
-	_, err = streamer.printAppended(path, offset, false)
-	if err != nil {
-		t.Fatalf("second printAppended() error = %v", err)
-	}
-	if out.String() != "" {
-		t.Fatalf("second output = %q, want empty", out.String())
-	}
-}
-
-func TestReadTailSnapshot_ReturnsLastLines(t *testing.T) {
-	t.Parallel()
-
-	path := writeLog(t, t.TempDir(), "one\ntwo\nthree\nfour\n")
-
-	snapshot, err := readTailSnapshot([]string{path}, 2)
-	if err != nil {
-		t.Fatalf("readTailSnapshot() error = %v", err)
-	}
-	if strings.Join(snapshot.lines, "\n") != "three\nfour" {
-		t.Fatalf("lines = %v, want three and four", snapshot.lines)
-	}
-	if snapshot.nextOffsetByPath[path] != int64(len("one\ntwo\nthree\nfour\n")) {
-		t.Fatalf("offset = %d, want end of complete log", snapshot.nextOffsetByPath[path])
-	}
-}
-
-func TestReadTailSnapshot_ReadsOlderFilesOnlyWhenNeeded(t *testing.T) {
+func TestStreamLogsReadsLatestLog(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	oldPath := writeNamedLog(t, dir, "2026-04-18-1.log", "one\n")
-	newPath := writeNamedLog(t, dir, "2026-04-19-1.log", "two\n")
-
-	snapshot, err := readTailSnapshot([]string{oldPath, newPath}, 2)
-	if err != nil {
-		t.Fatalf("readTailSnapshot() error = %v", err)
-	}
-	if strings.Join(snapshot.lines, "\n") != "one\ntwo" {
-		t.Fatalf("lines = %v, want one and two", snapshot.lines)
-	}
-}
-
-func TestReadTailSnapshot_DoesNotReadOldFilesWhenNewerFileSatisfiesTail(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	oldPath := writeNamedLog(t, dir, "2026-04-18-1.log", strings.Repeat("x", logScannerMaxSize+1))
-	newPath := writeNamedLog(t, dir, "2026-04-19-1.log", "new\n")
-
-	snapshot, err := readTailSnapshot([]string{oldPath, newPath}, 1)
-	if err != nil {
-		t.Fatalf("readTailSnapshot() error = %v", err)
-	}
-	if strings.Join(snapshot.lines, "\n") != "new" {
-		t.Fatalf("lines = %v, want new", snapshot.lines)
-	}
-	if _, ok := snapshot.nextOffsetByPath[oldPath]; ok {
-		t.Fatalf("old log offset recorded, want old file left unread")
-	}
-}
-
-func TestPrintAppended_HoldsPartialLineUntilNewline(t *testing.T) {
-	t.Parallel()
-
-	path := writeLog(t, t.TempDir(), "one\npartial")
-	var out bytes.Buffer
-	streamer := logStreamer{
-		logDir: filepath.Dir(path),
-		out:    ui.NewOutput(&out, io.Discard, false),
-	}
-
-	offset, err := streamer.printAppended(path, int64(len("one\n")), false)
-	if err != nil {
-		t.Fatalf("printAppended() error = %v", err)
-	}
-	if out.String() != "" {
-		t.Fatalf("output = %q, want empty", out.String())
-	}
-	if offset != int64(len("one\n")) {
-		t.Fatalf("offset = %d, want %d", offset, len("one\n"))
-	}
-
-	appendLog(t, path, " rest\n")
-	offset, err = streamer.printAppended(path, offset, false)
-	if err != nil {
-		t.Fatalf("second printAppended() error = %v", err)
-	}
-	if out.String() != "partial rest"+osutil.LineBreak {
-		t.Fatalf("output = %q, want completed line", out.String())
-	}
-	if offset != int64(len("one\npartial rest\n")) {
-		t.Fatalf("offset = %d, want %d", offset, len("one\npartial rest\n"))
-	}
-}
-
-func TestStreamLogs_WithoutPIDReadsLatestLog(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	oldPath := writeNamedLog(t, dir, "2026-04-18-1.log", "old\n")
-	newPath := writeNamedLog(t, dir, "2026-04-19-2.log", "new\n")
-	setLogModTime(t, oldPath, time.Date(2026, 4, 18, 1, 0, 0, 0, time.UTC))
-	setLogModTime(t, newPath, time.Date(2026, 4, 19, 1, 0, 0, 0, time.UTC))
+	oldPath := writeServerLog(t, dir, "2026-04-18-1.log", "old\n")
+	newPath := writeServerLog(t, dir, "2026-04-19-2.log", "new\n")
+	setServerLogModTime(t, oldPath, time.Date(2026, 4, 18, 1, 0, 0, 0, time.UTC))
+	setServerLogModTime(t, newPath, time.Date(2026, 4, 19, 1, 0, 0, 0, time.UTC))
 
 	var out bytes.Buffer
 	err := StreamLogs(context.Background(), dir, ui.NewOutput(&out, io.Discard, false), LogOptions{
-		Tail: 1,
+		Tail:   1,
+		Follow: false,
+		JSON:   false,
 	})
 	if err != nil {
 		t.Fatalf("StreamLogs() error = %v", err)
@@ -184,148 +38,76 @@ func TestStreamLogs_WithoutPIDReadsLatestLog(t *testing.T) {
 	}
 }
 
-func TestPrintChangedFiles_ReadsNewFilesFromBeginning(t *testing.T) {
+func TestStreamLogsJSON(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	oldPath := writeNamedLog(t, dir, "2026-04-18-1.log", "old\n")
-	offsets := map[string]int64{oldPath: int64(len("old\n"))}
-	newPath := writeNamedLog(t, dir, "2026-04-19-2.log", "new\n")
-	setLogModTime(t, oldPath, time.Date(2026, 4, 18, 1, 0, 0, 0, time.UTC))
-	setLogModTime(t, newPath, time.Date(2026, 4, 19, 1, 0, 0, 0, time.UTC))
+	writeServerLog(t, dir, "2026-04-19-1.log", "line\n")
 
 	var out bytes.Buffer
-	streamer := logStreamer{
-		logDir: dir,
-		out:    ui.NewOutput(&out, io.Discard, false),
-	}
-
-	if err := streamer.printChangedFiles(offsets, false); err != nil {
-		t.Fatalf("printChangedFiles() error = %v", err)
-	}
-	if out.String() != "new"+osutil.LineBreak {
-		t.Fatalf("output = %q, want new file contents", out.String())
-	}
-	if offsets[newPath] != int64(len("new\n")) {
-		t.Fatalf("new offset = %d, want %d", offsets[newPath], len("new\n"))
-	}
-}
-
-func TestFollowDiscoversNewLogFile(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	var out lockedBuffer
-	streamer := logStreamer{
-		logDir: dir,
-		out:    ui.NewOutput(&out, io.Discard, false),
-	}
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- streamer.follow(ctx, map[string]int64{}, false)
-	}()
-
-	writeNamedLog(t, dir, "2026-04-19-2.log", "new\n")
-	waitForOutput(t, &out, "new"+osutil.LineBreak)
-	cancel()
-
-	if err := <-errCh; err != nil {
-		t.Fatalf("StreamLogs() error = %v, want nil", err)
-	}
-}
-
-func writeLog(t *testing.T, dir, content string) string {
-	t.Helper()
-
-	return writeNamedLog(t, dir, "2026-04-19-1.log", content)
-}
-
-func writeNamedLog(t *testing.T, dir, name, content string) string {
-	t.Helper()
-
-	path := filepath.Join(dir, name)
-	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
-		t.Fatalf("write log %q: %v", path, err)
-	}
-	return path
-}
-
-func appendLog(t *testing.T, path, content string) {
-	t.Helper()
-
-	file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0)
+	err := StreamLogs(context.Background(), dir, ui.NewOutput(&out, io.Discard, false), LogOptions{
+		Tail:   1,
+		Follow: false,
+		JSON:   true,
+	})
 	if err != nil {
-		t.Fatalf("open log %q: %v", path, err)
+		t.Fatalf("StreamLogs() error = %v", err)
 	}
-	defer func() {
-		if closeErr := file.Close(); closeErr != nil {
-			t.Fatalf("close log %q: %v", path, closeErr)
-		}
-	}()
 
-	if _, err := file.WriteString(content); err != nil {
-		t.Fatalf("append log %q: %v", path, err)
+	var got serverLogLine
+	if err := json.Unmarshal(bytes.TrimSpace(out.Bytes()), &got); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
 	}
-}
-
-func setLogModTime(t *testing.T, path string, modTime time.Time) {
-	t.Helper()
-
-	if err := os.Chtimes(path, modTime, modTime); err != nil {
-		t.Fatalf("set log modtime %q: %v", path, err)
+	if got.Server != "app-manager" || got.Line != "line" {
+		t.Fatalf("output = %+v, want app-manager log line", got)
 	}
 }
 
-func TestStreamLogs_ContextCanceledFollowReturnsNil(t *testing.T) {
+func TestStreamLogsMissingLogFile(t *testing.T) {
+	t.Parallel()
+
+	err := StreamLogs(context.Background(), t.TempDir(), ui.NewOutput(io.Discard, io.Discard, false), LogOptions{
+		Tail:   1,
+		Follow: false,
+		JSON:   false,
+	})
+	if !errors.Is(err, errAppManagerLogsNotFound) {
+		t.Fatalf("StreamLogs() error = %v, want errAppManagerLogsNotFound", err)
+	}
+}
+
+func TestStreamLogsContextCanceledFollowReturnsNil(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	writeLog(t, dir, "one\n")
+	writeServerLog(t, dir, "2026-04-19-1.log", "one\n")
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
 	err := StreamLogs(ctx, dir, ui.NewOutput(io.Discard, io.Discard, false), LogOptions{
 		Tail:   0,
 		Follow: true,
+		JSON:   false,
 	})
 	if err != nil {
 		t.Fatalf("StreamLogs() error = %v, want nil", err)
 	}
 }
 
-type lockedBuffer struct {
-	buf bytes.Buffer
-	mu  sync.Mutex
-}
-
-func (b *lockedBuffer) Write(p []byte) (int, error) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	n, err := b.buf.Write(p)
-	if err != nil {
-		return n, fmt.Errorf("write locked buffer: %w", err)
-	}
-	return n, nil
-}
-
-func (b *lockedBuffer) String() string {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return b.buf.String()
-}
-
-func waitForOutput(t *testing.T, out *lockedBuffer, want string) {
+func writeServerLog(t *testing.T, dir string, name string, content string) string {
 	t.Helper()
 
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if out.String() == want {
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), osutil.FilePermOwnerOnly); err != nil {
+		t.Fatalf("write server log %q: %v", path, err)
 	}
-	t.Fatalf("output = %q, want %q", out.String(), want)
+	return path
+}
+
+func setServerLogModTime(t *testing.T, path string, modTime time.Time) {
+	t.Helper()
+
+	if err := os.Chtimes(path, modTime, modTime); err != nil {
+		t.Fatalf("set server log modtime %q: %v", path, err)
+	}
 }

--- a/src/cli/internal/config/config.go
+++ b/src/cli/internal/config/config.go
@@ -230,6 +230,16 @@ func (c *Config) AppManagerLogDir() string {
 	return filepath.Join(c.LogDir, "app-manager")
 }
 
+// AppLogsDir returns the directory containing app log directories.
+func (c *Config) AppLogsDir() string {
+	return filepath.Join(c.LogDir, "apps")
+}
+
+// AppLogDir returns the directory containing logs for one app.
+func (c *Config) AppLogDir(appID string) string {
+	return filepath.Join(c.AppLogsDir(), appID)
+}
+
 // AppManagerBinaryPath returns the path to the app-manager binary.
 // On Windows, the .exe suffix is automatically appended.
 func (c *Config) AppManagerBinaryPath() string {

--- a/src/cli/internal/logstream/logstream.go
+++ b/src/cli/internal/logstream/logstream.go
@@ -178,7 +178,14 @@ func (s Streamer) printChangedFiles(offsetByPath map[string]int64) error {
 }
 
 func (s Streamer) printAppended(path string, offset int64) (int64, error) {
-	if size := fileSize(path); size < offset {
+	size, ok, err := fileSize(path)
+	if err != nil {
+		return offset, err
+	}
+	if !ok {
+		return offset, nil
+	}
+	if size < offset {
 		offset = 0
 	} else if size == offset {
 		return offset, nil
@@ -379,12 +386,18 @@ func scanCompleteLines(file *os.File, offset int64, emit func(string) error) (in
 	}
 }
 
-func fileSize(path string) int64 {
+func fileSize(path string) (int64, bool, error) {
 	info, err := os.Stat(path)
-	if err != nil || info.IsDir() {
-		return 0
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("stat log: %w", err)
 	}
-	return info.Size()
+	if info.IsDir() {
+		return 0, false, nil
+	}
+	return info.Size(), true, nil
 }
 
 func ignoreError(error) {

--- a/src/cli/internal/logstream/logstream.go
+++ b/src/cli/internal/logstream/logstream.go
@@ -1,0 +1,391 @@
+// Package logstream provides shared file log tailing and following.
+package logstream
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"time"
+)
+
+const (
+	// ScannerBufSize is the initial scanner buffer size used for log lines.
+	ScannerBufSize = 64 * 1024
+	// ScannerMaxSize is the maximum supported size for one log line.
+	ScannerMaxSize = 1024 * 1024
+	// PollInterval controls how often followed files are checked for appended lines.
+	PollInterval = 200 * time.Millisecond
+)
+
+var (
+	// ErrLineTooLong is returned when a log line exceeds ScannerMaxSize.
+	ErrLineTooLong = errors.New("log line exceeds max size")
+	// ErrNoLogFiles is returned when no files are available and follow mode is disabled.
+	ErrNoLogFiles = errors.New("log files not found")
+)
+
+// File describes one log file available to the streamer.
+type File struct {
+	ModTime time.Time
+	Path    string
+	Size    int64
+}
+
+// Options configures file log streaming.
+type Options struct {
+	Tail    int
+	TailAll bool
+	Follow  bool
+}
+
+// Streamer tails and follows files returned by ListFiles.
+type Streamer struct {
+	ListFiles func() ([]File, error)
+	Emit      func(path string, line string) error
+}
+
+type tailSnapshot struct {
+	nextOffsetByPath map[string]int64
+	lines            []tailLine
+}
+
+type tailLine struct {
+	path string
+	text string
+}
+
+type tailFileSnapshot struct {
+	lines      []string
+	nextOffset int64
+}
+
+// Stream emits tailed lines and optionally follows future appended lines.
+func (s Streamer) Stream(ctx context.Context, opts Options) error {
+	files, err := s.ListFiles()
+	if err != nil {
+		return err
+	}
+	if len(files) == 0 && !opts.Follow {
+		return ErrNoLogFiles
+	}
+
+	offsets, err := s.emitInitial(files, opts)
+	if err != nil {
+		return err
+	}
+
+	if !opts.Follow {
+		return nil
+	}
+	return s.follow(ctx, offsets)
+}
+
+func (s Streamer) emitInitial(files []File, opts Options) (map[string]int64, error) {
+	if opts.TailAll {
+		return s.emitAll(files)
+	}
+
+	snapshot, err := readTailSnapshot(logFilePaths(files), opts.Tail)
+	if err != nil {
+		return nil, err
+	}
+	offsets := initialOffsets(files, snapshot)
+	for _, line := range snapshot.lines {
+		if err := s.Emit(line.path, line.text); err != nil {
+			return nil, err
+		}
+	}
+	return offsets, nil
+}
+
+func (s Streamer) emitAll(files []File) (map[string]int64, error) {
+	offsetByPath := make(map[string]int64, len(files))
+	for _, candidate := range files {
+		file, err := os.Open(candidate.Path)
+		if err != nil {
+			return nil, fmt.Errorf("open log: %w", err)
+		}
+		offset, scanErr := scanCompleteLines(file, 0, func(line string) error {
+			return s.Emit(candidate.Path, line)
+		})
+		closeErr := file.Close()
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		if closeErr != nil {
+			return nil, fmt.Errorf("close log: %w", closeErr)
+		}
+		offsetByPath[candidate.Path] = offset
+	}
+	return offsetByPath, nil
+}
+
+func (s Streamer) follow(ctx context.Context, offsetByPath map[string]int64) error {
+	ticker := time.NewTicker(PollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := s.printChangedFiles(offsetByPath); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func logFilePaths(files []File) []string {
+	paths := make([]string, 0, len(files))
+	for _, file := range files {
+		paths = append(paths, file.Path)
+	}
+	return paths
+}
+
+func initialOffsets(files []File, snapshot tailSnapshot) map[string]int64 {
+	offsetByPath := make(map[string]int64, len(files))
+	for _, file := range files {
+		offset, ok := snapshot.nextOffsetByPath[file.Path]
+		if !ok {
+			offset = file.Size
+		}
+		offsetByPath[file.Path] = offset
+	}
+	return offsetByPath
+}
+
+func (s Streamer) printChangedFiles(offsetByPath map[string]int64) error {
+	files, err := s.ListFiles()
+	if err != nil {
+		return err
+	}
+
+	for _, file := range files {
+		offset := offsetByPath[file.Path]
+		nextOffset, err := s.printAppended(file.Path, offset)
+		if err != nil {
+			return err
+		}
+		offsetByPath[file.Path] = nextOffset
+	}
+	return nil
+}
+
+func (s Streamer) printAppended(path string, offset int64) (int64, error) {
+	if size := fileSize(path); size < offset {
+		offset = 0
+	} else if size == offset {
+		return offset, nil
+	}
+
+	//nolint:gosec // G304: path comes from a caller-provided log file list.
+	file, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return offset, nil
+		}
+		return offset, fmt.Errorf("open log: %w", err)
+	}
+	defer func() {
+		ignoreError(file.Close())
+	}()
+
+	nextOffset, err := scanCompleteLines(file, offset, func(line string) error {
+		return s.Emit(path, line)
+	})
+	if err != nil {
+		return offset, err
+	}
+	return nextOffset, nil
+}
+
+func readTailSnapshot(paths []string, tail int) (tailSnapshot, error) {
+	snapshot := tailSnapshot{
+		nextOffsetByPath: make(map[string]int64, len(paths)),
+		lines:            nil,
+	}
+	if tail == 0 {
+		return snapshot, nil
+	}
+
+	chunks := make([][]tailLine, 0, len(paths))
+	remaining := tail
+	for i := len(paths) - 1; i >= 0 && remaining > 0; i-- {
+		path := paths[i]
+		fileTail, err := readFileTail(path, remaining)
+		if err != nil {
+			return tailSnapshot{}, err
+		}
+		snapshot.nextOffsetByPath[path] = fileTail.nextOffset
+		if len(fileTail.lines) == 0 {
+			continue
+		}
+		lines := make([]tailLine, 0, len(fileTail.lines))
+		for _, line := range fileTail.lines {
+			lines = append(lines, tailLine{path: path, text: line})
+		}
+		chunks = append(chunks, lines)
+		remaining -= len(lines)
+	}
+
+	for i := len(chunks) - 1; i >= 0; i-- {
+		snapshot.lines = append(snapshot.lines, chunks[i]...)
+	}
+	return snapshot, nil
+}
+
+func readFileTail(path string, maxLines int) (snapshot tailFileSnapshot, err error) {
+	//nolint:gosec // G304: path comes from a caller-provided log file list.
+	file, err := os.Open(path)
+	if err != nil {
+		return tailFileSnapshot{}, fmt.Errorf("open log: %w", err)
+	}
+	defer func() {
+		if closeErr := file.Close(); err == nil && closeErr != nil {
+			err = fmt.Errorf("close log: %w", closeErr)
+		}
+	}()
+
+	info, err := file.Stat()
+	if err != nil {
+		return tailFileSnapshot{}, fmt.Errorf("stat log: %w", err)
+	}
+	if info.IsDir() {
+		return tailFileSnapshot{lines: nil, nextOffset: 0}, nil
+	}
+
+	return readFileTailFrom(file, info.Size(), maxLines)
+}
+
+func readFileTailFrom(file *os.File, size int64, maxLines int) (tailFileSnapshot, error) {
+	if size == 0 {
+		return tailFileSnapshot{lines: nil, nextOffset: 0}, nil
+	}
+
+	buf := make([]byte, 0, ScannerBufSize)
+	chunk := make([]byte, ScannerBufSize)
+	for start := size; start > 0; {
+		nextStart, nextBuf, err := prependPreviousChunk(file, start, chunk, buf)
+		if err != nil {
+			return tailFileSnapshot{}, err
+		}
+		start = nextStart
+		buf = nextBuf
+
+		snapshot, done, err := tailSnapshotFromBuffer(buf, start, maxLines)
+		if err != nil || done {
+			return snapshot, err
+		}
+	}
+
+	return tailFileSnapshot{lines: nil, nextOffset: 0}, nil
+}
+
+func prependPreviousChunk(file *os.File, start int64, chunk, buf []byte) (int64, []byte, error) {
+	readSize := min(int64(len(chunk)), start)
+	readLen := int(readSize)
+	nextStart := start - readSize
+	if _, err := file.ReadAt(chunk[:readLen], nextStart); err != nil && !errors.Is(err, io.EOF) {
+		return 0, nil, fmt.Errorf("read log tail: %w", err)
+	}
+
+	nextBuf := make([]byte, readLen+len(buf))
+	copy(nextBuf, chunk[:readLen])
+	copy(nextBuf[readLen:], buf)
+	return nextStart, nextBuf, nil
+}
+
+func tailSnapshotFromBuffer(buf []byte, start int64, maxLines int) (tailFileSnapshot, bool, error) {
+	completeEnd := bytes.LastIndexByte(buf, '\n') + 1
+	if completeEnd == 0 {
+		if len(buf) > ScannerMaxSize {
+			return tailFileSnapshot{}, false, ErrLineTooLong
+		}
+		return tailFileSnapshot{lines: nil, nextOffset: 0}, false, nil
+	}
+
+	complete := buf[:completeEnd]
+	newlineCount := bytes.Count(complete, []byte{'\n'})
+	if newlineCount <= maxLines && start > 0 {
+		return tailFileSnapshot{lines: nil, nextOffset: 0}, false, nil
+	}
+
+	lines, err := tailLinesFromCompleteBytes(complete, maxLines)
+	if err != nil {
+		return tailFileSnapshot{}, false, err
+	}
+	return tailFileSnapshot{
+		lines:      lines,
+		nextOffset: start + int64(completeEnd),
+	}, true, nil
+}
+
+func tailLinesFromCompleteBytes(data []byte, maxLines int) ([]string, error) {
+	parts := bytes.Split(data, []byte{'\n'})
+	if len(parts) == 0 {
+		return nil, nil
+	}
+	parts = parts[:len(parts)-1]
+	if len(parts) > maxLines {
+		parts = parts[len(parts)-maxLines:]
+	}
+
+	lines := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if len(part) > ScannerMaxSize {
+			return nil, ErrLineTooLong
+		}
+		lines = append(lines, string(part))
+	}
+	return lines, nil
+}
+
+func scanCompleteLines(file *os.File, offset int64, emit func(string) error) (int64, error) {
+	if _, err := file.Seek(offset, io.SeekStart); err != nil {
+		return offset, fmt.Errorf("seek log: %w", err)
+	}
+
+	reader := bufio.NewReaderSize(file, ScannerBufSize)
+	nextOffset := offset
+	line := make([]byte, 0, ScannerBufSize)
+
+	for {
+		fragment, err := reader.ReadSlice('\n')
+		if len(line)+len(fragment) > ScannerMaxSize {
+			return nextOffset, ErrLineTooLong
+		}
+		line = append(line, fragment...)
+
+		switch {
+		case errors.Is(err, bufio.ErrBufferFull):
+			continue
+		case errors.Is(err, io.EOF):
+			return nextOffset, nil
+		case err != nil:
+			return nextOffset, fmt.Errorf("read log: %w", err)
+		}
+
+		nextOffset += int64(len(line))
+		if err := emit(string(bytes.TrimSuffix(line, []byte{'\n'}))); err != nil {
+			return nextOffset, err
+		}
+		line = line[:0]
+	}
+}
+
+func fileSize(path string) int64 {
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return 0
+	}
+	return info.Size()
+}
+
+func ignoreError(error) {
+}

--- a/src/cli/internal/logstream/logstream_test.go
+++ b/src/cli/internal/logstream/logstream_test.go
@@ -1,0 +1,197 @@
+package logstream_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"altinn.studio/studioctl/internal/logstream"
+	"altinn.studio/studioctl/internal/osutil"
+)
+
+func TestStreamTailsNewestLinesAcrossFiles(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	oldPath := writeLog(t, dir, "2026-04-19-1.log", "old\n")
+	newPath := writeLog(t, dir, "2026-04-20-1.log", "new-one\nnew-two\n")
+	setLogModTime(t, oldPath, time.Date(2026, 4, 19, 1, 0, 0, 0, time.UTC))
+	setLogModTime(t, newPath, time.Date(2026, 4, 20, 1, 0, 0, 0, time.UTC))
+
+	var out bytes.Buffer
+	err := logstream.Streamer{
+		ListFiles: listFiles(dir),
+		Emit: func(_ string, line string) error {
+			out.WriteString(line)
+			out.WriteString(osutil.LineBreak)
+			return nil
+		},
+	}.Stream(context.Background(), logstream.Options{
+		Tail:   2,
+		Follow: false,
+	})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	if out.String() != "new-one"+osutil.LineBreak+"new-two"+osutil.LineBreak {
+		t.Fatalf("output = %q, want newest lines", out.String())
+	}
+}
+
+func TestStreamFollowsAppendedCompleteLines(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := writeLog(t, dir, "2026-04-20-1.log", "one\n")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var out bytes.Buffer
+	listed := make(chan struct{})
+	var listedOnce sync.Once
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- logstream.Streamer{
+			ListFiles: func() ([]logstream.File, error) {
+				listedOnce.Do(func() { close(listed) })
+				return listFiles(dir)()
+			},
+			Emit: func(_ string, line string) error {
+				out.WriteString(line)
+				out.WriteString(osutil.LineBreak)
+				return nil
+			},
+		}.Stream(ctx, logstream.Options{
+			Tail:   0,
+			Follow: true,
+		})
+	}()
+
+	<-listed
+	appendLog(t, path, "two\n")
+	waitForOutput(t, &out, "two"+osutil.LineBreak)
+	cancel()
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+}
+
+func TestStreamTailAllEmitsAllCompleteLines(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeLog(t, dir, "2026-04-20-1.log", "one\ntwo\npartial")
+
+	var out bytes.Buffer
+	err := logstream.Streamer{
+		ListFiles: listFiles(dir),
+		Emit: func(_ string, line string) error {
+			out.WriteString(line)
+			out.WriteString(osutil.LineBreak)
+			return nil
+		},
+	}.Stream(context.Background(), logstream.Options{
+		TailAll: true,
+		Follow:  false,
+	})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	want := "one" + osutil.LineBreak + "two" + osutil.LineBreak
+	if out.String() != want {
+		t.Fatalf("output = %q, want complete lines", out.String())
+	}
+}
+
+func TestStreamWithoutFilesReturnsNoLogFiles(t *testing.T) {
+	t.Parallel()
+
+	err := logstream.Streamer{
+		ListFiles: func() ([]logstream.File, error) { return nil, nil },
+		Emit:      func(string, string) error { return nil },
+	}.Stream(context.Background(), logstream.Options{
+		Tail:   1,
+		Follow: false,
+	})
+	if !errors.Is(err, logstream.ErrNoLogFiles) {
+		t.Fatalf("Stream() error = %v, want ErrNoLogFiles", err)
+	}
+}
+
+func listFiles(dir string) func() ([]logstream.File, error) {
+	return func() ([]logstream.File, error) {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return nil, fmt.Errorf("read log dir: %w", err)
+		}
+		files := make([]logstream.File, 0, len(entries))
+		for _, entry := range entries {
+			info, err := entry.Info()
+			if err != nil || info.IsDir() {
+				continue
+			}
+			files = append(files, logstream.File{
+				ModTime: info.ModTime(),
+				Path:    filepath.Join(dir, entry.Name()),
+				Size:    info.Size(),
+			})
+		}
+		return files, nil
+	}
+}
+
+func writeLog(t *testing.T, dir string, name string, content string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), osutil.FilePermOwnerOnly); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	return path
+}
+
+func appendLog(t *testing.T, path string, content string) {
+	t.Helper()
+
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("open log: %v", err)
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			t.Fatalf("close log: %v", closeErr)
+		}
+	}()
+	if _, err := file.WriteString(content); err != nil {
+		t.Fatalf("append log: %v", err)
+	}
+}
+
+func setLogModTime(t *testing.T, path string, modTime time.Time) {
+	t.Helper()
+
+	if err := os.Chtimes(path, modTime, modTime); err != nil {
+		t.Fatalf("chtimes %q: %v", path, err)
+	}
+}
+
+func waitForOutput(t *testing.T, out *bytes.Buffer, want string) {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if out.String() == want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("output = %q, want %q", strings.TrimSpace(out.String()), strings.TrimSpace(want))
+}

--- a/src/cli/internal/logstream/logstream_test.go
+++ b/src/cli/internal/logstream/logstream_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -53,7 +52,7 @@ func TestStreamFollowsAppendedCompleteLines(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	var out bytes.Buffer
+	lines := make(chan string, 1)
 	listed := make(chan struct{})
 	var listedOnce sync.Once
 	errCh := make(chan error, 1)
@@ -64,8 +63,7 @@ func TestStreamFollowsAppendedCompleteLines(t *testing.T) {
 				return listFiles(dir)()
 			},
 			Emit: func(_ string, line string) error {
-				out.WriteString(line)
-				out.WriteString(osutil.LineBreak)
+				lines <- line
 				return nil
 			},
 		}.Stream(ctx, logstream.Options{
@@ -76,7 +74,14 @@ func TestStreamFollowsAppendedCompleteLines(t *testing.T) {
 
 	<-listed
 	appendLog(t, path, "two\n")
-	waitForOutput(t, &out, "two"+osutil.LineBreak)
+	select {
+	case got := <-lines:
+		if got != "two" {
+			t.Fatalf("line = %q, want two", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for appended log line")
+	}
 	cancel()
 
 	if err := <-errCh; err != nil {
@@ -181,17 +186,4 @@ func setLogModTime(t *testing.T, path string, modTime time.Time) {
 	if err := os.Chtimes(path, modTime, modTime); err != nil {
 		t.Fatalf("chtimes %q: %v", path, err)
 	}
-}
-
-func waitForOutput(t *testing.T, out *bytes.Buffer, want string) {
-	t.Helper()
-
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if out.String() == want {
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	t.Fatalf("output = %q, want %q", strings.TrimSpace(out.String()), strings.TrimSpace(want))
 }

--- a/src/cli/internal/logstream/logstream_test.go
+++ b/src/cli/internal/logstream/logstream_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sync"
 	"testing"
 	"time"
 
@@ -53,26 +52,28 @@ func TestStreamFollowsAppendedCompleteLines(t *testing.T) {
 	defer cancel()
 
 	lines := make(chan string, 1)
-	listed := make(chan struct{})
-	var listedOnce sync.Once
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- logstream.Streamer{
-			ListFiles: func() ([]logstream.File, error) {
-				listedOnce.Do(func() { close(listed) })
-				return listFiles(dir)()
-			},
+			ListFiles: listFiles(dir),
 			Emit: func(_ string, line string) error {
 				lines <- line
 				return nil
 			},
 		}.Stream(ctx, logstream.Options{
-			Tail:   0,
+			Tail:   1,
 			Follow: true,
 		})
 	}()
 
-	<-listed
+	select {
+	case got := <-lines:
+		if got != "one" {
+			t.Fatalf("initial line = %q, want one", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for initial log line")
+	}
 	appendLog(t, path, "two\n")
 	select {
 	case got := <-lines:


### PR DESCRIPTION
## Description

implement `studioctl app logs`, another thing needed for app backend integration tests to work with studioctl.
sharing some of this code with `servers logs`

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `app logs` command to read and stream application process and container logs with support for tailing, following in real-time, and JSON output formatting.
  * Support for multiple instances of the same app with round-robin load balancing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->