### PR TITLE
feat: studioctl - run apps with default `--random-host-port` to true

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -13,6 +13,10 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 - Add `env reset` for localtest to delete persisted localtest and workflow-engine database data, with interactive confirmation.
 - Add `env hosts add`, `env hosts remove`, and `env hosts status` for localtest, including managed hosts-file blocks, backup creation, and `--json` output.
 
+### Changed
+
+- Make `--random-host-port` default to `true` for `run` and `app run`.
+
 ### Fixed
 
 - Reading password input when using `studioctl auth` now works on macOS with bracketed paste enabled.

--- a/src/cli/internal/cmd/run.go
+++ b/src/cli/internal/cmd/run.go
@@ -96,7 +96,7 @@ func (c *RunCommand) UsageFor(commandPath string) string {
 		"  -p, --path PATH       Specify app directory (overrides auto-detect)",
 		"  -m, --mode MODE       Run mode: process or container (default: process)",
 		"  -d, --detach          Run app in background",
-		"  --random-host-port    Use a random host port",
+		"  --random-host-port    Use a random host port (default: true)",
 		"  --image-tag IMAGE     Use a specific app container image tag (container mode)",
 		"  --pull                Pull app container image before start (container mode)",
 		"  --skip-build          Skip building the app container image (container mode)",
@@ -189,7 +189,7 @@ func (c *RunCommand) parseRunFlags(args []string, commandPath string) (runFlags,
 	fs.BoolVar(&flags.detach, "d", false, "Run app in background")
 	fs.BoolVar(&flags.detach, "detach", false, "Run app in background")
 	fs.BoolVar(&flags.pullImage, "pull", false, "Pull app container image before start")
-	fs.BoolVar(&flags.randomHostPort, "random-host-port", false, "Use a random host port")
+	fs.BoolVar(&flags.randomHostPort, "random-host-port", true, "Use a random host port")
 	fs.BoolVar(&flags.skipBuild, "skip-build", false, "Skip building the app container image")
 	fs.BoolVar(&flags.jsonOutput, "json", false, "Output as JSON")
 

--- a/src/cli/internal/cmd/run_internal_test.go
+++ b/src/cli/internal/cmd/run_internal_test.go
@@ -118,6 +118,22 @@ func TestParseRunFlagsUsesProcessMode(t *testing.T) {
 	if flags.mode != runModeProcess {
 		t.Fatalf("mode = %q, want %q", flags.mode, runModeProcess)
 	}
+	if !flags.randomHostPort {
+		t.Fatal("randomHostPort = false, want true")
+	}
+}
+
+func TestParseRunFlagsCanDisableRandomHostPort(t *testing.T) {
+	t.Parallel()
+
+	cmd := &RunCommand{out: ui.NewOutput(io.Discard, io.Discard, false)}
+	flags, _, _, err := cmd.parseRunFlags([]string{"--random-host-port=false"}, "run")
+	if err != nil {
+		t.Fatalf("parseRunFlags() error = %v", err)
+	}
+	if flags.randomHostPort {
+		t.Fatal("randomHostPort = true, want false")
+	}
 }
 
 func TestRunDetachedOutputPrintJSON(t *testing.T) {


### PR DESCRIPTION
## Description

Since reaching the app is always through localtest container proxy, users shouldn't care about which port the app is on, so this PR makes the `--random-host-port` flag default to true. app-manager is responsible for discovery and making sure proxy/tunneling layers know where to route

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The `studioctl run` command's `--random-host-port` flag now defaults to enabled, changing application registration behaviour during startup. Users can disable it by passing `--random-host-port=false` if required.

* **Tests**
  * Enhanced test coverage for the `--random-host-port` flag to ensure correct default and override behaviours.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->