### PR TITLE
fix: studioctl - filelock, server state improvements

### DIFF
--- a/src/cli/internal/appmanager/client.go
+++ b/src/cli/internal/appmanager/client.go
@@ -456,7 +456,7 @@ func reconcilePersistedProcess(
 	}
 
 	if !running {
-		return restartFromPersistedState(ctx, cfg, desired, 0)
+		return restartFromPersistedState(ctx, cfg, client, desired, 0)
 	}
 
 	if state.Start == desired {
@@ -469,12 +469,18 @@ func reconcilePersistedProcess(
 		}
 	}
 
-	return restartFromPersistedState(ctx, cfg, desired, state.PID)
+	return restartFromPersistedState(ctx, cfg, client, desired, state.PID)
 }
 
-func restartFromPersistedState(ctx context.Context, cfg *config.Config, desired startConfig, pid int) error {
+func restartFromPersistedState(
+	ctx context.Context,
+	cfg *config.Config,
+	client *Client,
+	desired startConfig,
+	pid int,
+) error {
 	if pid > 0 {
-		if err := osutil.KillProcess(pid); err != nil {
+		if err := forceStopAppManager(ctx, client, pid); err != nil {
 			return fmt.Errorf("stop persisted app-manager pid %d: %w", pid, err)
 		}
 	}
@@ -572,8 +578,9 @@ func startProcess(ctx context.Context, cfg *config.Config, startConfig startConf
 	if err != nil {
 		return fmt.Errorf("start app-manager: %w", err)
 	}
+	startedPID := cmd.Process.Pid
 	err = writeAppManagerState(cfg, runtimeState{
-		PID:   cmd.Process.Pid,
+		PID:   startedPID,
 		Start: startConfig,
 	})
 	if err != nil {
@@ -595,7 +602,7 @@ func startProcess(ctx context.Context, cfg *config.Config, startConfig startConf
 		})
 	}
 
-	ignoreError(osutil.KillProcess(cmd.Process.Pid))
+	ignoreError(osutil.KillProcess(startedPID))
 	ignoreError(removeAppManagerState(cfg))
 	return err
 }

--- a/src/cli/internal/appmanager/client.go
+++ b/src/cli/internal/appmanager/client.go
@@ -160,23 +160,27 @@ func Shutdown(ctx context.Context, cfg *config.Config) (<-chan error, error) {
 	client := NewClient(cfg)
 	pid, err := currentManagedPID(ctx, client, cfg)
 	if err != nil {
-		ignoreError(lock.Close())
-		return nil, err
+		return nil, errors.Join(err, closeAppManagerLifecycleLock(lock))
 	}
 
 	if err := shutdownError(client.shutdown(ctx), pid); err != nil {
-		ignoreError(lock.Close())
-		return nil, err
+		return nil, errors.Join(err, closeAppManagerLifecycleLock(lock))
 	}
 
 	done := make(chan error, 1)
 	go func() {
 		defer close(done)
-		defer ignoreError(lock.Close())
-		done <- waitForManagedShutdown(ctx, cfg, client, pid)
+		done <- errors.Join(waitForManagedShutdown(ctx, cfg, client, pid), closeAppManagerLifecycleLock(lock))
 	}()
 
 	return done, nil
+}
+
+func closeAppManagerLifecycleLock(lock *osutil.FileLock) error {
+	if err := lock.Close(); err != nil {
+		return fmt.Errorf("close app-manager lifecycle lock: %w", err)
+	}
+	return nil
 }
 
 func shutdownError(err error, pid int) error {
@@ -393,12 +397,14 @@ func EnsureStartedWithStudioctlPath(
 	cfg *config.Config,
 	loadBalancerPort,
 	studioctlPath string,
-) error {
+) (err error) {
 	lock, err := osutil.AcquireFileLock(ctx, cfg.AppManagerLockPath())
 	if err != nil {
 		return fmt.Errorf("lock app-manager lifecycle: %w", err)
 	}
-	defer ignoreError(lock.Close())
+	defer func() {
+		err = errors.Join(err, closeAppManagerLifecycleLock(lock))
+	}()
 
 	desired := buildStartConfig(cfg, loadBalancerPort, studioctlPath)
 	client := NewClient(cfg)

--- a/src/cli/internal/cmd/servers.go
+++ b/src/cli/internal/cmd/servers.go
@@ -195,11 +195,27 @@ func (c *ServersCommand) runUp(ctx context.Context, args []string) error {
 		return fmt.Errorf("parsing flags: %w", err)
 	}
 
-	wasRunning := c.client.Health(ctx) == nil
+	before, beforeErr := c.client.Status(ctx)
+	if beforeErr != nil && !errors.Is(beforeErr, appmanager.ErrNotRunning) {
+		return fmt.Errorf("get app-manager status before start: %w", beforeErr)
+	}
 	if err := c.startAppManager(ctx); err != nil {
 		return fmt.Errorf("start app-manager: %w", err)
 	}
-	return serversUpOutput{Running: true, Started: !wasRunning, JSONOutput: jsonOutput}.Print(c.out)
+	after, afterErr := c.client.Status(ctx)
+	if afterErr != nil {
+		return fmt.Errorf("get app-manager status after start: %w", afterErr)
+	}
+
+	return serversUpOutput{
+		Running:    true,
+		Started:    serverStarted(before, after),
+		JSONOutput: jsonOutput,
+	}.Print(c.out)
+}
+
+func serverStarted(before, after *appmanager.Status) bool {
+	return before == nil || before.ProcessID != after.ProcessID
 }
 
 func (c *ServersCommand) runStatus(ctx context.Context, args []string) error {

--- a/src/cli/internal/cmd/servers_internal_test.go
+++ b/src/cli/internal/cmd/servers_internal_test.go
@@ -26,8 +26,8 @@ func TestServersStatusJSON_Running(t *testing.T) {
 	var out bytes.Buffer
 	command := &ServersCommand{
 		out: ui.NewOutput(&out, io.Discard, false),
-		client: fakeServersClient{
-			status: &appmanager.Status{
+		client: fakeServersClientWithStatus(
+			&appmanager.Status{
 				ProcessID:         42,
 				AppManagerVersion: "1.2.3",
 				DotnetVersion:     "10.0.0",
@@ -48,7 +48,8 @@ func TestServersStatusJSON_Running(t *testing.T) {
 					},
 				},
 			},
-		},
+			nil,
+		),
 	}
 
 	if err := command.Run(context.Background(), []string{"status", "--json"}); err != nil {
@@ -80,7 +81,7 @@ func TestServersUpJSON_AlreadyRunning(t *testing.T) {
 	var out bytes.Buffer
 	command := &ServersCommand{
 		out:    ui.NewOutput(&out, io.Discard, false),
-		client: fakeServersClient{},
+		client: fakeServersClientWithStatus(&appmanager.Status{ProcessID: 1}, nil),
 		ensureStarted: func(context.Context, *config.Config, string) error {
 			return nil
 		},
@@ -106,7 +107,7 @@ func TestServersUpJSON_ReconcilesWhenAlreadyRunning(t *testing.T) {
 	var out bytes.Buffer
 	command := &ServersCommand{
 		out:    ui.NewOutput(&out, io.Discard, false),
-		client: fakeServersClient{},
+		client: fakeServersClientWithStatus(&appmanager.Status{ProcessID: 1}, nil),
 		ensureStarted: func(context.Context, *config.Config, string) error {
 			ensured = true
 			return nil
@@ -126,8 +127,39 @@ func TestServersUpJSON_Started(t *testing.T) {
 
 	var out bytes.Buffer
 	command := &ServersCommand{
-		out:    ui.NewOutput(&out, io.Discard, false),
-		client: fakeServersClient{healthErr: appmanager.ErrNotRunning},
+		out: ui.NewOutput(&out, io.Discard, false),
+		client: fakeServersClientWithStatusSequence(
+			fakeStatusResult{err: appmanager.ErrNotRunning},
+			fakeStatusResult{status: &appmanager.Status{ProcessID: 2}},
+		),
+		ensureStarted: func(context.Context, *config.Config, string) error {
+			return nil
+		},
+	}
+
+	if err := command.Run(context.Background(), []string{"up", "--json"}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	var got serversUpOutput
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out.String())), &got); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if !got.Running || !got.Started {
+		t.Fatalf("output = %+v, want running true and started true", got)
+	}
+}
+
+func TestServersUpJSON_Restarted(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	command := &ServersCommand{
+		out: ui.NewOutput(&out, io.Discard, false),
+		client: fakeServersClientWithStatusSequence(
+			fakeStatusResult{status: &appmanager.Status{ProcessID: 1}},
+			fakeStatusResult{status: &appmanager.Status{ProcessID: 2}},
+		),
 		ensureStarted: func(context.Context, *config.Config, string) error {
 			return nil
 		},
@@ -152,7 +184,7 @@ func TestServersStatusJSON_NotRunning(t *testing.T) {
 	var out bytes.Buffer
 	command := &ServersCommand{
 		out:    ui.NewOutput(&out, io.Discard, false),
-		client: fakeServersClient{statusErr: appmanager.ErrNotRunning},
+		client: fakeServersClientWithStatus(nil, appmanager.ErrNotRunning),
 	}
 
 	if err := command.Run(context.Background(), []string{"status", "--json"}); err != nil {
@@ -379,17 +411,51 @@ func TestServersLogs_ReadsLatestLogWithoutStatus(t *testing.T) {
 }
 
 type fakeServersClient struct {
-	status    *appmanager.Status
-	statusErr error
-	healthErr error
+	status func(context.Context) (*appmanager.Status, error)
+	health func(context.Context) error
 }
 
-func (f fakeServersClient) Health(context.Context) error {
-	return f.healthErr
+type fakeStatusResult struct {
+	status *appmanager.Status
+	err    error
 }
 
-func (f fakeServersClient) Status(context.Context) (*appmanager.Status, error) {
-	return f.status, f.statusErr
+func (f *fakeServersClient) Health(ctx context.Context) error {
+	if f.health == nil {
+		return nil
+	}
+	return f.health(ctx)
+}
+
+func (f *fakeServersClient) Status(ctx context.Context) (*appmanager.Status, error) {
+	if f.status == nil {
+		return new(appmanager.Status), nil
+	}
+	return f.status(ctx)
+}
+
+func fakeServersClientWithStatus(status *appmanager.Status, err error) *fakeServersClient {
+	return &fakeServersClient{
+		status: func(context.Context) (*appmanager.Status, error) {
+			return status, err
+		},
+		health: nil,
+	}
+}
+
+func fakeServersClientWithStatusSequence(results ...fakeStatusResult) *fakeServersClient {
+	index := 0
+	return &fakeServersClient{
+		status: func(context.Context) (*appmanager.Status, error) {
+			if index >= len(results) {
+				return new(appmanager.Status), nil
+			}
+			result := results[index]
+			index++
+			return result.status, result.err
+		},
+		health: nil,
+	}
 }
 
 func writeServerLog(t *testing.T, dir, name, content string) string {

--- a/src/cli/internal/osutil/filelock_unix.go
+++ b/src/cli/internal/osutil/filelock_unix.go
@@ -71,16 +71,16 @@ func (l *FileLock) Close() error {
 		return errors.Join(fdErr, closeErr)
 	}
 
-	err := unix.Flock(fd, unix.LOCK_UN)
+	unlockErr := unix.Flock(fd, unix.LOCK_UN)
 	closeErr := l.file.Close()
 	l.file = nil
-	if err != nil {
-		return fmt.Errorf("unlock file: %w", err)
+	if unlockErr != nil {
+		unlockErr = fmt.Errorf("unlock file: %w", unlockErr)
 	}
 	if closeErr != nil {
-		return fmt.Errorf("close lock file: %w", closeErr)
+		closeErr = fmt.Errorf("close lock file: %w", closeErr)
 	}
-	return nil
+	return errors.Join(unlockErr, closeErr)
 }
 
 func fileDescriptor(file *os.File) (int, error) {

--- a/src/cli/internal/osutil/filelock_windows.go
+++ b/src/cli/internal/osutil/filelock_windows.go
@@ -62,14 +62,14 @@ func (l *FileLock) Close() error {
 		return nil
 	}
 
-	err := windows.UnlockFileEx(windows.Handle(l.file.Fd()), 0, 1, 0, &l.overlapped)
+	unlockErr := windows.UnlockFileEx(windows.Handle(l.file.Fd()), 0, 1, 0, &l.overlapped)
 	closeErr := l.file.Close()
 	l.file = nil
-	if err != nil {
-		return fmt.Errorf("unlock file: %w", err)
+	if unlockErr != nil {
+		unlockErr = fmt.Errorf("unlock file: %w", unlockErr)
 	}
 	if closeErr != nil {
-		return fmt.Errorf("close lock file: %w", closeErr)
+		closeErr = fmt.Errorf("close lock file: %w", closeErr)
 	}
-	return nil
+	return errors.Join(unlockErr, closeErr)
 }


### PR DESCRIPTION
## Description

followup on one of the earlier PRs

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved server restart detection by monitoring process ID changes between status checks, ensuring the `up` command correctly identifies when a server has been restarted.
  * Enhanced error handling for file lock operations to report both unlock and close failures together, providing clearer diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->