### PR TITLE
fix: studioctl - install script broken by interactive detection

### DIFF
--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -27,6 +27,7 @@ iwr https://altinn.studio/designer/api/v1/studioctl/install.ps1 -useb | iex
 ```
 
 The install flow also installs `app-manager` and localtest resources by default.
+If no terminal prompt is available, the installer uses the recommended writable user location.
 
 Pin to a specific version:
 

--- a/src/cli/cmd/studioctl/install.ps1
+++ b/src/cli/cmd/studioctl/install.ps1
@@ -59,10 +59,6 @@ if (-not $Asset) {
     $Asset = "studioctl-$os-$arch.exe"
 }
 
-if (-not $InstallDir -and [Console]::IsInputRedirected) {
-    throw "Non-interactive install requires -InstallDir or STUDIOCTL_INSTALL_DIR"
-}
-
 if ($Version -eq "latest") {
     $baseUrl = "https://github.com/$Repo/releases/latest/download"
 } else {

--- a/src/cli/cmd/studioctl/install.sh
+++ b/src/cli/cmd/studioctl/install.sh
@@ -27,7 +27,7 @@ Examples:
   curl -sSL .../install.sh | sh -s -- --version studioctl/v0.1.0
 
 Notes:
-  - If stdin is not a TTY, --install-dir or STUDIOCTL_INSTALL_DIR is required.
+  - If no terminal is available, --install-dir or STUDIOCTL_INSTALL_DIR is required.
   - Released scripts are pinned to a specific studioctl tag in this monorepo.
   - Binary integrity is verified via SHA256 checksum before execution.
   - The install step also installs app-manager alongside studioctl.
@@ -126,11 +126,6 @@ case "$arch" in
 
 if [ -z "$ASSET" ]; then
 	ASSET="studioctl-${os}-${arch}"
-fi
-
-if [ -z "$INSTALL_DIR" ] && [ ! -t 0 ]; then
-	echo "error: non-interactive install requires --install-dir or STUDIOCTL_INSTALL_DIR"
-	exit 1
 fi
 
 if [ "$VERSION" = "latest" ]; then

--- a/src/cli/cmd/studioctl/install.sh
+++ b/src/cli/cmd/studioctl/install.sh
@@ -27,7 +27,7 @@ Examples:
   curl -sSL .../install.sh | sh -s -- --version studioctl/v0.1.0
 
 Notes:
-  - If no terminal is available, --install-dir or STUDIOCTL_INSTALL_DIR is required.
+  - Without --install-dir, studioctl selects an install location.
   - Released scripts are pinned to a specific studioctl tag in this monorepo.
   - Binary integrity is verified via SHA256 checksum before execution.
   - The install step also installs app-manager alongside studioctl.

--- a/src/cli/internal/cmd/env.go
+++ b/src/cli/internal/cmd/env.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	"altinn.studio/devenv/pkg/container"
@@ -496,14 +495,24 @@ func (c *EnvCommand) confirmResetIfNeeded(ctx context.Context, flags envResetFla
 	if flags.yes {
 		return true, nil
 	}
-	if !ui.StdinIsTerminal() {
-		return false, fmt.Errorf("%w: --yes is required when stdin is not a terminal", ErrInvalidFlagValue)
+
+	input, cleanup, err := ui.InteractiveInput()
+	if err != nil {
+		return false, fmt.Errorf(
+			"%w: --yes is required when no terminal input is available",
+			ErrInvalidFlagValue,
+		)
 	}
+	defer func() {
+		if cleanupErr := cleanup(); cleanupErr != nil {
+			c.out.Verbosef("failed to close terminal input: %v", cleanupErr)
+		}
+	}()
 
 	confirmed, err := ui.Confirm(
 		ctx,
 		c.out,
-		os.Stdin,
+		input,
 		fmt.Sprintf("Delete persisted %s environment data? [y/N]: ", flags.runtime),
 	)
 	if err != nil {

--- a/src/cli/internal/cmd/self.go
+++ b/src/cli/internal/cmd/self.go
@@ -93,7 +93,8 @@ func (c *SelfCommand) runInstall(ctx context.Context, args []string) error {
 			"  -h, --help          Show this help message",
 			"",
 			"If --path is not specified, an interactive picker will prompt you to",
-			"choose from detected installation locations.",
+			"choose from detected installation locations. If no terminal input is",
+			"available, the recommended writable location is used automatically.",
 		))
 	}
 

--- a/src/cli/internal/cmd/self.go
+++ b/src/cli/internal/cmd/self.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"runtime"
 
 	"altinn.studio/studioctl/internal/appmanager"
@@ -111,7 +112,7 @@ func (c *SelfCommand) runInstall(ctx context.Context, args []string) error {
 	candidates := c.service.DetectCandidates()
 
 	if targetPath == "" {
-		selected, err := c.pickInstallLocation(ctx, candidates)
+		selected, err := c.resolveInstallLocation(ctx, candidates)
 		if err != nil {
 			return err
 		}
@@ -124,12 +125,43 @@ func (c *SelfCommand) runInstall(ctx context.Context, args []string) error {
 	return c.performInstall(ctx, targetPath, candidates, skipResources)
 }
 
-func (c *SelfCommand) pickInstallLocation(ctx context.Context, candidates []selfsvc.Candidate) (string, error) {
+func (c *SelfCommand) resolveInstallLocation(
+	ctx context.Context,
+	candidates []selfsvc.Candidate,
+) (string, error) {
+	input, cleanup, err := ui.InteractiveInput()
+	if err != nil {
+		c.out.Verbosef("terminal input unavailable, using default install location: %v", err)
+		return c.defaultInstallLocation(candidates)
+	}
+	defer func() {
+		if cleanupErr := cleanup(); cleanupErr != nil {
+			c.out.Verbosef("failed to close terminal input: %v", cleanupErr)
+		}
+	}()
+
+	return c.pickInstallLocation(ctx, input, candidates)
+}
+
+func (c *SelfCommand) defaultInstallLocation(candidates []selfsvc.Candidate) (string, error) {
+	target, ok := selfsvc.DefaultInstallLocation(candidates)
+	if ok {
+		return target, nil
+	}
+
+	return "", c.handleNoWritableLocations()
+}
+
+func (c *SelfCommand) pickInstallLocation(
+	ctx context.Context,
+	input io.Reader,
+	candidates []selfsvc.Candidate,
+) (string, error) {
 	if len(candidates) == 0 {
 		return "", c.handleNoWritableLocations()
 	}
 
-	picker := selfsvc.NewPicker(c.out, candidates)
+	picker := selfsvc.NewPicker(c.out, input, candidates)
 	selected, err := picker.Run(ctx)
 	if err != nil {
 		if errors.Is(err, selfsvc.ErrSkipped) {

--- a/src/cli/internal/cmd/self/picker.go
+++ b/src/cli/internal/cmd/self/picker.go
@@ -3,6 +3,7 @@ package self
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -20,14 +21,20 @@ type PickerOption struct {
 // Picker handles interactive selection of install location.
 type Picker struct {
 	out               *ui.Output
+	input             io.Reader
 	candidates        []Candidate
 	recommendedOption int // Index in filtered options, -1 if none
 }
 
 // NewPicker creates a new picker with the given candidates.
-func NewPicker(out *ui.Output, candidates []Candidate) *Picker {
+func NewPicker(out *ui.Output, input io.Reader, candidates []Candidate) *Picker {
+	if input == nil {
+		input = os.Stdin
+	}
+
 	return &Picker{
 		out:               out,
+		input:             input,
 		candidates:        candidates,
 		recommendedOption: -1,
 	}
@@ -107,7 +114,7 @@ func (p *Picker) hasRecommended() bool {
 
 func (p *Picker) readSelection(ctx context.Context, numOptions int) (int, error) {
 	for {
-		line, err := ui.ReadLine(ctx, os.Stdin)
+		line, err := ui.ReadLine(ctx, p.input)
 		if err != nil {
 			p.out.Println("") // newline after interrupt
 			return 0, fmt.Errorf("read selection: %w", err)

--- a/src/cli/internal/cmd/self/selfinstall.go
+++ b/src/cli/internal/cmd/self/selfinstall.go
@@ -190,6 +190,21 @@ func markRecommended(candidates []Candidate) {
 	}
 }
 
+// DefaultInstallLocation returns the candidate to use when prompting is unavailable.
+func DefaultInstallLocation(candidates []Candidate) (string, bool) {
+	for _, candidate := range candidates {
+		if candidate.Recommended && candidate.Writable {
+			return candidate.Path, true
+		}
+	}
+	for _, candidate := range candidates {
+		if candidate.Writable {
+			return candidate.Path, true
+		}
+	}
+	return "", false
+}
+
 func isWritable(dir string, out *ui.Output) bool {
 	if dir == "" {
 		return false

--- a/src/cli/internal/cmd/self/selfmanage_test.go
+++ b/src/cli/internal/cmd/self/selfmanage_test.go
@@ -1,10 +1,14 @@
 package self_test
 
 import (
+	"context"
 	"errors"
+	"io"
+	"strings"
 	"testing"
 
 	self "altinn.studio/studioctl/internal/cmd/self"
+	"altinn.studio/studioctl/internal/ui"
 )
 
 func TestNormalizeReleaseVersion(t *testing.T) {
@@ -85,6 +89,82 @@ func TestAppManagerAssetName(t *testing.T) {
 	}
 	if got != "app-manager-windows-amd64.tar.gz" {
 		t.Fatalf("AppManagerAssetName() = %q, want %q", got, "app-manager-windows-amd64.tar.gz")
+	}
+}
+
+func TestPickerUsesProvidedInput(t *testing.T) {
+	t.Parallel()
+
+	const installDir = "/tmp/studioctl-bin"
+	out := ui.NewOutput(io.Discard, io.Discard, false)
+	picker := self.NewPicker(
+		out,
+		strings.NewReader("\n"),
+		[]self.Candidate{
+			{
+				Path:        installDir,
+				Writable:    true,
+				Recommended: true,
+			},
+		},
+	)
+
+	got, err := picker.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Picker.Run() error = %v", err)
+	}
+	if got != installDir {
+		t.Fatalf("Picker.Run() = %q, want %q", got, installDir)
+	}
+}
+
+func TestDefaultInstallLocation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		want       string
+		candidates []self.Candidate
+		wantOK     bool
+	}{
+		{
+			name: "uses recommended writable candidate",
+			candidates: []self.Candidate{
+				{Path: "/not-selected", Writable: true},
+				{Path: "/selected", Writable: true, Recommended: true},
+			},
+			want:   "/selected",
+			wantOK: true,
+		},
+		{
+			name: "falls back to first writable candidate",
+			candidates: []self.Candidate{
+				{Path: "/not-writable", Writable: false, Recommended: true},
+				{Path: "/selected", Writable: true},
+			},
+			want:   "/selected",
+			wantOK: true,
+		},
+		{
+			name: "returns false when no writable candidates exist",
+			candidates: []self.Candidate{
+				{Path: "/not-writable", Writable: false, Recommended: true},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := self.DefaultInstallLocation(tc.candidates)
+			if ok != tc.wantOK {
+				t.Fatalf("DefaultInstallLocation() ok = %v, want %v", ok, tc.wantOK)
+			}
+			if got != tc.want {
+				t.Fatalf("DefaultInstallLocation() = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/src/cli/internal/osutil/terminal_input_unix.go
+++ b/src/cli/internal/osutil/terminal_input_unix.go
@@ -1,0 +1,21 @@
+//go:build !windows
+
+package osutil
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+const terminalInputPath = "/dev/tty"
+
+// OpenTerminalInput opens the controlling terminal for interactive input.
+func OpenTerminalInput() (io.Reader, func() error, error) {
+	f, err := os.OpenFile(terminalInputPath, os.O_RDONLY, 0)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open terminal input: %w", err)
+	}
+
+	return f, f.Close, nil
+}

--- a/src/cli/internal/osutil/terminal_input_windows.go
+++ b/src/cli/internal/osutil/terminal_input_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package osutil
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+const terminalInputPath = "CONIN$"
+
+// OpenTerminalInput opens the console for interactive input.
+func OpenTerminalInput() (io.Reader, func() error, error) {
+	f, err := os.OpenFile(terminalInputPath, os.O_RDONLY, 0)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open terminal input: %w", err)
+	}
+
+	return f, f.Close, nil
+}

--- a/src/cli/internal/ui/input.go
+++ b/src/cli/internal/ui/input.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"altinn.studio/studioctl/internal/osutil"
+
 	"golang.org/x/term"
 )
 
@@ -39,7 +41,7 @@ const (
 // Supports context cancellation and Ctrl+C detection.
 // Terminal state is always restored, even on interrupt.
 func ReadPassword(ctx context.Context, out *Output) ([]byte, error) {
-	if !StdinIsTerminal() {
+	if !stdinIsTerminal() {
 		return ReadLine(ctx, os.Stdin)
 	}
 
@@ -50,6 +52,19 @@ func ReadPassword(ctx context.Context, out *Output) ([]byte, error) {
 	defer cleanup()
 
 	return readPasswordBytes(ctx, os.Stdin)
+}
+
+// InteractiveInput returns input suitable for interactive prompts.
+func InteractiveInput() (io.Reader, func() error, error) {
+	if stdinIsTerminal() {
+		return os.Stdin, func() error { return nil }, nil
+	}
+
+	input, cleanup, err := osutil.OpenTerminalInput()
+	if err != nil {
+		return nil, nil, fmt.Errorf("open interactive input: %w", err)
+	}
+	return input, cleanup, nil
 }
 
 func makeRawStdin(out *Output) (func(), error) {

--- a/src/cli/internal/ui/term.go
+++ b/src/cli/internal/ui/term.go
@@ -11,8 +11,7 @@ type fdWriter interface {
 	Fd() uintptr
 }
 
-// StdinIsTerminal reports whether stdin is attached to an interactive terminal.
-func StdinIsTerminal() bool {
+func stdinIsTerminal() bool {
 	return isTerminalWriter(os.Stdin)
 }
 


### PR DESCRIPTION
## Description

centralizes this detection in Go code but reverts behavior to default paths instead of demanding --path/env var

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
