### PR TITLE
fix: studioctl - handle app-manager zombie shutdown

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -19,6 +19,7 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ### Fixed
 
+- Fix app-manager shutdown waits incorrectly reporting that an exited process is still running on Linux systems.
 - Reading password input when using `studioctl auth` now works on macOS with bracketed paste enabled.
 
 ### Removed

--- a/src/cli/app-manager/Studioctl/Endpoints.cs
+++ b/src/cli/app-manager/Studioctl/Endpoints.cs
@@ -89,17 +89,9 @@ internal static class Endpoints
         };
     }
 
-    private static async Task<IResult> Shutdown(IHostApplicationLifetime lifetime, CancellationToken cancellationToken)
+    private static IResult Shutdown(IHostApplicationLifetime lifetime)
     {
-        _ = Task.Run(
-            async () =>
-            {
-                await Task.Delay(TimeSpan.FromMilliseconds(50), cancellationToken);
-                lifetime.StopApplication();
-            },
-            cancellationToken
-        );
-
+        lifetime.StopApplication();
         return Results.Accepted(value: new CommandResponse("shutdown requested"));
     }
 

--- a/src/cli/internal/osutil/process_linux.go
+++ b/src/cli/internal/osutil/process_linux.go
@@ -1,11 +1,13 @@
-//go:build !windows && !linux
+//go:build linux
 
 package osutil
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"syscall"
 )
 
@@ -30,6 +32,9 @@ func ProcessRunning(pid int) (bool, error) {
 	err = process.Signal(syscall.Signal(0))
 	switch {
 	case err == nil:
+		if zombie, zombieErr := processZombie(pid); zombie || zombieErr != nil {
+			return false, zombieErr
+		}
 		return true, nil
 	case errors.Is(err, syscall.ESRCH), errors.Is(err, os.ErrProcessDone):
 		return false, nil
@@ -38,4 +43,24 @@ func ProcessRunning(pid int) (bool, error) {
 	default:
 		return false, fmt.Errorf("signal process: %w", err)
 	}
+}
+
+func processZombie(pid int) (bool, error) {
+	status, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/status")
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read process status: %w", err)
+	}
+
+	for line := range bytes.SplitSeq(status, []byte{'\n'}) {
+		if !bytes.HasPrefix(line, []byte("State:")) {
+			continue
+		}
+
+		return bytes.Contains(line, []byte("(zombie)")) || bytes.Contains(line, []byte("\tZ")), nil
+	}
+
+	return false, nil
 }

--- a/src/cli/internal/osutil/process_linux_test.go
+++ b/src/cli/internal/osutil/process_linux_test.go
@@ -1,0 +1,20 @@
+//go:build linux
+
+package osutil_test
+
+import (
+	"os"
+	"testing"
+
+	"altinn.studio/studioctl/internal/osutil"
+)
+
+func TestProcessRunning_CurrentProcessIsRunning(t *testing.T) {
+	running, err := osutil.ProcessRunning(os.Getpid())
+	if err != nil {
+		t.Fatalf("ProcessRunning() error = %v", err)
+	}
+	if !running {
+		t.Fatal("ProcessRunning() = false, want true")
+	}
+}


### PR DESCRIPTION
## Description

a process can be a zombie on linux systems between shutdown and parent has checked exit code, this PR handles that and also simplifies shutdown endpoint in app-manager

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
