### PR TITLE
chore: studioctl - dont include internaldev env in startup config

### DIFF
--- a/src/cli/internal/appmanager/client.go
+++ b/src/cli/internal/appmanager/client.go
@@ -55,7 +55,6 @@ type startConfig struct {
 	StudioctlPath               string `json:"studioctlPath"`
 	BoundTopologyBaseConfigPath string `json:"boundTopologyBaseConfigPath,omitempty"`
 	BoundTopologyConfigPath     string `json:"boundTopologyConfigPath,omitempty"`
-	InternalDev                 bool   `json:"internalDev"`
 }
 
 type runtimeState struct {
@@ -826,7 +825,6 @@ func buildStartConfig(cfg *config.Config, loadBalancerPort, studioctlPath string
 		StudioctlPath:               studioctlPath,
 		BoundTopologyBaseConfigPath: boundTopologyBaseConfigPath,
 		BoundTopologyConfigPath:     boundTopologyConfigPath,
-		InternalDev:                 config.IsTruthyEnv(os.Getenv(config.EnvInternalDevMode)),
 	}, nil
 }
 
@@ -840,7 +838,6 @@ func liveConfig(cfg *config.Config, status *Status) startConfig {
 		StudioctlPath:               status.StudioctlPath,
 		BoundTopologyBaseConfigPath: status.BoundTopologyBaseConfigPath,
 		BoundTopologyConfigPath:     status.BoundTopologyConfigPath,
-		InternalDev:                 status.InternalDev,
 	}
 }
 
@@ -1080,7 +1077,6 @@ func zeroRuntimeState() runtimeState {
 			StudioctlPath:               "",
 			BoundTopologyBaseConfigPath: "",
 			BoundTopologyConfigPath:     "",
-			InternalDev:                 false,
 		},
 		PID: 0,
 	}


### PR DESCRIPTION
## Description

It just leads to a lot of churn (diff in config leads to restart of app-manager).
When debug loggig is important a dev can do "servers down" first and then when it starts in a STUDIOCTL_INTERNAL_DEV session it will start debug loggin 

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
