### PR TITLE
fix: Frontend defaults to port 8080, not 8000

### DIFF
--- a/src/App/frontend/package.json
+++ b/src/App/frontend/package.json
@@ -193,7 +193,7 @@
         "localhost",
         "localhost:8080",
         "app-frontend.local.altinn.cloud",
-        "app-frontend.local.altinn.cloud:8000",
+        "app-frontend.local.altinn.cloud:8080",
         "altinncdn.no"
       ],
       "launch-options": {

--- a/src/App/frontend/test/e2e/config/localtest.json
+++ b/src/App/frontend/test/e2e/config/localtest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://on.cypress.io/cypress.schema.json",
   "baseUrl": "http://local.altinn.cloud:8000",
-  "frontendUrl": "http://app-frontend.local.altinn.cloud:8000",
+  "frontendUrl": "http://app-frontend.local.altinn.cloud:8080",
   "env": {
     "type": "localtest",
 


### PR DESCRIPTION
## Description

This broke cypress test-running, at least locally

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated local testing environment configuration to use port 8080 instead of port 8000 for the frontend application service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->