### PR TITLE
chore: studioctl - stop apps, env, server during self-management

### DIFF
--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -28,6 +28,7 @@ iwr https://altinn.studio/designer/api/v1/studioctl/install.ps1 -useb | iex
 
 The install flow also installs `app-manager` and localtest resources by default.
 If no terminal prompt is available, the installer uses the recommended writable user location.
+It stops running apps and localtest before replacement, and restarts `app-manager` if it was running.
 
 Pin to a specific version:
 
@@ -69,6 +70,7 @@ make user-install
 ```
 
 That installs `studioctl`, `app-manager`, and localtest resources into your user setup.
+It uses the same upgrade-safe flow as the release install scripts.
 
 Development loop:
 

--- a/src/cli/cmd/studioctl/install.sh
+++ b/src/cli/cmd/studioctl/install.sh
@@ -31,6 +31,7 @@ Notes:
   - Released scripts are pinned to a specific studioctl tag in this monorepo.
   - Binary integrity is verified via SHA256 checksum before execution.
   - The install step also installs app-manager alongside studioctl.
+  - The install step stops running apps and localtest before replacement, and restarts app-manager if it was running.
 USAGE
 }
 

--- a/src/cli/internal/cmd/env/localtest/env.go
+++ b/src/cli/internal/cmd/env/localtest/env.go
@@ -64,6 +64,11 @@ func NewEnv(cfg *config.Config, out *ui.Output, client container.ContainerClient
 	}
 }
 
+// Name returns the runtime name.
+func (e *Env) Name() string {
+	return "localtest"
+}
+
 // Preflight validates prerequisites before startup.
 func (e *Env) Preflight(ctx context.Context, opts envtypes.UpOptions) error {
 	return CheckForLegacyLocaltest(ctx, e.client, opts.PgAdmin)

--- a/src/cli/internal/cmd/env/registry/registry.go
+++ b/src/cli/internal/cmd/env/registry/registry.go
@@ -1,0 +1,56 @@
+// Package registry wires environment runtime implementations.
+package registry
+
+import (
+	"altinn.studio/devenv/pkg/container"
+	envtypes "altinn.studio/studioctl/internal/cmd/env"
+	envlocaltest "altinn.studio/studioctl/internal/cmd/env/localtest"
+	"altinn.studio/studioctl/internal/config"
+	"altinn.studio/studioctl/internal/ui"
+)
+
+type options struct {
+	cfg             *config.Config
+	out             *ui.Output
+	containerClient container.ContainerClient
+}
+
+// Option configures runtime implementation construction.
+type Option func(*options)
+
+// WithConfig sets the studioctl config.
+func WithConfig(cfg *config.Config) Option {
+	return func(opts *options) {
+		opts.cfg = cfg
+	}
+}
+
+// WithOutput sets the command output.
+func WithOutput(out *ui.Output) Option {
+	return func(opts *options) {
+		opts.out = out
+	}
+}
+
+// WithContainerClient sets the container runtime client.
+func WithContainerClient(client container.ContainerClient) Option {
+	return func(opts *options) {
+		opts.containerClient = client
+	}
+}
+
+// Envs returns all environment runtime implementations.
+func Envs(opts ...Option) []envtypes.Env {
+	resolved := options{
+		cfg:             nil,
+		out:             nil,
+		containerClient: nil,
+	}
+	for _, opt := range opts {
+		opt(&resolved)
+	}
+
+	return []envtypes.Env{
+		envlocaltest.NewEnv(resolved.cfg, resolved.out, resolved.containerClient),
+	}
+}

--- a/src/cli/internal/cmd/env/registry/registry.go
+++ b/src/cli/internal/cmd/env/registry/registry.go
@@ -2,11 +2,20 @@
 package registry
 
 import (
+	"errors"
+	"fmt"
+
 	"altinn.studio/devenv/pkg/container"
 	envtypes "altinn.studio/studioctl/internal/cmd/env"
 	envlocaltest "altinn.studio/studioctl/internal/cmd/env/localtest"
 	"altinn.studio/studioctl/internal/config"
 	"altinn.studio/studioctl/internal/ui"
+)
+
+var (
+	errConfigRequired          = errors.New("config is required")
+	errOutputRequired          = errors.New("output is required")
+	errContainerClientRequired = errors.New("container client is required")
 )
 
 type options struct {
@@ -40,7 +49,7 @@ func WithContainerClient(client container.ContainerClient) Option {
 }
 
 // Envs returns all environment runtime implementations.
-func Envs(opts ...Option) []envtypes.Env {
+func Envs(opts ...Option) ([]envtypes.Env, error) {
 	resolved := options{
 		cfg:             nil,
 		out:             nil,
@@ -49,8 +58,17 @@ func Envs(opts ...Option) []envtypes.Env {
 	for _, opt := range opts {
 		opt(&resolved)
 	}
+	if resolved.cfg == nil {
+		return nil, fmt.Errorf("registry: %w", errConfigRequired)
+	}
+	if resolved.out == nil {
+		return nil, fmt.Errorf("registry: %w", errOutputRequired)
+	}
+	if resolved.containerClient == nil {
+		return nil, fmt.Errorf("registry: %w", errContainerClientRequired)
+	}
 
 	return []envtypes.Env{
 		envlocaltest.NewEnv(resolved.cfg, resolved.out, resolved.containerClient),
-	}
+	}, nil
 }

--- a/src/cli/internal/cmd/env/types.go
+++ b/src/cli/internal/cmd/env/types.go
@@ -15,6 +15,7 @@ type Env interface {
 	Up(ctx context.Context, opts UpOptions) error
 	Down(ctx context.Context) error
 	Logs(ctx context.Context, opts LogsOptions) error
+	Name() string
 }
 
 // Resetter optionally extends Env with destructive persisted-data reset support.

--- a/src/cli/internal/cmd/self.go
+++ b/src/cli/internal/cmd/self.go
@@ -188,9 +188,7 @@ func (c *SelfCommand) performInstall(
 	candidates []selfsvc.Candidate,
 	skipResources bool,
 ) error {
-	state, err := c.transition.Prepare(ctx, selfsvc.TransitionOptions{
-		RequireAppStatus: false,
-	})
+	state, err := c.transition.Prepare(ctx)
 	if err != nil {
 		return fmt.Errorf("prepare install: %w", err)
 	}
@@ -333,9 +331,7 @@ func (c *SelfCommand) runUpdate(ctx context.Context, args []string) error {
 		return fmt.Errorf("%w: windows executable is locked while running", selfsvc.ErrUpdateUnsupported)
 	}
 
-	state, err := c.transition.Prepare(ctx, selfsvc.TransitionOptions{
-		RequireAppStatus: false,
-	})
+	state, err := c.transition.Prepare(ctx)
 	if err != nil {
 		return fmt.Errorf("prepare update: %w", err)
 	}
@@ -459,9 +455,7 @@ func (c *SelfCommand) runUninstall(ctx context.Context, args []string) error {
 		return nil
 	}
 
-	state, err := c.transition.Prepare(ctx, selfsvc.TransitionOptions{
-		RequireAppStatus: true,
-	})
+	state, err := c.transition.Prepare(ctx)
 	if err != nil {
 		return fmt.Errorf("prepare uninstall: %w", err)
 	}

--- a/src/cli/internal/cmd/self.go
+++ b/src/cli/internal/cmd/self.go
@@ -6,29 +6,33 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"os/exec"
 	"runtime"
+	"strings"
 
-	"altinn.studio/studioctl/internal/appmanager"
 	selfsvc "altinn.studio/studioctl/internal/cmd/self"
 	"altinn.studio/studioctl/internal/config"
-	"altinn.studio/studioctl/internal/envtopology"
 	"altinn.studio/studioctl/internal/osutil"
 	"altinn.studio/studioctl/internal/ui"
 )
 
+const selfMigrateSubcmd = "__migrate"
+
 // SelfCommand implements the 'self' subcommand.
 type SelfCommand struct {
-	cfg     *config.Config
-	out     *ui.Output
-	service *selfsvc.Service
+	cfg        *config.Config
+	out        *ui.Output
+	service    *selfsvc.Service
+	transition *selfsvc.Transition
 }
 
 // NewSelfCommand creates a new self command.
 func NewSelfCommand(cfg *config.Config, out *ui.Output) *SelfCommand {
 	return &SelfCommand{
-		cfg:     cfg,
-		out:     out,
-		service: selfsvc.NewService(cfg),
+		cfg:        cfg,
+		out:        out,
+		service:    selfsvc.NewService(cfg),
+		transition: selfsvc.NewTransition(cfg, out),
 	}
 }
 
@@ -70,7 +74,9 @@ func (c *SelfCommand) Run(ctx context.Context, args []string) error {
 	case "update":
 		return c.runUpdate(ctx, subArgs)
 	case "uninstall":
-		return c.runUninstall(subArgs)
+		return c.runUninstall(ctx, subArgs)
+	case selfMigrateSubcmd:
+		return c.runMigrate(ctx, subArgs)
 	case "-h", flagHelp, helpSubcmd:
 		c.out.Print(c.Usage())
 		return nil
@@ -182,12 +188,27 @@ func (c *SelfCommand) performInstall(
 	candidates []selfsvc.Candidate,
 	skipResources bool,
 ) error {
+	state, err := c.transition.Prepare(ctx, selfsvc.TransitionOptions{
+		RequireAppStatus: false,
+	})
+	if err != nil {
+		return fmt.Errorf("prepare install: %w", err)
+	}
+	installedStudioctlPath := ""
+	restoreOnFailure := true
+	defer func() {
+		if restoreOnFailure {
+			c.transition.Restore(ctx, state, installedStudioctlPath)
+		}
+	}()
+
 	c.out.Printlnf("Installing binary to %s...", targetPath)
 
 	result, err := c.service.InstallBinary(targetPath)
 	if err != nil {
 		return fmt.Errorf("install binary: %w", err)
 	}
+	installedStudioctlPath = result.InstalledPath
 
 	if result.AlreadyInstalled {
 		c.out.Successf("%s is already installed at this location.", osutil.CurrentBin())
@@ -208,7 +229,17 @@ func (c *SelfCommand) performInstall(
 		}
 	}
 
-	return c.installAppManager(ctx)
+	if err := c.installAppManager(ctx); err != nil {
+		return err
+	}
+	restoreOnFailure = false
+	if err := c.runInstalledMigrations(ctx, installedStudioctlPath); err != nil {
+		return fmt.Errorf("run install migrations: %w", err)
+	}
+	if err := c.transition.RestartIfNeeded(ctx, state, installedStudioctlPath); err != nil {
+		return fmt.Errorf("restart after install: %w", err)
+	}
+	return nil
 }
 
 func (c *SelfCommand) handleNoWritableLocations() error {
@@ -255,11 +286,6 @@ func (c *SelfCommand) installResources(ctx context.Context) error {
 func (c *SelfCommand) installAppManager(ctx context.Context) error {
 	c.out.Println("")
 
-	wasRunning, err := c.stopAppManagerForReplacement(ctx)
-	if err != nil {
-		return err
-	}
-
 	spinner := ui.NewSpinner(c.out, "Installing app-manager...")
 	if !c.cfg.Verbose {
 		spinner.Start()
@@ -268,14 +294,12 @@ func (c *SelfCommand) installAppManager(ctx context.Context) error {
 	result, err := c.service.InstallAppManager(ctx)
 	if err != nil {
 		spinner.StopWithError("Failed to install app-manager")
-		c.restartAppManagerAfterFailedReplacement(ctx, wasRunning, "")
 		return fmt.Errorf("install app-manager: %w", err)
 	}
 
 	spinner.StopWithSuccess("App-manager installed")
 	c.out.Verbosef("Installed to: %s", result.InstalledPath)
-
-	return c.restartAppManagerIfNeeded(ctx, wasRunning, "")
+	return nil
 }
 
 func (c *SelfCommand) runUpdate(ctx context.Context, args []string) error {
@@ -305,6 +329,24 @@ func (c *SelfCommand) runUpdate(ctx context.Context, args []string) error {
 		return fmt.Errorf("parsing flags: %w", err)
 	}
 
+	if runtime.GOOS == "windows" {
+		return fmt.Errorf("%w: windows executable is locked while running", selfsvc.ErrUpdateUnsupported)
+	}
+
+	state, err := c.transition.Prepare(ctx, selfsvc.TransitionOptions{
+		RequireAppStatus: false,
+	})
+	if err != nil {
+		return fmt.Errorf("prepare update: %w", err)
+	}
+	updatedStudioctlPath := ""
+	restoreOnFailure := true
+	defer func() {
+		if restoreOnFailure {
+			c.transition.Restore(ctx, state, updatedStudioctlPath)
+		}
+	}()
+
 	c.out.Printlnf("Current version: %s", c.cfg.Version)
 	result, err := c.service.UpdateBinary(
 		ctx,
@@ -316,103 +358,81 @@ func (c *SelfCommand) runUpdate(ctx context.Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("self update: %w", err)
 	}
+	updatedStudioctlPath = result.TargetPath
 
 	c.out.Verbosef("Updated binary path: %s", result.TargetPath)
 	c.out.Verbosef("Release source: %s", result.ReleaseSource)
 	c.out.Verbosef("Asset: %s", result.Asset)
-	if err := c.updateAppManager(ctx, result.Version, result.TargetPath); err != nil {
+	if err := c.updateAppManager(ctx, result.Version); err != nil {
 		return fmt.Errorf("update app-manager: %w", err)
+	}
+
+	restoreOnFailure = false
+	if err := c.runInstalledMigrations(ctx, result.TargetPath); err != nil {
+		return fmt.Errorf("run update migrations: %w", err)
+	}
+	if err := c.transition.RestartIfNeeded(ctx, state, result.TargetPath); err != nil {
+		return fmt.Errorf("restart after update: %w", err)
 	}
 
 	c.out.Successf("%s updated successfully.", osutil.CurrentBin())
 	return nil
 }
 
-func (c *SelfCommand) updateAppManager(ctx context.Context, version, studioctlPath string) error {
-	wasRunning, err := c.stopAppManagerForReplacement(ctx)
-	if err != nil {
-		return err
-	}
+func (c *SelfCommand) updateAppManager(
+	ctx context.Context,
+	version string,
+) error {
 	result, err := c.service.InstallAppManagerVersion(ctx, version)
 	if err != nil {
-		c.restartAppManagerAfterFailedReplacement(ctx, wasRunning, studioctlPath)
 		return fmt.Errorf("install app-manager: %w", err)
 	}
 	c.out.Verbosef("Updated app-manager path: %s", result.InstalledPath)
-
-	return c.restartAppManagerIfNeeded(ctx, wasRunning, studioctlPath)
+	return nil
 }
 
-func (c *SelfCommand) stopAppManagerForReplacement(ctx context.Context) (bool, error) {
-	done, err := appmanager.Shutdown(ctx, c.cfg)
+func (c *SelfCommand) runInstalledMigrations(ctx context.Context, studioctlPath string) error {
+	args := c.migrationCommandArgs()
+	c.out.Verbosef("Running migrations with: %s %v", studioctlPath, args)
+
+	//nolint:gosec // G204: studioctlPath is the just-installed studioctl binary path.
+	cmd := exec.CommandContext(ctx, studioctlPath, args...)
+	output, err := cmd.CombinedOutput()
 	if err != nil {
-		if errors.Is(err, appmanager.ErrNotRunning) {
-			return false, nil
+		msg := strings.TrimSpace(string(output))
+		if msg != "" {
+			return fmt.Errorf("run installed studioctl migrations: %w: %s", err, msg)
 		}
-		return false, fmt.Errorf("stop existing app-manager before install: %w", err)
-	}
-	if done == nil {
-		return false, nil
-	}
-
-	if shutdownErr := <-done; shutdownErr != nil {
-		if errors.Is(shutdownErr, appmanager.ErrNotRunning) {
-			return false, nil
-		}
-		return false, fmt.Errorf("stop existing app-manager before install: %w", shutdownErr)
-	}
-
-	return true, nil
-}
-
-func (c *SelfCommand) restartAppManagerAfterFailedReplacement(
-	ctx context.Context,
-	wasRunning bool,
-	studioctlPath string,
-) {
-	if !wasRunning {
-		return
-	}
-	if err := c.restartAppManager(ctx, studioctlPath); err != nil {
-		c.out.Verbosef("failed to restart app-manager after failed install: %v", err)
-	}
-}
-
-func (c *SelfCommand) restartAppManagerIfNeeded(ctx context.Context, wasRunning bool, studioctlPath string) error {
-	if !wasRunning {
-		return nil
-	}
-	if err := c.restartAppManager(ctx, studioctlPath); err != nil {
-		return fmt.Errorf("restart app-manager: %w", err)
+		return fmt.Errorf("run installed studioctl migrations: %w", err)
 	}
 	return nil
 }
 
-func (c *SelfCommand) restartAppManager(ctx context.Context, studioctlPath string) error {
-	topology := envtopology.NewLocal(envtopology.DefaultIngressPortString())
-	if studioctlPath == "" {
-		if err := appmanager.EnsureStarted(
-			ctx,
-			c.cfg,
-			topology.IngressPort(),
-		); err != nil {
-			return fmt.Errorf("ensure app-manager started: %w", err)
-		}
-		return nil
+func (c *SelfCommand) migrationCommandArgs() []string {
+	args := make([]string, 0, 7)
+	if c.cfg.Home != "" {
+		args = append(args, "--home", c.cfg.Home)
 	}
+	if c.cfg.SocketDir != "" {
+		args = append(args, "--socket-dir", c.cfg.SocketDir)
+	}
+	if c.cfg.Verbose {
+		args = append(args, "--verbose")
+	}
+	return append(args, "self", selfMigrateSubcmd)
+}
 
-	if err := appmanager.EnsureStartedWithStudioctlPath(
-		ctx,
-		c.cfg,
-		topology.IngressPort(),
-		studioctlPath,
-	); err != nil {
-		return fmt.Errorf("ensure app-manager started with studioctl path: %w", err)
+func (c *SelfCommand) runMigrate(ctx context.Context, args []string) error {
+	if len(args) != 0 {
+		return fmt.Errorf("%w: %s", ErrInvalidFlagValue, strings.Join(args, " "))
+	}
+	if err := c.transition.RunMigrations(ctx); err != nil {
+		return fmt.Errorf("run migrations: %w", err)
 	}
 	return nil
 }
 
-func (c *SelfCommand) runUninstall(args []string) error {
+func (c *SelfCommand) runUninstall(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("self uninstall", flag.ContinueOnError)
 	fs.Usage = func() {
 		c.out.Print(joinLines(
@@ -439,10 +459,24 @@ func (c *SelfCommand) runUninstall(args []string) error {
 		return nil
 	}
 
+	state, err := c.transition.Prepare(ctx, selfsvc.TransitionOptions{
+		RequireAppStatus: true,
+	})
+	if err != nil {
+		return fmt.Errorf("prepare uninstall: %w", err)
+	}
+	removed := false
+	defer func() {
+		if !removed {
+			c.transition.Restore(ctx, state, "")
+		}
+	}()
+
 	result, err := c.service.UninstallBinary()
 	if err != nil {
 		return fmt.Errorf("self uninstall: %w", err)
 	}
+	removed = true
 
 	c.out.Successf("Removed %s", result.RemovedPath)
 	c.out.Println("Localtest resources and configuration were not removed.")

--- a/src/cli/internal/cmd/self/self_transition.go
+++ b/src/cli/internal/cmd/self/self_transition.go
@@ -1,0 +1,395 @@
+package self
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"altinn.studio/devenv/pkg/container"
+	containertypes "altinn.studio/devenv/pkg/container/types"
+	"altinn.studio/studioctl/internal/appmanager"
+	envtypes "altinn.studio/studioctl/internal/cmd/env"
+	envregistry "altinn.studio/studioctl/internal/cmd/env/registry"
+	"altinn.studio/studioctl/internal/config"
+	"altinn.studio/studioctl/internal/envtopology"
+	"altinn.studio/studioctl/internal/migrations"
+	"altinn.studio/studioctl/internal/osutil"
+	"altinn.studio/studioctl/internal/ui"
+)
+
+const (
+	appShutdownTimeout = 10 * time.Second
+	// TODO: this code should not know about run-modes...
+	runModeContainer = "container"
+	runModeProcess   = "process"
+)
+
+var (
+	errAppContainerIDMissing = errors.New("app container id or name missing")
+	errAppProcessIDMissing   = errors.New("app process id missing")
+)
+
+type appManagerShutdownFunc func(context.Context, *config.Config) (<-chan error, error)
+type appManagerStartFunc func(context.Context, *config.Config, string, string) error
+type appRuntimeClient interface {
+	Status(ctx context.Context) (*appmanager.Status, error)
+	UnregisterApp(ctx context.Context, appID string) error
+}
+type containerClientFactory func(context.Context) (container.ContainerClient, error)
+type migrationRunnerFunc func(context.Context, *config.Config) error
+type stopProcessFunc func(context.Context, int) error
+
+// TransitionState captures process state needed after a self operation.
+type TransitionState struct {
+	previousStudioctlPath string
+	appManagerWasRunning  bool
+}
+
+// TransitionOptions controls how strict transition preparation should be.
+type TransitionOptions struct {
+	RequireAppStatus bool
+}
+
+// Transition coordinates app/env/app-manager shutdown around self operations.
+type Transition struct {
+	cfg             *config.Config
+	out             *ui.Output
+	appClient       appRuntimeClient
+	containerClient containerClientFactory
+	stopProcess     stopProcessFunc
+	shutdown        appManagerShutdownFunc
+	start           appManagerStartFunc
+	runMigrations   migrationRunnerFunc
+}
+
+// NewTransition creates a transition coordinator.
+func NewTransition(cfg *config.Config, out *ui.Output) *Transition {
+	return &Transition{
+		cfg:             cfg,
+		out:             out,
+		appClient:       appmanager.NewClient(cfg),
+		containerClient: container.Detect,
+		stopProcess: func(ctx context.Context, pid int) error {
+			return osutil.StopProcess(ctx, pid, appShutdownTimeout)
+		},
+		shutdown: appmanager.Shutdown,
+		start: func(ctx context.Context, cfg *config.Config, ingressPort, studioctlPath string) error {
+			if studioctlPath == "" {
+				return appmanager.EnsureStarted(ctx, cfg, ingressPort)
+			}
+			return appmanager.EnsureStartedWithStudioctlPath(ctx, cfg, ingressPort, studioctlPath)
+		},
+		runMigrations: migrations.Run,
+	}
+}
+
+// Prepare stops running apps, environments, and app-manager before a self operation.
+func (t *Transition) Prepare(ctx context.Context, opts TransitionOptions) (TransitionState, error) {
+	appManagerWasRunning, studioctlPath, err := t.stopApps(ctx, opts)
+	if err != nil {
+		return TransitionState{}, err
+	}
+	state := TransitionState{
+		previousStudioctlPath: studioctlPath,
+		appManagerWasRunning:  appManagerWasRunning,
+	}
+
+	if stopErr := t.stopEnvs(ctx); stopErr != nil {
+		return TransitionState{}, stopErr
+	}
+
+	wasRunning, err := t.stopAppManager(ctx)
+	if err != nil {
+		return TransitionState{}, err
+	}
+	state.appManagerWasRunning = state.appManagerWasRunning || wasRunning
+
+	return state, nil
+}
+
+// RunMigrations applies pending installation migrations.
+func (t *Transition) RunMigrations(ctx context.Context) error {
+	if t.runMigrations != nil {
+		if err := t.runMigrations(ctx, t.cfg); err != nil {
+			return fmt.Errorf("run installation migrations: %w", err)
+		}
+	}
+	return nil
+}
+
+// Restore restarts app-manager after a failed self operation when it was previously running.
+func (t *Transition) Restore(
+	ctx context.Context,
+	state TransitionState,
+	studioctlPath string,
+) {
+	if !state.appManagerWasRunning {
+		return
+	}
+	if err := t.restartAppManager(ctx, restartStudioctlPath(state, studioctlPath)); err != nil {
+		t.out.Verbosef("failed to restart app-manager after failed self operation: %v", err)
+	}
+}
+
+// RestartIfNeeded restarts app-manager after a successful self operation when it was previously running.
+func (t *Transition) RestartIfNeeded(
+	ctx context.Context,
+	state TransitionState,
+	studioctlPath string,
+) error {
+	if !state.appManagerWasRunning {
+		return nil
+	}
+	if err := t.restartAppManager(ctx, restartStudioctlPath(state, studioctlPath)); err != nil {
+		return fmt.Errorf("restart app-manager: %w", err)
+	}
+	return nil
+}
+
+func (t *Transition) stopApps(ctx context.Context, opts TransitionOptions) (bool, string, error) {
+	status, err := t.appClient.Status(ctx)
+	if err != nil {
+		if errors.Is(err, appmanager.ErrNotRunning) {
+			return false, "", nil
+		}
+		if opts.RequireAppStatus {
+			return false, "", fmt.Errorf("get app-manager status before self operation: %w", err)
+		}
+		t.out.Verbosef("skipping app shutdown before self operation: %v", err)
+		return false, "", nil
+	}
+
+	apps := sortDiscoveredApps(filterManagedApps(status.Apps))
+	if len(apps) == 0 {
+		return true, status.StudioctlPath, nil
+	}
+
+	t.out.Println("Stopping running apps...")
+
+	var containerClient container.ContainerClient
+	defer func() {
+		if containerClient != nil {
+			if closeErr := containerClient.Close(); closeErr != nil {
+				t.out.Verbosef("failed to close container client: %v", closeErr)
+			}
+		}
+	}()
+
+	var stopErrors []error
+	for _, app := range apps {
+		if err := t.stopApp(ctx, app, &containerClient); err != nil {
+			stopErrors = append(stopErrors, fmt.Errorf("%s: %w", app.AppID, err))
+			continue
+		}
+		t.unregisterBestEffort(ctx, app)
+		t.out.Verbosef("Stopped %s before self operation.", app.AppID)
+	}
+	if err := errors.Join(stopErrors...); err != nil {
+		return true, status.StudioctlPath, fmt.Errorf("stop running apps before self operation: %w", err)
+	}
+
+	return true, status.StudioctlPath, nil
+}
+
+func (t *Transition) stopEnvs(ctx context.Context) error {
+	containerClient := t.containerClient
+	if containerClient == nil {
+		containerClient = container.Detect
+	}
+	client, err := containerClient(ctx)
+	if err != nil {
+		t.out.Verbosef("skipping environment shutdown before self operation: %v", err)
+		return nil
+	}
+	defer func() {
+		if closeErr := client.Close(); closeErr != nil {
+			t.out.Verbosef("failed to close container client: %v", closeErr)
+		}
+	}()
+
+	for _, env := range envregistry.Envs(
+		envregistry.WithConfig(t.cfg),
+		envregistry.WithOutput(t.out),
+		envregistry.WithContainerClient(client),
+	) {
+		if err := env.Down(ctx); err != nil {
+			if errors.Is(err, envtypes.ErrAlreadyStopped) {
+				continue
+			}
+			return fmt.Errorf("stop %s before self operation: %w", env.Name(), err)
+		}
+	}
+
+	return nil
+}
+
+func (t *Transition) stopAppManager(ctx context.Context) (bool, error) {
+	shutdown := t.shutdown
+	if shutdown == nil {
+		shutdown = appmanager.Shutdown
+	}
+
+	done, err := shutdown(ctx, t.cfg)
+	if err != nil {
+		if errors.Is(err, appmanager.ErrNotRunning) {
+			return false, nil
+		}
+		return false, fmt.Errorf("stop app-manager before self operation: %w", err)
+	}
+	if done == nil {
+		return false, nil
+	}
+
+	if shutdownErr := <-done; shutdownErr != nil {
+		if errors.Is(shutdownErr, appmanager.ErrNotRunning) {
+			return false, nil
+		}
+		return false, fmt.Errorf("stop app-manager before self operation: %w", shutdownErr)
+	}
+
+	return true, nil
+}
+
+func (t *Transition) restartAppManager(ctx context.Context, studioctlPath string) error {
+	topology := envtopology.NewLocal(envtopology.DefaultIngressPortString())
+	start := t.start
+	if start == nil {
+		start = func(ctx context.Context, cfg *config.Config, ingressPort, studioctlPath string) error {
+			if studioctlPath == "" {
+				return appmanager.EnsureStarted(ctx, cfg, ingressPort)
+			}
+			return appmanager.EnsureStartedWithStudioctlPath(ctx, cfg, ingressPort, studioctlPath)
+		}
+	}
+	if err := start(ctx, t.cfg, topology.IngressPort(), studioctlPath); err != nil {
+		return fmt.Errorf("ensure app-manager started: %w", err)
+	}
+	return nil
+}
+
+func (t *Transition) stopApp(
+	ctx context.Context,
+	app appmanager.DiscoveredApp,
+	containerClient *container.ContainerClient,
+) error {
+	switch appStopMode(app) {
+	case runModeProcess:
+		pid := appProcessID(app)
+		if pid <= 0 {
+			return fmt.Errorf("%w: %s", errAppProcessIDMissing, app.AppID)
+		}
+		stopProcess := t.stopProcess
+		if stopProcess == nil {
+			stopProcess = func(ctx context.Context, pid int) error {
+				return osutil.StopProcess(ctx, pid, appShutdownTimeout)
+			}
+		}
+		if err := stopProcess(ctx, pid); err != nil {
+			return fmt.Errorf("stop app process %d: %w", pid, err)
+		}
+	case runModeContainer:
+		if err := t.ensureContainerRuntime(ctx, containerClient); err != nil {
+			return err
+		}
+		client := *containerClient
+		nameOrID := app.ContainerID
+		if nameOrID == "" {
+			nameOrID = app.Name
+		}
+		if nameOrID == "" {
+			return fmt.Errorf("%w: %s", errAppContainerIDMissing, app.AppID)
+		}
+		if err := client.ContainerStop(ctx, nameOrID, nil); err != nil &&
+			!errors.Is(err, containertypes.ErrContainerNotFound) {
+			return fmt.Errorf("stop app container %s: %w", nameOrID, err)
+		}
+		if err := client.ContainerRemove(ctx, nameOrID, true); err != nil &&
+			!errors.Is(err, containertypes.ErrContainerNotFound) {
+			return fmt.Errorf("remove app container %s: %w", nameOrID, err)
+		}
+	default:
+		return nil
+	}
+
+	return nil
+}
+
+func (t *Transition) ensureContainerRuntime(
+	ctx context.Context,
+	containerClient *container.ContainerClient,
+) error {
+	if *containerClient != nil {
+		return nil
+	}
+
+	containerClientFactory := t.containerClient
+	if containerClientFactory == nil {
+		containerClientFactory = container.Detect
+	}
+	client, err := containerClientFactory(ctx)
+	if err != nil {
+		return fmt.Errorf("connect to container runtime: %w", err)
+	}
+	*containerClient = client
+	return nil
+}
+
+func (t *Transition) unregisterBestEffort(ctx context.Context, app appmanager.DiscoveredApp) {
+	if err := t.appClient.UnregisterApp(ctx, app.AppID); err != nil {
+		t.out.Verbosef("failed to unregister app %s from app-manager: %v", app.AppID, err)
+	}
+}
+
+func sortDiscoveredApps(apps []appmanager.DiscoveredApp) []appmanager.DiscoveredApp {
+	sort.Slice(apps, func(i, j int) bool {
+		if apps[i].AppID != apps[j].AppID {
+			return apps[i].AppID < apps[j].AppID
+		}
+		return apps[i].BaseURL < apps[j].BaseURL
+	})
+	return apps
+}
+
+func filterManagedApps(apps []appmanager.DiscoveredApp) []appmanager.DiscoveredApp {
+	filtered := make([]appmanager.DiscoveredApp, 0, len(apps))
+	for _, app := range apps {
+		if hasStopHandle(app) {
+			filtered = append(filtered, app)
+		}
+	}
+	return filtered
+}
+
+func hasStopHandle(app appmanager.DiscoveredApp) bool {
+	return appProcessID(app) > 0 || app.ContainerID != "" || app.Name != ""
+}
+
+func appStopMode(app appmanager.DiscoveredApp) string {
+	if appHasContainerHandle(app) {
+		return runModeContainer
+	}
+	if appProcessID(app) > 0 {
+		return runModeProcess
+	}
+	return app.Source
+}
+
+func appHasContainerHandle(app appmanager.DiscoveredApp) bool {
+	return app.ContainerID != "" || (app.Name != "" && appProcessID(app) == 0)
+}
+
+func appProcessID(app appmanager.DiscoveredApp) int {
+	if app.ProcessID != nil {
+		return *app.ProcessID
+	}
+	return 0
+}
+
+func restartStudioctlPath(state TransitionState, replacementPath string) string {
+	if replacementPath != "" {
+		return replacementPath
+	}
+	return state.previousStudioctlPath
+}

--- a/src/cli/internal/cmd/self/self_transition.go
+++ b/src/cli/internal/cmd/self/self_transition.go
@@ -47,11 +47,6 @@ type TransitionState struct {
 	appManagerWasRunning  bool
 }
 
-// TransitionOptions controls how strict transition preparation should be.
-type TransitionOptions struct {
-	RequireAppStatus bool
-}
-
 // Transition coordinates app/env/app-manager shutdown around self operations.
 type Transition struct {
 	cfg             *config.Config
@@ -86,8 +81,8 @@ func NewTransition(cfg *config.Config, out *ui.Output) *Transition {
 }
 
 // Prepare stops running apps, environments, and app-manager before a self operation.
-func (t *Transition) Prepare(ctx context.Context, opts TransitionOptions) (TransitionState, error) {
-	appManagerWasRunning, studioctlPath, err := t.stopApps(ctx, opts)
+func (t *Transition) Prepare(ctx context.Context) (TransitionState, error) {
+	appManagerWasRunning, studioctlPath, err := t.stopApps(ctx)
 	if err != nil {
 		return TransitionState{}, err
 	}
@@ -148,17 +143,13 @@ func (t *Transition) RestartIfNeeded(
 	return nil
 }
 
-func (t *Transition) stopApps(ctx context.Context, opts TransitionOptions) (bool, string, error) {
+func (t *Transition) stopApps(ctx context.Context) (bool, string, error) {
 	status, err := t.appClient.Status(ctx)
 	if err != nil {
 		if errors.Is(err, appmanager.ErrNotRunning) {
 			return false, "", nil
 		}
-		if opts.RequireAppStatus {
-			return false, "", fmt.Errorf("get app-manager status before self operation: %w", err)
-		}
-		t.out.Verbosef("skipping app shutdown before self operation: %v", err)
-		return false, "", nil
+		return false, "", fmt.Errorf("get app-manager status before self operation: %w", err)
 	}
 
 	apps := sortDiscoveredApps(filterManagedApps(status.Apps))
@@ -209,11 +200,16 @@ func (t *Transition) stopEnvs(ctx context.Context) error {
 		}
 	}()
 
-	for _, env := range envregistry.Envs(
+	envs, err := envregistry.Envs(
 		envregistry.WithConfig(t.cfg),
 		envregistry.WithOutput(t.out),
 		envregistry.WithContainerClient(client),
-	) {
+	)
+	if err != nil {
+		return fmt.Errorf("build environment registry: %w", err)
+	}
+
+	for _, env := range envs {
 		if err := env.Down(ctx); err != nil {
 			if errors.Is(err, envtypes.ErrAlreadyStopped) {
 				continue

--- a/src/cli/internal/cmd/self/self_transition_internal_test.go
+++ b/src/cli/internal/cmd/self/self_transition_internal_test.go
@@ -1,0 +1,269 @@
+package self
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"reflect"
+	"testing"
+
+	containerruntime "altinn.studio/devenv/pkg/container"
+	"altinn.studio/studioctl/internal/appmanager"
+	"altinn.studio/studioctl/internal/config"
+	"altinn.studio/studioctl/internal/ui"
+)
+
+var errReplacementTestRuntimeUnavailable = errors.New("container runtime unavailable")
+var errSelfTransitionTestStatus = errors.New("status failed")
+var errStopFailed = errors.New("stop failed")
+var errMigrationFailed = errors.New("migration failed")
+
+const testAppID = "ttd/app"
+
+func TestSelfTransitionPrepareStopsAppsBeforeLocaltestAndAppManager(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig(t)
+	processID := 123
+	var order []string
+	client := &fakeAppRuntimeClient{
+		status: &appmanager.Status{
+			StudioctlPath: "/old/studioctl",
+			Apps: []appmanager.DiscoveredApp{
+				{
+					ProcessID: &processID,
+					AppID:     testAppID,
+					BaseURL:   "http://localhost:5005",
+				},
+			},
+		},
+	}
+	transition := &Transition{
+		cfg:       cfg,
+		out:       ui.NewOutput(&bytes.Buffer{}, io.Discard, true),
+		appClient: client,
+		containerClient: func(context.Context) (containerruntime.ContainerClient, error) {
+			order = append(order, "localtest")
+			return nil, errReplacementTestRuntimeUnavailable
+		},
+		stopProcess: func(_ context.Context, pid int) error {
+			if pid != processID {
+				t.Fatalf("pid = %d, want %d", pid, processID)
+			}
+			order = append(order, "apps")
+			return nil
+		},
+		shutdown: func(context.Context, *config.Config) (<-chan error, error) {
+			order = append(order, "app-manager")
+			done := make(chan error, 1)
+			done <- nil
+			return done, nil
+		},
+	}
+
+	state, err := transition.Prepare(t.Context(), TransitionOptions{})
+	if err != nil {
+		t.Fatalf("Prepare() error = %v", err)
+	}
+
+	wantOrder := []string{"apps", "localtest", "app-manager"}
+	if !reflect.DeepEqual(order, wantOrder) {
+		t.Fatalf("order = %+v, want %+v", order, wantOrder)
+	}
+	if !state.appManagerWasRunning || state.previousStudioctlPath != "/old/studioctl" {
+		t.Fatalf("state = %+v, want running app-manager with previous studioctl path", state)
+	}
+	if len(client.unregistered) != 1 || client.unregistered[0] != testAppID {
+		t.Fatalf("unregistered = %+v, want %s", client.unregistered, testAppID)
+	}
+}
+
+func TestSelfTransitionStatusFailureIsBestEffortUnlessRequired(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig(t)
+	transition := &Transition{
+		cfg: cfg,
+		out: ui.NewOutput(&bytes.Buffer{}, io.Discard, true),
+		appClient: &fakeAppRuntimeClient{
+			statusErr: errSelfTransitionTestStatus,
+		},
+		containerClient: func(context.Context) (containerruntime.ContainerClient, error) {
+			return nil, errReplacementTestRuntimeUnavailable
+		},
+		shutdown: func(context.Context, *config.Config) (<-chan error, error) {
+			done := make(chan error, 1)
+			done <- nil
+			return done, nil
+		},
+	}
+
+	if _, err := transition.Prepare(t.Context(), TransitionOptions{RequireAppStatus: false}); err != nil {
+		t.Fatalf("Prepare() optional app status error = %v", err)
+	}
+	if _, err := transition.Prepare(t.Context(), TransitionOptions{RequireAppStatus: true}); !errors.Is(
+		err,
+		errSelfTransitionTestStatus,
+	) {
+		t.Fatalf("Prepare() required app status error = %v, want status error", err)
+	}
+}
+
+func TestSelfTransitionAppStopFailureFails(t *testing.T) {
+	t.Parallel()
+
+	processID := 123
+	newTransition := func() *Transition {
+		return &Transition{
+			cfg: testConfig(t),
+			out: ui.NewOutput(&bytes.Buffer{}, io.Discard, true),
+			appClient: &fakeAppRuntimeClient{
+				status: &appmanager.Status{
+					StudioctlPath: "/old/studioctl",
+					Apps: []appmanager.DiscoveredApp{
+						{
+							ProcessID: &processID,
+							AppID:     testAppID,
+							BaseURL:   "http://localhost:5005",
+						},
+					},
+				},
+			},
+			containerClient: func(context.Context) (containerruntime.ContainerClient, error) {
+				return nil, errReplacementTestRuntimeUnavailable
+			},
+			stopProcess: func(context.Context, int) error {
+				return errStopFailed
+			},
+			shutdown: func(context.Context, *config.Config) (<-chan error, error) {
+				done := make(chan error, 1)
+				done <- nil
+				return done, nil
+			},
+		}
+	}
+
+	if _, err := newTransition().Prepare(t.Context(), TransitionOptions{}); !errors.Is(
+		err,
+		errStopFailed,
+	) {
+		t.Fatalf("Prepare() required app stop error = %v, want stop error", err)
+	}
+}
+
+func TestSelfTransitionRunsMigrationsBeforeRestart(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig(t)
+	var order []string
+	var restartedPath string
+	transition := &Transition{
+		cfg: cfg,
+		out: ui.NewOutput(&bytes.Buffer{}, io.Discard, true),
+		runMigrations: func(context.Context, *config.Config) error {
+			order = append(order, "migrations")
+			return nil
+		},
+		start: func(_ context.Context, _ *config.Config, _ string, studioctlPath string) error {
+			order = append(order, "app-manager")
+			restartedPath = studioctlPath
+			return nil
+		},
+	}
+
+	if err := transition.RunMigrations(t.Context()); err != nil {
+		t.Fatalf("RunMigrations() error = %v", err)
+	}
+	if err := transition.RestartIfNeeded(
+		t.Context(),
+		TransitionState{appManagerWasRunning: true, previousStudioctlPath: "/old/studioctl"},
+		"/new/studioctl",
+	); err != nil {
+		t.Fatalf("RestartIfNeeded() error = %v", err)
+	}
+
+	wantOrder := []string{"migrations", "app-manager"}
+	if !reflect.DeepEqual(order, wantOrder) {
+		t.Fatalf("order = %+v, want %+v", order, wantOrder)
+	}
+	if restartedPath != "/new/studioctl" {
+		t.Fatalf("restartedPath = %q, want new path", restartedPath)
+	}
+}
+
+func TestSelfTransitionMigrationFailureDoesNotRestart(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig(t)
+	var restarted bool
+	transition := &Transition{
+		cfg: cfg,
+		out: ui.NewOutput(&bytes.Buffer{}, io.Discard, true),
+		runMigrations: func(context.Context, *config.Config) error {
+			return errMigrationFailed
+		},
+		start: func(context.Context, *config.Config, string, string) error {
+			restarted = true
+			return nil
+		},
+	}
+
+	err := transition.RunMigrations(t.Context())
+	if !errors.Is(err, errMigrationFailed) {
+		t.Fatalf("RunMigrations() error = %v, want migration failure", err)
+	}
+	if restarted {
+		t.Fatal("app-manager restarted after migration failure")
+	}
+}
+
+func TestSelfTransitionRestoreUsesPreviousStudioctlPath(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig(t)
+	var restartedPath string
+	transition := &Transition{
+		cfg: cfg,
+		out: ui.NewOutput(&bytes.Buffer{}, io.Discard, true),
+		start: func(_ context.Context, _ *config.Config, _ string, studioctlPath string) error {
+			restartedPath = studioctlPath
+			return nil
+		},
+	}
+
+	transition.Restore(
+		t.Context(),
+		TransitionState{appManagerWasRunning: true, previousStudioctlPath: "/old/studioctl"},
+		"",
+	)
+
+	if restartedPath != "/old/studioctl" {
+		t.Fatalf("restartedPath = %q, want previous path", restartedPath)
+	}
+}
+
+type fakeAppRuntimeClient struct {
+	status       *appmanager.Status
+	statusErr    error
+	unregistered []string
+}
+
+func (f *fakeAppRuntimeClient) Status(context.Context) (*appmanager.Status, error) {
+	return f.status, f.statusErr
+}
+
+func (f *fakeAppRuntimeClient) UnregisterApp(_ context.Context, appID string) error {
+	f.unregistered = append(f.unregistered, appID)
+	return nil
+}
+
+func testConfig(t *testing.T) *config.Config {
+	t.Helper()
+
+	cfg, err := config.New(config.Flags{Home: t.TempDir(), SocketDir: "", Verbose: false}, "test-version")
+	if err != nil {
+		t.Fatalf("config.New() error = %v", err)
+	}
+	return cfg
+}

--- a/src/cli/internal/cmd/self/self_transition_internal_test.go
+++ b/src/cli/internal/cmd/self/self_transition_internal_test.go
@@ -62,7 +62,7 @@ func TestSelfTransitionPrepareStopsAppsBeforeLocaltestAndAppManager(t *testing.T
 		},
 	}
 
-	state, err := transition.Prepare(t.Context(), TransitionOptions{})
+	state, err := transition.Prepare(t.Context())
 	if err != nil {
 		t.Fatalf("Prepare() error = %v", err)
 	}
@@ -79,7 +79,7 @@ func TestSelfTransitionPrepareStopsAppsBeforeLocaltestAndAppManager(t *testing.T
 	}
 }
 
-func TestSelfTransitionStatusFailureIsBestEffortUnlessRequired(t *testing.T) {
+func TestSelfTransitionStatusFailureFails(t *testing.T) {
 	t.Parallel()
 
 	cfg := testConfig(t)
@@ -99,14 +99,11 @@ func TestSelfTransitionStatusFailureIsBestEffortUnlessRequired(t *testing.T) {
 		},
 	}
 
-	if _, err := transition.Prepare(t.Context(), TransitionOptions{RequireAppStatus: false}); err != nil {
-		t.Fatalf("Prepare() optional app status error = %v", err)
-	}
-	if _, err := transition.Prepare(t.Context(), TransitionOptions{RequireAppStatus: true}); !errors.Is(
+	if _, err := transition.Prepare(t.Context()); !errors.Is(
 		err,
 		errSelfTransitionTestStatus,
 	) {
-		t.Fatalf("Prepare() required app status error = %v, want status error", err)
+		t.Fatalf("Prepare() app status error = %v, want status error", err)
 	}
 }
 
@@ -144,7 +141,7 @@ func TestSelfTransitionAppStopFailureFails(t *testing.T) {
 		}
 	}
 
-	if _, err := newTransition().Prepare(t.Context(), TransitionOptions{}); !errors.Is(
+	if _, err := newTransition().Prepare(t.Context()); !errors.Is(
 		err,
 		errStopFailed,
 	) {

--- a/src/cli/internal/cmd/self/selfinstall.go
+++ b/src/cli/internal/cmd/self/selfinstall.go
@@ -405,7 +405,6 @@ func replacePathOnce(src, dst string) error {
 
 	//nolint:gosec // G304/G703: both paths are resolved inside the staged install flow.
 	if err := os.Rename(src, dst); err != nil {
-		//nolint:gosec // G304/G703: both paths are resolved inside the staged install flow.
 		restoreErr := os.Rename(backupPath, dst)
 		if restoreErr != nil {
 			return errors.Join(

--- a/src/cli/internal/cmd/self/service.go
+++ b/src/cli/internal/cmd/self/service.go
@@ -44,7 +44,7 @@ func (s *Service) InstallBinary(targetPath string) (InstallBinaryResult, error) 
 	if err != nil {
 		if errors.Is(err, ErrAlreadyInstalled) {
 			return InstallBinaryResult{
-				InstalledPath:    targetPath,
+				InstalledPath:    installedPath,
 				AlreadyInstalled: true,
 			}, nil
 		}

--- a/src/cli/internal/migrations/001_remove_legacy_network_metadata.go
+++ b/src/cli/internal/migrations/001_remove_legacy_network_metadata.go
@@ -1,0 +1,19 @@
+package migrations
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"altinn.studio/studioctl/internal/config"
+)
+
+func legacyNetworkMetadata(_ context.Context, cfg *config.Config) error {
+	path := filepath.Join(cfg.Home, "network-metadata.yaml")
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove legacy network metadata: %w", err)
+	}
+	return nil
+}

--- a/src/cli/internal/migrations/001_remove_legacy_network_metadata_test.go
+++ b/src/cli/internal/migrations/001_remove_legacy_network_metadata_test.go
@@ -1,0 +1,30 @@
+package migrations_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"altinn.studio/studioctl/internal/migrations"
+)
+
+func TestRunRemovesLegacyNetworkMetadata(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig(t)
+	path := filepath.Join(cfg.Home, "network-metadata.yaml")
+	if err := os.WriteFile(path, []byte("hostGateway: 172.17.0.1\n"), 0o600); err != nil {
+		t.Fatalf("write legacy network metadata: %v", err)
+	}
+
+	if err := migrations.Run(t.Context(), cfg); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("legacy network metadata stat error = %v, want not exist", err)
+	}
+	if err := migrations.Run(t.Context(), cfg); err != nil {
+		t.Fatalf("second Run() error = %v", err)
+	}
+}

--- a/src/cli/internal/migrations/migrations.go
+++ b/src/cli/internal/migrations/migrations.go
@@ -1,0 +1,136 @@
+// Package migrations runs idempotent studioctl home migrations during install and update.
+package migrations
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"altinn.studio/studioctl/internal/config"
+	"altinn.studio/studioctl/internal/osutil"
+)
+
+const stateFileName = "migrations.json"
+
+var (
+	// ErrConfigRequired is returned when migrations are run without config.
+	ErrConfigRequired = errors.New("config is required")
+	// ErrMigrationIDRequired is returned when a migration has no stable ID.
+	ErrMigrationIDRequired = errors.New("migration id is required")
+	// ErrMigrationApplyRequired is returned when a migration has no apply function.
+	ErrMigrationApplyRequired = errors.New("migration apply function is required")
+)
+
+// Migration is one idempotent change to the studioctl home/data layout.
+type Migration struct {
+	Up func(context.Context, *config.Config) error
+	ID string
+}
+
+type stateFile struct {
+	Applied []string `json:"applied"`
+}
+
+// Run applies all pending migrations.
+func Run(ctx context.Context, cfg *config.Config) error {
+	return RunAll(ctx, cfg, registeredMigrations())
+}
+
+// RunAll applies the provided migrations.
+func RunAll(ctx context.Context, cfg *config.Config, migrations []Migration) error {
+	if len(migrations) == 0 {
+		return nil
+	}
+	if cfg == nil {
+		return ErrConfigRequired
+	}
+
+	state, err := readState(cfg)
+	if err != nil {
+		return err
+	}
+	applied := appliedSet(state.Applied)
+
+	for _, migration := range migrations {
+		if migration.ID == "" {
+			return ErrMigrationIDRequired
+		}
+		if migration.Up == nil {
+			return fmt.Errorf("%w: %s", ErrMigrationApplyRequired, migration.ID)
+		}
+		if applied[migration.ID] {
+			continue
+		}
+		if err := migration.Up(ctx, cfg); err != nil {
+			return fmt.Errorf("apply migration %q: %w", migration.ID, err)
+		}
+		state.Applied = append(state.Applied, migration.ID)
+		applied[migration.ID] = true
+		if err := writeState(cfg, state); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func appliedSet(ids []string) map[string]bool {
+	applied := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		applied[id] = true
+	}
+	return applied
+}
+
+func readState(cfg *config.Config) (stateFile, error) {
+	path := statePath(cfg)
+	//nolint:gosec // G304: path is derived from the resolved studioctl home directory.
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return stateFile{Applied: nil}, nil
+		}
+		return stateFile{}, fmt.Errorf("read migration state: %w", err)
+	}
+
+	var state stateFile
+	if err := json.Unmarshal(raw, &state); err != nil {
+		return stateFile{}, fmt.Errorf("decode migration state: %w", err)
+	}
+	return state, nil
+}
+
+func writeState(cfg *config.Config, state stateFile) error {
+	path := statePath(cfg)
+	if err := os.MkdirAll(filepath.Dir(path), osutil.DirPermDefault); err != nil {
+		return fmt.Errorf("create migration state directory: %w", err)
+	}
+
+	raw, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode migration state: %w", err)
+	}
+
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, append(raw, '\n'), osutil.FilePermDefault); err != nil {
+		return fmt.Errorf("write migration state temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		removeErr := os.Remove(tmpPath)
+		if removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			return errors.Join(
+				fmt.Errorf("replace migration state: %w", err),
+				fmt.Errorf("remove migration state temp file: %w", removeErr),
+			)
+		}
+		return fmt.Errorf("replace migration state: %w", err)
+	}
+	return nil
+}
+
+func statePath(cfg *config.Config) string {
+	return filepath.Join(cfg.Home, stateFileName)
+}

--- a/src/cli/internal/migrations/migrations_test.go
+++ b/src/cli/internal/migrations/migrations_test.go
@@ -1,0 +1,76 @@
+package migrations_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"altinn.studio/studioctl/internal/config"
+	"altinn.studio/studioctl/internal/migrations"
+)
+
+func TestRunAppliesPendingMigrationsOnce(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig(t)
+	var applied []string
+	steps := []migrations.Migration{
+		{
+			ID: "001-first",
+			Up: func(context.Context, *config.Config) error {
+				applied = append(applied, "001-first")
+				return nil
+			},
+		},
+		{
+			ID: "002-second",
+			Up: func(context.Context, *config.Config) error {
+				applied = append(applied, "002-second")
+				return nil
+			},
+		},
+	}
+
+	if err := migrations.RunAll(t.Context(), cfg, steps); err != nil {
+		t.Fatalf("RunAll() error = %v", err)
+	}
+	if err := migrations.RunAll(t.Context(), cfg, steps); err != nil {
+		t.Fatalf("second RunAll() error = %v", err)
+	}
+
+	wantApplied := []string{"001-first", "002-second"}
+	if !reflect.DeepEqual(applied, wantApplied) {
+		t.Fatalf("applied = %+v, want %+v", applied, wantApplied)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(cfg.Home, "migrations.json"))
+	if err != nil {
+		t.Fatalf("read state file: %v", err)
+	}
+	const wantState = "{\n  \"applied\": [\n    \"001-first\",\n    \"002-second\"\n  ]\n}\n"
+	if string(raw) != wantState {
+		t.Fatalf("state file = %q, want %q", raw, wantState)
+	}
+}
+
+func TestRunRejectsInvalidMigration(t *testing.T) {
+	t.Parallel()
+
+	err := migrations.RunAll(t.Context(), testConfig(t), []migrations.Migration{{ID: "missing-up", Up: nil}})
+	if !errors.Is(err, migrations.ErrMigrationApplyRequired) {
+		t.Fatalf("RunAll() error = %v, want ErrMigrationApplyRequired", err)
+	}
+}
+
+func testConfig(t *testing.T) *config.Config {
+	t.Helper()
+
+	cfg, err := config.New(config.Flags{Home: t.TempDir()}, "test-version")
+	if err != nil {
+		t.Fatalf("config.New() error = %v", err)
+	}
+	return cfg
+}

--- a/src/cli/internal/migrations/registered.go
+++ b/src/cli/internal/migrations/registered.go
@@ -1,0 +1,10 @@
+package migrations
+
+func registeredMigrations() []Migration {
+	return []Migration{
+		{
+			ID: "001-remove-legacy-network-metadata",
+			Up: legacyNetworkMetadata,
+		},
+	}
+}


### PR DESCRIPTION
## Description

Orchestration of apps, env and servers (app-manager) are currently implementation details that may contain breaking changes  between releases, as such we should shutdown everything when doing self-management operations such as 
* `make user-install`
* `curl ...` / `iex ...` install scripts
* `studioctl self update` / `studioctl self uninstall`

This also adds the concept of migrations, so that we can cleanup config over time. TODO: dont accept downgrades, perhaps enforce uninstall + reinstall?

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a migrations system to handle home directory updates during installation and upgrades.

* **Improvements**
  * Enhanced installation and upgrade flow with improved application lifecycle management, including stopping applications before replacement and reliably restarting services afterwards.

* **Documentation**
  * Updated installation documentation to describe the updated app management and migration behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->