### PR TITLE
fix: broken build app backend through test/apps/

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 ###############################################################################
 * text=auto
 /src/App/backend/**/*.cs text eol=crlf
+/src/App/fileanalyzers/**/*.cs text eol=crlf
 
 # Go source files must use LF (required by gofmt and golangci-lint)
 *.go text eol=lf

--- a/src/test/apps/global.json
+++ b/src/test/apps/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "8.0.417",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
## Description

App backend has global.json pointing to .NET 8 SDK and treatwarningsaserrors, src/test/apps dont have global.json and so defaulted to .NET 10 SDK on my machine which had additional diagnostics that now turned to errors. This pins apps .NET SDK to same version as app backend as we use local references here.

I also got lineending diffs on some fileanalyzers files, ended up chaning gitattributes to match app backend. .editorconfig also says crlf...

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured line-ending normalisation for source files to ensure consistent formatting across the codebase.
  * Pinned .NET SDK version to a specific release to maintain consistent build environments and prevent unexpected SDK updates during development and testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->