### PR TITLE
fix: studioctl - named volume for workflow-engine db

### DIFF
--- a/src/Runtime/devenv/pkg/container/container.go
+++ b/src/Runtime/devenv/pkg/container/container.go
@@ -38,6 +38,9 @@ var ErrNetworkInUse = types.ErrNetworkInUse
 // ErrImageNotFound is returned when an image does not exist.
 var ErrImageNotFound = types.ErrImageNotFound
 
+// ErrVolumeNotFound is returned when a volume does not exist.
+var ErrVolumeNotFound = types.ErrVolumeNotFound
+
 // Re-exported platform, access mode, and detection source constants.
 const (
 	PlatformUnknown       = types.PlatformUnknown
@@ -130,6 +133,10 @@ type ContainerClient interface {
 
 	// NetworkRemove removes a network.
 	NetworkRemove(ctx context.Context, nameOrID string) error
+
+	// VolumeRemove removes a named volume.
+	// If force is true, the volume is removed even if the runtime supports forced removal.
+	VolumeRemove(ctx context.Context, name string, force bool) error
 
 	// ContainerLogs returns a stream of container logs.
 	// If follow is true, the stream will continue until the context is cancelled.

--- a/src/Runtime/devenv/pkg/container/dockerapi/docker_engine_api.go
+++ b/src/Runtime/devenv/pkg/container/dockerapi/docker_engine_api.go
@@ -362,13 +362,20 @@ func buildBindMounts(volumes []types.VolumeMount) []dockermount.Mount {
 	mounts := make([]dockermount.Mount, 0, len(volumes))
 	for _, v := range volumes {
 		mounts = append(mounts, dockermount.Mount{
-			Type:     dockermount.TypeBind,
+			Type:     dockerMountType(v.Type),
 			Source:   v.HostPath,
 			Target:   v.ContainerPath,
 			ReadOnly: v.ReadOnly,
 		})
 	}
 	return mounts
+}
+
+func dockerMountType(mountType types.VolumeMountType) dockermount.Type {
+	if mountType == types.VolumeMountTypeVolume {
+		return dockermount.TypeVolume
+	}
+	return dockermount.TypeBind
 }
 
 func detectPlatform(ctx context.Context, hostHint string, opts ...client.Opt) (types.ContainerPlatform, error) {
@@ -831,6 +838,17 @@ func (c *Client) NetworkRemove(ctx context.Context, nameOrID string) error {
 			return types.ErrNetworkInUse
 		}
 		return fmt.Errorf("failed to remove network: %w", err)
+	}
+	return nil
+}
+
+// VolumeRemove removes a named volume.
+func (c *Client) VolumeRemove(ctx context.Context, name string, force bool) error {
+	if err := c.cli.VolumeRemove(ctx, name, force); err != nil {
+		if cerrdefs.IsNotFound(err) {
+			return types.ErrVolumeNotFound
+		}
+		return fmt.Errorf("remove volume %s: %w", name, err)
 	}
 	return nil
 }

--- a/src/Runtime/devenv/pkg/container/dockerapi/docker_engine_api_test.go
+++ b/src/Runtime/devenv/pkg/container/dockerapi/docker_engine_api_test.go
@@ -34,6 +34,11 @@ func TestBuildBindMounts(t *testing.T) {
 			ContainerPath: "/etc/config.yaml",
 			ReadOnly:      true,
 		},
+		{
+			HostPath:      "localtest-workflow-engine-db-data",
+			ContainerPath: "/var/lib/postgresql",
+			Type:          types.VolumeMountTypeVolume,
+		},
 	})
 
 	want := []dockermount.Mount{
@@ -48,6 +53,12 @@ func TestBuildBindMounts(t *testing.T) {
 			Source:   "/tmp/config.yaml",
 			Target:   "/etc/config.yaml",
 			ReadOnly: true,
+		},
+		{
+			Type:     dockermount.TypeVolume,
+			Source:   "localtest-workflow-engine-db-data",
+			Target:   "/var/lib/postgresql",
+			ReadOnly: false,
 		},
 	}
 

--- a/src/Runtime/devenv/pkg/container/mock/mock.go
+++ b/src/Runtime/devenv/pkg/container/mock/mock.go
@@ -43,6 +43,7 @@ type Client struct {
 	NetworkCreateFunc    func(ctx context.Context, cfg types.NetworkConfig) (string, error)
 	NetworkInspectFunc   func(ctx context.Context, nameOrID string) (types.NetworkInfo, error)
 	NetworkRemoveFunc    func(ctx context.Context, nameOrID string) error
+	VolumeRemoveFunc     func(ctx context.Context, name string, force bool) error
 	ContainerLogsFunc    func(ctx context.Context, nameOrID string, follow bool, tail string) (io.ReadCloser, error)
 	ContainerWaitFunc    func(ctx context.Context, nameOrID string) (int, error)
 
@@ -272,6 +273,15 @@ func (c *Client) NetworkRemove(ctx context.Context, nameOrID string) error {
 	c.recordCall("NetworkRemove", nameOrID)
 	if c.NetworkRemoveFunc != nil {
 		return c.NetworkRemoveFunc(ctx, nameOrID)
+	}
+	return nil
+}
+
+// VolumeRemove implements ContainerClient.
+func (c *Client) VolumeRemove(ctx context.Context, name string, force bool) error {
+	c.recordCall("VolumeRemove", name, force)
+	if c.VolumeRemoveFunc != nil {
+		return c.VolumeRemoveFunc(ctx, name, force)
 	}
 	return nil
 }

--- a/src/Runtime/devenv/pkg/container/podman/podman.go
+++ b/src/Runtime/devenv/pkg/container/podman/podman.go
@@ -756,6 +756,32 @@ func (c *Client) NetworkRemove(ctx context.Context, nameOrID string) error {
 	return nil
 }
 
+// VolumeRemove removes a named volume.
+func (c *Client) VolumeRemove(ctx context.Context, name string, force bool) error {
+	args := []string{"volume", "rm"}
+	if force {
+		args = append(args, "-f")
+	}
+	args = append(args, name)
+
+	cmd := processutil.CommandContext(ctx, "podman", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if isVolumeNotFoundOutput(output) {
+			return types.ErrVolumeNotFound
+		}
+		return fmt.Errorf("podman volume rm failed: %w\nOutput: %s", err, string(output))
+	}
+	return nil
+}
+
+func isVolumeNotFoundOutput(output []byte) bool {
+	lower := strings.ToLower(string(output))
+	return strings.Contains(lower, "no such volume") ||
+		strings.Contains(lower, "no such object") ||
+		strings.Contains(lower, "volume does not exist")
+}
+
 // ContainerLogs returns a stream of container logs.
 func (c *Client) ContainerLogs(
 	ctx context.Context,

--- a/src/Runtime/devenv/pkg/container/podman/podman_test.go
+++ b/src/Runtime/devenv/pkg/container/podman/podman_test.go
@@ -102,3 +102,39 @@ func TestIsContainerNotFoundOutput(t *testing.T) {
 		})
 	}
 }
+
+func TestIsVolumeNotFoundOutput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		output []byte
+		want   bool
+	}{
+		{
+			name:   "no such volume",
+			output: []byte("Error: no such volume localtest-workflow-engine-db-data"),
+			want:   true,
+		},
+		{
+			name:   "volume does not exist",
+			output: []byte("Error: volume does not exist"),
+			want:   true,
+		},
+		{
+			name:   "non-not-found error",
+			output: []byte("Error: volume is being used by container"),
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := isVolumeNotFoundOutput(tt.output)
+			if got != tt.want {
+				t.Fatalf("isVolumeNotFoundOutput() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/src/Runtime/devenv/pkg/container/types/types.go
+++ b/src/Runtime/devenv/pkg/container/types/types.go
@@ -19,6 +19,9 @@ var ErrNetworkInUse = errors.New("network in use")
 // ErrImageNotFound is returned when an image does not exist.
 var ErrImageNotFound = errors.New("image not found")
 
+// ErrVolumeNotFound is returned when a volume does not exist.
+var ErrVolumeNotFound = errors.New("volume not found")
+
 // defaultPodmanCapabilities are capabilities that Docker includes by default but Podman doesn't.
 // Adding these ensures consistent behavior across runtimes.
 // See: https://github.com/containers/common/pull/1240
@@ -207,10 +210,20 @@ type ContainerListFilter struct {
 	All    bool
 }
 
-// VolumeMount defines a bind mount.
+// VolumeMountType defines the source type for a container volume mount.
+type VolumeMountType string
+
+// Supported volume mount types.
+const (
+	VolumeMountTypeBind   VolumeMountType = "bind"
+	VolumeMountTypeVolume VolumeMountType = "volume"
+)
+
+// VolumeMount defines a bind mount or named volume mount.
 type VolumeMount struct {
 	HostPath      string
 	ContainerPath string
+	Type          VolumeMountType
 	ReadOnly      bool
 }
 

--- a/src/Runtime/devenv/pkg/resource/executor.go
+++ b/src/Runtime/devenv/pkg/resource/executor.go
@@ -669,7 +669,7 @@ func containerSpecHash(c *Container, imageID string, networks []string) string {
 	for _, v := range c.Volumes {
 		volumeEntries = append(
 			volumeEntries,
-			fmt.Sprintf("%s|%s|%t", v.HostPath, v.ContainerPath, v.ReadOnly),
+			fmt.Sprintf("%s|%s|%t|%s", v.HostPath, v.ContainerPath, v.ReadOnly, normalizedVolumeMountType(v.Type)),
 		)
 	}
 	writeSortedList(&b, "volumes", volumeEntries)
@@ -685,6 +685,13 @@ func containerSpecHash(c *Container, imageID string, networks []string) string {
 
 	sum := sha256.Sum256([]byte(b.String()))
 	return hex.EncodeToString(sum[:])
+}
+
+func normalizedVolumeMountType(mountType types.VolumeMountType) types.VolumeMountType {
+	if mountType == "" {
+		return types.VolumeMountTypeBind
+	}
+	return mountType
 }
 
 func writeSortedList(b *strings.Builder, key string, values []string) {

--- a/src/Runtime/devenv/pkg/resource/executor_test.go
+++ b/src/Runtime/devenv/pkg/resource/executor_test.go
@@ -109,6 +109,30 @@ func TestContainerSpecHash_ChangesOnNetworkAliasChange(t *testing.T) {
 	}
 }
 
+func TestContainerSpecHash_ChangesOnVolumeMountTypeChange(t *testing.T) {
+	t.Parallel()
+
+	base := &Container{
+		Name:    "postgres",
+		Image:   RefID("image:postgres"),
+		Volumes: []types.VolumeMount{{HostPath: "data", ContainerPath: "/var/lib/postgresql"}},
+	}
+
+	baseHash := containerSpecHash(base, "sha256:image-v1", []string{"bridge"})
+
+	modified := *base
+	modified.Volumes = []types.VolumeMount{{
+		HostPath:      "data",
+		ContainerPath: "/var/lib/postgresql",
+		Type:          types.VolumeMountTypeVolume,
+	}}
+	modifiedHash := containerSpecHash(&modified, "sha256:image-v1", []string{"bridge"})
+
+	if baseHash == modifiedHash {
+		t.Fatalf("container spec hash did not change when volume mount type changed")
+	}
+}
+
 func TestExecutor_StopAndRemoveContainer_PropagatesStopError(t *testing.T) {
 	t.Parallel()
 

--- a/src/cli/internal/cmd/env/localtest/env.go
+++ b/src/cli/internal/cmd/env/localtest/env.go
@@ -492,6 +492,7 @@ func (e *Env) cleanupWorkflowEngineDbData(ctx context.Context, targetAbs string)
 		Volumes: []containertypes.VolumeMount{{
 			HostPath:      targetAbs,
 			ContainerPath: "/cleanup",
+			Type:          containertypes.VolumeMountTypeBind,
 			ReadOnly:      false,
 		}},
 		Networks: nil,

--- a/src/cli/internal/cmd/env/localtest/env.go
+++ b/src/cli/internal/cmd/env/localtest/env.go
@@ -406,9 +406,6 @@ func (e *Env) ensureResources(ctx context.Context, buildOpts ResourceBuildOption
 	if err := ensureLocaltestStorageDir(e.cfg.DataDir); err != nil {
 		return err
 	}
-	if err := ensureWorkflowEngineDbDataDir(e.cfg.DataDir); err != nil {
-		return err
-	}
 
 	if err := ValidateResourceHostPaths(buildOpts); err != nil {
 		return e.reinstallResourcesAfterValidationFailure(ctx, buildOpts, err)
@@ -432,18 +429,8 @@ func (e *Env) reinstallResourcesAfterValidationFailure(
 	if err := ensureLocaltestStorageDir(e.cfg.DataDir); err != nil {
 		return err
 	}
-	if err := ensureWorkflowEngineDbDataDir(e.cfg.DataDir); err != nil {
-		return err
-	}
 	if err := ValidateResourceHostPaths(buildOpts); err != nil {
 		return fmt.Errorf("validate resources after reinstall: %w", err)
-	}
-	return nil
-}
-
-func ensureWorkflowEngineDbDataDir(dataDir string) error {
-	if err := os.MkdirAll(workflowEngineDbDataPath(dataDir), osutil.DirPermDefault); err != nil {
-		return fmt.Errorf("create workflow-engine database data directory: %w", err)
 	}
 	return nil
 }
@@ -459,10 +446,13 @@ func (e *Env) deletePersistedData(ctx context.Context) error {
 	if err := removeResetDataPath(e.cfg.DataDir, filepath.Join(e.cfg.DataDir, "AltinnPlatformLocal")); err != nil {
 		return err
 	}
-	return e.removeWorkflowEngineDbData(ctx, workflowEngineDbDataPath(e.cfg.DataDir))
+	if err := e.removeLegacyWorkflowEngineDbData(ctx, workflowEngineDbDataPath(e.cfg.DataDir)); err != nil {
+		e.out.Verbosef("Failed to remove legacy workflow-engine database data: %v", err)
+	}
+	return e.removeWorkflowEngineDbVolume(ctx)
 }
 
-func (e *Env) removeWorkflowEngineDbData(ctx context.Context, target string) error {
+func (e *Env) removeLegacyWorkflowEngineDbData(ctx context.Context, target string) error {
 	targetAbs, exists, err := resetTargetPath(e.cfg.DataDir, target)
 	if err != nil {
 		return err
@@ -476,6 +466,16 @@ func (e *Env) removeWorkflowEngineDbData(ctx context.Context, target string) err
 	}
 
 	return removeResetDataPath(e.cfg.DataDir, target)
+}
+
+func (e *Env) removeWorkflowEngineDbVolume(ctx context.Context) error {
+	if err := e.client.VolumeRemove(ctx, workflowEngineDbVolume, true); err != nil {
+		if errors.Is(err, containertypes.ErrVolumeNotFound) {
+			return nil
+		}
+		return fmt.Errorf("remove workflow-engine database volume %q: %w", workflowEngineDbVolume, err)
+	}
+	return nil
 }
 
 func (e *Env) cleanupWorkflowEngineDbData(ctx context.Context, targetAbs string) error {

--- a/src/cli/internal/cmd/env/localtest/env_reset_test.go
+++ b/src/cli/internal/cmd/env/localtest/env_reset_test.go
@@ -2,6 +2,7 @@
 package localtest
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -38,6 +39,7 @@ func TestReset_RemovesPersistedDataWhenAlreadyStopped(t *testing.T) {
 
 	assertCallRecorded(t, clientCalls(env), "CreateContainer")
 	assertCallRecorded(t, clientCalls(env), "ContainerWait")
+	assertCallRecorded(t, clientCalls(env), "VolumeRemove")
 	assertNotExists(t, localtestDataDir)
 	assertNotExists(t, workflowEngineDataDir)
 }
@@ -73,8 +75,64 @@ func TestReset_StopsManagedResourcesBeforeRemovingPersistedData(t *testing.T) {
 	assertCallRecorded(t, client.Calls, "ContainerWait")
 	assertCallRecorded(t, client.Calls, "ContainerRemove")
 	assertCallRecorded(t, client.Calls, "NetworkRemove")
+	assertCallRecorded(t, client.Calls, "VolumeRemove")
 	assertNotExists(t, localtestDataDir)
 	assertNotExists(t, workflowEngineDataDir)
+}
+
+func TestReset_RemovesWorkflowEngineDbVolumeWithoutLegacyDataDir(t *testing.T) {
+	dataDir := t.TempDir()
+	localtestDataDir := filepath.Join(dataDir, "AltinnPlatformLocal")
+	createDir(t, localtestDataDir)
+
+	client := containermock.New()
+	client.VolumeRemoveFunc = func(_ context.Context, name string, force bool) error {
+		if name != workflowEngineDbVolume {
+			t.Fatalf("VolumeRemove() name = %q, want %q", name, workflowEngineDbVolume)
+		}
+		if !force {
+			t.Fatal("VolumeRemove() force = false, want true")
+		}
+		return nil
+	}
+
+	env := NewEnv(
+		&config.Config{
+			DataDir: dataDir,
+			Images:  testResetImages(),
+		},
+		ui.NewOutput(io.Discard, io.Discard, false),
+		client,
+	)
+	if err := env.Reset(context.Background()); err != nil {
+		t.Fatalf("Reset() error = %v", err)
+	}
+
+	assertCallNotRecorded(t, client.Calls, "CreateContainer")
+	assertCallRecorded(t, client.Calls, "VolumeRemove")
+	assertNotExists(t, localtestDataDir)
+}
+
+func TestReset_IgnoresMissingWorkflowEngineDbVolume(t *testing.T) {
+	dataDir := t.TempDir()
+	createDir(t, filepath.Join(dataDir, "AltinnPlatformLocal"))
+
+	client := containermock.New()
+	client.VolumeRemoveFunc = func(context.Context, string, bool) error {
+		return containertypes.ErrVolumeNotFound
+	}
+
+	env := NewEnv(
+		&config.Config{
+			DataDir: dataDir,
+			Images:  testResetImages(),
+		},
+		ui.NewOutput(io.Discard, io.Discard, false),
+		client,
+	)
+	if err := env.Reset(context.Background()); err != nil {
+		t.Fatalf("Reset() error = %v, want nil", err)
+	}
 }
 
 func TestReset_RefusesLegacyLocaltest(t *testing.T) {
@@ -108,10 +166,11 @@ func TestReset_RefusesLegacyLocaltest(t *testing.T) {
 	}
 }
 
-func TestReset_IncludesCleanupHelperLogsOnFailure(t *testing.T) {
+func TestReset_IgnoresLegacyWorkflowEngineDbDataCleanupFailure(t *testing.T) {
 	dataDir := t.TempDir()
 	createDir(t, filepath.Join(dataDir, "AltinnPlatformLocal"))
 	createDir(t, workflowEngineDbDataPath(dataDir))
+	var stderr bytes.Buffer
 
 	client := containermock.New()
 	client.ContainerWaitFunc = func(context.Context, string) (int, error) {
@@ -132,18 +191,20 @@ func TestReset_IncludesCleanupHelperLogsOnFailure(t *testing.T) {
 			DataDir: dataDir,
 			Images:  testResetImages(),
 		},
-		ui.NewOutput(io.Discard, io.Discard, false),
+		ui.NewOutput(io.Discard, &stderr, true),
 		client,
 	)
 	err := env.Reset(context.Background())
-	if err == nil {
-		t.Fatal("Reset() error = nil, want non-nil")
+	if err != nil {
+		t.Fatalf("Reset() error = %v, want nil", err)
 	}
-	if !errors.Is(err, errResetCleanupFailed) {
-		t.Fatalf("Reset() error = %v, want errResetCleanupFailed", err)
+	assertCallRecorded(t, client.Calls, "VolumeRemove")
+	gotStderr := stderr.String()
+	if !strings.Contains(gotStderr, "Failed to remove legacy workflow-engine database data") {
+		t.Fatalf("stderr = %q, want legacy cleanup verbose message", gotStderr)
 	}
-	if !strings.Contains(err.Error(), "permission denied") {
-		t.Fatalf("Reset() error = %q, want helper log output", err)
+	if !strings.Contains(gotStderr, "permission denied") {
+		t.Fatalf("stderr = %q, want helper log output", gotStderr)
 	}
 }
 
@@ -214,4 +275,13 @@ func assertCallRecorded(t *testing.T, calls []containermock.Call, method string)
 		}
 	}
 	t.Fatalf("calls = %v, want method %q", calls, method)
+}
+
+func assertCallNotRecorded(t *testing.T, calls []containermock.Call, method string) {
+	t.Helper()
+	for _, call := range calls {
+		if call.Method == method {
+			t.Fatalf("calls = %v, want no method %q", calls, method)
+		}
+	}
 }

--- a/src/cli/internal/cmd/env/localtest/resources.go
+++ b/src/cli/internal/cmd/env/localtest/resources.go
@@ -34,6 +34,7 @@ const (
 	infraDir                  = "infra"
 	workflowEngineInfraDir    = "workflow-engine"
 	workflowEngineDbDataDir   = "workflow-engine-db"
+	workflowEngineDbVolume    = "localtest-workflow-engine-db-data"
 	localtestServicePort      = "5101"
 
 	postgresHealthInterval    = 10 * time.Second
@@ -101,6 +102,7 @@ func newVolume(hostPath, containerPath string) types.VolumeMount {
 		HostPath:      hostPath,
 		ContainerPath: containerPath,
 		ReadOnly:      false,
+		Type:          types.VolumeMountTypeBind,
 	}
 }
 
@@ -109,6 +111,16 @@ func newReadOnlyVolume(hostPath, containerPath string) types.VolumeMount {
 		HostPath:      hostPath,
 		ContainerPath: containerPath,
 		ReadOnly:      true,
+		Type:          types.VolumeMountTypeBind,
+	}
+}
+
+func newNamedVolume(name, containerPath string) types.VolumeMount {
+	return types.VolumeMount{
+		HostPath:      name,
+		ContainerPath: containerPath,
+		ReadOnly:      false,
+		Type:          types.VolumeMountTypeVolume,
 	}
 }
 
@@ -227,8 +239,8 @@ func workflowEngineDbContainerSpec(dataDir string) ContainerSpec {
 			"TZ":                "Europe/Oslo",
 		},
 		[]types.VolumeMount{
-			newVolume(
-				workflowEngineDbDataPath(dataDir),
+			newNamedVolume(
+				workflowEngineDbVolume,
 				"/var/lib/postgresql",
 			),
 			newReadOnlyVolume(
@@ -726,6 +738,9 @@ func hostPathExpectations(opts ResourceBuildOptions) []hostPathExpectation {
 		spec := &all[i]
 		for j := range spec.Volumes {
 			volume := spec.Volumes[j]
+			if !isBindMount(volume) {
+				continue
+			}
 			if _, ok := seen[volume.HostPath]; ok {
 				continue
 			}
@@ -737,6 +752,10 @@ func hostPathExpectations(opts ResourceBuildOptions) []hostPathExpectation {
 		}
 	}
 	return result
+}
+
+func isBindMount(volume types.VolumeMount) bool {
+	return volume.Type == "" || volume.Type == types.VolumeMountTypeBind
 }
 
 // ValidateResourceHostPaths ensures all bind-mounted host paths exist and have expected type.

--- a/src/cli/internal/cmd/env/localtest/resources_internal_test.go
+++ b/src/cli/internal/cmd/env/localtest/resources_internal_test.go
@@ -101,7 +101,15 @@ func TestCoreContainers_ServiceCallbacksUseLocaltestNetworkAlias(t *testing.T) {
 	t.Setenv(config.EnvCI, "")
 
 	containers := coreContainers(t.TempDir(), testTopology(), true)
+	assertCoreContainerLayout(t, containers)
+	assertLocaltestContainerConfig(t, containers[0])
+	assertPdf3ContainerConfig(t, containers[1])
+	assertWorkflowEngineDbContainerConfig(t, containers[2])
+	assertWorkflowEngineContainerConfig(t, containers[3])
+}
 
+func assertCoreContainerLayout(t *testing.T, containers []ContainerSpec) {
+	t.Helper()
 	if len(containers) != len(coreContainerNames(true)) {
 		t.Fatalf("coreContainers() len = %d, want %d", len(containers), len(coreContainerNames(true)))
 	}
@@ -112,8 +120,10 @@ func TestCoreContainers_ServiceCallbacksUseLocaltestNetworkAlias(t *testing.T) {
 	) {
 		t.Fatalf("added core container names = %v, want localtest-prefixed names", got)
 	}
+}
 
-	localtest := containers[0]
+func assertLocaltestContainerConfig(t *testing.T, localtest ContainerSpec) {
+	t.Helper()
 	topology := testTopology()
 	wantAliases := topology.LocaltestIngressHosts()
 	if got := localtest.NetworkAliases; !slices.Equal(got, wantAliases) {
@@ -124,8 +134,10 @@ func TestCoreContainers_ServiceCallbacksUseLocaltestNetworkAlias(t *testing.T) {
 	assertEnvValue(t, localtest.Environment, "LocalPlatformSettings__LocalAppMode", "http")
 	assertEnvValue(t, localtest.Environment, "LocalPlatformSettings__LocalAppUrl", "")
 	assertEnvValue(t, localtest.Environment, "LocalPlatformSettings__LocalPdfServiceUrl", "http://localtest-pdf3:5031")
+}
 
-	pdf3 := containers[1]
+func assertPdf3ContainerConfig(t *testing.T, pdf3 ContainerSpec) {
+	t.Helper()
 	if got := pdf3.Ports; len(got) != 1 || got[0] != newPort("5300", "5031") {
 		t.Fatalf("pdf3.Ports = %v, want [5300:5031]", got)
 	}
@@ -142,8 +154,10 @@ func TestCoreContainers_ServiceCallbacksUseLocaltestNetworkAlias(t *testing.T) {
 			"http://local.altinn.cloud:8000",
 		)
 	}
+}
 
-	workflowEngineDb := containers[2]
+func assertWorkflowEngineDbContainerConfig(t *testing.T, workflowEngineDb ContainerSpec) {
+	t.Helper()
 	if got := workflowEngineDb.Ports; got != nil {
 		t.Fatalf("workflowEngineDb.Ports = %v, want nil", got)
 	}
@@ -156,8 +170,10 @@ func TestCoreContainers_ServiceCallbacksUseLocaltestNetworkAlias(t *testing.T) {
 			t.Fatalf("workflowEngineDb data volume Type = %q, want named volume", volume.Type)
 		}
 	}
+}
 
-	workflowEngine := containers[3]
+func assertWorkflowEngineContainerConfig(t *testing.T, workflowEngine ContainerSpec) {
+	t.Helper()
 	if got := workflowEngine.Ports; got != nil {
 		t.Fatalf("workflowEngine.Ports = %v, want nil", got)
 	}

--- a/src/cli/internal/cmd/env/localtest/resources_internal_test.go
+++ b/src/cli/internal/cmd/env/localtest/resources_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	containertypes "altinn.studio/devenv/pkg/container/types"
 	"altinn.studio/devenv/pkg/resource"
 	"altinn.studio/studioctl/internal/config"
 	"altinn.studio/studioctl/internal/envtopology"
@@ -145,6 +146,15 @@ func TestCoreContainers_ServiceCallbacksUseLocaltestNetworkAlias(t *testing.T) {
 	workflowEngineDb := containers[2]
 	if got := workflowEngineDb.Ports; got != nil {
 		t.Fatalf("workflowEngineDb.Ports = %v, want nil", got)
+	}
+	wantDbVolume := newNamedVolume(workflowEngineDbVolume, "/var/lib/postgresql")
+	if !slices.Contains(workflowEngineDb.Volumes, wantDbVolume) {
+		t.Fatalf("workflowEngineDb.Volumes missing named data volume: %v", workflowEngineDb.Volumes)
+	}
+	for _, volume := range workflowEngineDb.Volumes {
+		if volume.ContainerPath == "/var/lib/postgresql" && volume.Type != containertypes.VolumeMountTypeVolume {
+			t.Fatalf("workflowEngineDb data volume Type = %q, want named volume", volume.Type)
+		}
 	}
 
 	workflowEngine := containers[3]
@@ -378,7 +388,6 @@ func createCoreLayout(t *testing.T, dataDir string) {
 	for _, dir := range []string{
 		filepath.Join(dataDir, "testdata"),
 		filepath.Join(dataDir, "AltinnPlatformLocal"),
-		workflowEngineDbDataPath(dataDir),
 		filepath.Join(dataDir, "infra"),
 		filepath.Join(dataDir, "infra", "workflow-engine"),
 	} {


### PR DESCRIPTION
## Description

Discovered this while testing on Windows, bind mounted volumes dont work very well since PostgreSQL then tries to set permissions on the db dir, which doesnt work since the files are actually on windows filesystem. This migrates to managed volume which will live inside a linux fs and therefore work reliably everywhere. Tries to delete old volume if it exists

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added capability to remove named Docker volumes
  * Workflow-engine database now uses named volumes for improved data persistence and management
  * Extended volume mount support with configurable bind mounts and named volumes

* **Bug Fixes**
  * Improved error handling for missing or non-existent volumes during cleanup operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->