### PR TITLE
chore: remove info box for single page group

### DIFF
--- a/src/Designer/frontend/language/src/nb.json
+++ b/src/Designer/frontend/language/src/nb.json
@@ -2398,7 +2398,6 @@
   "ux_editor.page_delete_text": "Er du sikker på at du vil slette siden?\nAlle avhengigheter til den blir også slettet.",
   "ux_editor.page_group.markAsCompleted_switch": "Vis status “ferdig utfylt” på gruppen når alle obligatoriske felt er fylt ut eller sidene er lest",
   "ux_editor.page_group.name": "Gruppenavn",
-  "ux_editor.page_group.one_page_in_group_info_message": "En gruppe må ha minst to sider. Hvis det bare er én side, vises den som en enkeltside i navigasjonsmenyen.",
   "ux_editor.page_group.select_data_type": "Oppgaver utfyller skal svare på",
   "ux_editor.page_group.select_info_type": "Informasjon til utfyller",
   "ux_editor.page_group.select_type_title": "Vis innholdstype på gruppen i navigasjonsmenyen",

--- a/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/PageGroupAccordion.module.css
+++ b/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/PageGroupAccordion.module.css
@@ -49,7 +49,3 @@
   display: flex;
   flex-direction: column;
 }
-
-.alertMessage {
-  margin: var(--fds-spacing-1) var(--fds-spacing-8);
-}

--- a/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/PageGroupAccordion.test.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/PageGroupAccordion.test.tsx
@@ -117,14 +117,6 @@ describe('PageGroupAccordion', () => {
     expect(within(groupHeader).getByText('Side 3')).toBeInTheDocument();
   });
 
-  it('should display info message when group has just one page', async () => {
-    await renderPageGroupAccordion({ props: { pages: singlePageGroupMock } });
-    const infoMessage = screen.getByText(
-      textMock('ux_editor.page_group.one_page_in_group_info_message'),
-    );
-    expect(infoMessage).toBeInTheDocument();
-  });
-
   it('should display group name when group has multiple pages', async () => {
     await renderPageGroupAccordion({});
     const groupHeader = groupAccordionHeader(0);

--- a/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/PageGroupAccordion.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/PageGroupAccordion.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from 'react-i18next';
 import { PageAccordion } from './PageAccordion';
 import { FormLayout } from './FormLayout';
 import {
-  StudioAlert,
   StudioButton,
   StudioPopover,
   StudioDeleteButton,
@@ -183,11 +182,6 @@ export const PageGroupAccordion = ({
             </Accordion>
           );
         })}
-        {group.order.length === 1 && (
-          <StudioAlert data-color='info' className={classes.alertMessage}>
-            {t('ux_editor.page_group.one_page_in_group_info_message')}
-          </StudioAlert>
-        )}
         <StudioButton
           icon={<PlusIcon aria-hidden />}
           onClick={() => handleAddPageInsideGroup(groupIndex)}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove info box for single page groups.

https://digdir-samarbeid.slack.com/archives/C02EJ9HKQA3/p1776844576677219


<!--- Describe your changes in detail -->

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the informational message that displayed when a page group contained only one page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->