### PR TITLE
fix: prep for app backend integrationtest

### DIFF
--- a/src/Runtime/localtest/src/Services/LocalApp/Implementation/LocalAppHttp.cs
+++ b/src/Runtime/localtest/src/Services/LocalApp/Implementation/LocalAppHttp.cs
@@ -59,6 +59,7 @@ namespace LocalTest.Services.LocalApp.Implementation
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
             using var response = await Send(request, appId, cancellationToken);
+            response.EnsureSuccessStatusCode();
             return await response.Content.ReadAsStringAsync(cancellationToken);
         }
 
@@ -143,8 +144,12 @@ namespace LocalTest.Services.LocalApp.Implementation
                     timeoutCancellationTokenSource.Token
                 );
             });
+            if (content is null)
+            {
+                throw new InvalidOperationException("application metadata response is missing");
+            }
 
-            return JsonSerializer.Deserialize<Application>(content!, JSON_OPTIONS);
+            return JsonSerializer.Deserialize<Application>(content, JSON_OPTIONS);
         }
 
         public async Task<TextResource?> GetTextResource(string org, string app, string language, CancellationToken cancellationToken = default)

--- a/src/cli/app-manager/Discovery/AppRegistry.cs
+++ b/src/cli/app-manager/Discovery/AppRegistry.cs
@@ -11,6 +11,7 @@ internal sealed class AppRegistry : BackgroundService
 
     private readonly IReadOnlyList<IAppDiscovery> _discoveries;
     private readonly AppMetadataProbe _probe;
+    private readonly LocaltestStorageProbe _storageProbe;
     private readonly ILogger<AppRegistry> _logger;
     private readonly Channel<AppRegistryMessage> _messages = Channel.CreateUnbounded<AppRegistryMessage>();
     private readonly List<AppStartWaiter> _pendingStarts = [];
@@ -18,10 +19,16 @@ internal sealed class AppRegistry : BackgroundService
     private DiscoveredApp[] _apps = [];
     private bool _lastRefreshFailed;
 
-    public AppRegistry(IEnumerable<IAppDiscovery> discoveries, AppMetadataProbe probe, ILogger<AppRegistry> logger)
+    public AppRegistry(
+        IEnumerable<IAppDiscovery> discoveries,
+        AppMetadataProbe probe,
+        LocaltestStorageProbe storageProbe,
+        ILogger<AppRegistry> logger
+    )
     {
         _discoveries = [.. discoveries];
         _probe = probe;
+        _storageProbe = storageProbe;
         _logger = logger;
     }
 
@@ -190,6 +197,7 @@ internal sealed class AppRegistry : BackgroundService
         Volatile.Write(ref _apps, apps);
 
         LogRefresh(previous, apps);
+        await CompleteReadyStarts(apps, cancellationToken);
     }
 
     private async Task<DiscoveredApp[]> DiscoverApps(CancellationToken cancellationToken)
@@ -234,7 +242,6 @@ internal sealed class AppRegistry : BackgroundService
         )
         {
             apps[AppKey.From(result.App)] = result.App;
-            CompleteMatchingStarts(result.App);
         }
 
         return [.. apps.Values];
@@ -272,7 +279,7 @@ internal sealed class AppRegistry : BackgroundService
         );
     }
 
-    private void CompleteMatchingStarts(DiscoveredApp app)
+    private async Task CompleteReadyStarts(IReadOnlyList<DiscoveredApp> apps, CancellationToken cancellationToken)
     {
         for (var i = _pendingStarts.Count - 1; i >= 0; i--)
         {
@@ -283,11 +290,15 @@ internal sealed class AppRegistry : BackgroundService
                 continue;
             }
 
-            if (waiter.Matches(app))
-            {
-                waiter.TrySetResult(app.BaseUri.Value);
-                _pendingStarts.RemoveAt(i);
-            }
+            var app = apps.FirstOrDefault(waiter.Matches);
+            if (app is null)
+                continue;
+
+            if (!await _storageProbe.CanReadApplicationMetadata(app.AppId, cancellationToken))
+                continue;
+
+            waiter.TrySetResult(app.BaseUri.Value);
+            _pendingStarts.RemoveAt(i);
         }
     }
 
@@ -305,7 +316,9 @@ internal sealed class AppRegistry : BackgroundService
             if (now < waiter.Deadline)
                 continue;
 
-            waiter.TrySetException(new TimeoutException("matching app endpoint not found"));
+            waiter.TrySetException(
+                new TimeoutException("matching app endpoint not found or not reachable through localtest storage")
+            );
             _pendingStarts.RemoveAt(i);
         }
     }

--- a/src/cli/app-manager/Discovery/AppRegistry.cs
+++ b/src/cli/app-manager/Discovery/AppRegistry.cs
@@ -294,7 +294,10 @@ internal sealed class AppRegistry : BackgroundService
             if (app is null)
                 continue;
 
-            if (!await _storageProbe.CanReadApplicationMetadata(app.AppId, cancellationToken))
+            if (
+                await _storageProbe.ProbeApplicationMetadata(app.AppId, cancellationToken)
+                is LocaltestStorageProbeResult.NotReady
+            )
                 continue;
 
             waiter.TrySetResult(app.BaseUri.Value);

--- a/src/cli/app-manager/Discovery/LocaltestStorageProbe.cs
+++ b/src/cli/app-manager/Discovery/LocaltestStorageProbe.cs
@@ -1,0 +1,113 @@
+using System.Text.Json;
+
+namespace Altinn.Studio.AppManager.Discovery;
+
+internal sealed class LocaltestStorageProbe
+{
+    public const string HttpClientName = "localtest-storage-probe";
+
+    private static readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly Uri? _baseUri;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<LocaltestStorageProbe> _logger;
+
+    public LocaltestStorageProbe(
+        IConfiguration configuration,
+        IHttpClientFactory httpClientFactory,
+        ILogger<LocaltestStorageProbe> logger
+    )
+    {
+        _baseUri = ResolveBaseUri(configuration["Localtest:Url"]);
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    public async Task<bool> CanReadApplicationMetadata(string appId, CancellationToken cancellationToken)
+    {
+        if (_baseUri is null)
+            return true;
+
+        var path = BuildApplicationMetadataPath(appId);
+        if (path is null)
+            return false;
+
+        try
+        {
+            using var client = _httpClientFactory.CreateClient(HttpClientName);
+            client.BaseAddress = _baseUri;
+            using var response = await client.GetAsync(path, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug(
+                        "Storage metadata probe for {AppId} returned {StatusCode}",
+                        appId,
+                        (int)response.StatusCode
+                    );
+                }
+                return false;
+            }
+
+            await using var content = await response.Content.ReadAsStreamAsync(cancellationToken);
+            var metadata = await JsonSerializer.DeserializeAsync<ApplicationMetadataResponse>(
+                content,
+                _jsonOptions,
+                cancellationToken
+            );
+
+            var reachable = string.Equals(metadata?.Id, appId, StringComparison.OrdinalIgnoreCase);
+            if (!reachable && _logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug(
+                    "Storage metadata probe for {AppId} returned app id {ResolvedAppId}",
+                    appId,
+                    metadata?.Id ?? "<none>"
+                );
+            }
+
+            return reachable;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or JsonException or TaskCanceledException)
+        {
+            if (_logger.IsEnabled(LogLevel.Debug))
+                _logger.LogDebug(ex, "Storage metadata probe for {AppId} failed", appId);
+            return false;
+        }
+    }
+
+    private static string? BuildApplicationMetadataPath(string appId)
+    {
+        var parts = appId.Split('/', 2, StringSplitOptions.TrimEntries);
+        if (parts.Length != 2 || string.IsNullOrWhiteSpace(parts[0]) || string.IsNullOrWhiteSpace(parts[1]))
+            return null;
+
+        return $"/storage/api/v1/applications/{Uri.EscapeDataString(parts[0])}/{Uri.EscapeDataString(parts[1])}";
+    }
+
+    private static Uri? ResolveBaseUri(string? localtestUrl)
+    {
+        if (!Uri.TryCreate(localtestUrl, UriKind.Absolute, out var uri))
+            return null;
+
+        if (
+            !string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
+        )
+            return null;
+
+        return new UriBuilder(uri)
+        {
+            Path = "",
+            Query = "",
+            Fragment = "",
+        }.Uri;
+    }
+
+    private sealed record ApplicationMetadataResponse(string Id);
+}

--- a/src/cli/app-manager/Discovery/LocaltestStorageProbe.cs
+++ b/src/cli/app-manager/Discovery/LocaltestStorageProbe.cs
@@ -23,14 +23,17 @@ internal sealed class LocaltestStorageProbe
         _logger = logger;
     }
 
-    public async Task<bool> CanReadApplicationMetadata(string appId, CancellationToken cancellationToken)
+    public async Task<LocaltestStorageProbeResult> ProbeApplicationMetadata(
+        string appId,
+        CancellationToken cancellationToken
+    )
     {
         if (_baseUri is null)
-            return true;
+            return LocaltestStorageProbeResult.Unavailable;
 
         var path = BuildApplicationMetadataPath(appId);
         if (path is null)
-            return false;
+            return LocaltestStorageProbeResult.NotReady;
 
         try
         {
@@ -47,7 +50,7 @@ internal sealed class LocaltestStorageProbe
                         (int)response.StatusCode
                     );
                 }
-                return false;
+                return LocaltestStorageProbeResult.NotReady;
             }
 
             await using var content = await response.Content.ReadAsStreamAsync(cancellationToken);
@@ -67,17 +70,23 @@ internal sealed class LocaltestStorageProbe
                 );
             }
 
-            return reachable;
+            return reachable ? LocaltestStorageProbeResult.Ready : LocaltestStorageProbeResult.NotReady;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw;
         }
-        catch (Exception ex) when (ex is HttpRequestException or JsonException or TaskCanceledException)
+        catch (JsonException ex)
         {
             if (_logger.IsEnabled(LogLevel.Debug))
-                _logger.LogDebug(ex, "Storage metadata probe for {AppId} failed", appId);
-            return false;
+                _logger.LogDebug(ex, "Storage metadata probe for {AppId} returned invalid JSON", appId);
+            return LocaltestStorageProbeResult.NotReady;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            if (_logger.IsEnabled(LogLevel.Debug))
+                _logger.LogDebug(ex, "Storage metadata probe for {AppId} could not reach localtest", appId);
+            return LocaltestStorageProbeResult.Unavailable;
         }
     }
 
@@ -110,4 +119,11 @@ internal sealed class LocaltestStorageProbe
     }
 
     private sealed record ApplicationMetadataResponse(string Id);
+}
+
+internal enum LocaltestStorageProbeResult
+{
+    Ready,
+    NotReady,
+    Unavailable,
 }

--- a/src/cli/app-manager/Discovery/ServiceCollectionExtensions.cs
+++ b/src/cli/app-manager/Discovery/ServiceCollectionExtensions.cs
@@ -18,11 +18,19 @@ internal static class ServiceCollectionExtensions
                 client.Timeout = TimeSpan.FromSeconds(1);
             }
         );
+        services.AddHttpClient(
+            LocaltestStorageProbe.HttpClientName,
+            static client =>
+            {
+                client.Timeout = TimeSpan.FromSeconds(2);
+            }
+        );
         services.AddSingleton<IPortListenerSource, LinuxPortListeners>();
         services.AddSingleton<IPortListenerSource, MacPortListeners>();
         services.AddSingleton<IPortListenerSource, WindowsPortListeners>();
         services.AddSingleton<PortListeners>();
         services.AddSingleton<AppMetadataProbe>();
+        services.AddSingleton<LocaltestStorageProbe>();
         services.AddSingleton<IAppDiscovery, ProcessDiscovery>();
         services.AddSingleton<IAppDiscovery, ContainerDiscovery>();
         services.AddSingleton<AppRegistry>();

--- a/src/cli/app-manager/Platform/PortListeners/MacPortListeners.cs
+++ b/src/cli/app-manager/Platform/PortListeners/MacPortListeners.cs
@@ -7,6 +7,7 @@ internal sealed partial class MacPortListeners : IPortListenerSource
 {
     private const int SignalZero = 0;
     private const int ErrorPermissionDenied = 1;
+    private const int NetstatLocalAddressFieldIndex = 3;
     private readonly Dictionary<MacListenerKey, PortListener> _knownListeners = [];
 
     public bool SupportsCurrentPlatform() => OperatingSystem.IsMacOS();
@@ -119,7 +120,7 @@ internal sealed partial class MacPortListeners : IPortListenerSource
             return false;
 
         var fields = line.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        if (fields.Length < 4)
+        if (fields.Length <= NetstatLocalAddressFieldIndex)
             return false;
 
         if (!fields[0].StartsWith("tcp", StringComparison.OrdinalIgnoreCase))
@@ -128,7 +129,7 @@ internal sealed partial class MacPortListeners : IPortListenerSource
         if (!fields[^1].Equals("LISTEN", StringComparison.Ordinal))
             return false;
 
-        return TryParseListener(fields[^2].AsSpan(), out listener);
+        return TryParseListener(fields[NetstatLocalAddressFieldIndex].AsSpan(), out listener);
     }
 
     private static bool TryParseListener(ReadOnlySpan<char> addressField, out MacListenerKey listener)

--- a/src/cli/app-manager/Platform/RuntimeFiles.cs
+++ b/src/cli/app-manager/Platform/RuntimeFiles.cs
@@ -15,7 +15,6 @@ internal static class RuntimeFiles
         }
 
         EnsureParentDirectory(unixSocketPath, UnixSocketPathKey);
-        TryDelete(unixSocketPath);
     }
 
     public static void RegisterCleanup(IConfiguration configuration, IHostApplicationLifetime lifetime)

--- a/src/cli/app-manager/Studioctl/Endpoints.cs
+++ b/src/cli/app-manager/Studioctl/Endpoints.cs
@@ -18,7 +18,7 @@ internal static class Endpoints
         return studioctl;
     }
 
-    private static IResult GetStatus(AppRegistry registry, TunnelState tunnelState)
+    private static IResult GetStatus(AppRegistry registry, TunnelState tunnelState, IConfiguration configuration)
     {
         return Results.Ok(
             new StatusResponse(
@@ -28,6 +28,7 @@ internal static class Endpoints
                 Assembly.GetEntryAssembly()?.GetName().Version?.ToString() ?? "unknown",
                 EnvironmentValues.IsTruthy(Environment.GetEnvironmentVariable("STUDIOCTL_INTERNAL_DEV")),
                 Environment.GetEnvironmentVariable("Studioctl__Path") ?? "",
+                configuration["Localtest:Url"] ?? "",
                 new TunnelStatusResponse(tunnelState.Enabled, tunnelState.IsConnected, tunnelState.Url),
                 [
                     .. registry
@@ -114,6 +115,7 @@ internal static class Endpoints
         string AppManagerVersion,
         bool InternalDev,
         string StudioctlPath,
+        string LocaltestUrl,
         TunnelStatusResponse Tunnel,
         IReadOnlyList<DiscoveredAppResponse> Apps
     );

--- a/src/cli/internal/appmanager/client.go
+++ b/src/cli/internal/appmanager/client.go
@@ -110,6 +110,9 @@ var (
 	errUnexpectedShutdownStatus   = errors.New("unexpected app-manager shutdown response")
 	errAppManagerStartTimedOut    = errors.New("app-manager start timed out")
 	errInvalidPIDFile             = errors.New("pid file does not contain a positive pid")
+	errAppManagerSocketDir        = errors.New("app-manager socket path is a directory")
+	errAppManagerSocketInUse      = errors.New("app-manager socket is already in use")
+	errAppManagerForceStopTimeout = errors.New("app-manager did not stop after kill")
 	// ErrAppEndpointNotFound is returned when app-manager cannot find a matching app endpoint.
 	ErrAppEndpointNotFound = errors.New("matching app endpoint not found")
 )
@@ -608,14 +611,14 @@ func removeStaleAppManagerSocket(ctx context.Context, cfg *config.Config) error 
 		return fmt.Errorf("stat app-manager socket: %w", err)
 	}
 	if info.IsDir() {
-		return fmt.Errorf("app-manager socket path is a directory: %s", socketPath)
+		return fmt.Errorf("%w: %s", errAppManagerSocketDir, socketPath)
 	}
 
 	client := NewClient(cfg)
 	err = client.Health(ctx)
 	switch {
 	case err == nil:
-		return fmt.Errorf("app-manager socket is already in use: %s", socketPath)
+		return fmt.Errorf("%w: %s", errAppManagerSocketInUse, socketPath)
 	case !errors.Is(err, ErrNotRunning):
 		return fmt.Errorf("probe existing app-manager socket: %w", err)
 	}
@@ -683,7 +686,7 @@ func forceStopAppManager(ctx context.Context, client *Client, pid int) error {
 		time.Sleep(appManagerPollInterval)
 	}
 
-	return fmt.Errorf("app-manager pid %d did not stop after kill", pid)
+	return fmt.Errorf("%w: pid %d", errAppManagerForceStopTimeout, pid)
 }
 
 func appManagerStopped(ctx context.Context, client *Client, pid int) bool {
@@ -725,10 +728,7 @@ func waitForManagedShutdown(ctx context.Context, cfg *config.Config, client *Cli
 			if err := removeAppManagerState(cfg); err != nil {
 				return fmt.Errorf("remove stale app-manager pid file: %w", err)
 			}
-			if err := removeStaleAppManagerSocket(ctx, cfg); err != nil {
-				return err
-			}
-			return nil
+			return removeStaleAppManagerSocket(ctx, cfg)
 		}
 		time.Sleep(appManagerPollInterval)
 	}
@@ -758,10 +758,7 @@ func removePersistedAppManagerState(ctx context.Context, cfg *config.Config) err
 	if err := removeAppManagerState(cfg); err != nil {
 		return fmt.Errorf("remove stale app-manager pid file: %w", err)
 	}
-	if err := removeStaleAppManagerSocket(ctx, cfg); err != nil {
-		return err
-	}
-	return nil
+	return removeStaleAppManagerSocket(ctx, cfg)
 }
 
 func managedProcessStopped(pid int) (bool, error) {
@@ -1020,6 +1017,7 @@ func zeroRuntimeState() runtimeState {
 			WorkingDir:     "",
 			UnixSocketPath: "",
 			TunnelURL:      "",
+			LocaltestURL:   "",
 			StudioctlPath:  "",
 			InternalDev:    false,
 		},

--- a/src/cli/internal/appmanager/client.go
+++ b/src/cli/internal/appmanager/client.go
@@ -31,9 +31,10 @@ const (
 	registerPath = "/api/v1/studioctl/apps"
 	shutdownPath = "/api/v1/studioctl/shutdown"
 
-	appManagerUnixSocketEnv = "APP_MANAGER_UNIX_SOCKET_PATH"
-	appManagerTunnelURLEnv  = "Tunnel__Url"
-	appManagerStudioctlEnv  = "Studioctl__Path"
+	appManagerUnixSocketEnv   = "APP_MANAGER_UNIX_SOCKET_PATH"
+	appManagerTunnelURLEnv    = "Tunnel__Url"
+	appManagerLocaltestURLEnv = "Localtest__Url"
+	appManagerStudioctlEnv    = "Studioctl__Path"
 
 	appManagerStartTimeout          = 10 * time.Second
 	appManagerRegisterTimeoutMargin = 2 * time.Second
@@ -49,6 +50,7 @@ type startConfig struct {
 	WorkingDir     string `json:"workingDir"`
 	UnixSocketPath string `json:"unixSocketPath,omitempty"`
 	TunnelURL      string `json:"tunnelUrl"`
+	LocaltestURL   string `json:"localtestUrl"`
 	StudioctlPath  string `json:"studioctlPath"`
 	InternalDev    bool   `json:"internalDev"`
 }
@@ -63,6 +65,7 @@ type Status struct {
 	AppManagerVersion string          `json:"appManagerVersion"`
 	DotnetVersion     string          `json:"dotnetVersion"`
 	StudioctlPath     string          `json:"studioctlPath"`
+	LocaltestURL      string          `json:"localtestUrl"`
 	Tunnel            TunnelStatus    `json:"tunnel"`
 	Apps              []DiscoveredApp `json:"apps"`
 	ProcessID         int             `json:"processId"`
@@ -222,6 +225,7 @@ func (c *Client) Status(ctx context.Context) (*Status, error) {
 		AppManagerVersion string `json:"appManagerVersion"`
 		DotnetVersion     string `json:"dotnetVersion"`
 		StudioctlPath     string `json:"studioctlPath"`
+		LocaltestURL      string `json:"localtestUrl"`
 		Tunnel            struct {
 			URL       string `json:"url"`
 			Enabled   bool   `json:"enabled"`
@@ -249,6 +253,7 @@ func (c *Client) Status(ctx context.Context) (*Status, error) {
 		AppManagerVersion: status.AppManagerVersion,
 		DotnetVersion:     status.DotnetVersion,
 		StudioctlPath:     status.StudioctlPath,
+		LocaltestURL:      status.LocaltestURL,
 		InternalDev:       status.InternalDev,
 		Tunnel: TunnelStatus{
 			Enabled:   status.Tunnel.Enabled,
@@ -469,6 +474,11 @@ func TunnelURL(port string) string {
 	return "ws://127.0.0.1:" + port + appTunnelEndpointPath
 }
 
+// LocaltestURL returns the localtest HTTP URL for a host port.
+func LocaltestURL(port string) string {
+	return "http://127.0.0.1:" + port
+}
+
 func restartManagedProcess(
 	ctx context.Context,
 	cfg *config.Config,
@@ -514,6 +524,9 @@ func startProcess(ctx context.Context, cfg *config.Config, startConfig startConf
 	)
 	if startConfig.TunnelURL != "" {
 		cmd.Env = append(cmd.Env, appManagerTunnelURLEnv+"="+startConfig.TunnelURL)
+	}
+	if startConfig.LocaltestURL != "" {
+		cmd.Env = append(cmd.Env, appManagerLocaltestURLEnv+"="+startConfig.LocaltestURL)
 	}
 	if startConfig.StudioctlPath != "" {
 		cmd.Env = append(cmd.Env, appManagerStudioctlEnv+"="+startConfig.StudioctlPath)
@@ -693,6 +706,7 @@ func buildStartConfig(cfg *config.Config, loadBalancerPort, studioctlPath string
 		WorkingDir:     cfg.Home,
 		UnixSocketPath: cfg.AppManagerSocketPath(),
 		TunnelURL:      TunnelURL(loadBalancerPort),
+		LocaltestURL:   LocaltestURL(loadBalancerPort),
 		StudioctlPath:  studioctlPath,
 		InternalDev:    config.IsTruthyEnv(os.Getenv(config.EnvInternalDevMode)),
 	}
@@ -704,6 +718,7 @@ func liveConfig(cfg *config.Config, status *Status) startConfig {
 		WorkingDir:     cfg.Home,
 		UnixSocketPath: cfg.AppManagerSocketPath(),
 		TunnelURL:      status.Tunnel.URL,
+		LocaltestURL:   status.LocaltestURL,
 		StudioctlPath:  status.StudioctlPath,
 		InternalDev:    status.InternalDev,
 	}

--- a/src/cli/internal/appmanager/client.go
+++ b/src/cli/internal/appmanager/client.go
@@ -149,20 +149,28 @@ func appRegistrationTimeout(registration AppRegistration) time.Duration {
 
 // Shutdown stops app-manager and returns a completion channel that resolves when shutdown is fully complete.
 func Shutdown(ctx context.Context, cfg *config.Config) (<-chan error, error) {
+	lock, err := osutil.AcquireFileLock(ctx, cfg.AppManagerLockPath())
+	if err != nil {
+		return nil, fmt.Errorf("lock app-manager lifecycle: %w", err)
+	}
+
 	client := NewClient(cfg)
 	pid, err := currentManagedPID(ctx, client, cfg)
 	if err != nil {
+		ignoreError(lock.Close())
 		return nil, err
 	}
 
 	if err := shutdownError(client.shutdown(ctx), pid); err != nil {
+		ignoreError(lock.Close())
 		return nil, err
 	}
 
 	done := make(chan error, 1)
 	go func() {
+		defer close(done)
+		defer ignoreError(lock.Close())
 		done <- waitForManagedShutdown(ctx, cfg, client, pid)
-		close(done)
 	}()
 
 	return done, nil
@@ -383,6 +391,12 @@ func EnsureStartedWithStudioctlPath(
 	loadBalancerPort,
 	studioctlPath string,
 ) error {
+	lock, err := osutil.AcquireFileLock(ctx, cfg.AppManagerLockPath())
+	if err != nil {
+		return fmt.Errorf("lock app-manager lifecycle: %w", err)
+	}
+	defer ignoreError(lock.Close())
+
 	desired := buildStartConfig(cfg, loadBalancerPort, studioctlPath)
 	client := NewClient(cfg)
 
@@ -490,13 +504,13 @@ func restartManagedProcess(
 		return fmt.Errorf("shutdown app-manager for restart: %w", err)
 	}
 
-	if !waitForShutdown(ctx, client, cfg) {
-		if err := osutil.KillProcess(pid); err != nil {
-			return fmt.Errorf("kill app-manager after shutdown timeout: %w", err)
+	if !waitForShutdown(ctx, client, cfg, pid) {
+		if err := forceStopAppManager(ctx, client, pid); err != nil {
+			return fmt.Errorf("force stop app-manager after shutdown timeout: %w", err)
 		}
-		if err := removeAppManagerState(cfg); err != nil {
-			return fmt.Errorf("remove stale app-manager pid file: %w", err)
-		}
+	}
+	if err := removeAppManagerState(cfg); err != nil {
+		return fmt.Errorf("remove stale app-manager pid file: %w", err)
 	}
 
 	return startProcess(ctx, cfg, desired)
@@ -512,6 +526,9 @@ func startProcess(ctx context.Context, cfg *config.Config, startConfig startConf
 
 	if err := removeAppManagerState(cfg); err != nil {
 		return fmt.Errorf("remove stale app-manager pid file: %w", err)
+	}
+	if err := prepareAppManagerSocketForStart(ctx, cfg); err != nil {
+		return err
 	}
 	startedAt := time.Now()
 
@@ -574,6 +591,41 @@ func startProcess(ctx context.Context, cfg *config.Config, startConfig startConf
 	return err
 }
 
+func prepareAppManagerSocketForStart(ctx context.Context, cfg *config.Config) error {
+	if err := removeStaleAppManagerSocket(ctx, cfg); err != nil {
+		return fmt.Errorf("prepare app-manager socket: %w", err)
+	}
+	return nil
+}
+
+func removeStaleAppManagerSocket(ctx context.Context, cfg *config.Config) error {
+	socketPath := cfg.AppManagerSocketPath()
+	info, err := os.Lstat(socketPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat app-manager socket: %w", err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("app-manager socket path is a directory: %s", socketPath)
+	}
+
+	client := NewClient(cfg)
+	err = client.Health(ctx)
+	switch {
+	case err == nil:
+		return fmt.Errorf("app-manager socket is already in use: %s", socketPath)
+	case !errors.Is(err, ErrNotRunning):
+		return fmt.Errorf("probe existing app-manager socket: %w", err)
+	}
+
+	if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove stale app-manager socket: %w", err)
+	}
+	return nil
+}
+
 func waitForHealthy(ctx context.Context, cfg *config.Config, client *Client, logSince time.Time) (*Status, error) {
 	deadline := time.Now().Add(appManagerStartTimeout)
 	var lastErr error
@@ -605,10 +657,10 @@ func waitForHealthy(ctx context.Context, cfg *config.Config, client *Client, log
 	)
 }
 
-func waitForShutdown(ctx context.Context, client *Client, cfg *config.Config) bool {
+func waitForShutdown(ctx context.Context, client *Client, cfg *config.Config, pid int) bool {
 	deadline := time.Now().Add(appManagerStartTimeout)
 	for time.Now().Before(deadline) {
-		if err := client.Health(ctx); errors.Is(err, ErrNotRunning) {
+		if appManagerStopped(ctx, client, pid) {
 			ignoreError(removeAppManagerState(cfg))
 			return true
 		}
@@ -616,6 +668,28 @@ func waitForShutdown(ctx context.Context, client *Client, cfg *config.Config) bo
 	}
 
 	return false
+}
+
+func forceStopAppManager(ctx context.Context, client *Client, pid int) error {
+	if err := osutil.KillProcess(pid); err != nil {
+		return fmt.Errorf("kill app-manager pid %d: %w", pid, err)
+	}
+
+	deadline := time.Now().Add(appManagerShutdownWait)
+	for time.Now().Before(deadline) {
+		if appManagerStopped(ctx, client, pid) {
+			return nil
+		}
+		time.Sleep(appManagerPollInterval)
+	}
+
+	return fmt.Errorf("app-manager pid %d did not stop after kill", pid)
+}
+
+func appManagerStopped(ctx context.Context, client *Client, pid int) bool {
+	healthStopped := errors.Is(client.Health(ctx), ErrNotRunning)
+	processStopped, err := managedProcessStopped(pid)
+	return err == nil && healthStopped && processStopped
 }
 
 func currentManagedPID(ctx context.Context, client *Client, cfg *config.Config) (int, error) {
@@ -647,26 +721,24 @@ func currentManagedPID(ctx context.Context, client *Client, cfg *config.Config) 
 func waitForManagedShutdown(ctx context.Context, cfg *config.Config, client *Client, pid int) error {
 	deadline := time.Now().Add(appManagerShutdownWait)
 	for time.Now().Before(deadline) {
-		healthStopped := errors.Is(client.Health(ctx), ErrNotRunning)
-		processStopped, err := managedProcessStopped(pid)
-		if err != nil {
-			return err
-		}
-		if healthStopped && processStopped {
+		if appManagerStopped(ctx, client, pid) {
 			if err := removeAppManagerState(cfg); err != nil {
 				return fmt.Errorf("remove stale app-manager pid file: %w", err)
+			}
+			if err := removeStaleAppManagerSocket(ctx, cfg); err != nil {
+				return err
 			}
 			return nil
 		}
 		time.Sleep(appManagerPollInterval)
 	}
 
-	return stopPersistedProcess(cfg, pid)
+	return stopPersistedProcess(ctx, cfg, client, pid)
 }
 
-func stopPersistedProcess(cfg *config.Config, pid int) error {
+func stopPersistedProcess(ctx context.Context, cfg *config.Config, client *Client, pid int) error {
 	if pid <= 0 {
-		return removePersistedAppManagerState(cfg)
+		return removePersistedAppManagerState(ctx, cfg)
 	}
 
 	running, err := osutil.ProcessRunning(pid)
@@ -674,17 +746,20 @@ func stopPersistedProcess(cfg *config.Config, pid int) error {
 		return fmt.Errorf("check app-manager pid %d: %w", pid, err)
 	}
 	if running {
-		if err := osutil.KillProcess(pid); err != nil {
-			return fmt.Errorf("kill app-manager pid %d: %w", pid, err)
+		if err := forceStopAppManager(ctx, client, pid); err != nil {
+			return err
 		}
 	}
 
-	return removePersistedAppManagerState(cfg)
+	return removePersistedAppManagerState(ctx, cfg)
 }
 
-func removePersistedAppManagerState(cfg *config.Config) error {
+func removePersistedAppManagerState(ctx context.Context, cfg *config.Config) error {
 	if err := removeAppManagerState(cfg); err != nil {
 		return fmt.Errorf("remove stale app-manager pid file: %w", err)
+	}
+	if err := removeStaleAppManagerSocket(ctx, cfg); err != nil {
+		return err
 	}
 	return nil
 }

--- a/src/cli/internal/appmanager/client_internal_test.go
+++ b/src/cli/internal/appmanager/client_internal_test.go
@@ -1,11 +1,14 @@
 package appmanager
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"altinn.studio/studioctl/internal/config"
 )
 
 func TestLatestAppManagerLogPath_ReturnsNewestMatchingFile(t *testing.T) {
@@ -145,6 +148,36 @@ func TestLogLookup_HandlesDirectoryWithGlobMetacharacters(t *testing.T) {
 	}
 }
 
+func TestPrepareAppManagerSocketForStart_RemovesUnreachableSocket(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig(t)
+	if err := os.WriteFile(cfg.AppManagerSocketPath(), []byte("stale"), 0o600); err != nil {
+		t.Fatalf("write stale socket: %v", err)
+	}
+
+	if err := prepareAppManagerSocketForStart(context.Background(), cfg); err != nil {
+		t.Fatalf("prepareAppManagerSocketForStart() error = %v", err)
+	}
+	if _, err := os.Lstat(cfg.AppManagerSocketPath()); !os.IsNotExist(err) {
+		t.Fatalf("socket still exists or stat failed: %v", err)
+	}
+}
+
+func TestPrepareAppManagerSocketForStart_RejectsDirectory(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig(t)
+	if err := os.Mkdir(cfg.AppManagerSocketPath(), 0o700); err != nil {
+		t.Fatalf("create socket directory: %v", err)
+	}
+
+	err := prepareAppManagerSocketForStart(context.Background(), cfg)
+	if err == nil || !strings.Contains(err.Error(), "socket path is a directory") {
+		t.Fatalf("prepareAppManagerSocketForStart() error = %v, want directory error", err)
+	}
+}
+
 func writeTestLog(t *testing.T, dir, name, content string) string {
 	t.Helper()
 
@@ -153,6 +186,19 @@ func writeTestLog(t *testing.T, dir, name, content string) string {
 		t.Fatalf("write log %q: %v", path, err)
 	}
 	return path
+}
+
+func testConfig(t *testing.T) *config.Config {
+	t.Helper()
+
+	dir := t.TempDir()
+	return &config.Config{
+		Home:      dir,
+		SocketDir: dir,
+		LogDir:    filepath.Join(dir, "logs"),
+		DataDir:   filepath.Join(dir, "data"),
+		BinDir:    filepath.Join(dir, "bin"),
+	}
 }
 
 func assertLatestLogPath(t *testing.T, dir, want string) {

--- a/src/cli/internal/cmd/servers.go
+++ b/src/cli/internal/cmd/servers.go
@@ -195,13 +195,11 @@ func (c *ServersCommand) runUp(ctx context.Context, args []string) error {
 		return fmt.Errorf("parsing flags: %w", err)
 	}
 
-	if err := c.client.Health(ctx); err == nil {
-		return serversUpOutput{Running: true, Started: false, JSONOutput: jsonOutput}.Print(c.out)
-	}
+	wasRunning := c.client.Health(ctx) == nil
 	if err := c.startAppManager(ctx); err != nil {
 		return fmt.Errorf("start app-manager: %w", err)
 	}
-	return serversUpOutput{Running: true, Started: true, JSONOutput: jsonOutput}.Print(c.out)
+	return serversUpOutput{Running: true, Started: !wasRunning, JSONOutput: jsonOutput}.Print(c.out)
 }
 
 func (c *ServersCommand) runStatus(ctx context.Context, args []string) error {

--- a/src/cli/internal/cmd/servers_internal_test.go
+++ b/src/cli/internal/cmd/servers_internal_test.go
@@ -81,6 +81,9 @@ func TestServersUpJSON_AlreadyRunning(t *testing.T) {
 	command := &ServersCommand{
 		out:    ui.NewOutput(&out, io.Discard, false),
 		client: fakeServersClient{},
+		ensureStarted: func(context.Context, *config.Config, string) error {
+			return nil
+		},
 	}
 
 	if err := command.Run(context.Background(), []string{"up", "--json"}); err != nil {
@@ -93,6 +96,28 @@ func TestServersUpJSON_AlreadyRunning(t *testing.T) {
 	}
 	if !got.Running || got.Started {
 		t.Fatalf("output = %+v, want running true and started false", got)
+	}
+}
+
+func TestServersUpJSON_ReconcilesWhenAlreadyRunning(t *testing.T) {
+	t.Parallel()
+
+	var ensured bool
+	var out bytes.Buffer
+	command := &ServersCommand{
+		out:    ui.NewOutput(&out, io.Discard, false),
+		client: fakeServersClient{},
+		ensureStarted: func(context.Context, *config.Config, string) error {
+			ensured = true
+			return nil
+		},
+	}
+
+	if err := command.Run(context.Background(), []string{"up", "--json"}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !ensured {
+		t.Fatal("ensureStarted was not called")
 	}
 }
 

--- a/src/cli/internal/config/config.go
+++ b/src/cli/internal/config/config.go
@@ -225,6 +225,11 @@ func (c *Config) AppManagerPIDPath() string {
 	return filepath.Join(c.Home, "app-manager.pid")
 }
 
+// AppManagerLockPath returns the path to the app-manager lifecycle lock file.
+func (c *Config) AppManagerLockPath() string {
+	return filepath.Join(c.SocketDir, "app-manager.lock")
+}
+
 // AppManagerLogDir returns the directory containing app-manager log files.
 func (c *Config) AppManagerLogDir() string {
 	return filepath.Join(c.LogDir, "app-manager")

--- a/src/cli/internal/config/config.yaml
+++ b/src/cli/internal/config/config.yaml
@@ -6,7 +6,7 @@ images:
   core:
     localtest:
       image: ghcr.io/altinn/altinn-studio/runtime-localtest
-      tag: "e081aec06e"
+      tag: "a55bcc0a83"
     pdf3:
       image: ghcr.io/altinn/altinn-studio/runtime-pdf3-worker
       tag: "b885f9a75f"

--- a/src/cli/internal/config/config_test.go
+++ b/src/cli/internal/config/config_test.go
@@ -152,6 +152,9 @@ func TestNewWithEnvSocketDir(t *testing.T) {
 	if cfg.SocketDir != socketDir {
 		t.Errorf("SocketDir = %q, want %q", cfg.SocketDir, socketDir)
 	}
+	if cfg.AppManagerLockPath() != filepath.Join(socketDir, "app-manager.lock") {
+		t.Errorf("AppManagerLockPath() = %q, want lock in socket dir", cfg.AppManagerLockPath())
+	}
 }
 
 func TestNewDoctorFallback(t *testing.T) {

--- a/src/cli/internal/osutil/filelock.go
+++ b/src/cli/internal/osutil/filelock.go
@@ -1,0 +1,13 @@
+package osutil
+
+import (
+	"fmt"
+	"os"
+)
+
+func closeLockFile(file *os.File) error {
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close lock file: %w", err)
+	}
+	return nil
+}

--- a/src/cli/internal/osutil/filelock_test.go
+++ b/src/cli/internal/osutil/filelock_test.go
@@ -1,0 +1,31 @@
+package osutil
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func TestAcquireFileLock_BlocksSecondLock(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "test.lock")
+	lock, err := AcquireFileLock(context.Background(), path)
+	if err != nil {
+		t.Fatalf("AcquireFileLock() error = %v", err)
+	}
+	defer func() {
+		if err := lock.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = AcquireFileLock(ctx, path)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("AcquireFileLock() error = %v, want context canceled", err)
+	}
+}

--- a/src/cli/internal/osutil/filelock_test.go
+++ b/src/cli/internal/osutil/filelock_test.go
@@ -1,30 +1,32 @@
-package osutil
+package osutil_test
 
 import (
 	"context"
 	"errors"
 	"path/filepath"
 	"testing"
+
+	"altinn.studio/studioctl/internal/osutil"
 )
 
 func TestAcquireFileLock_BlocksSecondLock(t *testing.T) {
 	t.Parallel()
 
 	path := filepath.Join(t.TempDir(), "test.lock")
-	lock, err := AcquireFileLock(context.Background(), path)
+	lock, err := osutil.AcquireFileLock(context.Background(), path)
 	if err != nil {
 		t.Fatalf("AcquireFileLock() error = %v", err)
 	}
 	defer func() {
-		if err := lock.Close(); err != nil {
-			t.Fatalf("Close() error = %v", err)
+		if closeErr := lock.Close(); closeErr != nil {
+			t.Fatalf("Close() error = %v", closeErr)
 		}
 	}()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err = AcquireFileLock(ctx, path)
+	_, err = osutil.AcquireFileLock(ctx, path)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("AcquireFileLock() error = %v, want context canceled", err)
 	}

--- a/src/cli/internal/osutil/filelock_unix.go
+++ b/src/cli/internal/osutil/filelock_unix.go
@@ -15,6 +15,8 @@ import (
 
 const fileLockPollInterval = 100 * time.Millisecond
 
+var errFileDescriptorOverflow = errors.New("file descriptor exceeds int range")
+
 // FileLock is an exclusive advisory file lock.
 type FileLock struct {
 	file *os.File
@@ -26,27 +28,31 @@ func AcquireFileLock(ctx context.Context, path string) (*FileLock, error) {
 		return nil, fmt.Errorf("create lock directory: %w", err)
 	}
 
+	//nolint:gosec // G304: lock path is provided by resolved studioctl config, not user content.
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, FilePermDefault)
 	if err != nil {
 		return nil, fmt.Errorf("open lock file: %w", err)
 	}
 
+	fd, err := fileDescriptor(file)
+	if err != nil {
+		return nil, errors.Join(err, closeLockFile(file))
+	}
+
 	for {
-		err = unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+		err = unix.Flock(fd, unix.LOCK_EX|unix.LOCK_NB)
 		if err == nil {
 			return &FileLock{file: file}, nil
 		}
 		if !errors.Is(err, unix.EWOULDBLOCK) && !errors.Is(err, unix.EAGAIN) {
-			_ = file.Close()
-			return nil, fmt.Errorf("lock file: %w", err)
+			return nil, errors.Join(fmt.Errorf("lock file: %w", err), closeLockFile(file))
 		}
 
 		timer := time.NewTimer(fileLockPollInterval)
 		select {
 		case <-ctx.Done():
 			timer.Stop()
-			_ = file.Close()
-			return nil, fmt.Errorf("lock file: %w", ctx.Err())
+			return nil, errors.Join(fmt.Errorf("lock file: %w", ctx.Err()), closeLockFile(file))
 		case <-timer.C:
 		}
 	}
@@ -58,7 +64,14 @@ func (l *FileLock) Close() error {
 		return nil
 	}
 
-	err := unix.Flock(int(l.file.Fd()), unix.LOCK_UN)
+	fd, fdErr := fileDescriptor(l.file)
+	if fdErr != nil {
+		closeErr := l.file.Close()
+		l.file = nil
+		return errors.Join(fdErr, closeErr)
+	}
+
+	err := unix.Flock(fd, unix.LOCK_UN)
 	closeErr := l.file.Close()
 	l.file = nil
 	if err != nil {
@@ -68,4 +81,13 @@ func (l *FileLock) Close() error {
 		return fmt.Errorf("close lock file: %w", closeErr)
 	}
 	return nil
+}
+
+func fileDescriptor(file *os.File) (int, error) {
+	fd := file.Fd()
+	if fd > uintptr(^uint(0)>>1) {
+		return 0, errFileDescriptorOverflow
+	}
+
+	return int(fd), nil
 }

--- a/src/cli/internal/osutil/filelock_unix.go
+++ b/src/cli/internal/osutil/filelock_unix.go
@@ -1,0 +1,71 @@
+//go:build !windows
+
+package osutil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+const fileLockPollInterval = 100 * time.Millisecond
+
+// FileLock is an exclusive advisory file lock.
+type FileLock struct {
+	file *os.File
+}
+
+// AcquireFileLock opens path and waits until an exclusive advisory lock is held.
+func AcquireFileLock(ctx context.Context, path string) (*FileLock, error) {
+	if err := os.MkdirAll(filepath.Dir(path), DirPermDefault); err != nil {
+		return nil, fmt.Errorf("create lock directory: %w", err)
+	}
+
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, FilePermDefault)
+	if err != nil {
+		return nil, fmt.Errorf("open lock file: %w", err)
+	}
+
+	for {
+		err = unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+		if err == nil {
+			return &FileLock{file: file}, nil
+		}
+		if !errors.Is(err, unix.EWOULDBLOCK) && !errors.Is(err, unix.EAGAIN) {
+			_ = file.Close()
+			return nil, fmt.Errorf("lock file: %w", err)
+		}
+
+		timer := time.NewTimer(fileLockPollInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			_ = file.Close()
+			return nil, fmt.Errorf("lock file: %w", ctx.Err())
+		case <-timer.C:
+		}
+	}
+}
+
+// Close releases the lock and closes the lock file.
+func (l *FileLock) Close() error {
+	if l == nil || l.file == nil {
+		return nil
+	}
+
+	err := unix.Flock(int(l.file.Fd()), unix.LOCK_UN)
+	closeErr := l.file.Close()
+	l.file = nil
+	if err != nil {
+		return fmt.Errorf("unlock file: %w", err)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close lock file: %w", closeErr)
+	}
+	return nil
+}

--- a/src/cli/internal/osutil/filelock_windows.go
+++ b/src/cli/internal/osutil/filelock_windows.go
@@ -27,12 +27,14 @@ func AcquireFileLock(ctx context.Context, path string) (*FileLock, error) {
 		return nil, fmt.Errorf("create lock directory: %w", err)
 	}
 
+	//nolint:gosec // G304: lock path is provided by resolved studioctl config, not user content.
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, FilePermDefault)
 	if err != nil {
 		return nil, fmt.Errorf("open lock file: %w", err)
 	}
 
-	lock := &FileLock{file: file}
+	lock := new(FileLock)
+	lock.file = file
 	handle := windows.Handle(file.Fd())
 	flags := uint32(windows.LOCKFILE_EXCLUSIVE_LOCK | windows.LOCKFILE_FAIL_IMMEDIATELY)
 	for {
@@ -41,16 +43,14 @@ func AcquireFileLock(ctx context.Context, path string) (*FileLock, error) {
 			return lock, nil
 		}
 		if !errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
-			_ = file.Close()
-			return nil, fmt.Errorf("lock file: %w", err)
+			return nil, errors.Join(fmt.Errorf("lock file: %w", err), closeLockFile(file))
 		}
 
 		timer := time.NewTimer(fileLockPollInterval)
 		select {
 		case <-ctx.Done():
 			timer.Stop()
-			_ = file.Close()
-			return nil, fmt.Errorf("lock file: %w", ctx.Err())
+			return nil, errors.Join(fmt.Errorf("lock file: %w", ctx.Err()), closeLockFile(file))
 		case <-timer.C:
 		}
 	}

--- a/src/cli/internal/osutil/filelock_windows.go
+++ b/src/cli/internal/osutil/filelock_windows.go
@@ -1,0 +1,75 @@
+//go:build windows
+
+package osutil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+const fileLockPollInterval = 100 * time.Millisecond
+
+// FileLock is an exclusive advisory file lock.
+type FileLock struct {
+	file       *os.File
+	overlapped windows.Overlapped
+}
+
+// AcquireFileLock opens path and waits until an exclusive advisory lock is held.
+func AcquireFileLock(ctx context.Context, path string) (*FileLock, error) {
+	if err := os.MkdirAll(filepath.Dir(path), DirPermDefault); err != nil {
+		return nil, fmt.Errorf("create lock directory: %w", err)
+	}
+
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, FilePermDefault)
+	if err != nil {
+		return nil, fmt.Errorf("open lock file: %w", err)
+	}
+
+	lock := &FileLock{file: file}
+	handle := windows.Handle(file.Fd())
+	flags := uint32(windows.LOCKFILE_EXCLUSIVE_LOCK | windows.LOCKFILE_FAIL_IMMEDIATELY)
+	for {
+		err = windows.LockFileEx(handle, flags, 0, 1, 0, &lock.overlapped)
+		if err == nil {
+			return lock, nil
+		}
+		if !errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+			_ = file.Close()
+			return nil, fmt.Errorf("lock file: %w", err)
+		}
+
+		timer := time.NewTimer(fileLockPollInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			_ = file.Close()
+			return nil, fmt.Errorf("lock file: %w", ctx.Err())
+		case <-timer.C:
+		}
+	}
+}
+
+// Close releases the lock and closes the lock file.
+func (l *FileLock) Close() error {
+	if l == nil || l.file == nil {
+		return nil
+	}
+
+	err := windows.UnlockFileEx(windows.Handle(l.file.Fd()), 0, 1, 0, &l.overlapped)
+	closeErr := l.file.Close()
+	l.file = nil
+	if err != nil {
+		return fmt.Errorf("unlock file: %w", err)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close lock file: %w", closeErr)
+	}
+	return nil
+}


### PR DESCRIPTION
## Description

- use the storage applications endpoint to probe apps during appregistry, and only cache successful responses
- make app-manager process hanling more robusts (file locks for concurrency)

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added localtest storage connectivity validation during app discovery
  * Localtest URL now included in status endpoint responses

* **Bug Fixes**
  * Improved app-manager process reconciliation and lifecycle management
  * Enhanced socket file cleanup during startup and shutdown sequences
  * Better error handling for failed HTTP requests in metadata retrieval

* **Chores**
  * Updated localtest container image

<!-- end of auto-generated comment: release notes by coderabbit.ai -->