### PR TITLE
fix(workflow-engine): correct timing histograms and outcome counters

### DIFF
--- a/src/Runtime/workflow-engine/.docker/dashboards/workflow-engine.json
+++ b/src/Runtime/workflow-engine/.docker/dashboards/workflow-engine.json
@@ -1626,6 +1626,35 @@
                 }
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Mean"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#8e8e8e",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "dash",
+                  "dash": [
+                    10,
+                    5
+                  ]
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 1
+              }
+            ]
           }
         ]
       },
@@ -1677,10 +1706,19 @@
           "expr": "histogram_quantile(0.99, sum(rate(engine_workflows_time_total_seconds_bucket[5m])) by (le))",
           "legendFormat": "P99",
           "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(engine_workflows_time_total_seconds_sum[5m])) / sum(rate(engine_workflows_time_total_seconds_count[5m]))",
+          "legendFormat": "Mean",
+          "refId": "D"
         }
       ],
       "title": "Workflow Duration (per attempt)",
-      "description": "Workflow duration percentiles for a single attempt (queue + service). Retries land as separate samples; check Outcomes for retry rate.",
+      "description": "Workflow duration percentiles for a single attempt (queue + service). The dashed Mean line matches the stack height of the adjacent Workflow Time Breakdown \u2014 both compute rate(_sum)/rate(_count) over the same _total histogram. Retries land as separate samples; see Outcomes for retry rate.",
       "type": "timeseries"
     },
     {
@@ -1895,6 +1933,35 @@
                 }
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Mean"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#8e8e8e",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "dash",
+                  "dash": [
+                    10,
+                    5
+                  ]
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 1
+              }
+            ]
           }
         ]
       },
@@ -1946,10 +2013,19 @@
           "expr": "histogram_quantile(0.99, sum(rate(engine_steps_time_total_seconds_bucket[5m])) by (le))",
           "legendFormat": "P99",
           "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(engine_steps_time_total_seconds_sum[5m])) / sum(rate(engine_steps_time_total_seconds_count[5m]))",
+          "legendFormat": "Mean",
+          "refId": "D"
         }
       ],
       "title": "Step Duration (per attempt)",
-      "description": "Step duration percentiles for a single attempt (queue + service). Step retries land as separate samples \u2014 see Step Failures for retry rate.",
+      "description": "Step duration percentiles for a single attempt (queue + service). The dashed Mean line matches the stack height of the adjacent Step Time Breakdown \u2014 both compute rate(_sum)/rate(_count) over the same _total histogram. Step retries land as separate samples \u2014 see Step Failures for retry rate.",
       "type": "timeseries"
     },
     {

--- a/src/Runtime/workflow-engine/.docker/dashboards/workflow-engine.json
+++ b/src/Runtime/workflow-engine/.docker/dashboards/workflow-engine.json
@@ -1626,35 +1626,6 @@
                 }
               }
             ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Mean"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#8e8e8e",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "custom.lineStyle",
-                "value": {
-                  "fill": "dash",
-                  "dash": [
-                    10,
-                    5
-                  ]
-                }
-              },
-              {
-                "id": "custom.lineWidth",
-                "value": 1
-              }
-            ]
           }
         ]
       },
@@ -1706,19 +1677,10 @@
           "expr": "histogram_quantile(0.99, sum(rate(engine_workflows_time_total_seconds_bucket[5m])) by (le))",
           "legendFormat": "P99",
           "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum(rate(engine_workflows_time_total_seconds_sum[5m])) / sum(rate(engine_workflows_time_total_seconds_count[5m]))",
-          "legendFormat": "Mean",
-          "refId": "D"
         }
       ],
       "title": "Workflow Duration (per attempt)",
-      "description": "Workflow duration percentiles for a single attempt (queue + service). The dashed Mean line matches the stack height of the adjacent Workflow Time Breakdown \u2014 both compute rate(_sum)/rate(_count) over the same _total histogram. Retries land as separate samples; see Outcomes for retry rate.",
+      "description": "Workflow duration percentiles for a single attempt (queue + service). Retries land as separate samples; see Outcomes for retry rate.",
       "type": "timeseries"
     },
     {
@@ -1826,7 +1788,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(engine_workflows_time_queue_seconds_sum[5m])) / sum(rate(engine_workflows_time_queue_seconds_count[5m]))",
+          "expr": "histogram_quantile(0.95, sum(rate(engine_workflows_time_queue_seconds_bucket[5m])) by (le))",
           "legendFormat": "Queue Wait",
           "refId": "A"
         },
@@ -1835,13 +1797,13 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(engine_workflows_time_service_seconds_sum[5m])) / sum(rate(engine_workflows_time_service_seconds_count[5m]))",
+          "expr": "histogram_quantile(0.95, sum(rate(engine_workflows_time_service_seconds_bucket[5m])) by (le))",
           "legendFormat": "Execution",
           "refId": "B"
         }
       ],
-      "title": "Workflow Time Breakdown (mean, per attempt)",
-      "description": "Per-attempt mean of queue wait and active execution, stacked. Means are additive, so the stack height equals the mean total time per attempt. Use this view to see how time is split on average; for tail latency see Workflow Duration (P95).",
+      "title": "Workflow Time Breakdown (P95, per attempt)",
+      "description": "Per-attempt P95 of queue wait and active execution, stacked. Stack height is the sum of two marginal P95s \u2014 useful for seeing where tail latency is concentrated, but it does not reconcile arithmetically with the Workflow Duration panel's P95(total) because percentiles are not additive across the queue/service decomposition. Within a single attempt, queue + service does equal total by construction.",
       "type": "timeseries"
     },
     {
@@ -1933,35 +1895,6 @@
                 }
               }
             ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Mean"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#8e8e8e",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "custom.lineStyle",
-                "value": {
-                  "fill": "dash",
-                  "dash": [
-                    10,
-                    5
-                  ]
-                }
-              },
-              {
-                "id": "custom.lineWidth",
-                "value": 1
-              }
-            ]
           }
         ]
       },
@@ -2013,19 +1946,10 @@
           "expr": "histogram_quantile(0.99, sum(rate(engine_steps_time_total_seconds_bucket[5m])) by (le))",
           "legendFormat": "P99",
           "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum(rate(engine_steps_time_total_seconds_sum[5m])) / sum(rate(engine_steps_time_total_seconds_count[5m]))",
-          "legendFormat": "Mean",
-          "refId": "D"
         }
       ],
       "title": "Step Duration (per attempt)",
-      "description": "Step duration percentiles for a single attempt (queue + service). The dashed Mean line matches the stack height of the adjacent Step Time Breakdown \u2014 both compute rate(_sum)/rate(_count) over the same _total histogram. Step retries land as separate samples \u2014 see Step Failures for retry rate.",
+      "description": "Step duration percentiles for a single attempt (queue + service). Step retries land as separate samples \u2014 see Step Failures for retry rate.",
       "type": "timeseries"
     },
     {
@@ -2133,7 +2057,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(engine_steps_time_queue_seconds_sum[5m])) / sum(rate(engine_steps_time_queue_seconds_count[5m]))",
+          "expr": "histogram_quantile(0.95, sum(rate(engine_steps_time_queue_seconds_bucket[5m])) by (le))",
           "legendFormat": "Queue Wait",
           "refId": "A"
         },
@@ -2142,13 +2066,13 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(engine_steps_time_service_seconds_sum[5m])) / sum(rate(engine_steps_time_service_seconds_count[5m]))",
+          "expr": "histogram_quantile(0.95, sum(rate(engine_steps_time_service_seconds_bucket[5m])) by (le))",
           "legendFormat": "Execution",
           "refId": "B"
         }
       ],
-      "title": "Step Time Breakdown (mean, per attempt)",
-      "description": "Per-attempt mean of step queue wait (engine/DB overhead between steps) and active execution, stacked. Means are additive, so the stack height equals the mean total time per step. Use this view to see how time is split on average; for tail latency see Step Duration (P95).",
+      "title": "Step Time Breakdown (P95, per attempt)",
+      "description": "Per-attempt P95 of step queue wait (engine/DB overhead between steps) and active execution, stacked. Stack height is the sum of two marginal P95s \u2014 useful for seeing whether queue or service drives tail latency, but it does not reconcile arithmetically with the Step Duration panel's P95(total) because percentiles are not additive across the queue/service decomposition. Within a single attempt, queue + service does equal total by construction.",
       "type": "timeseries"
     },
     {
@@ -2924,7 +2848,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(engine_mainloop_time_queue_seconds_sum[5m])) / sum(rate(engine_mainloop_time_queue_seconds_count[5m]))",
+          "expr": "histogram_quantile(0.95, sum(rate(engine_mainloop_time_queue_seconds_bucket[5m])) by (le))",
           "legendFormat": "Queue Wait",
           "refId": "A"
         },
@@ -2933,13 +2857,13 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(engine_mainloop_time_service_seconds_sum[5m])) / sum(rate(engine_mainloop_time_service_seconds_count[5m]))",
+          "expr": "histogram_quantile(0.95, sum(rate(engine_mainloop_time_service_seconds_bucket[5m])) by (le))",
           "legendFormat": "Active Work",
           "refId": "B"
         }
       ],
-      "title": "Main Loop Time (mean)",
-      "description": "Mean time per main-loop iteration, stacked. Queue Wait = post-fetch wait (debounce or ~500ms idle ceiling), Active Work = fetch + dispatch. Means are additive so the stack height equals mean total iteration time. For iteration throughput see Main Loop Rate.",
+      "title": "Main Loop Time (P95)",
+      "description": "P95 of each main-loop iteration broken down: Queue (post-fetch wait \u2014 debounce or ~500ms idle ceiling) and Active Work (fetch + dispatch). Stacked sum of two marginal P95s \u2014 won't reconcile with a hypothetical joint P95 because percentiles are not additive. For iteration throughput see Main Loop Rate.",
       "type": "timeseries"
     },
     {

--- a/src/Runtime/workflow-engine/.docker/dashboards/workflow-engine.json
+++ b/src/Runtime/workflow-engine/.docker/dashboards/workflow-engine.json
@@ -827,13 +827,13 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "(sum(rate(engine_steps_execution_requeued_total[1m])) or vector(0)) + (sum(rate(engine_workflows_execution_requeued_total[1m])) or vector(0))",
+          "expr": "(sum(rate(engine_steps_execution_requeued_total[1m])) or vector(0)) + (sum(rate(engine_workflows_execution_requeued_total{reason=\"shutdown\"}[1m])) or vector(0))",
           "legendFormat": "Retries",
           "refId": "A"
         }
       ],
       "title": "Retries",
-      "description": "Combined workflow + step requeue rate per second (1m avg). Non-zero means commands are failing and being retried.",
+      "description": "Total retry events per second (1m avg): every step retry plus every shutdown-driven workflow requeue. Step retries already imply a workflow requeue with reason=step_retry, so that path is counted once via the step counter only.",
       "type": "stat"
     },
     {

--- a/src/Runtime/workflow-engine/.docker/dashboards/workflow-engine.json
+++ b/src/Runtime/workflow-engine/.docker/dashboards/workflow-engine.json
@@ -1700,7 +1700,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "drawStyle": "line",
-            "fillOpacity": 10,
+            "fillOpacity": 30,
             "gradientMode": "none",
             "lineInterpolation": "smooth",
             "lineWidth": 2,
@@ -1709,7 +1709,7 @@
             "spanNulls": true,
             "stacking": {
               "group": "A",
-              "mode": "none"
+              "mode": "normal"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -1788,7 +1788,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.95, sum(rate(engine_workflows_time_queue_seconds_bucket[5m])) by (le))",
+          "expr": "sum(rate(engine_workflows_time_queue_seconds_sum[5m])) / sum(rate(engine_workflows_time_queue_seconds_count[5m]))",
           "legendFormat": "Queue Wait",
           "refId": "A"
         },
@@ -1797,13 +1797,13 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.95, sum(rate(engine_workflows_time_service_seconds_bucket[5m])) by (le))",
+          "expr": "sum(rate(engine_workflows_time_service_seconds_sum[5m])) / sum(rate(engine_workflows_time_service_seconds_count[5m]))",
           "legendFormat": "Execution",
           "refId": "B"
         }
       ],
-      "title": "Workflow Time Breakdown (P95, per attempt)",
-      "description": "Per-attempt P95 of queue wait and active execution, plotted as independent lines. These do NOT sum to the Workflow Duration P95 \u2014 percentiles are not additive across decompositions. Per individual workflow attempt, queue + service does equal total (by construction in the engine), but the 95th-percentile attempt for queue is rarely the same attempt as the 95th-percentile attempt for service.",
+      "title": "Workflow Time Breakdown (mean, per attempt)",
+      "description": "Per-attempt mean of queue wait and active execution, stacked. Means are additive, so the stack height equals the mean total time per attempt. Use this view to see how time is split on average; for tail latency see Workflow Duration (P95).",
       "type": "timeseries"
     },
     {
@@ -1969,7 +1969,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "drawStyle": "line",
-            "fillOpacity": 10,
+            "fillOpacity": 30,
             "gradientMode": "none",
             "lineInterpolation": "smooth",
             "lineWidth": 2,
@@ -1978,7 +1978,7 @@
             "spanNulls": true,
             "stacking": {
               "group": "A",
-              "mode": "none"
+              "mode": "normal"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -2057,7 +2057,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.95, sum(rate(engine_steps_time_queue_seconds_bucket[5m])) by (le))",
+          "expr": "sum(rate(engine_steps_time_queue_seconds_sum[5m])) / sum(rate(engine_steps_time_queue_seconds_count[5m]))",
           "legendFormat": "Queue Wait",
           "refId": "A"
         },
@@ -2066,13 +2066,13 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.95, sum(rate(engine_steps_time_service_seconds_bucket[5m])) by (le))",
+          "expr": "sum(rate(engine_steps_time_service_seconds_sum[5m])) / sum(rate(engine_steps_time_service_seconds_count[5m]))",
           "legendFormat": "Execution",
           "refId": "B"
         }
       ],
-      "title": "Step Time Breakdown (P95, per attempt)",
-      "description": "Per-attempt P95 of step queue wait (engine/DB overhead between steps) and active execution, plotted as independent lines. These do NOT sum to the Step Duration P95 \u2014 percentiles are not additive across decompositions. Use this view to see whether queue or service is the dominant contributor at the tail.",
+      "title": "Step Time Breakdown (mean, per attempt)",
+      "description": "Per-attempt mean of step queue wait (engine/DB overhead between steps) and active execution, stacked. Means are additive, so the stack height equals the mean total time per step. Use this view to see how time is split on average; for tail latency see Step Duration (P95).",
       "type": "timeseries"
     },
     {
@@ -2848,7 +2848,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.95, sum(rate(engine_mainloop_time_queue_seconds_bucket[5m])) by (le))",
+          "expr": "sum(rate(engine_mainloop_time_queue_seconds_sum[5m])) / sum(rate(engine_mainloop_time_queue_seconds_count[5m]))",
           "legendFormat": "Queue Wait",
           "refId": "A"
         },
@@ -2857,13 +2857,13 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.95, sum(rate(engine_mainloop_time_service_seconds_bucket[5m])) by (le))",
+          "expr": "sum(rate(engine_mainloop_time_service_seconds_sum[5m])) / sum(rate(engine_mainloop_time_service_seconds_count[5m]))",
           "legendFormat": "Active Work",
           "refId": "B"
         }
       ],
-      "title": "Main Loop Time (P95)",
-      "description": "P95 of each main-loop iteration broken down: Queue (post-fetch wait \u2014 debounce or ~500ms idle ceiling), Active Work (fetch + dispatch). Note: P95s are independent \u2014 they cannot be summed to derive total iteration time. For iteration throughput, see Main Loop Rate.",
+      "title": "Main Loop Time (mean)",
+      "description": "Mean time per main-loop iteration, stacked. Queue Wait = post-fetch wait (debounce or ~500ms idle ceiling), Active Work = fetch + dispatch. Means are additive so the stack height equals mean total iteration time. For iteration throughput see Main Loop Rate.",
       "type": "timeseries"
     },
     {

--- a/src/Runtime/workflow-engine/.docker/dashboards/workflow-engine.json
+++ b/src/Runtime/workflow-engine/.docker/dashboards/workflow-engine.json
@@ -1329,7 +1329,7 @@
         }
       ],
       "title": "Workflow Outcomes",
-      "description": "Rate of workflow lifecycle events (5m avg). Failed/Canceled/Requeued broken down by reason — failed: execution / dependency_failed / poison; canceled: before_processing / during_processing; requeued: step_retry / shutdown.",
+      "description": "Rate of workflow lifecycle events (5m avg). Failed/Canceled/Requeued broken down by reason \u2014 failed: execution / dependency_failed / poison; canceled: before_processing / during_processing; requeued: step_retry / shutdown.",
       "type": "timeseries"
     },
     {
@@ -1631,7 +1631,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
+        "w": 6,
         "x": 0,
         "y": 19
       },
@@ -1762,8 +1762,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 8,
+        "w": 6,
+        "x": 6,
         "y": 19
       },
       "id": 22,
@@ -1803,7 +1803,7 @@
         }
       ],
       "title": "Workflow Time Breakdown (P95, per attempt)",
-      "description": "Per-attempt P95 split: time waiting in the queue vs active execution. Stacked because queue + service ≈ total within a single attempt.",
+      "description": "Per-attempt P95 split: time waiting in the queue vs active execution. Stacked because queue + service \u2248 total within a single attempt.",
       "type": "timeseries"
     },
     {
@@ -1900,8 +1900,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 16,
+        "w": 6,
+        "x": 12,
         "y": 19
       },
       "id": 23,
@@ -1949,7 +1949,130 @@
         }
       ],
       "title": "Step Duration (per attempt)",
-      "description": "Step duration percentiles for a single attempt (queue + service). Step retries land as separate samples — see Step Failures for retry rate.",
+      "description": "Step duration percentiles for a single attempt (queue + service). Step retries land as separate samples \u2014 see Step Failures for retry rate.",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "unit": "s",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Queue Wait"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "light-orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Execution"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "light-blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 19
+      },
+      "id": 53,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(engine_steps_time_queue_seconds_bucket[5m])) by (le))",
+          "legendFormat": "Queue Wait",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(engine_steps_time_service_seconds_bucket[5m])) by (le))",
+          "legendFormat": "Execution",
+          "refId": "B"
+        }
+      ],
+      "title": "Step Time Breakdown (P95, per attempt)",
+      "description": "Per-attempt P95 split: time between the previous step finishing and this one starting (mostly engine/DB overhead) vs active execution. Stacked because queue + service \u2248 total within an attempt.",
       "type": "timeseries"
     },
     {
@@ -2740,7 +2863,7 @@
         }
       ],
       "title": "Main Loop Time (P95)",
-      "description": "P95 of each main-loop iteration broken down: Queue (post-fetch wait — debounce or ~500ms idle ceiling), Active Work (fetch + dispatch). Note: P95s are independent — they cannot be summed to derive total iteration time. For iteration throughput, see Main Loop Rate.",
+      "description": "P95 of each main-loop iteration broken down: Queue (post-fetch wait \u2014 debounce or ~500ms idle ceiling), Active Work (fetch + dispatch). Note: P95s are independent \u2014 they cannot be summed to derive total iteration time. For iteration throughput, see Main Loop Rate.",
       "type": "timeseries"
     },
     {
@@ -3172,7 +3295,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
+        "w": 12,
         "x": 0,
         "y": 47
       },
@@ -3313,8 +3436,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 8,
+        "w": 12,
+        "x": 12,
         "y": 47
       },
       "id": 52,
@@ -3356,129 +3479,6 @@
       ],
       "title": "Errors & Recovery",
       "description": "Error rate broken down by subsystem (workflowProcessing / fetchAndLock / dbMaintenance / metricsCollector) plus stale-workflow reclaim rate.",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "drawStyle": "line",
-            "fillOpacity": 30,
-            "gradientMode": "none",
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "showPoints": "never",
-            "spanNulls": true,
-            "stacking": {
-              "group": "A",
-              "mode": "normal"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "unit": "s",
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Queue Wait"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "light-orange",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Execution"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "light-blue",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 47
-      },
-      "id": 53,
-      "options": {
-        "legend": {
-          "calcs": [
-            "mean",
-            "max"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "histogram_quantile(0.95, sum(rate(engine_steps_time_queue_seconds_bucket[5m])) by (le))",
-          "legendFormat": "Queue Wait",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "histogram_quantile(0.95, sum(rate(engine_steps_time_service_seconds_bucket[5m])) by (le))",
-          "legendFormat": "Execution",
-          "refId": "B"
-        }
-      ],
-      "title": "Step Time Breakdown (P95, per attempt)",
-      "description": "Per-attempt P95 split: time between the previous step finishing and this one starting (mostly engine/DB overhead) vs active execution. Stacked because queue + service ≈ total within an attempt.",
       "type": "timeseries"
     },
     {
@@ -3952,7 +3952,7 @@
         }
       ],
       "title": "Lease Lost",
-      "description": "Rate of in-flight workflows abandoned because the row's lease token no longer matches at write-back. Non-zero indicates heartbeat lag or aggressive maintenance reclaim — workflows self-heal via reclaim, but downstream side effects may have been duplicated.",
+      "description": "Rate of in-flight workflows abandoned because the row's lease token no longer matches at write-back. Non-zero indicates heartbeat lag or aggressive maintenance reclaim \u2014 workflows self-heal via reclaim, but downstream side effects may have been duplicated.",
       "type": "stat"
     },
     {
@@ -4018,7 +4018,7 @@
         }
       ],
       "title": "Fetch Race Dropped",
-      "description": "Rate of fetched workflows skipped because they were already in-flight on this host — same-host DbMaintenance reclaim raced the main fetch loop. Self-heals on the next maintenance sweep.",
+      "description": "Rate of fetched workflows skipped because they were already in-flight on this host \u2014 same-host DbMaintenance reclaim raced the main fetch loop. Self-heals on the next maintenance sweep.",
       "type": "stat"
     },
     {
@@ -4084,7 +4084,7 @@
         }
       ],
       "title": "Update Buffer Dropped",
-      "description": "Rate of fire-and-forget status updates dropped because the update-buffer channel was full. These are real losses (intermediate progress updates) — non-zero signals backpressure exceeding the buffer's capacity.",
+      "description": "Rate of fire-and-forget status updates dropped because the update-buffer channel was full. These are real losses (intermediate progress updates) \u2014 non-zero signals backpressure exceeding the buffer's capacity.",
       "type": "stat"
     }
   ],

--- a/src/Runtime/workflow-engine/.docker/dashboards/workflow-engine.json
+++ b/src/Runtime/workflow-engine/.docker/dashboards/workflow-engine.json
@@ -407,8 +407,8 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(engine_errors_total[5m]))",
-          "legendFormat": "Errors (total)",
+          "expr": "sum by (operation) (rate(engine_errors_total[5m]))",
+          "legendFormat": "Errors ({{operation}})",
           "refId": "A"
         },
         {
@@ -416,8 +416,8 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(engine_workflows_execution_failed_total[5m]))",
-          "legendFormat": "Workflow Failures",
+          "expr": "sum by (reason) (rate(engine_workflows_execution_failed_total[5m]))",
+          "legendFormat": "Workflow Failures ({{reason}})",
           "refId": "B"
         },
         {
@@ -449,7 +449,7 @@
         }
       ],
       "title": "Failures",
-      "description": "All failure signals: general errors, workflow/step/DB failures (rate/s), and maintenance consecutive failure count (right axis).",
+      "description": "All failure signals: errors broken down by subsystem, workflow failures by reason, plus step/DB failures and maintenance consecutive failure count (right axis).",
       "type": "timeseries"
     },
     {
@@ -1064,6 +1064,21 @@
                 }
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Queries"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
           }
         ]
       },
@@ -1107,10 +1122,19 @@
           "expr": "sum(rate(engine_workflows_request_accepted_total[5m]))",
           "legendFormat": "Accepted",
           "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(engine_workflows_query_received_total[5m]))",
+          "legendFormat": "Queries",
+          "refId": "C"
         }
       ],
       "title": "Workflow Requests",
-      "description": "Rate of incoming workflow requests vs accepted (5m avg)",
+      "description": "Rate of incoming workflow write requests vs accepted, plus read-side query traffic (5m avg)",
       "type": "timeseries"
     },
     {
@@ -1175,8 +1199,8 @@
           },
           {
             "matcher": {
-              "id": "byName",
-              "options": "Failed"
+              "id": "byRegexp",
+              "options": "^Failed"
             },
             "properties": [
               {
@@ -1213,6 +1237,21 @@
                 "id": "color",
                 "value": {
                   "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Resumed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
                   "mode": "fixed"
                 }
               }
@@ -1257,8 +1296,8 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(engine_workflows_execution_failed_total[5m]))",
-          "legendFormat": "Failed",
+          "expr": "sum by (reason) (rate(engine_workflows_execution_failed_total[5m]))",
+          "legendFormat": "Failed ({{reason}})",
           "refId": "B"
         },
         {
@@ -1266,8 +1305,8 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(engine_workflows_execution_canceled_total[5m]))",
-          "legendFormat": "Canceled",
+          "expr": "sum by (reason) (rate(engine_workflows_execution_canceled_total[5m]))",
+          "legendFormat": "Canceled ({{reason}})",
           "refId": "C"
         },
         {
@@ -1275,13 +1314,22 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(engine_workflows_execution_requeued_total[5m]))",
-          "legendFormat": "Requeued",
+          "expr": "sum by (reason) (rate(engine_workflows_execution_requeued_total[5m]))",
+          "legendFormat": "Requeued ({{reason}})",
           "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(engine_workflows_execution_resumed_total[5m]))",
+          "legendFormat": "Resumed",
+          "refId": "E"
         }
       ],
       "title": "Workflow Outcomes",
-      "description": "Rate of workflow completions by outcome (5m avg)",
+      "description": "Rate of workflow lifecycle events (5m avg). Failed/Canceled/Requeued broken down by reason — failed: execution / dependency_failed / poison; canceled: before_processing / during_processing; requeued: step_retry / shutdown.",
       "type": "timeseries"
     },
     {
@@ -1387,6 +1435,21 @@
                 }
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Finished"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#8e8e8e",
+                  "mode": "fixed"
+                }
+              }
+            ]
           }
         ]
       },
@@ -1447,10 +1510,19 @@
           "expr": "sum(engine_workflows_successful)",
           "legendFormat": "Successful",
           "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(engine_workflows_finished)",
+          "legendFormat": "Finished",
+          "refId": "E"
         }
       ],
       "title": "Workflow Inventory",
-      "description": "Current workflow counts by state (gauge values over time)",
+      "description": "Current workflow counts by state (gauge values over time). Finished = all terminal (success + failed + canceled + dep-failed).",
       "type": "timeseries"
     },
     {
@@ -1607,8 +1679,8 @@
           "refId": "C"
         }
       ],
-      "title": "Workflow Duration (E2E)",
-      "description": "End-to-end workflow duration percentiles including queue and retry time",
+      "title": "Workflow Duration (per attempt)",
+      "description": "Workflow duration percentiles for a single attempt (queue + service). Retries land as separate samples; check Outcomes for retry rate.",
       "type": "timeseries"
     },
     {
@@ -1730,8 +1802,8 @@
           "refId": "B"
         }
       ],
-      "title": "Workflow Time Breakdown (P95)",
-      "description": "Where workflows spend their time: waiting in queue vs active execution (P95 stacked)",
+      "title": "Workflow Time Breakdown (P95, per attempt)",
+      "description": "Per-attempt P95 split: time waiting in the queue vs active execution. Stacked because queue + service ≈ total within a single attempt.",
       "type": "timeseries"
     },
     {
@@ -1876,8 +1948,8 @@
           "refId": "C"
         }
       ],
-      "title": "Step Duration (E2E)",
-      "description": "End-to-end step duration percentiles including queue and retry time",
+      "title": "Step Duration (per attempt)",
+      "description": "Step duration percentiles for a single attempt (queue + service). Step retries land as separate samples — see Step Failures for retry rate.",
       "type": "timeseries"
     },
     {
@@ -2668,7 +2740,7 @@
         }
       ],
       "title": "Main Loop Time (P95)",
-      "description": "How the main loop spends each iteration: waiting for work vs actively processing (P95 stacked)",
+      "description": "P95 of each main-loop iteration broken down: Queue (post-fetch wait — debounce or ~500ms idle ceiling), Active Work (fetch + dispatch). Note: P95s are independent — they cannot be summed to derive total iteration time. For iteration throughput, see Main Loop Rate.",
       "type": "timeseries"
     },
     {
@@ -3209,8 +3281,8 @@
         "overrides": [
           {
             "matcher": {
-              "id": "byName",
-              "options": "Errors"
+              "id": "byRegexp",
+              "options": "^Errors"
             },
             "properties": [
               {
@@ -3268,8 +3340,8 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(engine_errors_total[5m]))",
-          "legendFormat": "Errors",
+          "expr": "sum by (operation) (rate(engine_errors_total[5m]))",
+          "legendFormat": "Errors ({{operation}})",
           "refId": "A"
         },
         {
@@ -3283,7 +3355,7 @@
         }
       ],
       "title": "Errors & Recovery",
-      "description": "General error rate and stale workflow reclaims (crashed worker recovery)",
+      "description": "Error rate broken down by subsystem (workflowProcessing / fetchAndLock / dbMaintenance / metricsCollector) plus stale-workflow reclaim rate.",
       "type": "timeseries"
     },
     {
@@ -3405,8 +3477,8 @@
           "refId": "B"
         }
       ],
-      "title": "Step Time Breakdown (P95)",
-      "description": "Where steps spend their time: waiting in queue vs active execution (P95 stacked)",
+      "title": "Step Time Breakdown (P95, per attempt)",
+      "description": "Per-attempt P95 split: time between the previous step finishing and this one starting (mostly engine/DB overhead) vs active execution. Stacked because queue + service ≈ total within an attempt.",
       "type": "timeseries"
     },
     {
@@ -3803,6 +3875,217 @@
       "title": "Connections & Pool Limits",
       "description": "Currently executing commands, total open connections, and pool max boundary. Executing near pool limit = saturation.",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 64
+      },
+      "id": 70,
+      "panels": [],
+      "title": "Lease & Recovery Signals",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.01
+              }
+            ]
+          },
+          "unit": "ops",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 0,
+        "y": 65
+      },
+      "id": 71,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true,
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(engine_workflows_execution_lease_lost_total[5m]))",
+          "legendFormat": "Lease Lost",
+          "refId": "A"
+        }
+      ],
+      "title": "Lease Lost",
+      "description": "Rate of in-flight workflows abandoned because the row's lease token no longer matches at write-back. Non-zero indicates heartbeat lag or aggressive maintenance reclaim — workflows self-heal via reclaim, but downstream side effects may have been duplicated.",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.01
+              }
+            ]
+          },
+          "unit": "ops",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 8,
+        "y": 65
+      },
+      "id": 72,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true,
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(engine_workflows_fetch_race_dropped_total[5m]))",
+          "legendFormat": "Fetch Race Dropped",
+          "refId": "A"
+        }
+      ],
+      "title": "Fetch Race Dropped",
+      "description": "Rate of fetched workflows skipped because they were already in-flight on this host — same-host DbMaintenance reclaim raced the main fetch loop. Self-heals on the next maintenance sweep.",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.01
+              }
+            ]
+          },
+          "unit": "ops",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 16,
+        "y": 65
+      },
+      "id": 73,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true,
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(engine_update_buffer_dropped_total[5m]))",
+          "legendFormat": "Update Buffer Dropped",
+          "refId": "A"
+        }
+      ],
+      "title": "Update Buffer Dropped",
+      "description": "Rate of fire-and-forget status updates dropped because the update-buffer channel was full. These are real losses (intermediate progress updates) — non-zero signals backpressure exceeding the buffer's capacity.",
+      "type": "stat"
     }
   ],
   "preload": false,

--- a/src/Runtime/workflow-engine/.docker/dashboards/workflow-engine.json
+++ b/src/Runtime/workflow-engine/.docker/dashboards/workflow-engine.json
@@ -1700,7 +1700,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "drawStyle": "line",
-            "fillOpacity": 30,
+            "fillOpacity": 10,
             "gradientMode": "none",
             "lineInterpolation": "smooth",
             "lineWidth": 2,
@@ -1709,7 +1709,7 @@
             "spanNulls": true,
             "stacking": {
               "group": "A",
-              "mode": "normal"
+              "mode": "none"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -1803,7 +1803,7 @@
         }
       ],
       "title": "Workflow Time Breakdown (P95, per attempt)",
-      "description": "Per-attempt P95 split: time waiting in the queue vs active execution. Stacked because queue + service \u2248 total within a single attempt.",
+      "description": "Per-attempt P95 of queue wait and active execution, plotted as independent lines. These do NOT sum to the Workflow Duration P95 \u2014 percentiles are not additive across decompositions. Per individual workflow attempt, queue + service does equal total (by construction in the engine), but the 95th-percentile attempt for queue is rarely the same attempt as the 95th-percentile attempt for service.",
       "type": "timeseries"
     },
     {
@@ -1969,7 +1969,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "drawStyle": "line",
-            "fillOpacity": 30,
+            "fillOpacity": 10,
             "gradientMode": "none",
             "lineInterpolation": "smooth",
             "lineWidth": 2,
@@ -1978,7 +1978,7 @@
             "spanNulls": true,
             "stacking": {
               "group": "A",
-              "mode": "normal"
+              "mode": "none"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -2072,7 +2072,7 @@
         }
       ],
       "title": "Step Time Breakdown (P95, per attempt)",
-      "description": "Per-attempt P95 split: time between the previous step finishing and this one starting (mostly engine/DB overhead) vs active execution. Stacked because queue + service \u2248 total within an attempt.",
+      "description": "Per-attempt P95 of step queue wait (engine/DB overhead between steps) and active execution, plotted as independent lines. These do NOT sum to the Step Duration P95 \u2014 percentiles are not additive across decompositions. Use this view to see whether queue or service is the dominant contributor at the tail.",
       "type": "timeseries"
     },
     {

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Core/Engine.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Core/Engine.cs
@@ -298,7 +298,6 @@ internal sealed class Engine(
 
         if (updated)
         {
-            Metrics.WorkflowsCanceled.Add(1);
             var canceledImmediately = tracker.TryCancel(workflowId);
             return new CancelWorkflowResult.Requested(workflowId, now, canceledImmediately);
         }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Core/WorkflowHandler.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Core/WorkflowHandler.cs
@@ -126,6 +126,9 @@ internal sealed class WorkflowHandler(
                 else
                 {
                     workflow.Status = PersistentItemStatus.Requeued;
+                    Metrics.WorkflowsRequeued.Add(1, ("reason", "shutdown"));
+                    RecordWorkflowServiceTime(workflow);
+                    RecordWorkflowTotalTime(workflow);
                 }
             }
 
@@ -178,6 +181,13 @@ internal sealed class WorkflowHandler(
 
             workflow.EngineActivity?.Errored();
             Metrics.WorkflowsFailed.Add(1, ("reason", "execution"));
+        }
+        else if (workflow.Status == PersistentItemStatus.Requeued)
+        {
+            RecordWorkflowServiceTime(workflow);
+            RecordWorkflowTotalTime(workflow);
+
+            Metrics.WorkflowsRequeued.Add(1, ("reason", "step_retry"));
         }
 
         await statusWriteBuffer.Submit(workflow, ct);

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Core/WorkflowHandler.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Core/WorkflowHandler.cs
@@ -195,7 +195,7 @@ internal sealed class WorkflowHandler(
 
     private async Task ProcessSteps(Workflow workflow, CancellationToken ct)
     {
-        var queueAnchor = workflow.ExecutionStartedAt!.Value;
+        var queueAnchor = workflow.ExecutionStartedAt ?? throw new UnreachableException();
 
         for (int i = 0; i < workflow.Steps.Count; i++)
         {
@@ -258,7 +258,7 @@ internal sealed class WorkflowHandler(
             RecordStepTotalTime(step, queueAnchor);
             StopActivity(step);
 
-            queueAnchor = step.UpdatedAt!.Value;
+            queueAnchor = step.UpdatedAt ?? throw new UnreachableException();
 
             if (step.Status == PersistentItemStatus.Completed)
             {

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Core/WorkflowHandler.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Core/WorkflowHandler.cs
@@ -185,6 +185,8 @@ internal sealed class WorkflowHandler(
 
     private async Task ProcessSteps(Workflow workflow, CancellationToken ct)
     {
+        var queueAnchor = workflow.ExecutionStartedAt!.Value;
+
         for (int i = 0; i < workflow.Steps.Count; i++)
         {
             ct.ThrowIfCancellationRequested();
@@ -198,7 +200,7 @@ internal sealed class WorkflowHandler(
 
             StartProcessStepActivity(workflow, step);
 
-            RecordStepQueueTime(workflow, step);
+            RecordStepQueueTime(step, queueAnchor);
 
             step.Status = PersistentItemStatus.Processing;
             step.ExecutionStartedAt = timeProvider.GetUtcNow();
@@ -243,8 +245,10 @@ internal sealed class WorkflowHandler(
             );
 
             RecordStepServiceTime(step);
-            RecordStepTotalTime(step, previous);
+            RecordStepTotalTime(step, queueAnchor);
             StopActivity(step);
+
+            queueAnchor = step.UpdatedAt!.Value;
 
             if (step.Status == PersistentItemStatus.Completed)
             {
@@ -410,15 +414,14 @@ internal sealed class WorkflowHandler(
 
     private void RecordWorkflowTotalTime(Workflow workflow)
     {
-        var scheduledStart = workflow.StartAt ?? workflow.CreatedAt;
-        var totalDuration = timeProvider.GetUtcNow().Subtract(scheduledStart).TotalSeconds;
+        var anchor = workflow.BackoffUntil ?? workflow.CreatedAt;
+        var totalDuration = timeProvider.GetUtcNow().Subtract(anchor).TotalSeconds;
         Metrics.WorkflowTotalTime.Record(totalDuration, workflow.GetHistorgramTags());
     }
 
-    private void RecordStepQueueTime(Workflow workflow, Step step)
+    private void RecordStepQueueTime(Step step, DateTimeOffset anchor)
     {
-        var latest = workflow.BackoffUntil ?? step.CreatedAt;
-        var queueDuration = timeProvider.GetUtcNow().Subtract(latest).TotalSeconds;
+        var queueDuration = timeProvider.GetUtcNow().Subtract(anchor).TotalSeconds;
         Metrics.StepQueueTime.Record(queueDuration, step.GetHistorgramTags());
     }
 
@@ -429,14 +432,10 @@ internal sealed class WorkflowHandler(
         Metrics.StepServiceTime.Record(serviceDuration, step.GetHistorgramTags());
     }
 
-    private void RecordStepTotalTime(Step currentStep, Step? previousStep)
+    private void RecordStepTotalTime(Step step, DateTimeOffset anchor)
     {
-        var totalDuration = timeProvider
-            .GetUtcNow()
-            .Subtract(previousStep?.UpdatedAt ?? currentStep.CreatedAt)
-            .TotalSeconds;
-
-        Metrics.StepTotalTime.Record(totalDuration, currentStep.GetHistorgramTags());
+        var totalDuration = timeProvider.GetUtcNow().Subtract(anchor).TotalSeconds;
+        Metrics.StepTotalTime.Record(totalDuration, step.GetHistorgramTags());
     }
 }
 

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Core/WorkflowHandler.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Core/WorkflowHandler.cs
@@ -83,7 +83,7 @@ internal sealed class WorkflowHandler(
             workflow.Status = PersistentItemStatus.Canceled;
             workflow.EngineActivity?.Errored(errorMessage: "Canceled before processing started");
 
-            Metrics.WorkflowsCanceled.Add(1);
+            Metrics.WorkflowsCanceled.Add(1, ("reason", "before_processing"));
             RecordWorkflowServiceTime(workflow);
             RecordWorkflowTotalTime(workflow);
 
@@ -119,7 +119,7 @@ internal sealed class WorkflowHandler(
                 if (workflow.CancellationRequestedAt is not null)
                 {
                     workflow.Status = PersistentItemStatus.Canceled;
-                    Metrics.WorkflowsCanceled.Add(1);
+                    Metrics.WorkflowsCanceled.Add(1, ("reason", "during_processing"));
                     RecordWorkflowServiceTime(workflow);
                     RecordWorkflowTotalTime(workflow);
                 }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Telemetry/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Telemetry/Extensions/ServiceCollectionExtensions.cs
@@ -103,10 +103,16 @@ public static class ServiceCollectionExtensions
                 .WithMetrics(builder =>
                 {
                     // Bucket boundaries (in seconds) for workflow/step/mainloop timing histograms.
-                    // The default OTel boundaries (0, 5, 10, 25, ...) have no resolution below 5s,
-                    // causing histogram_quantile to report ~4.8s for sub-second workflows.
+                    // Spans sub-millisecond (per-step DB write overhead) up to multi-minute workflows.
+                    // Without sub-ms boundaries, histogram_quantile linearly interpolates inside the
+                    // lowest bucket and pins to a constant value — e.g. P95 = 0.95 × 5ms = 4.75ms when
+                    // all samples land in (0, 5ms].
                     double[] durationBuckets =
                     [
+                        0.0001,
+                        0.0005,
+                        0.001,
+                        0.0025,
                         0.005,
                         0.01,
                         0.025,

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Telemetry/Metrics.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Telemetry/Metrics.cs
@@ -74,17 +74,17 @@ public static class Metrics
     public static readonly Histogram<double> WorkflowQueueTime = Meter.CreateHistogram<double>(
         "engine.workflows.time.queue",
         "s",
-        "Amount of time a workflow spent in the queue before and between executions (seconds)"
+        "Time the workflow waited in the queue before this attempt was picked up by a worker (seconds). Recorded once per attempt."
     );
     public static readonly Histogram<double> WorkflowServiceTime = Meter.CreateHistogram<double>(
         "engine.workflows.time.service",
         "s",
-        "Amount of time a workflow's steps spent being actively executed (seconds). Includes time spent on database IO."
+        "Time spent actively processing this workflow attempt (seconds). Includes step execution and database IO. Recorded once per attempt."
     );
     public static readonly Histogram<double> WorkflowTotalTime = Meter.CreateHistogram<double>(
         "engine.workflows.time.total",
         "s",
-        "Amount of time a workflow spent in the engine, start to finish (seconds). Includes time spend on the queue due to retries."
+        "Total wall-clock time of this workflow attempt — queue + service (seconds). Recorded once per attempt."
     );
 
     public static readonly Counter<long> StepRequestsAccepted = Meter.CreateCounter<long>(
@@ -97,17 +97,17 @@ public static class Metrics
     public static readonly Histogram<double> StepQueueTime = Meter.CreateHistogram<double>(
         "engine.steps.time.queue",
         "s",
-        "Amount of time a step spent in the queue before being picked up by a worker (seconds)"
+        "Time between the prior step finishing (or the workflow attempt starting, for the first step) and this step beginning execution (seconds). Mostly captures engine-internal database IO. Recorded once per step per attempt."
     );
     public static readonly Histogram<double> StepServiceTime = Meter.CreateHistogram<double>(
         "engine.steps.time.service",
         "s",
-        "Amount of time a step spent being actively executed (seconds). Includes time spent on database IO."
+        "Time spent actively executing this step (seconds). Includes command execution and database IO. Recorded once per step per attempt."
     );
     public static readonly Histogram<double> StepTotalTime = Meter.CreateHistogram<double>(
         "engine.steps.time.total",
         "s",
-        "Amount of time a step spent in the engine, start to finish (seconds). Includes time spend on the queue due to retries."
+        "Total time for this step within the workflow attempt — queue + service (seconds). Recorded once per step per attempt."
     );
 
     public static readonly Counter<long> UpdateBufferDeduplicatedItems = Meter.CreateCounter<long>(


### PR DESCRIPTION
## Summary

Tightens up the engine's timing histograms and outcome counters, fixes a couple of measurement bugs uncovered while reviewing the dashboard, and refreshes the Grafana dashboard accordingly.

- **Per-attempt timing semantics** — workflow and step `queue / service / total` now consistently measure a single attempt with shared anchors, so per-sample `queue + service ≈ total` actually holds. Retry pressure stays observable via the dedicated `WorkflowsRequeued` / `WorkflowsReclaimed` / `StepsRequeued` counters.
- **Step queue anchor fix** — chained steps used to absorb the previous step's wall-clock into their queue measurement; now anchored at the previous processed step's `UpdatedAt` (or the workflow attempt start for the first step). The metric is now a clean proxy for engine/DB overhead between steps.
- **`WorkflowsCanceled` double-count fix** — dropped the API-side increment; the outcome-side handler is now the single source of truth, mirroring `WorkflowsSucceeded` / `WorkflowsFailed`.
- **`WorkflowsRequeued` wired up** — the counter existed but was never incremented; now ticks on both the step-retry path and the shutdown-requeue path, with a `reason` tag.
- **`reason` tag added to `WorkflowsCanceled`** — `before_processing` vs `during_processing`, matching the `WorkflowsFailed` convention.
- **Histogram bucket resolution extended** to sub-millisecond — without finer boundaries, the now-narrowly-defined step queue (~µs of DB overhead) was pinning P95 to a constant 4.75ms via interpolation inside the bottom bucket.
- **Dashboard refresh** — Latency & Timing row regrouped to hold all four duration/breakdown panels; Outcomes panel now breaks Failed / Canceled / Requeued down by `reason`; new Lease & Recovery Signals row exposes `WorkflowsLeaseLost`, `WorkflowFetchRaceDropped`, and `UpdateBufferDropped`; descriptions tightened to spell out what each panel does and does not reconcile against.

## Related
- ~~Stacked on #18507~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added granular error and cancellation metrics with reason-based breakdowns (e.g., shutdown vs step retry requeues).
  * Introduced lease and recovery signal monitoring for token mismatches and dropped messages.
  * Enhanced workflow outcome tracking with per-reason visibility.
  * Improved timing metrics to clarify per-attempt measurements.
  * Refined dashboard visualisations with finer metric granularity and new observability panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->