### PR TITLE
chore: release studioctl v0.1.0-preview.6

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-preview.6] - 2026-04-20
+
 ### Added
 
 - Add `--json` output for `app build`.


### PR DESCRIPTION
## Description

Prepare release v0.1.0-preview.6

- [Added] Add `--json` output for `app build`.
- [Added] Add `--json` output for `env up`, `env down`, `env status`, and `env logs`.
- [Added] Add `--json` output for `servers up`, `servers status`, and `servers down`.
- [Added] Add `--json` output for detached `run` and `app run`.
- [Added] Add `app ps` for listing running app processes and containers.
- [Added] Add `app stop` and top-level `stop` for stopping discovered app processes and containers.
- [Added] Add `app logs` for reading app process and container logs.
- [Added] Support for multiple instances of the same app and roundrobin loadbalancing similar to deployed environments.
- [Changed] Rename app run mode `native` to `process`.

@coderabbitai ignore

**Full Changelog**: https://github.com/Altinn/altinn-studio/compare/studioctl/v0.1.0-preview.5...studioctl/v0.1.0-preview.6