### PR TITLE
fix(workflow-engine): remove race in dedup buffer test

### DIFF
--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Core.Tests/WorkflowUpdateBufferTests.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Core.Tests/WorkflowUpdateBufferTests.cs
@@ -380,12 +380,10 @@ public class WorkflowUpdateBufferTests
     [Fact]
     public async Task Submit_DeduplicatesSameWorkflowInBatch()
     {
-        // Use a gate to block the first flush so items accumulate in the channel
         var settings = CreateSettings(maxBatchSize: 10);
         var (buffer, repo) = CreateBuffer(settings);
 
         IReadOnlyList<BatchWorkflowStatusUpdate>? capturedUpdates = null;
-        var gate = new TaskCompletionSource();
         repo.Setup(r =>
                 r.BatchUpdateWorkflowsAndSteps(
                     It.IsAny<IReadOnlyList<BatchWorkflowStatusUpdate>>(),
@@ -395,14 +393,17 @@ public class WorkflowUpdateBufferTests
             .Callback<IReadOnlyList<BatchWorkflowStatusUpdate>, CancellationToken>(
                 (updates, _) => capturedUpdates ??= updates
             )
-            .Returns(async (IReadOnlyList<BatchWorkflowStatusUpdate> _, CancellationToken _) => await gate.Task);
+            .Returns(Task.CompletedTask);
 
         using var serviceCts = new CancellationTokenSource();
-        await buffer.StartAsync(serviceCts.Token);
 
         try
         {
-            // Submit 3 updates for the same workflow — only the last should survive deduplication
+            // Submit 3 updates for the same workflow *before* starting the buffer. With a bounded
+            // channel that has capacity, WriteAsync completes synchronously, so all 3 items land
+            // in the channel before the drain loop runs. Starting the buffer then picks them up
+            // together, which is the only way to reliably exercise the in-batch dedup path
+            // without racing the reader's Task.Yield() against the test thread's submits.
             var sharedId = Guid.NewGuid();
             var tasks = Enumerable
                 .Range(1, 3)
@@ -415,8 +416,7 @@ public class WorkflowUpdateBufferTests
                 })
                 .ToList();
 
-            // Release the gate — all items process
-            gate.SetResult();
+            await buffer.StartAsync(serviceCts.Token);
 
             await Task.WhenAll(tasks);
 


### PR DESCRIPTION
## Summary
- Fixes a pre-existing race in `Submit_DeduplicatesSameWorkflowInBatch`. Previously the test started the buffer's background service before submitting, which let the drain loop race the test thread: if the reader woke on the first submit before the second and third were written, the three items flushed as separate batches and the first captured batch missed the final `Completed` state.
- Moves all three submits to *before* `StartAsync`. With a bounded channel that has capacity, `WriteAsync` completes synchronously, so all items land in the channel before the drain loop runs. Starting the buffer then picks them up together, reliably exercising the in-batch dedup path.
- Test-only change — no production code touched.

Observed flakiness on `origin/main`: six of eight runs failed. With this fix: ten of ten runs pass, and the full `WorkflowUpdateBufferTests` class (eight tests) stays green.

## Test plan
- [x] Run `Submit_DeduplicatesSameWorkflowInBatch` 10x in a row — all pass
- [x] Run full `WorkflowUpdateBufferTests` class — 8/8 pass
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved workflow deduplication test to ensure batch submissions occur prior to buffer processing, eliminating reliance on mock blocking mechanisms whilst maintaining validation of deduplication behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->