### PR TITLE
fix(workflow-engine): correct ErrorHistory round-trip and expose on StepStatusResponse

### DIFF
--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Data/Context/EngineDbContext.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Data/Context/EngineDbContext.cs
@@ -122,18 +122,17 @@ internal sealed class EngineDbContext : DbContext
         // EF expression trees don't support throw expressions; value is never null (serialized by us)
 #pragma warning disable NX0003
         public static readonly ValueConverter<T?, string> Converter = new(
-            v => JsonSerializer.Serialize(v, JsonSerializerOptions.Default),
-            v => JsonSerializer.Deserialize<T>(v, JsonSerializerOptions.Default)!
+            v => JsonSerializer.Serialize(v, JsonOptions.Default),
+            v => JsonSerializer.Deserialize<T>(v, JsonOptions.Default)!
         );
 #pragma warning restore NX0003
 
         public static readonly ValueComparer<T?> Comparer = new(
             equalsExpression: (a, b) => Serialize(a) == Serialize(b),
             hashCodeExpression: v => Serialize(v).GetHashCode(),
-            snapshotExpression: v =>
-                v == null ? null : JsonSerializer.Deserialize<T>(Serialize(v), JsonSerializerOptions.Default)
+            snapshotExpression: v => v == null ? null : JsonSerializer.Deserialize<T>(Serialize(v), JsonOptions.Default)
         );
 
-        private static string Serialize(T? value) => JsonSerializer.Serialize(value, JsonSerializerOptions.Default);
+        private static string Serialize(T? value) => JsonSerializer.Serialize(value, JsonOptions.Default);
     }
 }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/StepStatusResponse.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/StepStatusResponse.cs
@@ -70,6 +70,13 @@ public sealed record StepStatusResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public RetryStrategy? RetryStrategy { get; init; }
 
+    /// <summary>
+    /// History of errors recorded across this step's execution attempts. Omitted when no errors have occurred.
+    /// </summary>
+    [JsonPropertyName("errorHistory")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<ErrorEntry>? ErrorHistory { get; init; }
+
     internal static StepStatusResponse FromStep(Step step) =>
         new()
         {
@@ -83,6 +90,7 @@ public sealed record StepStatusResponse
             RetryCount = step.RequeueCount,
             StateOut = step.StateOut,
             RetryStrategy = step.RetryStrategy,
+            ErrorHistory = step.ErrorHistory.Count > 0 ? step.ErrorHistory : null,
         };
 
     public sealed record CommandDetails

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Core.Tests/WorkflowHandlerTests.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Core.Tests/WorkflowHandlerTests.cs
@@ -16,28 +16,30 @@ public class WorkflowHandlerTests
 {
     private static readonly TimeProvider FixedTime = TimeProvider.System;
 
+    private static readonly EngineSettings _defaultSettings = new()
+    {
+        DefaultStepCommandTimeout = TimeSpan.FromSeconds(30),
+        DefaultStepRetryStrategy = RetryStrategy.None(),
+        DatabaseCommandTimeout = TimeSpan.FromSeconds(10),
+        DatabaseRetryStrategy = RetryStrategy.None(),
+        MetricsCollectionInterval = TimeSpan.FromSeconds(5),
+        MaxWorkflowsPerRequest = 100,
+        MaxStepsPerWorkflow = 50,
+        MaxLabels = 50,
+        HeartbeatInterval = TimeSpan.FromSeconds(3),
+        StaleWorkflowThreshold = TimeSpan.FromSeconds(15),
+        MaxReclaimCount = 3,
+        Concurrency = new ConcurrencySettings
+        {
+            MaxWorkers = 5,
+            MaxDbOperations = 5,
+            MaxHttpCalls = 5,
+        },
+    };
+
     private static WorkflowHandler CreateHandler(IWorkflowExecutor executor, EngineSettings? settings = null)
     {
-        settings ??= new EngineSettings
-        {
-            DefaultStepCommandTimeout = TimeSpan.FromSeconds(30),
-            DefaultStepRetryStrategy = RetryStrategy.None(),
-            DatabaseCommandTimeout = TimeSpan.FromSeconds(10),
-            DatabaseRetryStrategy = RetryStrategy.None(),
-            MetricsCollectionInterval = TimeSpan.FromSeconds(5),
-            MaxWorkflowsPerRequest = 100,
-            MaxStepsPerWorkflow = 50,
-            MaxLabels = 50,
-            HeartbeatInterval = TimeSpan.FromSeconds(3),
-            StaleWorkflowThreshold = TimeSpan.FromSeconds(15),
-            MaxReclaimCount = 3,
-            Concurrency = new ConcurrencySettings
-            {
-                MaxWorkers = 5,
-                MaxDbOperations = 5,
-                MaxHttpCalls = 5,
-            },
-        };
+        settings ??= _defaultSettings;
 
         var buffer = new Mock<IWorkflowUpdateBuffer>();
         buffer
@@ -123,25 +125,9 @@ public class WorkflowHandlerTests
     public async Task Handle_StepRetryableError_WithRetries_WorkflowRequeued()
     {
         var executor = MockExecutor(ExecutionResult.RetryableError("transient"));
-        var settings = new EngineSettings
+        var settings = _defaultSettings with
         {
-            DefaultStepCommandTimeout = TimeSpan.FromSeconds(30),
             DefaultStepRetryStrategy = RetryStrategy.Constant(TimeSpan.FromMilliseconds(100), maxRetries: 3),
-            DatabaseCommandTimeout = TimeSpan.FromSeconds(10),
-            DatabaseRetryStrategy = RetryStrategy.None(),
-            MetricsCollectionInterval = TimeSpan.FromSeconds(5),
-            MaxWorkflowsPerRequest = 100,
-            MaxStepsPerWorkflow = 50,
-            MaxLabels = 50,
-            HeartbeatInterval = TimeSpan.FromSeconds(3),
-            StaleWorkflowThreshold = TimeSpan.FromSeconds(15),
-            MaxReclaimCount = 3,
-            Concurrency = new ConcurrencySettings
-            {
-                MaxWorkers = 5,
-                MaxDbOperations = 5,
-                MaxHttpCalls = 5,
-            },
         };
         var handler = CreateHandler(executor.Object, settings);
         var workflow = CreateWorkflow(CreateStep());
@@ -477,25 +463,9 @@ public class WorkflowHandlerTests
     public async Task Handle_RetryableError_ErrorHistory_IsPopulated()
     {
         var executor = MockExecutor(ExecutionResult.RetryableError("oops"));
-        var settings = new EngineSettings
+        var settings = _defaultSettings with
         {
-            DefaultStepCommandTimeout = TimeSpan.FromSeconds(30),
             DefaultStepRetryStrategy = RetryStrategy.Constant(TimeSpan.FromMilliseconds(100), maxRetries: 3),
-            DatabaseCommandTimeout = TimeSpan.FromSeconds(10),
-            DatabaseRetryStrategy = RetryStrategy.None(),
-            MetricsCollectionInterval = TimeSpan.FromSeconds(5),
-            MaxWorkflowsPerRequest = 100,
-            MaxStepsPerWorkflow = 50,
-            MaxLabels = 50,
-            HeartbeatInterval = TimeSpan.FromSeconds(3),
-            StaleWorkflowThreshold = TimeSpan.FromSeconds(15),
-            MaxReclaimCount = 3,
-            Concurrency = new ConcurrencySettings
-            {
-                MaxWorkers = 5,
-                MaxDbOperations = 5,
-                MaxHttpCalls = 5,
-            },
         };
         var handler = CreateHandler(executor.Object, settings);
         var workflow = CreateWorkflow(CreateStep());
@@ -535,25 +505,9 @@ public class WorkflowHandlerTests
                 .Select(i => ExecutionResult.RetryableError($"fail-{i}", httpStatusCode: 500))
                 .ToArray()
         );
-        var settings = new EngineSettings
+        var settings = _defaultSettings with
         {
-            DefaultStepCommandTimeout = TimeSpan.FromSeconds(30),
             DefaultStepRetryStrategy = RetryStrategy.Constant(TimeSpan.FromMilliseconds(1), maxRetries: cycles),
-            DatabaseCommandTimeout = TimeSpan.FromSeconds(10),
-            DatabaseRetryStrategy = RetryStrategy.None(),
-            MetricsCollectionInterval = TimeSpan.FromSeconds(5),
-            MaxWorkflowsPerRequest = 100,
-            MaxStepsPerWorkflow = 50,
-            MaxLabels = 50,
-            HeartbeatInterval = TimeSpan.FromSeconds(3),
-            StaleWorkflowThreshold = TimeSpan.FromSeconds(15),
-            MaxReclaimCount = 3,
-            Concurrency = new ConcurrencySettings
-            {
-                MaxWorkers = 5,
-                MaxDbOperations = 5,
-                MaxHttpCalls = 5,
-            },
         };
         var handler = CreateHandler(executor.Object, settings);
         var workflow = CreateWorkflow(CreateStep());

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Core.Tests/WorkflowHandlerTests.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Core.Tests/WorkflowHandlerTests.cs
@@ -520,4 +520,59 @@ public class WorkflowHandlerTests
 
         Assert.Single(workflow.Steps[0].ErrorHistory);
     }
+
+    [Fact]
+    public async Task Handle_MultipleRetryableFailures_ErrorHistory_AccumulatesPopulatedEntries()
+    {
+        // Each Handle invocation represents one pickup by the processor. Simulate N retry cycles
+        // against the same in-memory workflow and verify every appended entry carries real data —
+        // this is the in-memory guard complementing the integration-level DB round-trip test.
+        const int cycles = 5;
+
+        var executor = MockExecutor(
+            Enumerable
+                .Range(0, cycles)
+                .Select(i => ExecutionResult.RetryableError($"fail-{i}", httpStatusCode: 500))
+                .ToArray()
+        );
+        var settings = new EngineSettings
+        {
+            DefaultStepCommandTimeout = TimeSpan.FromSeconds(30),
+            DefaultStepRetryStrategy = RetryStrategy.Constant(TimeSpan.FromMilliseconds(1), maxRetries: cycles),
+            DatabaseCommandTimeout = TimeSpan.FromSeconds(10),
+            DatabaseRetryStrategy = RetryStrategy.None(),
+            MetricsCollectionInterval = TimeSpan.FromSeconds(5),
+            MaxWorkflowsPerRequest = 100,
+            MaxStepsPerWorkflow = 50,
+            MaxLabels = 50,
+            HeartbeatInterval = TimeSpan.FromSeconds(3),
+            StaleWorkflowThreshold = TimeSpan.FromSeconds(15),
+            MaxReclaimCount = 3,
+            Concurrency = new ConcurrencySettings
+            {
+                MaxWorkers = 5,
+                MaxDbOperations = 5,
+                MaxHttpCalls = 5,
+            },
+        };
+        var handler = CreateHandler(executor.Object, settings);
+        var workflow = CreateWorkflow(CreateStep());
+
+        for (int i = 0; i < cycles; i++)
+        {
+            workflow.Status = PersistentItemStatus.Processing;
+            workflow.Steps[0].Status = PersistentItemStatus.Enqueued;
+            await handler.Handle(workflow, CancellationToken.None);
+        }
+
+        var entries = workflow.Steps[0].ErrorHistory;
+        Assert.Equal(cycles, entries.Count);
+        for (int i = 0; i < entries.Count; i++)
+        {
+            Assert.Equal($"fail-{i}", entries[i].Message);
+            Assert.Equal(500, entries[i].HttpStatusCode);
+            Assert.True(entries[i].WasRetryable);
+            Assert.True(entries[i].Timestamp > DateTimeOffset.MinValue);
+        }
+    }
 }

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Integration.Tests/.snapshots/EngineTests.ErrorHistory_SurvivesMultiRetryDbRoundTrip_WithPopulatedFields.verified.txt
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Integration.Tests/.snapshots/EngineTests.ErrorHistory_SurvivesMultiRetryDbRoundTrip_WithPopulatedFields.verified.txt
@@ -1,0 +1,55 @@
+﻿{
+  databaseId: {Scrubbed},
+  operationId: op-wf,
+  idempotencyKey: idem-Guid_1,
+  namespace: ttd:e2e-tests,
+  createdAt: {Scrubbed},
+  updatedAt: {Scrubbed},
+  backoffUntil: {Scrubbed},
+  labels: {
+    app: e2e-tests,
+    org: ttd
+  },
+  overallStatus: Completed,
+  steps: [
+    {
+      databaseId: {Scrubbed},
+      operationId: /error-history-target,
+      processingOrder: 0,
+      updatedAt: {Scrubbed},
+      command: {
+        type: webhook
+      },
+      status: Completed,
+      retryCount: 3,
+      retryStrategy: {
+        backoffType: Constant,
+        baseInterval: 00:00:00.1000000,
+        maxRetries: 5,
+        maxDelay: 00:00:00.1000000,
+        maxDuration: null,
+        nonRetryableHttpStatusCodes: null
+      },
+      errorHistory: [
+        {
+          timestamp: DateTimeOffset_1,
+          message: Webhook execution failed with status 500: boom-1,
+          httpStatusCode: 500,
+          wasRetryable: true
+        },
+        {
+          timestamp: DateTimeOffset_2,
+          message: Webhook execution failed with status 500: boom-2,
+          httpStatusCode: 500,
+          wasRetryable: true
+        },
+        {
+          timestamp: DateTimeOffset_3,
+          message: Webhook execution failed with status 500: boom-3,
+          httpStatusCode: 500,
+          wasRetryable: true
+        }
+      ]
+    }
+  ]
+}

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Integration.Tests/.snapshots/EngineTests.Response_GetWorkflow_AfterRetries_ShowsRetryState.verified.txt
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Integration.Tests/.snapshots/EngineTests.Response_GetWorkflow_AfterRetries_ShowsRetryState.verified.txt
@@ -21,7 +21,21 @@
         type: webhook
       },
       status: Completed,
-      retryCount: 2
+      retryCount: 2,
+      errorHistory: [
+        {
+          timestamp: DateTimeOffset_1,
+          message: Webhook execution failed with status 500: <no body content>,
+          httpStatusCode: 500,
+          wasRetryable: true
+        },
+        {
+          timestamp: DateTimeOffset_2,
+          message: Webhook execution failed with status 500: <no body content>,
+          httpStatusCode: 500,
+          wasRetryable: true
+        }
+      ]
     }
   ]
 }

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Integration.Tests/EngineTests.ErrorHistory.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Integration.Tests/EngineTests.ErrorHistory.cs
@@ -1,0 +1,76 @@
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WorkflowEngine.Models;
+using WorkflowEngine.Resilience.Models;
+
+namespace WorkflowEngine.Integration.Tests;
+
+public partial class EngineTests
+{
+    /// <summary>
+    /// Regression test for <see href="https://github.com/Altinn/altinn-studio/issues/18556">#18556</see>.
+    /// Drives a step through multiple retryable failures so the workflow round-trips through the DB
+    /// each retry cycle, then asserts the <c>ErrorHistory</c> entries exposed via the status API
+    /// still carry populated fields. The prior bug silently wrote every entry as defaults on re-read
+    /// due to a PascalCase/camelCase mismatch between the EF jsonb converter and the direct-SQL
+    /// UPDATE path.
+    /// </summary>
+    [Fact]
+    public async Task ErrorHistory_SurvivesMultiRetryDbRoundTrip_WithPopulatedFields()
+    {
+        // Arrange — WireMock returns 500 three times, then 200
+        fixture
+            .WireMock.Given(Request.Create().UsingAnyMethod())
+            .InScenario("error-history-roundtrip")
+            .WillSetStateTo("failed-1")
+            .RespondWith(Response.Create().WithStatusCode(500).WithBody("boom-1"));
+        fixture
+            .WireMock.Given(Request.Create().UsingAnyMethod())
+            .InScenario("error-history-roundtrip")
+            .WhenStateIs("failed-1")
+            .WillSetStateTo("failed-2")
+            .RespondWith(Response.Create().WithStatusCode(500).WithBody("boom-2"));
+        fixture
+            .WireMock.Given(Request.Create().UsingAnyMethod())
+            .InScenario("error-history-roundtrip")
+            .WhenStateIs("failed-2")
+            .WillSetStateTo("succeeded")
+            .RespondWith(Response.Create().WithStatusCode(500).WithBody("boom-3"));
+        fixture
+            .WireMock.Given(Request.Create().UsingAnyMethod())
+            .InScenario("error-history-roundtrip")
+            .WhenStateIs("succeeded")
+            .RespondWith(Response.Create().WithStatusCode(200));
+
+        var step = _testHelpers.CreateWebhookStep(
+            "/error-history-target",
+            retryStrategy: RetryStrategy.Constant(TimeSpan.FromMilliseconds(100), maxRetries: 5)
+        );
+        var request = _testHelpers.CreateEnqueueRequest(_testHelpers.CreateWorkflow("wf", [step]));
+        var accepted = await _client.Enqueue(request);
+        var workflowId = accepted.Workflows.Single().DatabaseId;
+
+        // Act — wait for completion (3 failed attempts, then success) and inspect the status payload
+        var completed = await _client.WaitForWorkflowStatus(
+            workflowId,
+            PersistentItemStatus.Completed,
+            timeout: TimeSpan.FromSeconds(30)
+        );
+
+        // Assert — 3 entries, each with real data; none defaulted
+        var entries = completed.Steps.Single().ErrorHistory;
+        Assert.NotNull(entries);
+        Assert.Equal(3, entries.Count);
+
+        Assert.All(
+            entries,
+            entry =>
+            {
+                Assert.False(string.IsNullOrWhiteSpace(entry.Message), "Message must not be null or whitespace");
+                Assert.True(entry.Timestamp > DateTimeOffset.MinValue, "Timestamp must not be the default value");
+                Assert.Equal(500, entry.HttpStatusCode);
+                Assert.True(entry.WasRetryable);
+            }
+        );
+    }
+}

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Integration.Tests/EngineTests.ErrorHistory.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Integration.Tests/EngineTests.ErrorHistory.cs
@@ -57,7 +57,8 @@ public partial class EngineTests
             timeout: TimeSpan.FromSeconds(30)
         );
 
-        // Assert — 3 entries, each with real data; none defaulted
+        // Assert — 3 entries, each with real data; none defaulted. Explicit assertions defend against
+        // the regression pattern (defaulted fields) independently of any future snapshot edits.
         var entries = completed.Steps.Single().ErrorHistory;
         Assert.NotNull(entries);
         Assert.Equal(3, entries.Count);
@@ -72,5 +73,11 @@ public partial class EngineTests
                 Assert.True(entry.WasRetryable);
             }
         );
+
+        // Snapshot — documents the exact response shape, including how the WireMock body ("boom-N") gets
+        // embedded into the ErrorEntry message. No sibling test exercises a non-empty upstream body.
+        using var response = await _client.GetWorkflowRaw(workflowId);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        await VerifyJson(body);
     }
 }


### PR DESCRIPTION
## Summary

- Fix `ErrorHistory` jsonb serializer mismatch: EF `JsonbConverter` (read path) used framework `JsonSerializerOptions.Default` (PascalCase, case-sensitive) while the direct-SQL UPDATE path (write path) used local `JsonOptions.Default` (camelCase). Because `ErrorEntry` is a positional record, every re-read defaulted all parameters — producing entries with null message, `0001-01-01` timestamp, null httpStatusCode, false wasRetryable (pattern observed in TT02). Unified to `JsonOptions.Default`.
- Expose `ErrorHistory` on `StepStatusResponse` as `IReadOnlyList<ErrorEntry>?`, omitted from JSON when empty.
- Add unit test for multi-retry accumulation of populated `ErrorHistory` entries.
- Add integration regression test that forces 3 retryable 500s → success and asserts the resulting `ErrorHistory` entries have populated `message`, `timestamp > MinValue`, `httpStatusCode == 500`, `wasRetryable == true` — the guard that would have caught this.
- Regenerate `Response_GetWorkflow_AfterRetries_ShowsRetryState.verified.txt` to include the new `errorHistory` field with real values.


### Blast radius of the serializer unification

Only `Labels` and `ErrorHistory` use `JsonbConverter`. `Labels` is `Dictionary<string,string>` — property-naming policy doesn't touch user-supplied dictionary keys, so existing rows remain readable and writes produce the same shape. `ErrorHistory` rows are already camelCase (only written via the direct-SQL path), and `PropertyNameCaseInsensitive = true` keeps any hypothetical legacy shape readable. **No data migration needed.**

## Related issues
- Closes #18556

## Test plan

- [x] `dotnet build` — clean
- [x] `dotnet test` — 444 / 444 pass, incl. the new `ErrorHistory_SurvivesMultiRetryDbRoundTrip_WithPopulatedFields`
- [x] Updated Verify snapshot reviewed (populated fields replacing the previously-absent `errorHistory` section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
  * Step status responses now include comprehensive error history tracking, capturing all accumulated execution errors across retry attempts. Each recorded error entry contains the failure message, HTTP status code, retryability flag, and timestamp. This provides detailed visibility into step failure patterns and helps understand execution recovery progression throughout workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->