### PR TITLE
fix: releaser - validate base branch divergence as part of changelog validation

### DIFF
--- a/src/tools/releaser/internal/validate.go
+++ b/src/tools/releaser/internal/validate.go
@@ -17,6 +17,9 @@ var (
 	ErrChangelogNotModified = errors.New("changelog was not modified")
 	// ErrNoNewUnreleasedEntries indicates [Unreleased] has no entries added compared to base.
 	ErrNoNewUnreleasedEntries = errors.New("unreleased section has no new entries compared to base")
+	// ErrBaseChangelogOutdated indicates that the base branch changelog changed
+	// after the PR branch diverged.
+	ErrBaseChangelogOutdated = errors.New("base branch contains newer changelog changes")
 )
 
 // ValidationRequest describes inputs for changelog validation.
@@ -69,6 +72,11 @@ func RunValidationWithDeps(ctx context.Context, req ValidationRequest, git *GitC
 		return fmt.Errorf("get repo root: %w", err)
 	}
 
+	err = validateBaseChangelogCurrent(ctx, git, req.Base, req.Head, clPath)
+	if err != nil {
+		return err
+	}
+
 	diffOutput, err := git.Run(ctx, "diff", "--name-only", req.Base, req.Head)
 	if err != nil {
 		return fmt.Errorf("git diff: %w", err)
@@ -104,6 +112,30 @@ func ChangelogWasModified(diffOutput, changelogPath string) bool {
 		}
 	}
 	return false
+}
+
+func validateBaseChangelogCurrent(ctx context.Context, git *GitCLI, base, head, changelogPath string) error {
+	mergeBase, err := git.Run(ctx, "merge-base", base, head)
+	if err != nil {
+		return fmt.Errorf("git merge-base: %w", err)
+	}
+	if mergeBase == base {
+		return nil
+	}
+
+	diffOutput, err := git.Run(ctx, "diff", "--name-only", mergeBase, base, "--", changelogPath)
+	if err != nil {
+		return fmt.Errorf("git diff base changelog: %w", err)
+	}
+	if !ChangelogWasModified(diffOutput, changelogPath) {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"%w: %s changed on the base branch after this branch diverged; rebase or merge the base branch before validating changelog",
+		ErrBaseChangelogOutdated,
+		changelogPath,
+	)
 }
 
 // ValidateUnreleasedOrReleasePromotion validates that Unreleased has content,

--- a/src/tools/releaser/internal/validate_test.go
+++ b/src/tools/releaser/internal/validate_test.go
@@ -46,6 +46,7 @@ func TestRunValidation(t *testing.T) {
 	t.Run("reject synthetic release header without removals", testRunValidationRejectsSyntheticReleaseHeader)
 	t.Run("fails when changelog not modified", testRunValidationFailsChangelogNotModified)
 	t.Run("fails when unreleased is empty without promotion", testRunValidationFailsEmptyUnreleased)
+	t.Run("fails when base changelog changed after branch diverged", testRunValidationFailsOutdatedBaseChangelog)
 }
 
 func testRunValidationValidChangelogUpdate(t *testing.T) {
@@ -211,6 +212,37 @@ func testRunValidationFailsEmptyUnreleased(t *testing.T) {
 `, "empty unreleased")
 
 	assertValidationError(t, runValidation(t, repo, base, head), changelog.ErrUnreleasedNoHeader)
+}
+
+func testRunValidationFailsOutdatedBaseChangelog(t *testing.T) {
+	repo, branchPoint := setupValidationRepo(t, `# Changelog
+
+## [Unreleased]
+
+### Added
+
+- Release me
+`)
+	head := commitValidationFile(t, repo, "README.md", "branch change\n", "branch change")
+
+	runGitCmd(t, repo, "checkout", branchPoint)
+	base := commitValidationFile(t, repo, "src/cli/CHANGELOG.md", `# Changelog
+
+## [Unreleased]
+
+## [1.0.0] - 2025-01-01
+
+### Added
+
+- Release me
+`, "promote release")
+	runGitCmd(t, repo, "checkout", head)
+
+	err := runValidation(t, repo, base, head)
+	assertValidationError(t, err, internal.ErrBaseChangelogOutdated)
+	if !strings.Contains(err.Error(), "rebase or merge the base branch") {
+		t.Fatalf("RunValidation() error = %v, want rebase guidance", err)
+	}
 }
 
 func setupValidationRepo(t *testing.T, initialChangelog string) (string, string) {


### PR DESCRIPTION
## Description

When the merge base is behind base branch head (and it has changelog.md changes), we got this error in the validation workflow

```
Run go run . validate-changelog -component studioctl -base "77147c589289a508baf3c98e2faec6f1e17f52da" -head "2d6be36bed5b18896e1b1e66fdb21ce0142e73a8"
    [git] "rev-parse" "--show-toplevel"
    [git] "diff" "--name-only" "77147c589289a508baf3c98e2faec6f1e17f52da" "2d6be36bed5b18896e1b1e66fdb21ce0142e73a8"
    [git] "show" "77147c589289a508baf3c98e2faec6f1e17f52da:src/cli/CHANGELOG.md"
error: validate changelog: validate changelog: [Unreleased] section missing category header (### Added, ### Fixed, etc.)
exit status 1
```

this PR makes the error message accurate instead

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Validation Enhancements**
  * Introduced a pre-validation check that detects when the base branch's changelog file contains modifications made after your feature branch diverged from it. When detected, the system alerts you with clear guidance on rebasing or merging the base branch, helping prevent integration conflicts and ensuring a smoother merge process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->