### PR TITLE
feat: studioctl - env reset command

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `env reset` for localtest to delete persisted localtest and workflow-engine database data, with interactive confirmation.
+
 ## [0.1.0-preview.6] - 2026-04-20
 
 ### Added

--- a/src/cli/internal/cmd/auth.go
+++ b/src/cli/internal/cmd/auth.go
@@ -376,12 +376,9 @@ func (c *AuthCommand) runLogout(_ context.Context, args []string) error {
 // confirmOverwrite prompts the user to confirm overwriting existing credentials.
 // Returns (confirmed, error) where error is ui.ErrInterrupted on Ctrl+C.
 func (c *AuthCommand) confirmOverwrite(ctx context.Context) (bool, error) {
-	c.out.Print("Overwrite existing credentials? [y/N]: ")
-	response, err := ui.ReadLine(ctx, os.Stdin)
+	confirmed, err := ui.Confirm(ctx, c.out, os.Stdin, "Overwrite existing credentials? [y/N]: ")
 	if err != nil {
-		c.out.Println("")
-		return false, fmt.Errorf("read confirmation: %w", err)
+		return false, fmt.Errorf("confirm overwrite: %w", err)
 	}
-	answer := strings.TrimSpace(strings.ToLower(string(response)))
-	return answer == "y" || answer == "yes", nil
+	return confirmed, nil
 }

--- a/src/cli/internal/cmd/env.go
+++ b/src/cli/internal/cmd/env.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"os"
 
 	"altinn.studio/devenv/pkg/container"
 	envtypes "altinn.studio/studioctl/internal/cmd/env"
@@ -16,6 +17,8 @@ import (
 )
 
 const runtimeLocaltest = "localtest"
+
+var errResetUnsupported = errors.New("reset is not supported for runtime")
 
 // EnvCommand implements the 'env' subcommand.
 type EnvCommand struct {
@@ -84,6 +87,19 @@ func (o envStatusOutput) Print(out *ui.Output) error {
 	return nil
 }
 
+type envResetOutput struct {
+	Runtime    string `json:"runtime"`
+	Reset      bool   `json:"reset"`
+	JSONOutput bool   `json:"-"`
+}
+
+func (o envResetOutput) Print(out *ui.Output) error {
+	if o.JSONOutput {
+		return printJSONOutput(out, "env reset", o)
+	}
+	return nil
+}
+
 // NewEnvCommand creates a new env command.
 func NewEnvCommand(cfg *config.Config, out *ui.Output) *EnvCommand {
 	return &EnvCommand{cfg: cfg, out: out}
@@ -105,6 +121,7 @@ func (c *EnvCommand) Usage() string {
 		"Subcommands:",
 		"  up       Start the environment",
 		"  down     Stop the environment",
+		"  reset    Delete persisted environment data",
 		"  status   Show environment status",
 		"  logs     Stream environment logs",
 		"",
@@ -116,6 +133,9 @@ func (c *EnvCommand) Usage() string {
 		"  --monitoring     Start monitoring stack",
 		"  --pgadmin        Start pgAdmin for the workflow-engine database",
 		"  --open           Open localtest in browser after starting",
+		"",
+		"Options for 'env reset':",
+		"  -y, --yes        Skip confirmation prompt",
 		"",
 		fmt.Sprintf("Run '%s env <subcommand> --help' for more information.", osutil.CurrentBin()),
 	)
@@ -136,6 +156,8 @@ func (c *EnvCommand) Run(ctx context.Context, args []string) error {
 		return c.runUp(ctx, subArgs)
 	case "down":
 		return c.runDown(ctx, subArgs)
+	case "reset":
+		return c.runReset(ctx, subArgs)
 	case "status":
 		return c.runStatus(ctx, subArgs)
 	case "logs":
@@ -343,6 +365,109 @@ func (c *EnvCommand) runDown(ctx context.Context, args []string) error {
 			JSONOutput:     flags.jsonOutput,
 		}.Print(c.out)
 	})
+}
+
+// envResetFlags holds parsed flags for the env reset command.
+type envResetFlags struct {
+	runtime    string
+	yes        bool
+	jsonOutput bool
+}
+
+func (c *EnvCommand) parseResetFlags(args []string) (envResetFlags, bool, error) {
+	fs := flag.NewFlagSet("env reset", flag.ContinueOnError)
+	var f envResetFlags
+	fs.StringVar(&f.runtime, "r", runtimeLocaltest, "Runtime to use")
+	fs.StringVar(&f.runtime, "runtime", runtimeLocaltest, "Runtime to use")
+	fs.BoolVar(&f.yes, "y", false, "Skip confirmation prompt")
+	fs.BoolVar(&f.yes, "yes", false, "Skip confirmation prompt")
+	fs.BoolVar(&f.jsonOutput, "json", false, "Output as JSON")
+
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return f, true, nil
+		}
+		return f, false, fmt.Errorf("parsing flags: %w", err)
+	}
+
+	return f, false, nil
+}
+
+func (c *EnvCommand) runReset(ctx context.Context, args []string) error {
+	flags, helpShown, err := c.parseResetFlags(args)
+	if err != nil {
+		return err
+	}
+	if helpShown {
+		return nil
+	}
+	if err := validateResetRuntime(flags.runtime); err != nil {
+		return err
+	}
+	if proceed, err := c.confirmResetIfNeeded(ctx, flags); err != nil {
+		return err
+	} else if !proceed {
+		return nil
+	}
+
+	return c.withContainerClient(ctx, func(client container.ContainerClient) error {
+		env, err := c.getEnvWithOutput(flags.runtime, client, commandOutput(c.out, flags.jsonOutput))
+		if err != nil {
+			return err
+		}
+
+		resetter, ok := env.(envtypes.Resetter)
+		if !ok {
+			return fmt.Errorf("%w: %s", errResetUnsupported, flags.runtime)
+		}
+
+		if err := resetter.Reset(ctx); err != nil {
+			return fmt.Errorf("env reset: %w", err)
+		}
+
+		return envResetOutput{
+			Runtime:    flags.runtime,
+			Reset:      true,
+			JSONOutput: flags.jsonOutput,
+		}.Print(c.out)
+	})
+}
+
+func validateResetRuntime(runtime string) error {
+	switch runtime {
+	case runtimeLocaltest:
+		return nil
+	default:
+		return fmt.Errorf("%w: %s", ErrUnsupportedRuntime, runtime)
+	}
+}
+
+func (c *EnvCommand) confirmResetIfNeeded(ctx context.Context, flags envResetFlags) (bool, error) {
+	if flags.jsonOutput && !flags.yes {
+		return false, fmt.Errorf("%w: --json requires --yes", ErrInvalidFlagValue)
+	}
+	if flags.yes {
+		return true, nil
+	}
+	if !ui.StdinIsTerminal() {
+		return false, fmt.Errorf("%w: --yes is required when stdin is not a terminal", ErrInvalidFlagValue)
+	}
+
+	confirmed, err := ui.Confirm(
+		ctx,
+		c.out,
+		os.Stdin,
+		fmt.Sprintf("Delete persisted %s environment data? [y/N]: ", flags.runtime),
+	)
+	if err != nil {
+		return false, fmt.Errorf("confirm reset: %w", err)
+	}
+	if !confirmed {
+		c.out.Println("Reset cancelled")
+		return false, nil
+	}
+
+	return true, nil
 }
 
 // envStatusFlags holds parsed flags for the env status command.

--- a/src/cli/internal/cmd/env/localtest/env.go
+++ b/src/cli/internal/cmd/env/localtest/env.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"altinn.studio/devenv/pkg/container"
@@ -31,10 +34,16 @@ var (
 
 	// ErrLegacyLocaltestRunning is returned when legacy localtest containers are detected.
 	ErrLegacyLocaltestRunning = errors.New("legacy localtest is running (started outside this CLI)")
+
+	errResetTargetOutsideDataDir = errors.New("reset target outside data directory")
+	errResetCleanupFailed        = errors.New("workflow-engine data cleanup helper failed")
+	errResetTargetSymlink        = errors.New("reset target must not be a symlink")
 )
 
 // teardownTimeout is the maximum time to wait for environment teardown.
 const teardownTimeout = 30 * time.Second
+
+const cleanupHelperLogTail = "100"
 
 const stoppingEnvironmentMessage = "Stopping localtest environment..."
 
@@ -127,6 +136,34 @@ func (e *Env) Down(ctx context.Context) error {
 	}
 
 	e.out.Success("Environment stopped")
+	return nil
+}
+
+// Reset stops localtest if needed and deletes persisted data.
+func (e *Env) Reset(ctx context.Context) error {
+	toolchain := e.client.Toolchain()
+	e.out.Verbosef("Using container toolchain: %s via %s", toolchain.Platform, toolchain.AccessMode)
+
+	if err := CheckForLegacyLocaltest(ctx, e.client, true); err != nil {
+		return err
+	}
+
+	hasResources, err := e.hasManagedResources(ctx)
+	if err != nil {
+		return err
+	}
+	if hasResources {
+		if err := e.destroyResources(ctx, e.buildDestroyOptions(), stoppingEnvironmentMessage); err != nil {
+			return fmt.Errorf("stop environment: %w", err)
+		}
+	}
+
+	e.out.Println("Deleting persisted localtest data...")
+	if err := e.deletePersistedData(ctx); err != nil {
+		return err
+	}
+
+	e.out.Success("Environment data reset")
 	return nil
 }
 
@@ -366,6 +403,9 @@ func (e *Env) ensureResources(ctx context.Context, buildOpts ResourceBuildOption
 	if err := ensurePgpass(e.cfg.DataDir); err != nil {
 		return err
 	}
+	if err := ensureLocaltestStorageDir(e.cfg.DataDir); err != nil {
+		return err
+	}
 	if err := ensureWorkflowEngineDbDataDir(e.cfg.DataDir); err != nil {
 		return err
 	}
@@ -389,6 +429,9 @@ func (e *Env) reinstallResourcesAfterValidationFailure(
 	if err := ensurePgpass(e.cfg.DataDir); err != nil {
 		return err
 	}
+	if err := ensureLocaltestStorageDir(e.cfg.DataDir); err != nil {
+		return err
+	}
 	if err := ensureWorkflowEngineDbDataDir(e.cfg.DataDir); err != nil {
 		return err
 	}
@@ -403,6 +446,163 @@ func ensureWorkflowEngineDbDataDir(dataDir string) error {
 		return fmt.Errorf("create workflow-engine database data directory: %w", err)
 	}
 	return nil
+}
+
+func ensureLocaltestStorageDir(dataDir string) error {
+	if err := os.MkdirAll(filepath.Join(dataDir, "AltinnPlatformLocal"), osutil.DirPermDefault); err != nil {
+		return fmt.Errorf("create localtest storage directory: %w", err)
+	}
+	return nil
+}
+
+func (e *Env) deletePersistedData(ctx context.Context) error {
+	if err := removeResetDataPath(e.cfg.DataDir, filepath.Join(e.cfg.DataDir, "AltinnPlatformLocal")); err != nil {
+		return err
+	}
+	return e.removeWorkflowEngineDbData(ctx, workflowEngineDbDataPath(e.cfg.DataDir))
+}
+
+func (e *Env) removeWorkflowEngineDbData(ctx context.Context, target string) error {
+	targetAbs, exists, err := resetTargetPath(e.cfg.DataDir, target)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+
+	if err := e.cleanupWorkflowEngineDbData(ctx, targetAbs); err != nil {
+		return err
+	}
+
+	return removeResetDataPath(e.cfg.DataDir, target)
+}
+
+func (e *Env) cleanupWorkflowEngineDbData(ctx context.Context, targetAbs string) error {
+	helperName := fmt.Sprintf("studioctl-reset-workflow-engine-db-%d", time.Now().UnixNano())
+	containerCfg := containertypes.ContainerConfig{
+		Labels:         nil,
+		HealthCheck:    nil,
+		Name:           helperName,
+		Image:          e.cfg.Images.Core.WorkflowEngineDb.Ref(),
+		User:           "",
+		RestartPolicy:  "",
+		ExtraHosts:     nil,
+		NetworkAliases: nil,
+		Volumes: []containertypes.VolumeMount{{
+			HostPath:      targetAbs,
+			ContainerPath: "/cleanup",
+			ReadOnly:      false,
+		}},
+		Networks: nil,
+		Ports:    nil,
+		Env:      nil,
+		Command:  []string{"sh", "-ceu", "rm -rf /cleanup/* /cleanup/.[!.]* /cleanup/..?*"},
+		CapAdd:   nil,
+		Detach:   true,
+	}
+
+	if _, err := e.client.CreateContainer(ctx, containerCfg); err != nil {
+		return fmt.Errorf("start workflow-engine data cleanup helper: %w", err)
+	}
+
+	exitCode, waitErr := e.client.ContainerWait(ctx, helperName)
+	failureDetails := ""
+	if waitErr == nil && exitCode != 0 {
+		failureDetails = e.cleanupHelperFailureDetails(ctx, helperName)
+	}
+	removeErr := e.client.ContainerRemove(ctx, helperName, true)
+	if waitErr != nil {
+		if removeErr != nil {
+			e.out.Verbosef("failed to remove cleanup helper container %q: %v", helperName, removeErr)
+		}
+		return fmt.Errorf("wait for workflow-engine data cleanup helper: %w", waitErr)
+	}
+	if removeErr != nil {
+		return fmt.Errorf("remove workflow-engine data cleanup helper: %w", removeErr)
+	}
+	if exitCode != 0 {
+		if failureDetails != "" {
+			return fmt.Errorf("%w: exit code %d: %s", errResetCleanupFailed, exitCode, failureDetails)
+		}
+		return fmt.Errorf("%w: exit code %d", errResetCleanupFailed, exitCode)
+	}
+
+	return nil
+}
+
+func (e *Env) cleanupHelperFailureDetails(ctx context.Context, helperName string) string {
+	logs, err := e.client.ContainerLogs(ctx, helperName, false, cleanupHelperLogTail)
+	if err != nil {
+		e.out.Verbosef("failed to read cleanup helper logs for %q: %v", helperName, err)
+		return ""
+	}
+	defer func() {
+		if cerr := logs.Close(); cerr != nil {
+			e.out.Verbosef("failed to close cleanup helper logs for %q: %v", helperName, cerr)
+		}
+	}()
+
+	data, err := io.ReadAll(logs)
+	if err != nil {
+		e.out.Verbosef("failed to read cleanup helper log stream for %q: %v", helperName, err)
+		return ""
+	}
+
+	text := strings.TrimSpace(string(data))
+	if text == "" {
+		return ""
+	}
+	return "logs: " + text
+}
+
+func removeResetDataPath(dataDir, target string) error {
+	targetAbs, exists, err := resetTargetPath(dataDir, target)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+
+	if err := os.RemoveAll(targetAbs); err != nil {
+		return fmt.Errorf("remove persisted data %q: %w", targetAbs, err)
+	}
+
+	return nil
+}
+
+func resetTargetPath(dataDir, target string) (string, bool, error) {
+	dataDirAbs, err := filepath.Abs(dataDir)
+	if err != nil {
+		return "", false, fmt.Errorf("resolve data directory: %w", err)
+	}
+
+	targetAbs, err := filepath.Abs(target)
+	if err != nil {
+		return "", false, fmt.Errorf("resolve reset target %q: %w", target, err)
+	}
+
+	rel, err := filepath.Rel(dataDirAbs, targetAbs)
+	if err != nil {
+		return "", false, fmt.Errorf("relativize reset target %q: %w", targetAbs, err)
+	}
+	if rel == "." || rel == "" || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", false, fmt.Errorf("%w: %s", errResetTargetOutsideDataDir, targetAbs)
+	}
+
+	info, err := os.Lstat(targetAbs)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return targetAbs, false, nil
+		}
+		return "", false, fmt.Errorf("stat reset target %q: %w", targetAbs, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", false, fmt.Errorf("%w: %s", errResetTargetSymlink, targetAbs)
+	}
+
+	return targetAbs, true, nil
 }
 
 func ensurePgpass(dataDir string) error {

--- a/src/cli/internal/cmd/env/localtest/env_reset_test.go
+++ b/src/cli/internal/cmd/env/localtest/env_reset_test.go
@@ -1,0 +1,217 @@
+//nolint:testpackage // Same-package test keeps reset-path coverage small and avoids test-only exports.
+package localtest
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	containermock "altinn.studio/devenv/pkg/container/mock"
+	containertypes "altinn.studio/devenv/pkg/container/types"
+	"altinn.studio/studioctl/internal/config"
+	"altinn.studio/studioctl/internal/ui"
+)
+
+func TestReset_RemovesPersistedDataWhenAlreadyStopped(t *testing.T) {
+	dataDir := t.TempDir()
+	localtestDataDir := filepath.Join(dataDir, "AltinnPlatformLocal")
+	workflowEngineDataDir := workflowEngineDbDataPath(dataDir)
+	createDir(t, localtestDataDir)
+	createDir(t, workflowEngineDataDir)
+
+	env := NewEnv(
+		&config.Config{
+			DataDir: dataDir,
+			Images:  testResetImages(),
+		},
+		ui.NewOutput(io.Discard, io.Discard, false),
+		containermock.New(),
+	)
+	if err := env.Reset(context.Background()); err != nil {
+		t.Fatalf("Reset() error = %v", err)
+	}
+
+	assertCallRecorded(t, clientCalls(env), "CreateContainer")
+	assertCallRecorded(t, clientCalls(env), "ContainerWait")
+	assertNotExists(t, localtestDataDir)
+	assertNotExists(t, workflowEngineDataDir)
+}
+
+func TestReset_StopsManagedResourcesBeforeRemovingPersistedData(t *testing.T) {
+	dataDir := t.TempDir()
+	localtestDataDir := filepath.Join(dataDir, "AltinnPlatformLocal")
+	workflowEngineDataDir := workflowEngineDbDataPath(dataDir)
+	createDir(t, localtestDataDir)
+	createDir(t, workflowEngineDataDir)
+
+	client := containermock.New()
+	client.ContainerInspectFunc = func(context.Context, string) (containertypes.ContainerInfo, error) {
+		return containertypes.ContainerInfo{}, nil
+	}
+	client.NetworkInspectFunc = func(context.Context, string) (containertypes.NetworkInfo, error) {
+		return containertypes.NetworkInfo{}, nil
+	}
+
+	env := NewEnv(
+		&config.Config{
+			DataDir: dataDir,
+			Images:  testResetImages(),
+		},
+		ui.NewOutput(io.Discard, io.Discard, false),
+		client,
+	)
+	if err := env.Reset(context.Background()); err != nil {
+		t.Fatalf("Reset() error = %v", err)
+	}
+
+	assertCallRecorded(t, client.Calls, "CreateContainer")
+	assertCallRecorded(t, client.Calls, "ContainerWait")
+	assertCallRecorded(t, client.Calls, "ContainerRemove")
+	assertCallRecorded(t, client.Calls, "NetworkRemove")
+	assertNotExists(t, localtestDataDir)
+	assertNotExists(t, workflowEngineDataDir)
+}
+
+func TestReset_RefusesLegacyLocaltest(t *testing.T) {
+	dataDir := t.TempDir()
+	createDir(t, filepath.Join(dataDir, "AltinnPlatformLocal"))
+	createDir(t, workflowEngineDbDataPath(dataDir))
+
+	client := containermock.New()
+	client.ContainerInspectFunc = func(_ context.Context, name string) (containertypes.ContainerInfo, error) {
+		if name == ContainerLocaltest {
+			return containertypes.ContainerInfo{
+				Name:   ContainerLocaltest,
+				Labels: map[string]string{},
+				State:  containertypes.ContainerState{Running: true},
+			}, nil
+		}
+		return containertypes.ContainerInfo{}, containertypes.ErrContainerNotFound
+	}
+
+	env := NewEnv(
+		&config.Config{
+			DataDir: dataDir,
+			Images:  testResetImages(),
+		},
+		ui.NewOutput(io.Discard, io.Discard, false),
+		client,
+	)
+	err := env.Reset(context.Background())
+	if !errors.Is(err, ErrLegacyLocaltestRunning) {
+		t.Fatalf("Reset() error = %v, want ErrLegacyLocaltestRunning", err)
+	}
+}
+
+func TestReset_IncludesCleanupHelperLogsOnFailure(t *testing.T) {
+	dataDir := t.TempDir()
+	createDir(t, filepath.Join(dataDir, "AltinnPlatformLocal"))
+	createDir(t, workflowEngineDbDataPath(dataDir))
+
+	client := containermock.New()
+	client.ContainerWaitFunc = func(context.Context, string) (int, error) {
+		return 17, nil
+	}
+	client.ContainerLogsFunc = func(_ context.Context, nameOrID string, follow bool, tail string) (io.ReadCloser, error) {
+		if follow {
+			t.Fatal("ContainerLogs() follow = true, want false")
+		}
+		if tail != cleanupHelperLogTail {
+			t.Fatalf("ContainerLogs() tail = %q, want %q", tail, cleanupHelperLogTail)
+		}
+		return io.NopCloser(strings.NewReader("permission denied\nrm: cannot remove /cleanup/foo\n")), nil
+	}
+
+	env := NewEnv(
+		&config.Config{
+			DataDir: dataDir,
+			Images:  testResetImages(),
+		},
+		ui.NewOutput(io.Discard, io.Discard, false),
+		client,
+	)
+	err := env.Reset(context.Background())
+	if err == nil {
+		t.Fatal("Reset() error = nil, want non-nil")
+	}
+	if !errors.Is(err, errResetCleanupFailed) {
+		t.Fatalf("Reset() error = %v, want errResetCleanupFailed", err)
+	}
+	if !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("Reset() error = %q, want helper log output", err)
+	}
+}
+
+func TestRemoveResetDataPath_RejectsSymlink(t *testing.T) {
+	if runtime.GOOS == osWindows {
+		t.Skip("symlink creation requires elevated privileges on some Windows setups")
+	}
+
+	dataDir := t.TempDir()
+	targetDir := t.TempDir()
+	linkPath := filepath.Join(dataDir, workflowEngineDbDataDir)
+	if err := os.Symlink(targetDir, linkPath); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	err := removeResetDataPath(dataDir, linkPath)
+	if !errors.Is(err, errResetTargetSymlink) {
+		t.Fatalf("removeResetDataPath() error = %v, want errResetTargetSymlink", err)
+	}
+}
+
+func clientCalls(env *Env) []containermock.Call {
+	client, ok := env.client.(*containermock.Client)
+	if !ok {
+		return nil
+	}
+	return client.Calls
+}
+
+func testResetImages() config.ImagesConfig {
+	return config.ImagesConfig{
+		Core: config.CoreImages{
+			Localtest:        config.ImageSpec{Image: "ghcr.io/altinn/test-localtest", Tag: "latest"},
+			PDF3:             config.ImageSpec{Image: "ghcr.io/altinn/test-pdf3", Tag: "latest"},
+			WorkflowEngineDb: config.ImageSpec{Image: "postgres", Tag: "18"},
+			WorkflowEngine:   config.ImageSpec{Image: "ghcr.io/altinn/test-workflow-engine", Tag: "latest"},
+			PgAdmin:          config.ImageSpec{Image: "dpage/pgadmin4", Tag: "latest"},
+		},
+		Monitoring: config.MonitoringImages{
+			Tempo:         config.ImageSpec{Image: "grafana/tempo", Tag: "latest"},
+			Mimir:         config.ImageSpec{Image: "grafana/mimir", Tag: "latest"},
+			Loki:          config.ImageSpec{Image: "grafana/loki", Tag: "latest"},
+			OtelCollector: config.ImageSpec{Image: "otel/opentelemetry-collector-contrib", Tag: "latest"},
+			Grafana:       config.ImageSpec{Image: "grafana/grafana", Tag: "latest"},
+		},
+	}
+}
+
+func createDir(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", path, err)
+	}
+}
+
+func assertNotExists(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("Stat(%q) error = %v, want not exists", path, err)
+	}
+}
+
+func assertCallRecorded(t *testing.T, calls []containermock.Call, method string) {
+	t.Helper()
+	for _, call := range calls {
+		if call.Method == method {
+			return
+		}
+	}
+	t.Fatalf("calls = %v, want method %q", calls, method)
+}

--- a/src/cli/internal/cmd/env/localtest/resources.go
+++ b/src/cli/internal/cmd/env/localtest/resources.go
@@ -71,7 +71,7 @@ type ContainerSpec struct {
 	NetworkAliases []string
 	Dependencies   []string
 	Command        []string
-	UseDefaultUser bool // When true, ignore host user override and use the image's default user
+	UseDefaultUser bool // When true, ignore host user override and use the image's default user.
 }
 
 // ContainerStatus describes one localtest container.

--- a/src/cli/internal/cmd/env/localtest/resources_internal_test.go
+++ b/src/cli/internal/cmd/env/localtest/resources_internal_test.go
@@ -342,7 +342,7 @@ func TestEnsurePgpassWritesReadableSourceFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat pgpass: %v", err)
 	}
-	if runtime.GOOS != "windows" && info.Mode().Perm() != osutil.FilePermDefault {
+	if runtime.GOOS != osWindows && info.Mode().Perm() != osutil.FilePermDefault {
 		got := info.Mode().Perm()
 		t.Fatalf("pgpass mode = %v, want %v", got, osutil.FilePermDefault)
 	}

--- a/src/cli/internal/cmd/env/localtest/runtime_config.go
+++ b/src/cli/internal/cmd/env/localtest/runtime_config.go
@@ -6,6 +6,8 @@ import (
 	"runtime"
 )
 
+const osWindows = "windows"
+
 func newRuntimeConfig() RuntimeConfig {
 	return RuntimeConfig{
 		User: runtimeContainerUser(),
@@ -14,7 +16,7 @@ func newRuntimeConfig() RuntimeConfig {
 
 func runtimeContainerUser() string {
 	// Keep empty on Windows because os.Getuid/getgid are unsupported there.
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == osWindows {
 		return ""
 	}
 	return fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid())

--- a/src/cli/internal/cmd/env/types.go
+++ b/src/cli/internal/cmd/env/types.go
@@ -17,6 +17,11 @@ type Env interface {
 	Logs(ctx context.Context, opts LogsOptions) error
 }
 
+// Resetter optionally extends Env with destructive persisted-data reset support.
+type Resetter interface {
+	Reset(ctx context.Context) error
+}
+
 // UpOptions configures environment startup.
 type UpOptions struct {
 	Detach      bool

--- a/src/cli/internal/ui/confirm.go
+++ b/src/cli/internal/ui/confirm.go
@@ -1,0 +1,21 @@
+package ui
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Confirm prompts for a y/N confirmation.
+// Returns (confirmed, error) where error is ErrInterrupted on Ctrl+C.
+func Confirm(ctx context.Context, out *Output, in io.Reader, prompt string) (bool, error) {
+	out.Print(prompt)
+	response, err := ReadLine(ctx, in)
+	if err != nil {
+		out.Println("")
+		return false, fmt.Errorf("read confirmation: %w", err)
+	}
+	answer := strings.TrimSpace(strings.ToLower(string(response)))
+	return answer == "y" || answer == "yes", nil
+}


### PR DESCRIPTION
## Description

Adds `studioctl env reset`. Currently data like instances are never deleted, now it can be deleted with this command.

- #18545 made also workflow-engine-db use a host mounted volume so that its' data survives for the same duration as localtest generally. Some containers are going to set stricter permissions on volume data so for `env reset`
- localtest volume uses a container with same user as host, which means we can use normal fs operations on the volume dir and have no surprises
- workflow-engine-db container uses custom user and has special logic in terms of permissions on files. Overriding user can be a bit unpredictable as code/scripts can make assumptions based on it so I thought the safeest thing was to have an image run to clear the data with the same image ref instead
- is an interface on `env`
- localtest impl shuts down localtest if needed

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
