### PR TITLE
fix(admin): downgrade react-router-dom in admin to match shared package version

### DIFF
--- a/src/Designer/frontend/admin/package.json
+++ b/src/Designer/frontend/admin/package.json
@@ -32,7 +32,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-i18next": "16.5.6",
-    "react-router-dom": "7.13.1"
+    "react-router-dom": "6.30.3"
   },
   "devDependencies": {
     "jest": "29.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8155,7 +8155,7 @@ __metadata:
     react: "npm:19.2.4"
     react-dom: "npm:19.2.4"
     react-i18next: "npm:16.5.6"
-    react-router-dom: "npm:7.13.1"
+    react-router-dom: "npm:6.30.3"
     typescript: "npm:5.9.3"
     vite: "npm:^6.3.2"
   languageName: unknown
@@ -20189,18 +20189,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:7.13.1":
-  version: 7.13.1
-  resolution: "react-router-dom@npm:7.13.1"
-  dependencies:
-    react-router: "npm:7.13.1"
-  peerDependencies:
-    react: ">=18"
-    react-dom: ">=18"
-  checksum: 10/bda00612fc5032ad2b693d9d6dc9049690c7967900a166887ce60727be5b375a1c9d5c9e4083a80a2baa548428edf74c1cd2a43255a771e9cab7ea33b42aefc2
-  languageName: node
-  linkType: hard
-
 "react-router@npm:6.30.3":
   version: 6.30.3
   resolution: "react-router@npm:6.30.3"
@@ -20225,22 +20213,6 @@ __metadata:
     react-dom:
       optional: true
   checksum: 10/8bc0a1eebf37136851ee345e53b137b5a7ec0de10c842861a06810bb54c0a389826734a7454f4afe8731daf39499948ba73657e60a6bd2acb93b3e567fd79127
-  languageName: node
-  linkType: hard
-
-"react-router@npm:7.13.1":
-  version: 7.13.1
-  resolution: "react-router@npm:7.13.1"
-  dependencies:
-    cookie: "npm:^1.0.1"
-    set-cookie-parser: "npm:^2.6.0"
-  peerDependencies:
-    react: ">=18"
-    react-dom: ">=18"
-  peerDependenciesMeta:
-    react-dom:
-      optional: true
-  checksum: 10/da3c9f52ccb968647090013f735b8506b5f6a0290a43259d78e9ef6a664715978b6de90417e56b18717ce4ffc306e02826f0418e046aae22936a6f8cf386bc79
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Two versions (v6 and v7) are being bundled together in production, causing router hooks to fail because each version defines its own React context.

| BEFORE | AFTER |
|--------|--------|
| <img width="2294" height="1820" alt="Screenshot from 2026-04-28 11-00-39" src="https://github.com/user-attachments/assets/ccf2df82-8729-49af-b451-c3583b7e3f71" /> | <img width="2294" height="1820" alt="Screenshot from 2026-04-28 11-00-06" src="https://github.com/user-attachments/assets/de6fbbcf-2279-4bc6-88e6-2b5d70f525fc" /> |

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated runtime routing library dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->