### PR TITLE
chore: studictl localtest workflow-engine volume for db

### DIFF
--- a/src/cli/internal/cmd/env/localtest/env.go
+++ b/src/cli/internal/cmd/env/localtest/env.go
@@ -366,6 +366,9 @@ func (e *Env) ensureResources(ctx context.Context, buildOpts ResourceBuildOption
 	if err := ensurePgpass(e.cfg.DataDir); err != nil {
 		return err
 	}
+	if err := ensureWorkflowEngineDbDataDir(e.cfg.DataDir); err != nil {
+		return err
+	}
 
 	if err := ValidateResourceHostPaths(buildOpts); err != nil {
 		e.out.Verbosef("Resource layout invalid, forcing reinstall: %v", err)
@@ -375,11 +378,21 @@ func (e *Env) ensureResources(ctx context.Context, buildOpts ResourceBuildOption
 		if err := ensurePgpass(e.cfg.DataDir); err != nil {
 			return err
 		}
+		if err := ensureWorkflowEngineDbDataDir(e.cfg.DataDir); err != nil {
+			return err
+		}
 		if err := ValidateResourceHostPaths(buildOpts); err != nil {
 			return fmt.Errorf("validate resources after reinstall: %w", err)
 		}
 	}
 
+	return nil
+}
+
+func ensureWorkflowEngineDbDataDir(dataDir string) error {
+	if err := os.MkdirAll(workflowEngineDbDataPath(dataDir), osutil.DirPermDefault); err != nil {
+		return fmt.Errorf("create workflow-engine database data directory: %w", err)
+	}
 	return nil
 }
 

--- a/src/cli/internal/cmd/env/localtest/env.go
+++ b/src/cli/internal/cmd/env/localtest/env.go
@@ -371,21 +371,30 @@ func (e *Env) ensureResources(ctx context.Context, buildOpts ResourceBuildOption
 	}
 
 	if err := ValidateResourceHostPaths(buildOpts); err != nil {
-		e.out.Verbosef("Resource layout invalid, forcing reinstall: %v", err)
-		if installErr := e.installResources(ctx, true); installErr != nil {
-			return installErr
-		}
-		if err := ensurePgpass(e.cfg.DataDir); err != nil {
-			return err
-		}
-		if err := ensureWorkflowEngineDbDataDir(e.cfg.DataDir); err != nil {
-			return err
-		}
-		if err := ValidateResourceHostPaths(buildOpts); err != nil {
-			return fmt.Errorf("validate resources after reinstall: %w", err)
-		}
+		return e.reinstallResourcesAfterValidationFailure(ctx, buildOpts, err)
 	}
 
+	return nil
+}
+
+func (e *Env) reinstallResourcesAfterValidationFailure(
+	ctx context.Context,
+	buildOpts ResourceBuildOptions,
+	cause error,
+) error {
+	e.out.Verbosef("Resource layout invalid, forcing reinstall: %v", cause)
+	if err := e.installResources(ctx, true); err != nil {
+		return err
+	}
+	if err := ensurePgpass(e.cfg.DataDir); err != nil {
+		return err
+	}
+	if err := ensureWorkflowEngineDbDataDir(e.cfg.DataDir); err != nil {
+		return err
+	}
+	if err := ValidateResourceHostPaths(buildOpts); err != nil {
+		return fmt.Errorf("validate resources after reinstall: %w", err)
+	}
 	return nil
 }
 

--- a/src/cli/internal/cmd/env/localtest/resources.go
+++ b/src/cli/internal/cmd/env/localtest/resources.go
@@ -33,6 +33,7 @@ const (
 	buildCacheRefPDF3         = "ghcr.io/altinn/altinn-studio/localtest-pdf3-cache:latest"
 	infraDir                  = "infra"
 	workflowEngineInfraDir    = "workflow-engine"
+	workflowEngineDbDataDir   = "workflow-engine-db"
 	localtestServicePort      = "5101"
 
 	postgresHealthInterval    = 10 * time.Second
@@ -226,6 +227,10 @@ func workflowEngineDbContainerSpec(dataDir string) ContainerSpec {
 			"TZ":                "Europe/Oslo",
 		},
 		[]types.VolumeMount{
+			newVolume(
+				workflowEngineDbDataPath(dataDir),
+				"/var/lib/postgresql",
+			),
 			newReadOnlyVolume(
 				workflowEngineInfraFilePath(dataDir, "postgres-init.sql"),
 				"/docker-entrypoint-initdb.d/01-tuning.sql",
@@ -298,6 +303,10 @@ func workflowEngineInfraFilePath(dataDir, name string) string {
 
 func workflowEngineInfraPath(dataDir string) string {
 	return filepath.Join(dataDir, infraDir, workflowEngineInfraDir)
+}
+
+func workflowEngineDbDataPath(dataDir string) string {
+	return filepath.Join(dataDir, workflowEngineDbDataDir)
 }
 
 func monitoringContainers(dataDir string, topology envtopology.Local) []ContainerSpec {

--- a/src/cli/internal/cmd/env/localtest/resources_internal_test.go
+++ b/src/cli/internal/cmd/env/localtest/resources_internal_test.go
@@ -378,6 +378,7 @@ func createCoreLayout(t *testing.T, dataDir string) {
 	for _, dir := range []string{
 		filepath.Join(dataDir, "testdata"),
 		filepath.Join(dataDir, "AltinnPlatformLocal"),
+		workflowEngineDbDataPath(dataDir),
 		filepath.Join(dataDir, "infra"),
 		filepath.Join(dataDir, "infra", "workflow-engine"),
 	} {


### PR DESCRIPTION
## Description

studioctl localtest currently doesnt purge data during "down", since the future of localtest data is distributed, we are going to need separate functionality to purge/reset data but for now atleast the defaults should be the same 

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workflow engine database data directory initialisation and persistence handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->