### PR TITLE
fix: studioctl - readpassword including macos bracketed paste

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to studioctl will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
@@ -11,13 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `env reset` for localtest to delete persisted localtest and workflow-engine database data, with interactive confirmation.
 
-### Removed
-
-- Breaking: remove `--checks` from `studioctl doctor`; `studioctl doctor` now always runs localtest environment diagnostics and reports localtest, PDF, and workflow-engine health in text and JSON output.
-
 ### Fixed
 
 - Reading password input when using `studioctl auth` now works on macOS with bracketed paste enabled.
+
+### Removed
+
+- Breaking: remove `--checks` from `studioctl doctor`; `studioctl doctor` now always runs localtest environment diagnostics and reports localtest, PDF, and workflow-engine health in text and JSON output.
 
 ## [0.1.0-preview.6] - 2026-04-20
 

--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Breaking: remove `--checks` from `studioctl doctor`; `studioctl doctor` now always runs localtest environment diagnostics and reports localtest, PDF, and workflow-engine health in text and JSON output.
 
+### Fixed
+
+- Reading password input when using `studioctl auth` now works on macOS with bracketed paste enabled.
+
 ## [0.1.0-preview.6] - 2026-04-20
 
 ### Added

--- a/src/cli/internal/ui/input.go
+++ b/src/cli/internal/ui/input.go
@@ -1,13 +1,13 @@
 package ui
 
 import (
-	"bufio"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"net"
 	"os"
+	"strings"
 	"time"
 
 	"golang.org/x/term"
@@ -22,6 +22,7 @@ var errFDOverflow = errors.New("file descriptor overflow")
 const (
 	ctrlC      = 3   // Ctrl+C (ETX)
 	ctrlD      = 4   // Ctrl+D (EOT)
+	esc        = 27  // Escape
 	backspaceB = 8   // Backspace (BS)
 	cr         = 13  // Carriage return
 	lf         = 10  // Line feed
@@ -29,6 +30,9 @@ const (
 
 	// Keep this short so cancellation responds quickly without busy-waiting.
 	inputReadDeadline = 50 * time.Millisecond
+
+	bracketedPasteStart = "\x1b[200~"
+	bracketedPasteEnd   = "\x1b[201~"
 )
 
 // ReadPassword reads a password from stdin with echo disabled.
@@ -69,7 +73,6 @@ func makeRawStdin(out *Output) (func(), error) {
 // ReadLine reads one line from r.
 // Context cancellation is honored while waiting for input when r supports read deadlines.
 func ReadLine(ctx context.Context, r io.Reader) ([]byte, error) {
-	reader := bufio.NewReader(r)
 	line := make([]byte, 0, 128)
 
 	setReadDeadline, supportsDeadline := setupReadDeadline(r)
@@ -80,7 +83,7 @@ func ReadLine(ctx context.Context, r io.Reader) ([]byte, error) {
 			return nil, err
 		}
 
-		b, err := reader.ReadByte()
+		b, err := readByte(r)
 		if err != nil {
 			if isReadTimeout(err) {
 				continue
@@ -104,8 +107,7 @@ func ReadLine(ctx context.Context, r io.Reader) ([]byte, error) {
 }
 
 func readPasswordBytes(ctx context.Context, r io.Reader) ([]byte, error) {
-	reader := bufio.NewReader(r)
-	password := make([]byte, 0, 64)
+	input := newPasswordInput()
 
 	setReadDeadline, supportsDeadline := setupReadDeadline(r)
 	defer clearReadDeadline(setReadDeadline, supportsDeadline)
@@ -115,32 +117,141 @@ func readPasswordBytes(ctx context.Context, r io.Reader) ([]byte, error) {
 			return nil, err
 		}
 
-		b, err := reader.ReadByte()
+		b, err := readByte(r)
 		if err != nil {
 			if isReadTimeout(err) {
 				continue
 			}
 			if errors.Is(err, io.EOF) {
-				return password, nil
+				return input.finish()
 			}
 			return nil, fmt.Errorf("read password byte: %w", err)
 		}
 
-		switch b {
-		case ctrlC:
-			return nil, ErrInterrupted
-		case ctrlD:
-			return password, nil
-		case cr, lf:
-			return password, nil
-		case backspaceB, backspaceD:
-			if n := len(password); n > 0 {
-				password = password[:n-1]
-			}
-		default:
-			password = append(password, b)
+		done, applyErr := input.write(b)
+		if applyErr != nil {
+			return nil, applyErr
+		}
+		if done {
+			return input.password, nil
 		}
 	}
+}
+
+func readByte(r io.Reader) (byte, error) {
+	var buf [1]byte
+	n, err := r.Read(buf[:])
+	if n == 1 {
+		return buf[0], nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("read byte: %w", err)
+	}
+	return 0, io.ErrNoProgress
+}
+
+type passwordInput struct {
+	password         []byte
+	escapeSequence   []byte
+	inBracketedPaste bool
+	finishAfterPaste bool
+}
+
+func newPasswordInput() passwordInput {
+	return passwordInput{
+		password:         make([]byte, 0, 64),
+		escapeSequence:   make([]byte, 0, len(bracketedPasteStart)),
+		inBracketedPaste: false,
+		finishAfterPaste: false,
+	}
+}
+
+func (p *passwordInput) finish() ([]byte, error) {
+	if len(p.escapeSequence) == 0 {
+		return p.password, nil
+	}
+	if _, err := p.applyBytes(p.escapeSequence); err != nil {
+		return nil, err
+	}
+	return p.password, nil
+}
+
+func (p *passwordInput) write(b byte) (bool, error) {
+	if len(p.escapeSequence) > 0 || b == esc {
+		return p.writeEscapeCandidate(b)
+	}
+	return p.applyByte(b)
+}
+
+func (p *passwordInput) writeEscapeCandidate(b byte) (bool, error) {
+	p.escapeSequence = append(p.escapeSequence, b)
+	sequence := string(p.escapeSequence)
+
+	switch {
+	case sequence == bracketedPasteStart:
+		p.inBracketedPaste = true
+		p.finishAfterPaste = false
+		p.clearEscapeSequence()
+		return false, nil
+	case sequence == bracketedPasteEnd:
+		p.inBracketedPaste = false
+		p.clearEscapeSequence()
+		return p.finishAfterPaste, nil
+	case strings.HasPrefix(bracketedPasteStart, sequence) ||
+		strings.HasPrefix(bracketedPasteEnd, sequence):
+		return false, nil
+	default:
+		return p.flushEscapeSequence()
+	}
+}
+
+func (p *passwordInput) clearEscapeSequence() {
+	p.escapeSequence = p.escapeSequence[:0]
+}
+
+func (p *passwordInput) flushEscapeSequence() (bool, error) {
+	sequence := p.escapeSequence
+	defer p.clearEscapeSequence()
+	return p.applyBytes(sequence)
+}
+
+func (p *passwordInput) applyBytes(data []byte) (bool, error) {
+	for _, b := range data {
+		done, err := p.applyByte(b)
+		if done || err != nil {
+			return done, err
+		}
+	}
+	return false, nil
+}
+
+func (p *passwordInput) applyByte(b byte) (bool, error) {
+	if p.finishAfterPaste {
+		return false, nil
+	}
+	if p.inBracketedPaste {
+		if b == cr || b == lf {
+			p.finishAfterPaste = true
+			return false, nil
+		}
+		p.password = append(p.password, b)
+		return false, nil
+	}
+	if b == ctrlC {
+		return false, ErrInterrupted
+	}
+
+	switch b {
+	case ctrlD, cr, lf:
+		return true, nil
+	case backspaceB, backspaceD:
+		if n := len(p.password); n > 0 {
+			p.password = p.password[:n-1]
+		}
+	default:
+		p.password = append(p.password, b)
+	}
+	return false, nil
 }
 
 type readerWithDeadline interface {

--- a/src/cli/internal/ui/input_internal_test.go
+++ b/src/cli/internal/ui/input_internal_test.go
@@ -31,6 +31,28 @@ func TestReadLine_CancelDoesNotLeaveReaderBehind(t *testing.T) {
 	)
 }
 
+func TestReadLine_DoesNotReadPastNewline(t *testing.T) {
+	t.Parallel()
+
+	reader := strings.NewReader("token\nnext\n")
+
+	data, err := ReadLine(context.Background(), reader)
+	if err != nil {
+		t.Fatalf("ReadLine() error = %v", err)
+	}
+	if got, want := string(data), "token"; got != want {
+		t.Fatalf("ReadLine() = %q, want %q", got, want)
+	}
+
+	remaining, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if got, want := string(remaining), "next\n"; got != want {
+		t.Fatalf("remaining input = %q, want %q", got, want)
+	}
+}
+
 func TestReadPasswordBytes_HandlesControlInput(t *testing.T) {
 	t.Parallel()
 
@@ -40,6 +62,73 @@ func TestReadPasswordBytes_HandlesControlInput(t *testing.T) {
 	}
 	if got, want := string(data), "abd"; got != want {
 		t.Fatalf("readPasswordBytes() = %q, want %q", got, want)
+	}
+}
+
+func TestReadPasswordBytes_StripsBracketedPasteMarkers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "pasted token",
+			in:   "\x1b[200~secret\x1b[201~\n",
+			want: "secret",
+		},
+		{
+			name: "pasted token with trailing newline",
+			in:   "\x1b[200~secret\n\x1b[201~",
+			want: "secret",
+		},
+		{
+			name: "pasted ctrl c is data",
+			in:   "\x1b[200~sec\x03ret\n\x1b[201~",
+			want: "sec\x03ret",
+		},
+		{
+			name: "escape sequence is kept when not bracketed paste",
+			in:   "sec\x1b[31mret\n",
+			want: "sec\x1b[31mret",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			data, err := readPasswordBytes(context.Background(), strings.NewReader(test.in))
+			if err != nil {
+				t.Fatalf("readPasswordBytes() error = %v", err)
+			}
+			if got := string(data); got != test.want {
+				t.Fatalf("readPasswordBytes() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestReadPasswordBytes_DoesNotReadPastBracketedPasteEnd(t *testing.T) {
+	t.Parallel()
+
+	reader := strings.NewReader("\x1b[200~secret\n\x1b[201~next\n")
+
+	data, err := readPasswordBytes(context.Background(), reader)
+	if err != nil {
+		t.Fatalf("readPasswordBytes() error = %v", err)
+	}
+	if got, want := string(data), "secret"; got != want {
+		t.Fatalf("readPasswordBytes() = %q, want %q", got, want)
+	}
+
+	remaining, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if got, want := string(remaining), "next\n"; got != want {
+		t.Fatalf("remaining input = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Description

Tested using Terminal.app on macOS while enabling bracketed paste mode (`printf "\e[?2004h"` and verified with `cat -v`).
Also tested Linux and Windows still works

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed password input in the `studioctl auth` command to work correctly on macOS when bracketed paste is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->