### PR TITLE
feat: studioctl - cmd for adding /etc/hosts entries for env hosts

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -11,6 +11,7 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 ### Added
 
 - Add `env reset` for localtest to delete persisted localtest and workflow-engine database data, with interactive confirmation.
+- Add `env hosts add`, `env hosts remove`, and `env hosts status` for localtest, including managed hosts-file blocks, backup creation, and `--json` output.
 
 ### Fixed
 

--- a/src/cli/internal/cmd/doctor.go
+++ b/src/cli/internal/cmd/doctor.go
@@ -325,6 +325,7 @@ func (c *DoctorCommand) renderDoctorLocaltestEnvSection(
 			if check.URL != "" {
 				value += " (" + check.URL + ")"
 			}
+			showHostsHint := check.Label == "DNS:" && check.Level == envlocaltest.DiagnosticLevelError
 
 			label := "  " + check.Label
 			switch check.Level {
@@ -338,6 +339,9 @@ func (c *DoctorCommand) renderDoctorLocaltestEnvSection(
 				doctorKeyValueStatus(table, false, label, "ERROR: "+value)
 			default:
 				doctorKeyValue(table, label, value)
+			}
+			if showHostsHint {
+				table.Row(ui.Empty(), ui.Empty(), ui.Dim("run '"+osutil.CurrentBin()+" env hosts add'"))
 			}
 		}
 	}

--- a/src/cli/internal/cmd/env.go
+++ b/src/cli/internal/cmd/env.go
@@ -654,11 +654,13 @@ func (c *EnvCommand) runHostsAdd(_ context.Context, args []string) error {
 		return err
 	}
 	printHostWarnings(c.out, warnings)
+	addWarnings := localtestHostsAddWarnings()
+	printHostWarnings(c.out, addWarnings)
 
 	output := envHostsMutationOutput{
 		Runtime:  flags.runtime,
 		Targets:  make([]envHostsMutationTargetOutput, 0, len(targets)),
-		Warnings: warnings,
+		Warnings: append(warnings, addWarnings...),
 	}
 
 	for _, target := range targets {
@@ -816,14 +818,14 @@ func (c *EnvCommand) localtestHostsSpec() ([]osutil.HostsTarget, []string, local
 		return nil, nil, localtestHostsSpec{}, err
 	}
 	topology := envtopology.NewLocal(envtopology.DefaultIngressPortString())
-	return targets, localtestHostsWarnings(), localtestHostsSpec{
+	return targets, nil, localtestHostsSpec{
 		address:   envlocaltest.HostsLoopbackAddress,
 		blockName: envlocaltest.HostsBlockName,
 		hostnames: topology.HostFileHostnames(),
 	}, nil
 }
 
-func localtestHostsWarnings() []string {
+func localtestHostsAddWarnings() []string {
 	if !osutil.IsWSL() {
 		return nil
 	}

--- a/src/cli/internal/cmd/env.go
+++ b/src/cli/internal/cmd/env.go
@@ -18,15 +18,21 @@ import (
 	"altinn.studio/studioctl/internal/ui"
 )
 
-const runtimeLocaltest = "localtest"
+const (
+	runtimeLocaltest    = "localtest"
+	envStatusSubcommand = authStatusSubcommand
+)
 
-var errResetUnsupported = errors.New("reset is not supported for runtime")
-var localHostsFileTargets = osutil.LocalHostsFileTargets
+var (
+	errNoHostsFileTarget = errors.New("no hosts file target available")
+	errResetUnsupported  = errors.New("reset is not supported for runtime")
+)
 
 // EnvCommand implements the 'env' subcommand.
 type EnvCommand struct {
-	cfg *config.Config
-	out *ui.Output
+	hostsFileTargets func() ([]osutil.HostsTarget, error)
+	cfg              *config.Config
+	out              *ui.Output
 }
 
 type envUpOutput struct {
@@ -136,7 +142,11 @@ func (o envResetOutput) Print(out *ui.Output) error {
 
 // NewEnvCommand creates a new env command.
 func NewEnvCommand(cfg *config.Config, out *ui.Output) *EnvCommand {
-	return &EnvCommand{cfg: cfg, out: out}
+	return &EnvCommand{
+		hostsFileTargets: osutil.LocalHostsFileTargets,
+		cfg:              cfg,
+		out:              out,
+	}
 }
 
 // Name returns the command name.
@@ -195,7 +205,7 @@ func (c *EnvCommand) Run(ctx context.Context, args []string) error {
 		return c.runHosts(ctx, subArgs)
 	case "reset":
 		return c.runReset(ctx, subArgs)
-	case "status":
+	case envStatusSubcommand:
 		return c.runStatus(ctx, subArgs)
 	case "logs":
 		return c.runLogs(ctx, subArgs)
@@ -625,7 +635,7 @@ func (c *EnvCommand) runHosts(ctx context.Context, args []string) error {
 	switch subCmd {
 	case "add":
 		return c.runHostsAdd(ctx, subArgs)
-	case "status":
+	case envStatusSubcommand:
 		return c.runHostsStatus(ctx, subArgs)
 	case "remove":
 		return c.runHostsRemove(ctx, subArgs)
@@ -649,24 +659,24 @@ func (c *EnvCommand) runHostsAdd(_ context.Context, args []string) error {
 		return fmt.Errorf("%w: %s", ErrUnsupportedRuntime, flags.runtime)
 	}
 
-	targets, warnings, spec, err := c.localtestHostsSpec()
+	targets, spec, err := c.localtestHostsSpec()
 	if err != nil {
 		return err
 	}
-	printHostWarnings(c.out, warnings)
 	addWarnings := localtestHostsAddWarnings()
 	printHostWarnings(c.out, addWarnings)
 
 	output := envHostsMutationOutput{
 		Runtime:  flags.runtime,
 		Targets:  make([]envHostsMutationTargetOutput, 0, len(targets)),
-		Warnings: append(warnings, addWarnings...),
+		Warnings: addWarnings,
 	}
 
 	for _, target := range targets {
 		result, ensureErr := envlocaltest.EnsureManagedHosts(target.Path, spec.blockName, spec.address, spec.hostnames)
 		if ensureErr == nil {
 			output.Targets = append(output.Targets, envHostsMutationTargetOutput{
+				Error:  "",
 				Label:  target.Label,
 				Path:   target.Path,
 				Result: result,
@@ -685,10 +695,13 @@ func (c *EnvCommand) runHostsAdd(_ context.Context, args []string) error {
 
 		if handled := printOptionalHostWarning(c.out, target, "add", ensureErr); handled {
 			output.Targets = append(output.Targets, envHostsMutationTargetOutput{
-				Error:  humanHostsError(target, "add", ensureErr).Error(),
-				Label:  target.Label,
-				Path:   target.Path,
-				Result: envlocaltest.HostsWriteResult{},
+				Error: humanHostsError(target, "add", ensureErr).Error(),
+				Label: target.Label,
+				Path:  target.Path,
+				Result: envlocaltest.HostsWriteResult{
+					BackupPath: "",
+					Changed:    false,
+				},
 			})
 			continue
 		}
@@ -713,16 +726,16 @@ func (c *EnvCommand) runHostsStatus(_ context.Context, args []string) error {
 		return fmt.Errorf("%w: %s", ErrUnsupportedRuntime, flags.runtime)
 	}
 
-	targets, warnings, spec, err := c.localtestHostsSpec()
+	targets, spec, err := c.localtestHostsSpec()
 	if err != nil {
 		return err
 	}
-	printHostWarnings(c.out, warnings)
 
 	output := envHostsStatusOutput{
+		Path:     "",
 		Runtime:  flags.runtime,
 		Hosts:    make([]envHostsStatusHostOutput, 0, len(spec.hostnames)),
-		Warnings: warnings,
+		Warnings: nil,
 	}
 	table := ui.NewTable(
 		ui.NewColumn("Hostname"),
@@ -756,22 +769,22 @@ func (c *EnvCommand) runHostsRemove(_ context.Context, args []string) error {
 		return fmt.Errorf("%w: %s", ErrUnsupportedRuntime, flags.runtime)
 	}
 
-	targets, warnings, spec, err := c.localtestHostsSpec()
+	targets, spec, err := c.localtestHostsSpec()
 	if err != nil {
 		return err
 	}
-	printHostWarnings(c.out, warnings)
 
 	output := envHostsMutationOutput{
 		Runtime:  flags.runtime,
 		Targets:  make([]envHostsMutationTargetOutput, 0, len(targets)),
-		Warnings: warnings,
+		Warnings: nil,
 	}
 
 	for _, target := range targets {
 		result, removeErr := envlocaltest.RemoveManagedHosts(target.Path, spec.blockName)
 		if removeErr == nil {
 			output.Targets = append(output.Targets, envHostsMutationTargetOutput{
+				Error:  "",
 				Label:  target.Label,
 				Path:   target.Path,
 				Result: result,
@@ -790,10 +803,13 @@ func (c *EnvCommand) runHostsRemove(_ context.Context, args []string) error {
 
 		if handled := printOptionalHostWarning(c.out, target, "remove", removeErr); handled {
 			output.Targets = append(output.Targets, envHostsMutationTargetOutput{
-				Error:  humanHostsError(target, "remove", removeErr).Error(),
-				Label:  target.Label,
-				Path:   target.Path,
-				Result: envlocaltest.HostsWriteResult{},
+				Error: humanHostsError(target, "remove", removeErr).Error(),
+				Label: target.Label,
+				Path:  target.Path,
+				Result: envlocaltest.HostsWriteResult{
+					BackupPath: "",
+					Changed:    false,
+				},
 			})
 			continue
 		}
@@ -812,13 +828,17 @@ type localtestHostsSpec struct {
 	hostnames []string
 }
 
-func (c *EnvCommand) localtestHostsSpec() ([]osutil.HostsTarget, []string, localtestHostsSpec, error) {
-	targets, err := localHostsFileTargets()
+func (c *EnvCommand) localtestHostsSpec() ([]osutil.HostsTarget, localtestHostsSpec, error) {
+	hostsFileTargets := c.hostsFileTargets
+	if hostsFileTargets == nil {
+		hostsFileTargets = osutil.LocalHostsFileTargets
+	}
+	targets, err := hostsFileTargets()
 	if err != nil {
-		return nil, nil, localtestHostsSpec{}, err
+		return nil, localtestHostsSpec{}, err
 	}
 	topology := envtopology.NewLocal(envtopology.DefaultIngressPortString())
-	return targets, nil, localtestHostsSpec{
+	return targets, localtestHostsSpec{
 		address:   envlocaltest.HostsLoopbackAddress,
 		blockName: envlocaltest.HostsBlockName,
 		hostnames: topology.HostFileHostnames(),
@@ -846,9 +866,13 @@ func (c *EnvCommand) inspectRequiredHostsTarget(
 		if handled := appendOptionalHostStatusWarning(c.out, target, err); handled {
 			continue
 		}
-		return osutil.HostsTarget{}, envlocaltest.HostsFileStatus{}, fmt.Errorf("inspect hosts file %q: %w", target.Path, err)
+		return osutil.HostsTarget{}, envlocaltest.HostsFileStatus{}, fmt.Errorf(
+			"inspect hosts file %q: %w",
+			target.Path,
+			err,
+		)
 	}
-	return osutil.HostsTarget{}, envlocaltest.HostsFileStatus{}, errors.New("no hosts file target available")
+	return osutil.HostsTarget{}, envlocaltest.HostsFileStatus{}, errNoHostsFileTarget
 }
 
 func renderHostsByHostname(
@@ -875,8 +899,9 @@ func renderHostsByHostname(
 			})
 		case hasMissingHost(missing, host):
 			rows = append(rows, envHostsStatusHostOutput{
-				Host:  host,
-				State: envlocaltest.HostsStateMissing,
+				Detail: "",
+				Host:   host,
+				State:  envlocaltest.HostsStateMissing,
 			})
 		case status.Managed && status.State == envlocaltest.HostsStateInstalled:
 			rows = append(rows, envHostsStatusHostOutput{
@@ -936,27 +961,30 @@ func printOptionalHostWarning(out *ui.Output, target osutil.HostsTarget, action 
 
 func formatHostsCommandError(target osutil.HostsTarget, action string, err error) error {
 	humanErr := humanHostsError(target, action, err)
-	if strings.Contains(humanErr.Error(), "\n") {
-		return fmt.Errorf("%s hosts file %q:\n%s", action, target.Path, humanErr.Error())
-	}
 	return fmt.Errorf("%s hosts file %q: %w", action, target.Path, humanErr)
+}
+
+type hostsHumanError string
+
+func (e hostsHumanError) Error() string {
+	return string(e)
 }
 
 func humanHostsError(target osutil.HostsTarget, action string, err error) error {
 	var conflictErr *envlocaltest.HostsConflictError
 	switch {
 	case errors.As(err, &conflictErr):
-		return fmt.Errorf("conflicting entries must be resolved manually: %s", conflictErr.Error())
+		return hostsHumanError("conflicting entries must be resolved manually: " + conflictErr.Error())
 	case osutil.IsPermissionError(err):
-		return fmt.Errorf("%s", hostsPermissionMessage(target, action))
+		return hostsHumanError(hostsPermissionMessage(target, action))
 	default:
 		return err
 	}
 }
 
 func hostsPermissionMessage(target osutil.HostsTarget, action string) string {
-	switch {
-	case target.Label == "Windows":
+	switch target.Label {
+	case "Windows":
 		return fmt.Sprintf(
 			"%s requires administrator privileges\nrerun in an elevated PowerShell or edit %s manually",
 			action,

--- a/src/cli/internal/cmd/env.go
+++ b/src/cli/internal/cmd/env.go
@@ -7,11 +7,13 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"altinn.studio/devenv/pkg/container"
 	envtypes "altinn.studio/studioctl/internal/cmd/env"
 	envlocaltest "altinn.studio/studioctl/internal/cmd/env/localtest"
 	"altinn.studio/studioctl/internal/config"
+	"altinn.studio/studioctl/internal/envtopology"
 	"altinn.studio/studioctl/internal/osutil"
 	"altinn.studio/studioctl/internal/ui"
 )
@@ -19,6 +21,7 @@ import (
 const runtimeLocaltest = "localtest"
 
 var errResetUnsupported = errors.New("reset is not supported for runtime")
+var localHostsFileTargets = osutil.LocalHostsFileTargets
 
 // EnvCommand implements the 'env' subcommand.
 type EnvCommand struct {
@@ -93,6 +96,37 @@ type envResetOutput struct {
 	JSONOutput bool   `json:"-"`
 }
 
+type envHostsFlags struct {
+	runtime    string
+	jsonOutput bool
+}
+
+type envHostsStatusHostOutput struct {
+	Detail string `json:"detail,omitempty"`
+	Host   string `json:"host"`
+	State  string `json:"state"`
+}
+
+type envHostsStatusOutput struct {
+	Path     string                     `json:"path,omitempty"`
+	Runtime  string                     `json:"runtime"`
+	Hosts    []envHostsStatusHostOutput `json:"hosts"`
+	Warnings []string                   `json:"warnings,omitempty"`
+}
+
+type envHostsMutationTargetOutput struct {
+	Error  string                        `json:"error,omitempty"`
+	Label  string                        `json:"label"`
+	Path   string                        `json:"path"`
+	Result envlocaltest.HostsWriteResult `json:"result"`
+}
+
+type envHostsMutationOutput struct {
+	Runtime  string                         `json:"runtime"`
+	Targets  []envHostsMutationTargetOutput `json:"targets"`
+	Warnings []string                       `json:"warnings,omitempty"`
+}
+
 func (o envResetOutput) Print(out *ui.Output) error {
 	if o.JSONOutput {
 		return printJSONOutput(out, "env reset", o)
@@ -121,6 +155,7 @@ func (c *EnvCommand) Usage() string {
 		"Subcommands:",
 		"  up       Start the environment",
 		"  down     Stop the environment",
+		"  hosts    Manage localtest hosts-file entries",
 		"  reset    Delete persisted environment data",
 		"  status   Show environment status",
 		"  logs     Stream environment logs",
@@ -156,6 +191,8 @@ func (c *EnvCommand) Run(ctx context.Context, args []string) error {
 		return c.runUp(ctx, subArgs)
 	case "down":
 		return c.runDown(ctx, subArgs)
+	case "hosts":
+		return c.runHosts(ctx, subArgs)
 	case "reset":
 		return c.runReset(ctx, subArgs)
 	case "status":
@@ -539,6 +576,398 @@ func renderLocaltestStatus(out *ui.Output, status *envlocaltest.Status) {
 		table.Row(ui.Text(ctr.Name), ui.Text(ctr.Status))
 	}
 	out.RenderTable(table)
+}
+
+func (c *EnvCommand) hostsUsage() string {
+	return joinLines(
+		fmt.Sprintf("Usage: %s env hosts <subcommand> [options]", osutil.CurrentBin()),
+		"",
+		"Manage localtest hosts-file entries.",
+		"",
+		"Subcommands:",
+		"  add       Add studioctl-managed localtest hosts entries",
+		"  status    Show localtest hosts-file status",
+		"  remove    Remove studioctl-managed localtest hosts entries",
+		"",
+		"Options:",
+		"  -r, --runtime    Runtime to use (default: localtest)",
+		"  --json           Output as JSON",
+		"",
+		fmt.Sprintf("Run '%s env hosts <subcommand> --help' for more information.", osutil.CurrentBin()),
+	)
+}
+
+func parseEnvHostsFlags(name string, args []string) (envHostsFlags, bool, error) {
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	var f envHostsFlags
+	fs.StringVar(&f.runtime, "r", runtimeLocaltest, "Runtime to use")
+	fs.StringVar(&f.runtime, "runtime", runtimeLocaltest, "Runtime to use")
+	fs.BoolVar(&f.jsonOutput, "json", false, "Output as JSON")
+
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return f, true, nil
+		}
+		return f, false, fmt.Errorf("parsing flags: %w", err)
+	}
+	return f, false, nil
+}
+
+func (c *EnvCommand) runHosts(ctx context.Context, args []string) error {
+	if len(args) == 0 {
+		c.out.Print(c.hostsUsage())
+		return nil
+	}
+
+	subCmd := args[0]
+	subArgs := args[1:]
+
+	switch subCmd {
+	case "add":
+		return c.runHostsAdd(ctx, subArgs)
+	case "status":
+		return c.runHostsStatus(ctx, subArgs)
+	case "remove":
+		return c.runHostsRemove(ctx, subArgs)
+	case "-h", flagHelp, helpSubcmd:
+		c.out.Print(c.hostsUsage())
+		return nil
+	default:
+		return fmt.Errorf("%w: %s", ErrUnknownSubcommand, subCmd)
+	}
+}
+
+func (c *EnvCommand) runHostsAdd(_ context.Context, args []string) error {
+	flags, helpShown, err := parseEnvHostsFlags("env hosts add", args)
+	if err != nil {
+		return err
+	}
+	if helpShown {
+		return nil
+	}
+	if flags.runtime != runtimeLocaltest {
+		return fmt.Errorf("%w: %s", ErrUnsupportedRuntime, flags.runtime)
+	}
+
+	targets, warnings, spec, err := c.localtestHostsSpec()
+	if err != nil {
+		return err
+	}
+	printHostWarnings(c.out, warnings)
+
+	output := envHostsMutationOutput{
+		Runtime:  flags.runtime,
+		Targets:  make([]envHostsMutationTargetOutput, 0, len(targets)),
+		Warnings: warnings,
+	}
+
+	for _, target := range targets {
+		result, ensureErr := envlocaltest.EnsureManagedHosts(target.Path, spec.blockName, spec.address, spec.hostnames)
+		if ensureErr == nil {
+			output.Targets = append(output.Targets, envHostsMutationTargetOutput{
+				Label:  target.Label,
+				Path:   target.Path,
+				Result: result,
+			})
+			if flags.jsonOutput {
+				continue
+			}
+			if result.Changed {
+				c.out.Successf("Added hosts entries to %s", target.Path)
+				c.out.Printlnf("Backup saved to %s", result.BackupPath)
+			} else {
+				c.out.Printlnf("Managed localtest hosts entries already present in %s", target.Path)
+			}
+			continue
+		}
+
+		if handled := printOptionalHostWarning(c.out, target, "add", ensureErr); handled {
+			output.Targets = append(output.Targets, envHostsMutationTargetOutput{
+				Error:  humanHostsError(target, "add", ensureErr).Error(),
+				Label:  target.Label,
+				Path:   target.Path,
+				Result: envlocaltest.HostsWriteResult{},
+			})
+			continue
+		}
+		return formatHostsCommandError(target, "add", ensureErr)
+	}
+
+	if flags.jsonOutput {
+		return printJSONOutput(c.out, "env hosts add", output)
+	}
+	return nil
+}
+
+func (c *EnvCommand) runHostsStatus(_ context.Context, args []string) error {
+	flags, helpShown, err := parseEnvHostsFlags("env hosts status", args)
+	if err != nil {
+		return err
+	}
+	if helpShown {
+		return nil
+	}
+	if flags.runtime != runtimeLocaltest {
+		return fmt.Errorf("%w: %s", ErrUnsupportedRuntime, flags.runtime)
+	}
+
+	targets, warnings, spec, err := c.localtestHostsSpec()
+	if err != nil {
+		return err
+	}
+	printHostWarnings(c.out, warnings)
+
+	output := envHostsStatusOutput{
+		Runtime:  flags.runtime,
+		Hosts:    make([]envHostsStatusHostOutput, 0, len(spec.hostnames)),
+		Warnings: warnings,
+	}
+	table := ui.NewTable(
+		ui.NewColumn("Hostname"),
+		ui.NewColumn("State"),
+		ui.NewColumn("Details"),
+	)
+
+	target, status, err := c.inspectRequiredHostsTarget(targets, spec)
+	if err != nil {
+		return err
+	}
+	output.Path = target.Path
+	output.Hosts = renderHostsByHostname(status, spec.address, spec.hostnames)
+	if flags.jsonOutput {
+		return printJSONOutput(c.out, "env hosts status", output)
+	}
+	appendHostsByHostnameRows(table, output.Hosts)
+	c.out.RenderTable(table)
+	return nil
+}
+
+func (c *EnvCommand) runHostsRemove(_ context.Context, args []string) error {
+	flags, helpShown, err := parseEnvHostsFlags("env hosts remove", args)
+	if err != nil {
+		return err
+	}
+	if helpShown {
+		return nil
+	}
+	if flags.runtime != runtimeLocaltest {
+		return fmt.Errorf("%w: %s", ErrUnsupportedRuntime, flags.runtime)
+	}
+
+	targets, warnings, spec, err := c.localtestHostsSpec()
+	if err != nil {
+		return err
+	}
+	printHostWarnings(c.out, warnings)
+
+	output := envHostsMutationOutput{
+		Runtime:  flags.runtime,
+		Targets:  make([]envHostsMutationTargetOutput, 0, len(targets)),
+		Warnings: warnings,
+	}
+
+	for _, target := range targets {
+		result, removeErr := envlocaltest.RemoveManagedHosts(target.Path, spec.blockName)
+		if removeErr == nil {
+			output.Targets = append(output.Targets, envHostsMutationTargetOutput{
+				Label:  target.Label,
+				Path:   target.Path,
+				Result: result,
+			})
+			if flags.jsonOutput {
+				continue
+			}
+			if result.Changed {
+				c.out.Successf("Removed managed hosts entries from %s", target.Path)
+				c.out.Printlnf("Backup saved to %s", result.BackupPath)
+			} else {
+				c.out.Printlnf("No managed localtest hosts entries found in %s", target.Path)
+			}
+			continue
+		}
+
+		if handled := printOptionalHostWarning(c.out, target, "remove", removeErr); handled {
+			output.Targets = append(output.Targets, envHostsMutationTargetOutput{
+				Error:  humanHostsError(target, "remove", removeErr).Error(),
+				Label:  target.Label,
+				Path:   target.Path,
+				Result: envlocaltest.HostsWriteResult{},
+			})
+			continue
+		}
+		return formatHostsCommandError(target, "remove", removeErr)
+	}
+
+	if flags.jsonOutput {
+		return printJSONOutput(c.out, "env hosts remove", output)
+	}
+	return nil
+}
+
+type localtestHostsSpec struct {
+	address   string
+	blockName string
+	hostnames []string
+}
+
+func (c *EnvCommand) localtestHostsSpec() ([]osutil.HostsTarget, []string, localtestHostsSpec, error) {
+	targets, err := localHostsFileTargets()
+	if err != nil {
+		return nil, nil, localtestHostsSpec{}, err
+	}
+	topology := envtopology.NewLocal(envtopology.DefaultIngressPortString())
+	return targets, localtestHostsWarnings(), localtestHostsSpec{
+		address:   envlocaltest.HostsLoopbackAddress,
+		blockName: envlocaltest.HostsBlockName,
+		hostnames: topology.HostFileHostnames(),
+	}, nil
+}
+
+func localtestHostsWarnings() []string {
+	if !osutil.IsWSL() {
+		return nil
+	}
+	return []string{
+		"WSL note: studioctl opens URLs in the Windows browser; if local domains do not resolve there, also update the Windows hosts file manually (usually C:\\Windows\\System32\\drivers\\etc\\hosts).",
+	}
+}
+
+func (c *EnvCommand) inspectRequiredHostsTarget(
+	targets []osutil.HostsTarget,
+	spec localtestHostsSpec,
+) (osutil.HostsTarget, envlocaltest.HostsFileStatus, error) {
+	for _, target := range targets {
+		status, err := envlocaltest.InspectHostsFile(target.Path, spec.blockName, spec.address, spec.hostnames)
+		if err == nil {
+			return target, status, nil
+		}
+		if handled := appendOptionalHostStatusWarning(c.out, target, err); handled {
+			continue
+		}
+		return osutil.HostsTarget{}, envlocaltest.HostsFileStatus{}, fmt.Errorf("inspect hosts file %q: %w", target.Path, err)
+	}
+	return osutil.HostsTarget{}, envlocaltest.HostsFileStatus{}, errors.New("no hosts file target available")
+}
+
+func renderHostsByHostname(
+	status envlocaltest.HostsFileStatus,
+	address string,
+	hostnames []string,
+) []envHostsStatusHostOutput {
+	conflicts := make(map[string][]string, len(status.Conflicts))
+	for _, conflict := range status.Conflicts {
+		conflicts[conflict.Host] = conflict.Addresses
+	}
+	missing := make(map[string]struct{}, len(status.Missing))
+	for _, host := range status.Missing {
+		missing[host] = struct{}{}
+	}
+	rows := make([]envHostsStatusHostOutput, 0, len(hostnames))
+	for _, host := range hostnames {
+		switch {
+		case conflicts[host] != nil:
+			rows = append(rows, envHostsStatusHostOutput{
+				Detail: strings.Join(conflicts[host], ", "),
+				Host:   host,
+				State:  envlocaltest.HostsStateConflict,
+			})
+		case hasMissingHost(missing, host):
+			rows = append(rows, envHostsStatusHostOutput{
+				Host:  host,
+				State: envlocaltest.HostsStateMissing,
+			})
+		case status.Managed && status.State == envlocaltest.HostsStateInstalled:
+			rows = append(rows, envHostsStatusHostOutput{
+				Detail: address,
+				Host:   host,
+				State:  "managed",
+			})
+		default:
+			rows = append(rows, envHostsStatusHostOutput{
+				Detail: address,
+				Host:   host,
+				State:  envlocaltest.HostsStatePresent,
+			})
+		}
+	}
+	return rows
+}
+
+func hasMissingHost(missing map[string]struct{}, host string) bool {
+	_, ok := missing[host]
+	return ok
+}
+
+func appendHostsByHostnameRows(table *ui.Table, hosts []envHostsStatusHostOutput) {
+	for _, host := range hosts {
+		table.Row(ui.Text(host.Host), ui.Text(host.State), ui.Text(host.Detail))
+	}
+}
+
+func printHostWarnings(out *ui.Output, warnings []string) {
+	for _, warning := range warnings {
+		out.Warning(warning)
+	}
+}
+
+func appendOptionalHostStatusWarning(out *ui.Output, target osutil.HostsTarget, err error) bool {
+	if !target.Required {
+		out.Warningf("Skipping optional %s hosts file (%s): %v", target.Label, target.Path, err)
+		return true
+	}
+	return false
+}
+
+func printOptionalHostWarning(out *ui.Output, target osutil.HostsTarget, action string, err error) bool {
+	if target.Required {
+		return false
+	}
+	out.Warningf(
+		"Skipping optional %s hosts file during %s (%s): %v",
+		target.Label,
+		action,
+		target.Path,
+		humanHostsError(target, action, err),
+	)
+	return true
+}
+
+func formatHostsCommandError(target osutil.HostsTarget, action string, err error) error {
+	humanErr := humanHostsError(target, action, err)
+	if strings.Contains(humanErr.Error(), "\n") {
+		return fmt.Errorf("%s hosts file %q:\n%s", action, target.Path, humanErr.Error())
+	}
+	return fmt.Errorf("%s hosts file %q: %w", action, target.Path, humanErr)
+}
+
+func humanHostsError(target osutil.HostsTarget, action string, err error) error {
+	var conflictErr *envlocaltest.HostsConflictError
+	switch {
+	case errors.As(err, &conflictErr):
+		return fmt.Errorf("conflicting entries must be resolved manually: %s", conflictErr.Error())
+	case osutil.IsPermissionError(err):
+		return fmt.Errorf("%s", hostsPermissionMessage(target, action))
+	default:
+		return err
+	}
+}
+
+func hostsPermissionMessage(target osutil.HostsTarget, action string) string {
+	switch {
+	case target.Label == "Windows":
+		return fmt.Sprintf(
+			"%s requires administrator privileges\nrerun in an elevated PowerShell or edit %s manually",
+			action,
+			target.Path,
+		)
+	default:
+		return fmt.Sprintf(
+			"%s requires elevated privileges\nrerun with sudo:\n  sudo %s env hosts %s",
+			action,
+			osutil.CurrentBinPath(),
+			action,
+		)
+	}
 }
 
 // envLogsFlags holds parsed flags for the env logs command.

--- a/src/cli/internal/cmd/env/localtest/hosts.go
+++ b/src/cli/internal/cmd/env/localtest/hosts.go
@@ -1,0 +1,9 @@
+package localtest
+
+const (
+	// HostsBlockName identifies the managed hosts-file block for localtest.
+	HostsBlockName = "studioctl localtest"
+
+	// HostsLoopbackAddress is the IPv4 loopback address used for localtest hosts.
+	HostsLoopbackAddress = "127.0.0.1"
+)

--- a/src/cli/internal/cmd/env/localtest/hostsfile.go
+++ b/src/cli/internal/cmd/env/localtest/hostsfile.go
@@ -35,6 +35,8 @@ var (
 
 	// ErrHostsConflict is returned when desired hostnames already have conflicting active mappings.
 	ErrHostsConflict = errors.New("conflicting host entries")
+
+	errHostsBackupRaceRetries = errors.New("exhausted hosts backup race retries")
 )
 
 // HostsWriteResult describes one hosts-file mutation.
@@ -45,16 +47,16 @@ type HostsWriteResult struct {
 
 // HostsConflict contains one hostname and its active addresses.
 type HostsConflict struct {
-	Addresses []string `json:"addresses"`
 	Host      string   `json:"host"`
+	Addresses []string `json:"addresses"`
 }
 
 // HostsFileStatus describes whether a hosts file satisfies the desired localtest mappings.
 type HostsFileStatus struct {
+	State     string          `json:"state"`
 	Conflicts []HostsConflict `json:"conflicts,omitempty"`
 	Missing   []string        `json:"missing,omitempty"`
 	Managed   bool            `json:"managed"`
-	State     string          `json:"state"`
 }
 
 // HostsConflictError contains conflicting active mappings that must be resolved manually.
@@ -95,7 +97,10 @@ func EnsureManagedHosts(path, blockName, address string, hostnames []string) (Ho
 		return HostsWriteResult{}, err
 	}
 	if !changed {
-		return HostsWriteResult{Changed: false}, nil
+		return HostsWriteResult{
+			BackupPath: "",
+			Changed:    false,
+		}, nil
 	}
 
 	backupPath, err := writeHostsBackup(path, content, info.Mode())
@@ -122,7 +127,10 @@ func RemoveManagedHosts(path, blockName string) (HostsWriteResult, error) {
 		return HostsWriteResult{}, err
 	}
 	if !changed {
-		return HostsWriteResult{Changed: false}, nil
+		return HostsWriteResult{
+			BackupPath: "",
+			Changed:    false,
+		}, nil
 	}
 
 	backupPath, err := writeHostsBackup(path, content, info.Mode())
@@ -173,8 +181,10 @@ func inspectHostsContent(content, blockName, address string, hostnames []string)
 	mappings := parseActiveHosts(content)
 	normalizedHosts := normalizeHostnames(hostnames)
 	status := HostsFileStatus{
-		Managed: managed.present,
-		State:   HostsStateInstalled,
+		State:     HostsStateInstalled,
+		Managed:   managed.present,
+		Conflicts: nil,
+		Missing:   nil,
 	}
 
 	for _, host := range normalizedHosts {
@@ -265,11 +275,11 @@ func removeManagedHostsContent(content, blockName string) (string, bool, error) 
 
 type managedBlock struct {
 	content   string
-	exact     bool
-	present   bool
 	lineBreak string
 	prefix    string
 	suffix    string
+	exact     bool
+	present   bool
 }
 
 func extractManagedBlock(content, blockName string) (managedBlock, error) {
@@ -280,7 +290,14 @@ func extractManagedBlock(content, blockName string) (managedBlock, error) {
 	endCount := strings.Count(content, endMarker)
 	switch {
 	case startCount == 0 && endCount == 0:
-		return managedBlock{lineBreak: detectFileLineBreak(content)}, nil
+		return managedBlock{
+			content:   "",
+			lineBreak: detectFileLineBreak(content),
+			prefix:    "",
+			suffix:    "",
+			exact:     false,
+			present:   false,
+		}, nil
 	case startCount != 1 || endCount != 1:
 		return managedBlock{}, fmt.Errorf("%w: %s", ErrMalformedManagedHostsBlock, blockName)
 	}
@@ -301,10 +318,11 @@ func extractManagedBlock(content, blockName string) (managedBlock, error) {
 	block := content[blockStart:blockEnd]
 	return managedBlock{
 		content:   block,
-		present:   true,
 		prefix:    content[:blockStart],
 		suffix:    content[blockEnd:],
 		lineBreak: lineBreak,
+		exact:     false,
+		present:   true,
 	}, nil
 }
 
@@ -347,7 +365,7 @@ func appendManagedBlock(content, block, lineBreak string) string {
 
 func parseActiveHosts(content string) map[string]map[string]struct{} {
 	result := make(map[string]map[string]struct{})
-	for _, rawLine := range strings.Split(content, "\n") {
+	for rawLine := range strings.SplitSeq(content, "\n") {
 		line := strings.TrimSpace(strings.TrimSuffix(rawLine, "\r"))
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
@@ -510,22 +528,41 @@ func writeHostsBackup(path, content string, mode fs.FileMode) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		file, err := os.OpenFile(backupPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, fileModeOrDefault(mode))
-		if err == nil {
-			if _, err := file.WriteString(content); err != nil {
-				_ = file.Close()
-				return "", fmt.Errorf("write hosts backup %q: %w", backupPath, err)
-			}
-			if err := file.Close(); err != nil {
-				return "", fmt.Errorf("close hosts backup %q: %w", backupPath, err)
-			}
+
+		writeErr := writeHostsBackupFile(backupPath, content, fileModeOrDefault(mode))
+		switch {
+		case writeErr == nil:
 			return backupPath, nil
-		}
-		if !errors.Is(err, fs.ErrExist) {
-			return "", fmt.Errorf("write hosts backup %q: %w", backupPath, err)
+		case errors.Is(writeErr, fs.ErrExist):
+			continue
+		default:
+			return "", writeErr
 		}
 	}
-	return "", fmt.Errorf("allocate hosts backup path for %q: exhausted race retries", path)
+	return "", fmt.Errorf("allocate hosts backup path for %q: %w", path, errHostsBackupRaceRetries)
+}
+
+func writeHostsBackupFile(path, content string, mode fs.FileMode) error {
+	//nolint:gosec // Path is derived from caller-controlled hosts path.
+	file, err := os.OpenFile(
+		path,
+		os.O_WRONLY|os.O_CREATE|os.O_EXCL,
+		mode,
+	)
+	if err != nil {
+		return fmt.Errorf("open hosts backup %q: %w", path, err)
+	}
+	if _, err = file.WriteString(content); err != nil {
+		closeErr := closeFile(file, fmt.Sprintf("hosts backup file %q", path))
+		if closeErr != nil {
+			return errors.Join(
+				fmt.Errorf("write hosts backup %q: %w", path, err),
+				closeErr,
+			)
+		}
+		return fmt.Errorf("write hosts backup %q: %w", path, err)
+	}
+	return closeFile(file, fmt.Sprintf("hosts backup file %q", path))
 }
 
 func nextHostsBackupPath(path string) (string, error) {
@@ -574,7 +611,7 @@ func hostsBackupIndex(base, name string) (int, bool) {
 	return index, true
 }
 
-func writeHostsFileAtomic(path, content string, mode fs.FileMode) error {
+func writeHostsFileAtomic(path, content string, mode fs.FileMode) (retErr error) {
 	dir := filepath.Dir(path)
 	tmpFile, err := os.CreateTemp(dir, "."+filepath.Base(path)+".studioctl.tmp-*")
 	if err != nil {
@@ -583,26 +620,34 @@ func writeHostsFileAtomic(path, content string, mode fs.FileMode) error {
 	tmpPath := tmpFile.Name()
 	cleanup := true
 	defer func() {
-		if cleanup {
-			_ = os.Remove(tmpPath)
+		if !cleanup {
+			return
+		}
+		if tmpFile != nil {
+			closeErr := closeFile(tmpFile, fmt.Sprintf("temp hosts file %q", tmpPath))
+			if closeErr != nil {
+				retErr = errors.Join(retErr, fmt.Errorf("write hosts file %q: %w", path, closeErr))
+			}
+		}
+		removeErr := removePathIfExists(tmpPath)
+		if removeErr != nil {
+			retErr = errors.Join(retErr, fmt.Errorf("write hosts file %q: %w", path, removeErr))
 		}
 	}()
 
 	if err := tmpFile.Chmod(mode); err != nil {
-		_ = tmpFile.Close()
 		return fmt.Errorf("write hosts file %q: chmod temp file: %w", path, err)
 	}
 	if _, err := tmpFile.WriteString(content); err != nil {
-		_ = tmpFile.Close()
 		return fmt.Errorf("write hosts file %q: write temp file: %w", path, err)
 	}
 	if err := tmpFile.Sync(); err != nil {
-		_ = tmpFile.Close()
 		return fmt.Errorf("write hosts file %q: sync temp file: %w", path, err)
 	}
-	if err := tmpFile.Close(); err != nil {
-		return fmt.Errorf("write hosts file %q: close temp file: %w", path, err)
+	if err := closeFile(tmpFile, fmt.Sprintf("temp hosts file %q", tmpPath)); err != nil {
+		return fmt.Errorf("write hosts file %q: %w", path, err)
 	}
+	tmpFile = nil
 	if err := replacePathAtomic(tmpPath, path); err != nil {
 		return fmt.Errorf("write hosts file %q: replace target: %w", path, err)
 	}
@@ -615,66 +660,73 @@ func writeHostsFileAtomic(path, content string, mode fs.FileMode) error {
 
 func replacePathAtomic(src, dst string) error {
 	if runtime.GOOS != "windows" {
-		return os.Rename(src, dst)
-	}
-
-	if err := os.Rename(src, dst); err == nil {
-		return nil
-	} else if !errors.Is(err, os.ErrExist) && !errors.Is(err, os.ErrPermission) {
-		backupPath, backupErr := reserveReplaceBackupPath(dst)
-		if backupErr != nil {
-			return err
-		}
-		if moveErr := os.Rename(dst, backupPath); moveErr != nil {
-			_ = os.Remove(backupPath)
-			return err
-		}
-		if renameErr := os.Rename(src, dst); renameErr != nil {
-			restoreErr := os.Rename(backupPath, dst)
-			if restoreErr != nil {
-				return errors.Join(renameErr, restoreErr)
-			}
-			return renameErr
-		}
-		if removeErr := os.Remove(backupPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
-			return removeErr
+		if err := os.Rename(src, dst); err != nil {
+			return fmt.Errorf("rename %q to %q: %w", src, dst, err)
 		}
 		return nil
 	}
 
+	renameErr := os.Rename(src, dst)
+	if renameErr == nil {
+		return nil
+	}
+
+	canRetry := errors.Is(renameErr, os.ErrExist) || errors.Is(renameErr, os.ErrPermission)
+	if !canRetry {
+		return fmt.Errorf("rename %q to %q: %w", src, dst, renameErr)
+	}
+
+	return replacePathAtomicWindows(src, dst)
+}
+
+func replacePathAtomicWindows(src, dst string) error {
 	backupPath, err := reserveReplaceBackupPath(dst)
 	if err != nil {
 		return err
 	}
+
 	if moveErr := os.Rename(dst, backupPath); moveErr != nil {
-		_ = os.Remove(backupPath)
-		return moveErr
+		removeErr := removePathIfExists(backupPath)
+		wrappedMoveErr := fmt.Errorf("rename %q to %q: %w", dst, backupPath, moveErr)
+		if removeErr != nil {
+			return errors.Join(wrappedMoveErr, removeErr)
+		}
+		return wrappedMoveErr
 	}
-	if err := os.Rename(src, dst); err != nil {
+	if moveErr := os.Rename(src, dst); moveErr != nil {
+		wrappedMoveErr := fmt.Errorf("rename %q to %q: %w", src, dst, moveErr)
 		restoreErr := os.Rename(backupPath, dst)
 		if restoreErr != nil {
-			return errors.Join(err, restoreErr)
+			return errors.Join(
+				wrappedMoveErr,
+				fmt.Errorf("rename %q to %q: %w", backupPath, dst, restoreErr),
+			)
 		}
-		return err
+		return wrappedMoveErr
 	}
-	if removeErr := os.Remove(backupPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
-		return removeErr
-	}
-	return nil
+	return removePathIfExists(backupPath)
 }
 
 func reserveReplaceBackupPath(dst string) (string, error) {
 	backup, err := os.CreateTemp(filepath.Dir(dst), "."+filepath.Base(dst)+".old-*")
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("reserve backup path for %q: create temp file: %w", dst, err)
 	}
 	backupPath := backup.Name()
-	if err := backup.Close(); err != nil {
-		_ = os.Remove(backupPath)
-		return "", err
+	closeErr := closeFile(backup, fmt.Sprintf("temporary backup file %q", backupPath))
+	if closeErr != nil {
+		removeErr := removePathIfExists(backupPath)
+		if removeErr != nil {
+			return "", errors.Join(
+				fmt.Errorf("reserve backup path for %q: %w", dst, closeErr),
+				removeErr,
+			)
+		}
+		return "", fmt.Errorf("reserve backup path for %q: %w", dst, closeErr)
 	}
-	if err := os.Remove(backupPath); err != nil {
-		return "", err
+	removeErr := removePathIfExists(backupPath)
+	if removeErr != nil {
+		return "", fmt.Errorf("reserve backup path for %q: %w", dst, removeErr)
 	}
 	return backupPath, nil
 }
@@ -683,10 +735,37 @@ func syncDirIfSupported(path string) error {
 	if runtime.GOOS == "windows" {
 		return nil
 	}
-	dir, err := os.Open(path)
+
+	dir, err := os.Open(path) //nolint:gosec // Path is derived from caller-controlled hosts file location.
 	if err != nil {
-		return err
+		return fmt.Errorf("open directory %q: %w", path, err)
 	}
-	defer dir.Close()
-	return dir.Sync()
+	syncErr := dir.Sync()
+	if syncErr != nil {
+		closeErr := closeFile(dir, fmt.Sprintf("directory %q", path))
+		if closeErr != nil {
+			return errors.Join(fmt.Errorf("sync directory %q: %w", path, syncErr), closeErr)
+		}
+		return fmt.Errorf("sync directory %q: %w", path, syncErr)
+	}
+	return closeFile(dir, fmt.Sprintf("directory %q", path))
+}
+
+func closeFile(file *os.File, name string) error {
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", name, err)
+	}
+	return nil
+}
+
+func removePathIfExists(path string) error {
+	err := os.Remove(path)
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, os.ErrNotExist):
+		return nil
+	default:
+		return fmt.Errorf("remove %q: %w", path, err)
+	}
 }

--- a/src/cli/internal/cmd/env/localtest/hostsfile.go
+++ b/src/cli/internal/cmd/env/localtest/hostsfile.go
@@ -1,0 +1,692 @@
+package localtest
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+
+	"altinn.studio/studioctl/internal/osutil"
+)
+
+const (
+	// HostsStateInstalled means the managed block is present and matches the desired content.
+	HostsStateInstalled = "installed"
+
+	// HostsStatePresent means all desired hostnames resolve in the file, but not via the exact managed block.
+	HostsStatePresent = "present"
+
+	// HostsStateMissing means one or more desired hostnames are missing.
+	HostsStateMissing = "missing"
+
+	// HostsStateConflict means one or more desired hostnames map to unexpected addresses.
+	HostsStateConflict = "conflict"
+)
+
+var (
+	// ErrMalformedManagedHostsBlock is returned when the managed hosts-file block markers are invalid.
+	ErrMalformedManagedHostsBlock = errors.New("malformed managed hosts block")
+
+	// ErrHostsConflict is returned when desired hostnames already have conflicting active mappings.
+	ErrHostsConflict = errors.New("conflicting host entries")
+)
+
+// HostsWriteResult describes one hosts-file mutation.
+type HostsWriteResult struct {
+	BackupPath string `json:"backupPath,omitempty"`
+	Changed    bool   `json:"changed"`
+}
+
+// HostsConflict contains one hostname and its active addresses.
+type HostsConflict struct {
+	Addresses []string `json:"addresses"`
+	Host      string   `json:"host"`
+}
+
+// HostsFileStatus describes whether a hosts file satisfies the desired localtest mappings.
+type HostsFileStatus struct {
+	Conflicts []HostsConflict `json:"conflicts,omitempty"`
+	Missing   []string        `json:"missing,omitempty"`
+	Managed   bool            `json:"managed"`
+	State     string          `json:"state"`
+}
+
+// HostsConflictError contains conflicting active mappings that must be resolved manually.
+type HostsConflictError struct {
+	Conflicts []HostsConflict
+}
+
+func (e *HostsConflictError) Error() string {
+	parts := make([]string, 0, len(e.Conflicts))
+	for _, conflict := range e.Conflicts {
+		parts = append(parts, conflict.Host+" -> "+strings.Join(conflict.Addresses, ", "))
+	}
+	return fmt.Sprintf("%s:\n%s", ErrHostsConflict, strings.Join(parts, "\n"))
+}
+
+// Is makes errors.Is(err, ErrHostsConflict) work for HostsConflictError.
+func (e *HostsConflictError) Is(target error) bool {
+	return target == ErrHostsConflict
+}
+
+// InspectHostsFile reports whether the given hosts file satisfies the desired host mappings.
+func InspectHostsFile(path, blockName, address string, hostnames []string) (HostsFileStatus, error) {
+	content, err := os.ReadFile(path) //nolint:gosec // Caller controls the system hosts file path.
+	if err != nil {
+		return HostsFileStatus{}, fmt.Errorf("read hosts file %q: %w", path, err)
+	}
+	return inspectHostsContent(string(content), blockName, address, hostnames)
+}
+
+// EnsureManagedHosts updates a hosts file to contain the exact managed block for the desired hostnames.
+func EnsureManagedHosts(path, blockName, address string, hostnames []string) (HostsWriteResult, error) {
+	content, info, err := readHostsFile(path)
+	if err != nil {
+		return HostsWriteResult{}, err
+	}
+	updated, changed, err := ensureManagedHostsContent(content, blockName, address, hostnames)
+	if err != nil {
+		return HostsWriteResult{}, err
+	}
+	if !changed {
+		return HostsWriteResult{Changed: false}, nil
+	}
+
+	backupPath, err := writeHostsBackup(path, content, info.Mode())
+	if err != nil {
+		return HostsWriteResult{}, err
+	}
+	if err := writeHostsFileAtomic(path, updated, fileModeOrDefault(info.Mode())); err != nil {
+		return HostsWriteResult{}, err
+	}
+	return HostsWriteResult{
+		BackupPath: backupPath,
+		Changed:    true,
+	}, nil
+}
+
+// RemoveManagedHosts removes the exact managed block from a hosts file if present.
+func RemoveManagedHosts(path, blockName string) (HostsWriteResult, error) {
+	content, info, err := readHostsFile(path)
+	if err != nil {
+		return HostsWriteResult{}, err
+	}
+	updated, changed, err := removeManagedHostsContent(content, blockName)
+	if err != nil {
+		return HostsWriteResult{}, err
+	}
+	if !changed {
+		return HostsWriteResult{Changed: false}, nil
+	}
+
+	backupPath, err := writeHostsBackup(path, content, info.Mode())
+	if err != nil {
+		return HostsWriteResult{}, err
+	}
+	if err := writeHostsFileAtomic(path, updated, fileModeOrDefault(info.Mode())); err != nil {
+		return HostsWriteResult{}, err
+	}
+	return HostsWriteResult{
+		BackupPath: backupPath,
+		Changed:    true,
+	}, nil
+}
+
+func readHostsFile(path string) (string, fs.FileInfo, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", nil, fmt.Errorf("stat hosts file %q: %w", path, err)
+	}
+	content, err := os.ReadFile(path) //nolint:gosec // Caller controls the system hosts file path.
+	if err != nil {
+		return "", nil, fmt.Errorf("read hosts file %q: %w", path, err)
+	}
+	return string(content), info, nil
+}
+
+func fileModeOrDefault(mode fs.FileMode) fs.FileMode {
+	perm := mode.Perm()
+	if perm == 0 {
+		return osutil.FilePermDefault
+	}
+	return perm
+}
+
+func inspectHostsContent(content, blockName, address string, hostnames []string) (HostsFileStatus, error) {
+	managed, err := extractManagedBlock(content, blockName)
+	if err != nil {
+		return HostsFileStatus{}, err
+	}
+	lineBreak := managed.lineBreak
+	if lineBreak == "" {
+		lineBreak = detectFileLineBreak(content)
+	}
+	desiredBlock := renderManagedBlock(blockName, address, hostnames, lineBreak)
+	managed.exact = managed.present && managed.content == desiredBlock
+
+	mappings := parseActiveHosts(content)
+	normalizedHosts := normalizeHostnames(hostnames)
+	status := HostsFileStatus{
+		Managed: managed.present,
+		State:   HostsStateInstalled,
+	}
+
+	for _, host := range normalizedHosts {
+		addresses := sortedAddresses(mappings[host])
+		switch {
+		case len(addresses) == 0:
+			status.Missing = append(status.Missing, host)
+		case allLoopbackAddresses(addresses):
+			continue
+		default:
+			status.Conflicts = append(status.Conflicts, HostsConflict{
+				Host:      host,
+				Addresses: addresses,
+			})
+		}
+	}
+
+	hasUnmanagedDesiredMappings := hasHostMappings(managed.prefix+managed.suffix, normalizedHosts)
+	switch {
+	case len(status.Conflicts) > 0:
+		status.State = HostsStateConflict
+	case len(status.Missing) > 0:
+		status.State = HostsStateMissing
+	case managed.present && managed.exact && !hasUnmanagedDesiredMappings:
+		status.State = HostsStateInstalled
+	default:
+		status.State = HostsStatePresent
+	}
+	return status, nil
+}
+
+func ensureManagedHostsContent(content, blockName, address string, hostnames []string) (string, bool, error) {
+	status, err := inspectHostsContent(content, blockName, address, hostnames)
+	if err != nil {
+		return "", false, err
+	}
+	if len(status.Conflicts) > 0 {
+		return "", false, &HostsConflictError{Conflicts: status.Conflicts}
+	}
+
+	managed, err := extractManagedBlock(content, blockName)
+	if err != nil {
+		return "", false, err
+	}
+
+	lineBreak := managed.lineBreak
+	if lineBreak == "" {
+		lineBreak = detectFileLineBreak(content)
+	}
+	desiredBlock := renderManagedBlock(blockName, address, hostnames, lineBreak)
+	managed.exact = managed.present && managed.content == desiredBlock
+
+	if managed.present {
+		if managed.exact {
+			return content, false, nil
+		}
+
+		updated := managed.prefix + desiredBlock + managed.suffix
+		if updated == content {
+			return content, false, nil
+		}
+		return updated, true, nil
+	}
+
+	updated := appendManagedBlock(content, desiredBlock, lineBreak)
+	if updated == content {
+		return content, false, nil
+	}
+	return updated, true, nil
+}
+
+func removeManagedHostsContent(content, blockName string) (string, bool, error) {
+	managed, err := extractManagedBlock(content, blockName)
+	if err != nil {
+		return "", false, err
+	}
+	if !managed.present {
+		return content, false, nil
+	}
+
+	updated := managed.prefix + managed.suffix
+	updated = trimLeadingBlankLines(trimTrailingBlankLines(updated))
+	if updated != "" && !hasTrailingLineBreak(updated) {
+		updated += managed.lineBreak
+	}
+	return updated, updated != content, nil
+}
+
+type managedBlock struct {
+	content   string
+	exact     bool
+	present   bool
+	lineBreak string
+	prefix    string
+	suffix    string
+}
+
+func extractManagedBlock(content, blockName string) (managedBlock, error) {
+	startMarker := "# BEGIN " + blockName
+	endMarker := "# END " + blockName
+
+	startCount := strings.Count(content, startMarker)
+	endCount := strings.Count(content, endMarker)
+	switch {
+	case startCount == 0 && endCount == 0:
+		return managedBlock{lineBreak: detectFileLineBreak(content)}, nil
+	case startCount != 1 || endCount != 1:
+		return managedBlock{}, fmt.Errorf("%w: %s", ErrMalformedManagedHostsBlock, blockName)
+	}
+
+	startIdx := strings.Index(content, startMarker)
+	endIdx := strings.Index(content, endMarker)
+	if endIdx < startIdx {
+		return managedBlock{}, fmt.Errorf("%w: %s", ErrMalformedManagedHostsBlock, blockName)
+	}
+
+	blockStart := lineStartIndex(content, startIdx)
+	blockEnd := lineEndIndex(content, endIdx+len(endMarker))
+	if blockEnd < startIdx {
+		return managedBlock{}, fmt.Errorf("%w: %s", ErrMalformedManagedHostsBlock, blockName)
+	}
+
+	lineBreak := detectFileLineBreak(content)
+	block := content[blockStart:blockEnd]
+	return managedBlock{
+		content:   block,
+		present:   true,
+		prefix:    content[:blockStart],
+		suffix:    content[blockEnd:],
+		lineBreak: lineBreak,
+	}, nil
+}
+
+func renderManagedBlock(blockName, address string, hostnames []string, lineBreak string) string {
+	if lineBreak == "" {
+		lineBreak = "\n"
+	}
+
+	normalizedHosts := normalizeHostnames(hostnames)
+	var builder strings.Builder
+	builder.WriteString("# BEGIN ")
+	builder.WriteString(blockName)
+	builder.WriteString(lineBreak)
+	for _, host := range normalizedHosts {
+		builder.WriteString(address)
+		builder.WriteString(" ")
+		builder.WriteString(host)
+		builder.WriteString(lineBreak)
+	}
+	builder.WriteString("# END ")
+	builder.WriteString(blockName)
+	builder.WriteString(lineBreak)
+	return builder.String()
+}
+
+func appendManagedBlock(content, block, lineBreak string) string {
+	if content == "" {
+		return block
+	}
+
+	updated := content
+	if !hasTrailingLineBreak(updated) {
+		updated += lineBreak
+	}
+	if !strings.HasSuffix(updated, lineBreak+lineBreak) {
+		updated += lineBreak
+	}
+	return updated + block
+}
+
+func parseActiveHosts(content string) map[string]map[string]struct{} {
+	result := make(map[string]map[string]struct{})
+	for _, rawLine := range strings.Split(content, "\n") {
+		line := strings.TrimSpace(strings.TrimSuffix(rawLine, "\r"))
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		address := fields[0]
+		if strings.HasPrefix(address, "#") {
+			continue
+		}
+		for _, host := range fields[1:] {
+			if strings.HasPrefix(host, "#") {
+				break
+			}
+			if _, ok := result[host]; !ok {
+				result[host] = make(map[string]struct{})
+			}
+			result[host][address] = struct{}{}
+		}
+	}
+	return result
+}
+
+func sortedAddresses(values map[string]struct{}) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	addresses := make([]string, 0, len(values))
+	for address := range values {
+		addresses = append(addresses, address)
+	}
+	sort.Strings(addresses)
+	return addresses
+}
+
+func normalizeHostnames(hostnames []string) []string {
+	seen := make(map[string]struct{}, len(hostnames))
+	result := make([]string, 0, len(hostnames))
+	for _, host := range hostnames {
+		host = strings.TrimSpace(host)
+		if host == "" {
+			continue
+		}
+		if _, ok := seen[host]; ok {
+			continue
+		}
+		seen[host] = struct{}{}
+		result = append(result, host)
+	}
+	return result
+}
+
+func hasHostMappings(content string, hostnames []string) bool {
+	mappings := parseActiveHosts(content)
+	for _, host := range hostnames {
+		if len(mappings[host]) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func allLoopbackAddresses(addresses []string) bool {
+	if len(addresses) == 0 {
+		return false
+	}
+	for _, address := range addresses {
+		ip := net.ParseIP(address)
+		if ip == nil || !ip.IsLoopback() {
+			return false
+		}
+	}
+	return true
+}
+
+func detectFileLineBreak(content string) string {
+	if strings.Contains(content, "\r\n") {
+		return "\r\n"
+	}
+	return "\n"
+}
+
+func hasTrailingLineBreak(content string) bool {
+	return strings.HasSuffix(content, "\n") || strings.HasSuffix(content, "\r\n")
+}
+
+func lineStartIndex(content string, idx int) int {
+	if idx <= 0 {
+		return 0
+	}
+	last := strings.LastIndex(content[:idx], "\n")
+	if last == -1 {
+		return 0
+	}
+	return last + 1
+}
+
+func lineEndIndex(content string, idx int) int {
+	if idx >= len(content) {
+		return len(content)
+	}
+	for idx < len(content) {
+		switch content[idx] {
+		case '\r':
+			if idx+1 < len(content) && content[idx+1] == '\n' {
+				return idx + 2
+			}
+			return idx + 1
+		case '\n':
+			return idx + 1
+		default:
+			idx++
+		}
+	}
+	return len(content)
+}
+
+func trimTrailingBlankLines(content string) string {
+	for {
+		trimmed := strings.TrimSuffix(strings.TrimSuffix(content, "\n"), "\r")
+		if trimmed == content {
+			return content
+		}
+		lineStart := strings.LastIndex(trimmed, "\n")
+		lastLine := trimmed
+		if lineStart >= 0 {
+			lastLine = trimmed[lineStart+1:]
+		}
+		if strings.TrimSpace(strings.TrimSuffix(lastLine, "\r")) != "" {
+			return trimmed
+		}
+		content = trimmed
+	}
+}
+
+func trimLeadingBlankLines(content string) string {
+	for {
+		if content == "" {
+			return content
+		}
+		lineEnd := strings.Index(content, "\n")
+		line := content
+		next := ""
+		if lineEnd >= 0 {
+			line = content[:lineEnd]
+			next = content[lineEnd+1:]
+		}
+		if strings.TrimSpace(strings.TrimSuffix(line, "\r")) != "" {
+			return content
+		}
+		content = next
+	}
+}
+
+func writeHostsBackup(path, content string, mode fs.FileMode) (string, error) {
+	for range 100 {
+		backupPath, err := nextHostsBackupPath(path)
+		if err != nil {
+			return "", err
+		}
+		file, err := os.OpenFile(backupPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, fileModeOrDefault(mode))
+		if err == nil {
+			if _, err := file.WriteString(content); err != nil {
+				_ = file.Close()
+				return "", fmt.Errorf("write hosts backup %q: %w", backupPath, err)
+			}
+			if err := file.Close(); err != nil {
+				return "", fmt.Errorf("close hosts backup %q: %w", backupPath, err)
+			}
+			return backupPath, nil
+		}
+		if !errors.Is(err, fs.ErrExist) {
+			return "", fmt.Errorf("write hosts backup %q: %w", backupPath, err)
+		}
+	}
+	return "", fmt.Errorf("allocate hosts backup path for %q: exhausted race retries", path)
+}
+
+func nextHostsBackupPath(path string) (string, error) {
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", fmt.Errorf("read hosts backup directory %q: %w", dir, err)
+	}
+
+	next := 0
+	for _, entry := range entries {
+		index, ok := hostsBackupIndex(base, entry.Name())
+		if ok && index >= next {
+			next = index + 1
+		}
+	}
+	return hostsBackupPath(path, next), nil
+}
+
+func hostsBackupPath(path string, index int) string {
+	if index == 0 {
+		return path + ".studioctl.bak"
+	}
+	return fmt.Sprintf("%s.studioctl.%d.bak", path, index)
+}
+
+func hostsBackupIndex(base, name string) (int, bool) {
+	if name == base+".studioctl.bak" {
+		return 0, true
+	}
+
+	prefix := base + ".studioctl."
+	suffix := ".bak"
+	if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, suffix) {
+		return 0, false
+	}
+	indexText := strings.TrimSuffix(strings.TrimPrefix(name, prefix), suffix)
+	if indexText == "" {
+		return 0, false
+	}
+	index, err := strconv.Atoi(indexText)
+	if err != nil || index < 1 {
+		return 0, false
+	}
+	return index, true
+}
+
+func writeHostsFileAtomic(path, content string, mode fs.FileMode) error {
+	dir := filepath.Dir(path)
+	tmpFile, err := os.CreateTemp(dir, "."+filepath.Base(path)+".studioctl.tmp-*")
+	if err != nil {
+		return fmt.Errorf("write hosts file %q: create temp file: %w", path, err)
+	}
+	tmpPath := tmpFile.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if err := tmpFile.Chmod(mode); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("write hosts file %q: chmod temp file: %w", path, err)
+	}
+	if _, err := tmpFile.WriteString(content); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("write hosts file %q: write temp file: %w", path, err)
+	}
+	if err := tmpFile.Sync(); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("write hosts file %q: sync temp file: %w", path, err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("write hosts file %q: close temp file: %w", path, err)
+	}
+	if err := replacePathAtomic(tmpPath, path); err != nil {
+		return fmt.Errorf("write hosts file %q: replace target: %w", path, err)
+	}
+	cleanup = false
+	if err := syncDirIfSupported(dir); err != nil {
+		return fmt.Errorf("write hosts file %q: sync directory: %w", path, err)
+	}
+	return nil
+}
+
+func replacePathAtomic(src, dst string) error {
+	if runtime.GOOS != "windows" {
+		return os.Rename(src, dst)
+	}
+
+	if err := os.Rename(src, dst); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrExist) && !errors.Is(err, os.ErrPermission) {
+		backupPath, backupErr := reserveReplaceBackupPath(dst)
+		if backupErr != nil {
+			return err
+		}
+		if moveErr := os.Rename(dst, backupPath); moveErr != nil {
+			_ = os.Remove(backupPath)
+			return err
+		}
+		if renameErr := os.Rename(src, dst); renameErr != nil {
+			restoreErr := os.Rename(backupPath, dst)
+			if restoreErr != nil {
+				return errors.Join(renameErr, restoreErr)
+			}
+			return renameErr
+		}
+		if removeErr := os.Remove(backupPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			return removeErr
+		}
+		return nil
+	}
+
+	backupPath, err := reserveReplaceBackupPath(dst)
+	if err != nil {
+		return err
+	}
+	if moveErr := os.Rename(dst, backupPath); moveErr != nil {
+		_ = os.Remove(backupPath)
+		return moveErr
+	}
+	if err := os.Rename(src, dst); err != nil {
+		restoreErr := os.Rename(backupPath, dst)
+		if restoreErr != nil {
+			return errors.Join(err, restoreErr)
+		}
+		return err
+	}
+	if removeErr := os.Remove(backupPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+		return removeErr
+	}
+	return nil
+}
+
+func reserveReplaceBackupPath(dst string) (string, error) {
+	backup, err := os.CreateTemp(filepath.Dir(dst), "."+filepath.Base(dst)+".old-*")
+	if err != nil {
+		return "", err
+	}
+	backupPath := backup.Name()
+	if err := backup.Close(); err != nil {
+		_ = os.Remove(backupPath)
+		return "", err
+	}
+	if err := os.Remove(backupPath); err != nil {
+		return "", err
+	}
+	return backupPath, nil
+}
+
+func syncDirIfSupported(path string) error {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	dir, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+	return dir.Sync()
+}

--- a/src/cli/internal/cmd/env/localtest/hostsfile_internal_test.go
+++ b/src/cli/internal/cmd/env/localtest/hostsfile_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -396,7 +397,9 @@ func TestWriteHostsFileAtomicReplacesExistingFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("os.Stat() error = %v", err)
 	}
-	if info.Mode().Perm() != 0o600 {
-		t.Fatalf("perm = %o, want %o", info.Mode().Perm(), 0o600)
+	if runtime.GOOS != osWindows {
+		if info.Mode().Perm() != 0o600 {
+			t.Fatalf("perm = %o, want %o", info.Mode().Perm(), 0o600)
+		}
 	}
 }

--- a/src/cli/internal/cmd/env/localtest/hostsfile_internal_test.go
+++ b/src/cli/internal/cmd/env/localtest/hostsfile_internal_test.go
@@ -1,0 +1,402 @@
+package localtest
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const testBlockName = "studioctl localtest"
+
+func TestInspectHostsContentInstalled(t *testing.T) {
+	t.Parallel()
+
+	content := strings.Join([]string{
+		"# BEGIN studioctl localtest",
+		"127.0.0.1 local.altinn.cloud",
+		"127.0.0.1 pdf.local.altinn.cloud",
+		"# END studioctl localtest",
+		"",
+	}, "\n")
+
+	status, err := inspectHostsContent(
+		content,
+		testBlockName,
+		"127.0.0.1",
+		[]string{"local.altinn.cloud", "pdf.local.altinn.cloud"},
+	)
+	if err != nil {
+		t.Fatalf("inspectHostsContent() error = %v", err)
+	}
+	if status.State != HostsStateInstalled {
+		t.Fatalf("State = %q, want %q", status.State, HostsStateInstalled)
+	}
+	if !status.Managed {
+		t.Fatal("Managed = false, want true")
+	}
+}
+
+func TestInspectHostsContentPresentOutsideManagedBlock(t *testing.T) {
+	t.Parallel()
+
+	content := "127.0.0.1 local.altinn.cloud pdf.local.altinn.cloud\n"
+
+	status, err := inspectHostsContent(
+		content,
+		testBlockName,
+		"127.0.0.1",
+		[]string{"local.altinn.cloud", "pdf.local.altinn.cloud"},
+	)
+	if err != nil {
+		t.Fatalf("inspectHostsContent() error = %v", err)
+	}
+	if status.State != HostsStatePresent {
+		t.Fatalf("State = %q, want %q", status.State, HostsStatePresent)
+	}
+	if status.Managed {
+		t.Fatal("Managed = true, want false")
+	}
+}
+
+func TestInspectHostsContentPresentWithDuplicateOutsideManagedBlock(t *testing.T) {
+	t.Parallel()
+
+	content := strings.Join([]string{
+		"127.0.0.1 local.altinn.cloud",
+		"",
+		"# BEGIN studioctl localtest",
+		"127.0.0.1 local.altinn.cloud",
+		"127.0.0.1 pdf.local.altinn.cloud",
+		"# END studioctl localtest",
+		"",
+	}, "\n")
+
+	status, err := inspectHostsContent(
+		content,
+		testBlockName,
+		"127.0.0.1",
+		[]string{"local.altinn.cloud", "pdf.local.altinn.cloud"},
+	)
+	if err != nil {
+		t.Fatalf("inspectHostsContent() error = %v", err)
+	}
+	if status.State != HostsStatePresent {
+		t.Fatalf("State = %q, want %q", status.State, HostsStatePresent)
+	}
+	if !status.Managed {
+		t.Fatal("Managed = false, want true")
+	}
+}
+
+func TestInspectHostsContentConflict(t *testing.T) {
+	t.Parallel()
+
+	content := "10.0.0.1 local.altinn.cloud\n127.0.0.1 pdf.local.altinn.cloud\n"
+
+	status, err := inspectHostsContent(
+		content,
+		testBlockName,
+		"127.0.0.1",
+		[]string{"local.altinn.cloud", "pdf.local.altinn.cloud"},
+	)
+	if err != nil {
+		t.Fatalf("inspectHostsContent() error = %v", err)
+	}
+	if status.State != HostsStateConflict {
+		t.Fatalf("State = %q, want %q", status.State, HostsStateConflict)
+	}
+	if len(status.Conflicts) != 1 || status.Conflicts[0].Host != "local.altinn.cloud" {
+		t.Fatalf("Conflicts = %+v, want local.altinn.cloud conflict", status.Conflicts)
+	}
+}
+
+func TestInspectHostsContentAllowsDualStackLoopback(t *testing.T) {
+	t.Parallel()
+
+	content := "127.0.0.1 local.altinn.cloud\n::1 local.altinn.cloud\n"
+
+	status, err := inspectHostsContent(
+		content,
+		testBlockName,
+		"127.0.0.1",
+		[]string{"local.altinn.cloud"},
+	)
+	if err != nil {
+		t.Fatalf("inspectHostsContent() error = %v", err)
+	}
+	if status.State != HostsStatePresent {
+		t.Fatalf("State = %q, want %q", status.State, HostsStatePresent)
+	}
+	if len(status.Conflicts) != 0 {
+		t.Fatalf("Conflicts = %+v, want none", status.Conflicts)
+	}
+}
+
+func TestEnsureManagedHostsContentAppendsManagedBlock(t *testing.T) {
+	t.Parallel()
+
+	original := "127.0.0.1 localhost\n"
+	updated, changed, err := ensureManagedHostsContent(
+		original,
+		testBlockName,
+		"127.0.0.1",
+		[]string{"local.altinn.cloud", "pdf.local.altinn.cloud"},
+	)
+	if err != nil {
+		t.Fatalf("ensureManagedHostsContent() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("changed = false, want true")
+	}
+	wantBlock := strings.Join([]string{
+		"# BEGIN studioctl localtest",
+		"127.0.0.1 local.altinn.cloud",
+		"127.0.0.1 pdf.local.altinn.cloud",
+		"# END studioctl localtest",
+		"",
+	}, "\n")
+	if !strings.Contains(updated, wantBlock) {
+		t.Fatalf("updated content missing managed block:\n%s", updated)
+	}
+	if !strings.Contains(updated, "127.0.0.1 localhost\n") {
+		t.Fatalf("updated content lost existing entries:\n%s", updated)
+	}
+}
+
+func TestEnsureManagedHostsContentPreservesDuplicatesOutsideManagedBlock(t *testing.T) {
+	t.Parallel()
+
+	original := strings.Join([]string{
+		"127.0.0.1 localhost local.altinn.cloud",
+		"127.0.0.1 pdf.local.altinn.cloud # keep note",
+		"",
+		"# BEGIN studioctl localtest",
+		"127.0.0.1 local.altinn.cloud",
+		"127.0.0.1 pdf.local.altinn.cloud",
+		"# END studioctl localtest",
+		"",
+	}, "\n")
+
+	updated, changed, err := ensureManagedHostsContent(
+		original,
+		testBlockName,
+		"127.0.0.1",
+		[]string{"local.altinn.cloud", "pdf.local.altinn.cloud"},
+	)
+	if err != nil {
+		t.Fatalf("ensureManagedHostsContent() error = %v", err)
+	}
+	if changed {
+		t.Fatal("changed = true, want false")
+	}
+	if updated != original {
+		t.Fatalf("updated = %q, want original %q", updated, original)
+	}
+}
+
+func TestEnsureManagedHostsContentWithoutManagedBlockPreservesUnrelatedEntries(t *testing.T) {
+	t.Parallel()
+
+	original := strings.Join([]string{
+		"127.0.0.1 localhost",
+		"127.0.1.1 myhost",
+		"127.0.0.1 local.altinn.cloud",
+		"",
+	}, "\n")
+
+	updated, changed, err := ensureManagedHostsContent(
+		original,
+		testBlockName,
+		"127.0.0.1",
+		[]string{"local.altinn.cloud", "pdf.local.altinn.cloud"},
+	)
+	if err != nil {
+		t.Fatalf("ensureManagedHostsContent() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("changed = false, want true")
+	}
+	if !strings.Contains(updated, "127.0.0.1 localhost\n") {
+		t.Fatalf("updated content lost localhost entry:\n%s", updated)
+	}
+	if !strings.Contains(updated, "127.0.1.1 myhost\n") {
+		t.Fatalf("updated content lost unrelated entry:\n%s", updated)
+	}
+	if !strings.Contains(updated, "127.0.0.1 local.altinn.cloud\n") {
+		t.Fatalf("updated content missing local.altinn.cloud entry:\n%s", updated)
+	}
+}
+
+func TestEnsureManagedHostsContentRejectsConflicts(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := ensureManagedHostsContent(
+		"10.0.0.1 local.altinn.cloud\n",
+		testBlockName,
+		"127.0.0.1",
+		[]string{"local.altinn.cloud"},
+	)
+	if err == nil {
+		t.Fatal("ensureManagedHostsContent() error = nil, want conflict")
+	}
+	if !errors.Is(err, ErrHostsConflict) {
+		t.Fatalf("error = %v, want ErrHostsConflict", err)
+	}
+}
+
+func TestEnsureManagedHostsContentAcceptsDualStackLoopback(t *testing.T) {
+	t.Parallel()
+
+	original := "::1 local.altinn.cloud\n"
+	updated, changed, err := ensureManagedHostsContent(
+		original,
+		testBlockName,
+		"127.0.0.1",
+		[]string{"local.altinn.cloud"},
+	)
+	if err != nil {
+		t.Fatalf("ensureManagedHostsContent() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("changed = false, want true")
+	}
+	want := strings.Join([]string{
+		"::1 local.altinn.cloud",
+		"",
+		"# BEGIN studioctl localtest",
+		"127.0.0.1 local.altinn.cloud",
+		"# END studioctl localtest",
+		"",
+	}, "\n")
+	if updated != want {
+		t.Fatalf("updated = %q, want %q", updated, want)
+	}
+}
+
+func TestRemoveManagedHostsContent(t *testing.T) {
+	t.Parallel()
+
+	content := strings.Join([]string{
+		"127.0.0.1 localhost",
+		"",
+		"# BEGIN studioctl localtest",
+		"127.0.0.1 local.altinn.cloud",
+		"# END studioctl localtest",
+		"",
+	}, "\n")
+
+	updated, changed, err := removeManagedHostsContent(content, testBlockName)
+	if err != nil {
+		t.Fatalf("removeManagedHostsContent() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("changed = false, want true")
+	}
+	if updated != "127.0.0.1 localhost\n" {
+		t.Fatalf("updated = %q, want %q", updated, "127.0.0.1 localhost\n")
+	}
+}
+
+func TestRemoveManagedHostsContentPreservesCRLF(t *testing.T) {
+	t.Parallel()
+
+	content := strings.Join([]string{
+		"127.0.0.1 localhost",
+		"",
+		"# BEGIN studioctl localtest",
+		"127.0.0.1 local.altinn.cloud",
+		"# END studioctl localtest",
+		"",
+	}, "\r\n")
+
+	updated, changed, err := removeManagedHostsContent(content, testBlockName)
+	if err != nil {
+		t.Fatalf("removeManagedHostsContent() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("changed = false, want true")
+	}
+	if updated != "127.0.0.1 localhost\r\n" {
+		t.Fatalf("updated = %q, want %q", updated, "127.0.0.1 localhost\r\n")
+	}
+}
+
+func TestInspectHostsContentRejectsMalformedManagedBlock(t *testing.T) {
+	t.Parallel()
+
+	_, err := inspectHostsContent(
+		"# BEGIN studioctl localtest\n127.0.0.1 local.altinn.cloud\n",
+		testBlockName,
+		"127.0.0.1",
+		[]string{"local.altinn.cloud"},
+	)
+	if err == nil {
+		t.Fatal("inspectHostsContent() error = nil, want malformed block error")
+	}
+	if !errors.Is(err, ErrMalformedManagedHostsBlock) {
+		t.Fatalf("error = %v, want ErrMalformedManagedHostsBlock", err)
+	}
+}
+
+func TestWriteHostsBackupAllocatesNextPath(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "hosts")
+	if err := os.WriteFile(path+".studioctl.bak", []byte("existing"), 0o644); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+	if err := os.WriteFile(path+".studioctl.1.bak", []byte("existing"), 0o644); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+	if err := os.WriteFile(path+".studioctl.4.bak", []byte("existing"), 0o644); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	backupPath, err := writeHostsBackup(path, "new", 0o644)
+	if err != nil {
+		t.Fatalf("writeHostsBackup() error = %v", err)
+	}
+	want := path + ".studioctl.5.bak"
+	if backupPath != want {
+		t.Fatalf("backupPath = %q, want %q", backupPath, want)
+	}
+
+	content, err := os.ReadFile(backupPath)
+	if err != nil {
+		t.Fatalf("os.ReadFile() error = %v", err)
+	}
+	if string(content) != "new" {
+		t.Fatalf("content = %q, want %q", string(content), "new")
+	}
+}
+
+func TestWriteHostsFileAtomicReplacesExistingFile(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "hosts")
+	if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	if err := writeHostsFileAtomic(path, "new", 0o600); err != nil {
+		t.Fatalf("writeHostsFileAtomic() error = %v", err)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("os.ReadFile() error = %v", err)
+	}
+	if string(content) != "new" {
+		t.Fatalf("content = %q, want %q", string(content), "new")
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("os.Stat() error = %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("perm = %o, want %o", info.Mode().Perm(), 0o600)
+	}
+}

--- a/src/cli/internal/cmd/env_internal_test.go
+++ b/src/cli/internal/cmd/env_internal_test.go
@@ -5,12 +5,17 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"altinn.studio/devenv/pkg/container/mock"
 	containertypes "altinn.studio/devenv/pkg/container/types"
+	envlocaltest "altinn.studio/studioctl/internal/cmd/env/localtest"
 	"altinn.studio/studioctl/internal/config"
+	"altinn.studio/studioctl/internal/envtopology"
+	"altinn.studio/studioctl/internal/osutil"
 	"altinn.studio/studioctl/internal/ui"
 )
 
@@ -56,4 +61,126 @@ func TestEnvUpJSONRejectsForeground(t *testing.T) {
 	if !strings.Contains(err.Error(), "--json requires --detach=true") {
 		t.Fatalf("runUp() error = %v, want detach/json error", err)
 	}
+}
+
+func TestEnvHostsStatusJSON(t *testing.T) {
+	hostsPath := filepath.Join(t.TempDir(), "hosts")
+	content := "127.0.0.1 localhost\n"
+	if err := os.WriteFile(hostsPath, []byte(content), osutil.FilePermDefault); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	originalTargets := localHostsFileTargets
+	localHostsFileTargets = func() ([]osutil.HostsTarget, error) {
+		return []osutil.HostsTarget{{Label: "Linux", Path: hostsPath, Required: true}}, nil
+	}
+	t.Cleanup(func() {
+		localHostsFileTargets = originalTargets
+	})
+
+	var out bytes.Buffer
+	command := &EnvCommand{
+		cfg: &config.Config{},
+		out: ui.NewOutput(&out, io.Discard, false),
+	}
+
+	if err := command.runHostsStatus(context.Background(), []string{"--json"}); err != nil {
+		t.Fatalf("runHostsStatus() error = %v", err)
+	}
+
+	var got envHostsStatusOutput
+	if err := json.Unmarshal(bytes.TrimSpace(out.Bytes()), &got); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if got.Runtime != runtimeLocaltest {
+		t.Fatalf("Runtime = %q, want %q", got.Runtime, runtimeLocaltest)
+	}
+	if got.Path != hostsPath {
+		t.Fatalf("Path = %q, want %q", got.Path, hostsPath)
+	}
+	if len(got.Hosts) != len(defaultLocalHostnames()) {
+		t.Fatalf("len(Hosts) = %d, want %d", len(got.Hosts), len(defaultLocalHostnames()))
+	}
+	for i, host := range got.Hosts {
+		if host.Host != defaultLocalHostnames()[i] {
+			t.Fatalf("Hosts[%d].Host = %q, want %q", i, host.Host, defaultLocalHostnames()[i])
+		}
+		if host.State != envlocaltest.HostsStateMissing {
+			t.Fatalf("Hosts[%d].State = %q, want %q", i, host.State, envlocaltest.HostsStateMissing)
+		}
+		if host.Detail != "" {
+			t.Fatalf("Hosts[%d].Detail = %q, want empty", i, host.Detail)
+		}
+	}
+}
+
+func TestEnvHostsAddJSON(t *testing.T) {
+	dir := t.TempDir()
+	hostsPath := filepath.Join(dir, "hosts")
+	content := "127.0.0.1 localhost\n"
+	if err := os.WriteFile(hostsPath, []byte(content), osutil.FilePermDefault); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	originalTargets := localHostsFileTargets
+	localHostsFileTargets = func() ([]osutil.HostsTarget, error) {
+		return []osutil.HostsTarget{{Label: "Linux", Path: hostsPath, Required: true}}, nil
+	}
+	t.Cleanup(func() {
+		localHostsFileTargets = originalTargets
+	})
+
+	var out bytes.Buffer
+	command := &EnvCommand{
+		cfg: &config.Config{},
+		out: ui.NewOutput(&out, io.Discard, false),
+	}
+
+	if err := command.runHostsAdd(context.Background(), []string{"--json"}); err != nil {
+		t.Fatalf("runHostsAdd() error = %v", err)
+	}
+
+	var got envHostsMutationOutput
+	if err := json.Unmarshal(bytes.TrimSpace(out.Bytes()), &got); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if got.Runtime != runtimeLocaltest {
+		t.Fatalf("Runtime = %q, want %q", got.Runtime, runtimeLocaltest)
+	}
+	if len(got.Targets) != 1 {
+		t.Fatalf("len(Targets) = %d, want 1", len(got.Targets))
+	}
+	target := got.Targets[0]
+	if target.Path != hostsPath {
+		t.Fatalf("target.Path = %q, want %q", target.Path, hostsPath)
+	}
+	if !target.Result.Changed {
+		t.Fatalf("target.Result.Changed = false, want true")
+	}
+	wantBackupPath := hostsPath + ".studioctl.bak"
+	if target.Result.BackupPath != wantBackupPath {
+		t.Fatalf("target.Result.BackupPath = %q, want %q", target.Result.BackupPath, wantBackupPath)
+	}
+
+	updated, err := os.ReadFile(hostsPath)
+	if err != nil {
+		t.Fatalf("os.ReadFile(hosts) error = %v", err)
+	}
+	for _, host := range defaultLocalHostnames() {
+		if !bytes.Contains(updated, []byte(host)) {
+			t.Fatalf("updated hosts file missing %q:\n%s", host, string(updated))
+		}
+	}
+
+	backup, err := os.ReadFile(wantBackupPath)
+	if err != nil {
+		t.Fatalf("os.ReadFile(backup) error = %v", err)
+	}
+	if string(backup) != content {
+		t.Fatalf("backup content = %q, want %q", string(backup), content)
+	}
+}
+
+func defaultLocalHostnames() []string {
+	return envtopology.NewLocal(envtopology.DefaultIngressPortString()).HostFileHostnames()
 }

--- a/src/cli/internal/cmd/env_internal_test.go
+++ b/src/cli/internal/cmd/env_internal_test.go
@@ -70,16 +70,11 @@ func TestEnvHostsStatusJSON(t *testing.T) {
 		t.Fatalf("os.WriteFile() error = %v", err)
 	}
 
-	originalTargets := localHostsFileTargets
-	localHostsFileTargets = func() ([]osutil.HostsTarget, error) {
-		return []osutil.HostsTarget{{Label: "Linux", Path: hostsPath, Required: true}}, nil
-	}
-	t.Cleanup(func() {
-		localHostsFileTargets = originalTargets
-	})
-
 	var out bytes.Buffer
 	command := &EnvCommand{
+		hostsFileTargets: func() ([]osutil.HostsTarget, error) {
+			return []osutil.HostsTarget{{Label: "Linux", Path: hostsPath, Required: true}}, nil
+		},
 		cfg: &config.Config{},
 		out: ui.NewOutput(&out, io.Discard, false),
 	}
@@ -122,16 +117,11 @@ func TestEnvHostsAddJSON(t *testing.T) {
 		t.Fatalf("os.WriteFile() error = %v", err)
 	}
 
-	originalTargets := localHostsFileTargets
-	localHostsFileTargets = func() ([]osutil.HostsTarget, error) {
-		return []osutil.HostsTarget{{Label: "Linux", Path: hostsPath, Required: true}}, nil
-	}
-	t.Cleanup(func() {
-		localHostsFileTargets = originalTargets
-	})
-
 	var out bytes.Buffer
 	command := &EnvCommand{
+		hostsFileTargets: func() ([]osutil.HostsTarget, error) {
+			return []osutil.HostsTarget{{Label: "Linux", Path: hostsPath, Required: true}}, nil
+		},
 		cfg: &config.Config{},
 		out: ui.NewOutput(&out, io.Discard, false),
 	}

--- a/src/cli/internal/cmd/env_test.go
+++ b/src/cli/internal/cmd/env_test.go
@@ -20,6 +20,16 @@ func TestEnvCommand_RunUp_Help(t *testing.T) {
 	}
 }
 
+func TestEnvCommand_RunHosts_Help(t *testing.T) {
+	t.Parallel()
+
+	command := newTestEnvCommand(t)
+	err := command.Run(context.Background(), []string{"hosts", "--help"})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+}
+
 func newTestEnvCommand(t *testing.T) *cmd.EnvCommand {
 	t.Helper()
 

--- a/src/cli/internal/envtopology/topology.go
+++ b/src/cli/internal/envtopology/topology.go
@@ -117,6 +117,18 @@ func (l Local) LocaltestIngressHosts() []string {
 	return hosts
 }
 
+// HostFileHostnames returns local environment hostnames that must resolve on the host machine.
+func (l Local) HostFileHostnames() []string {
+	return []string{
+		appHost,
+		pdfHost,
+		workflowEngineHost,
+		pgAdminHost,
+		frontendHost,
+		otelHost,
+	}
+}
+
 // OTelHost returns the local OpenTelemetry collector host name.
 func (l Local) OTelHost() string {
 	return otelHost

--- a/src/cli/internal/envtopology/topology_test.go
+++ b/src/cli/internal/envtopology/topology_test.go
@@ -52,3 +52,20 @@ func TestLocaltestIngressHosts(t *testing.T) {
 		t.Fatalf("LocaltestIngressHosts() = %v, want %v", got, want)
 	}
 }
+
+func TestHostFileHostnames(t *testing.T) {
+	t.Parallel()
+
+	got := envtopology.NewLocal("8000").HostFileHostnames()
+	want := []string{
+		"local.altinn.cloud",
+		"pdf.local.altinn.cloud",
+		"workflow-engine.local.altinn.cloud",
+		"pgadmin.local.altinn.cloud",
+		"app-frontend.local.altinn.cloud",
+		"otel.local.altinn.cloud",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("HostFileHostnames() = %v, want %v", got, want)
+	}
+}

--- a/src/cli/internal/osutil/browser.go
+++ b/src/cli/internal/osutil/browser.go
@@ -18,6 +18,8 @@ var (
 	errUnsupportedURLScheme  = errors.New("unsupported browser url scheme")
 )
 
+const goosLinux = "linux"
+
 // OpenContext opens the given URL in the default browser with context support.
 func OpenContext(ctx context.Context, rawURL string) error {
 	safeURL, err := validateBrowserURL(rawURL)
@@ -25,13 +27,13 @@ func OpenContext(ctx context.Context, rawURL string) error {
 		return err
 	}
 
-	if runtime.GOOS == "linux" && IsWSL() {
+	if runtime.GOOS == goosLinux && IsWSL() {
 		return openWSL(ctx, safeURL)
 	}
 
 	var cmd *exec.Cmd
 	switch runtime.GOOS {
-	case "linux":
+	case goosLinux:
 		cmd = processutil.CommandContext(ctx, "xdg-open", safeURL)
 	case "darwin":
 		cmd = processutil.CommandContext(ctx, "open", safeURL)

--- a/src/cli/internal/osutil/hosts.go
+++ b/src/cli/internal/osutil/hosts.go
@@ -1,0 +1,50 @@
+package osutil
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// HostsTarget describes one system hosts file that may need localtest entries.
+type HostsTarget struct {
+	Label    string `json:"label"`
+	Path     string `json:"path"`
+	Required bool   `json:"required"`
+}
+
+// LocalHostsFileTargets returns hosts files that should be updated on the current system.
+func LocalHostsFileTargets() ([]HostsTarget, error) {
+	switch runtime.GOOS {
+	case "darwin":
+		return []HostsTarget{{Label: "macOS", Path: "/etc/hosts", Required: true}}, nil
+	case "linux":
+		return []HostsTarget{{Label: "Linux", Path: "/etc/hosts", Required: true}}, nil
+	case "windows":
+		path, err := windowsHostsPathNative()
+		if err != nil {
+			return nil, err
+		}
+		return []HostsTarget{{Label: "Windows", Path: path, Required: true}}, nil
+	default:
+		return nil, fmt.Errorf("%w: %s", ErrUnsupportedPlatform, runtime.GOOS)
+	}
+}
+
+// IsPermissionError reports whether err is a filesystem permission failure.
+func IsPermissionError(err error) bool {
+	return errors.Is(err, os.ErrPermission)
+}
+
+func windowsHostsPathNative() (string, error) {
+	systemRoot := os.Getenv("SystemRoot")
+	if systemRoot == "" {
+		systemRoot = os.Getenv("WINDIR")
+	}
+	if systemRoot == "" {
+		return "", fmt.Errorf("resolve Windows SystemRoot: %w", os.ErrNotExist)
+	}
+	return filepath.Join(systemRoot, "System32", "drivers", "etc", "hosts"), nil
+}

--- a/src/cli/internal/osutil/osutil.go
+++ b/src/cli/internal/osutil/osutil.go
@@ -21,6 +21,25 @@ func CurrentBin() string {
 	return name
 }
 
+// CurrentBinPath returns the current executable path when available, with a stable fallback.
+func CurrentBinPath() string {
+	path, err := os.Executable()
+	if err == nil && path != "" {
+		return path
+	}
+	if len(os.Args) == 0 || os.Args[0] == "" {
+		return fallbackCommandName
+	}
+	if filepath.IsAbs(os.Args[0]) {
+		return os.Args[0]
+	}
+	abs, err := filepath.Abs(os.Args[0])
+	if err != nil || abs == "" {
+		return os.Args[0]
+	}
+	return abs
+}
+
 func displayCommandName(name string) string {
 	if strings.EqualFold(filepath.Ext(name), ".exe") {
 		return strings.TrimSuffix(name, filepath.Ext(name))


### PR DESCRIPTION
## Description

Tested on Windows, Mac and Linux. Is idempotent so will noop or update as needed

```sh
$ s env hosts status
Hostname                            State    Details
local.altinn.cloud                  present  127.0.0.1
pdf.local.altinn.cloud              missing  
workflow-engine.local.altinn.cloud  missing  
pgadmin.local.altinn.cloud          missing  
app-frontend.local.altinn.cloud     missing  
otel.local.altinn.cloud             missing
$ s env hosts add
WSL note: studioctl opens URLs in the Windows browser; if local domains do not resolve there, also update the Windows hosts file manually (usually C:\Windows\System32\drivers\etc\hosts).
add hosts file "/etc/hosts":
add requires elevated privileges
rerun with sudo:
  sudo /home/martin/.local/bin/studioctl env hosts add
$ sudo /home/martin/.local/bin/studioctl env hosts add
WSL note: studioctl opens URLs in the Windows browser; if local domains do not resolve there, also update the Windows hosts file manually (usually C:\Windows\System32\drivers\etc\hosts).
Added hosts entries to /etc/hosts
Backup saved to /etc/hosts.studioctl.5.bak
$ cat /etc/hosts
...
  16 │ # BEGIN studioctl localtest
  17 │ 127.0.0.1 local.altinn.cloud
  18 │ 127.0.0.1 pdf.local.altinn.cloud
  19 │ 127.0.0.1 workflow-engine.local.altinn.cloud
  20 │ 127.0.0.1 pgadmin.local.altinn.cloud
  21 │ 127.0.0.1 app-frontend.local.altinn.cloud
  22 │ 127.0.0.1 otel.local.altinn.cloud
  23 │ # END studioctl localtest
...
$ s env hosts status
Hostname                            State    Details
local.altinn.cloud                  present  127.0.0.1
pdf.local.altinn.cloud              present  127.0.0.1
workflow-engine.local.altinn.cloud  present  127.0.0.1
pgadmin.local.altinn.cloud          present  127.0.0.1
app-frontend.local.altinn.cloud     present  127.0.0.1
otel.local.altinn.cloud             present  127.0.0.1
$ s env hosts remove
remove hosts file "/etc/hosts":
remove requires elevated privileges
rerun with sudo:
  sudo /home/martin/.local/bin/studioctl env hosts remove
$ sudo /home/martin/.local/bin/studioctl env hosts remove
WSL note: studioctl opens URLs in the Windows browser; if local domains do not resolve there, also update the Windows hosts file manually (usually C:\Windows\System32\drivers\etc\hosts).
Removed managed hosts entries from /etc/hosts
Backup saved to /etc/hosts.studioctl.6.bak
```

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added `env hosts` subcommand to manage local hosts-file entries for localtest environments, supporting `add`, `status`, and `remove` operations with JSON output support.
* Enhanced diagnostic output in environment checks with suggested remediation commands for DNS errors.

**Improvements**
* Automatic hosts-file backup creation during modifications.
* Cross-platform hosts-file management with support for Windows, macOS, and Linux.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->