### PR TITLE
chore(workflow-engine): standardize xml docstrings and re-enable warnings-as-errors

### DIFF
--- a/.github/workflows/runtime-workflow-engine-app-tests.yaml
+++ b/.github/workflows/runtime-workflow-engine-app-tests.yaml
@@ -13,6 +13,7 @@ on:
       - 'src/Runtime/workflow-engine-app/tests/**'
       - 'src/Runtime/workflow-engine-app/Directory.Build.props'
       - 'src/Runtime/workflow-engine-app/Directory.Packages.props'
+      - 'src/Runtime/workflow-engine-app/typos.toml'
       - '.github/workflows/runtime-workflow-engine-app-tests.yaml'
   workflow_dispatch:
 
@@ -51,3 +52,18 @@ jobs:
 
       - name: Test
         run: dotnet test --no-build
+
+  spell-check:
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
+    name: Spell check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Run typos
+        uses: crate-ci/typos@7c572958218557a3272c2d6719629443b5cc26fd # v1.45.2
+        with:
+          config: src/Runtime/workflow-engine-app/typos.toml
+          files: src/Runtime/workflow-engine-app

--- a/.github/workflows/runtime-workflow-engine-app-tests.yaml
+++ b/.github/workflows/runtime-workflow-engine-app-tests.yaml
@@ -36,6 +36,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Spell check
+        uses: crate-ci/typos@7c572958218557a3272c2d6719629443b5cc26fd # v1.45.2
+        with:
+          config: src/Runtime/workflow-engine-app/typos.toml
+          files: src/Runtime/workflow-engine-app
+
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:
@@ -52,18 +58,3 @@ jobs:
 
       - name: Test
         run: dotnet test --no-build
-
-  spell-check:
-    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
-    name: Spell check
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Run typos
-        uses: crate-ci/typos@7c572958218557a3272c2d6719629443b5cc26fd # v1.45.2
-        with:
-          config: src/Runtime/workflow-engine-app/typos.toml
-          files: src/Runtime/workflow-engine-app

--- a/.github/workflows/runtime-workflow-engine-tests.yaml
+++ b/.github/workflows/runtime-workflow-engine-tests.yaml
@@ -9,6 +9,7 @@ on:
       - 'src/Runtime/workflow-engine/tests/**'
       - 'src/Runtime/workflow-engine/Directory.Build.props'
       - 'src/Runtime/workflow-engine/Directory.Packages.props'
+      - 'src/Runtime/workflow-engine/typos.toml'
       - '.github/workflows/runtime-workflow-engine-tests.yaml'
   workflow_dispatch:
 
@@ -47,3 +48,18 @@ jobs:
 
       - name: Test
         run: dotnet test --no-build --blame-hang --blame-hang-timeout 5m
+
+  spell-check:
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
+    name: Spell check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Run typos
+        uses: crate-ci/typos@7c572958218557a3272c2d6719629443b5cc26fd # v1.45.2
+        with:
+          config: src/Runtime/workflow-engine/typos.toml
+          files: src/Runtime/workflow-engine

--- a/.github/workflows/runtime-workflow-engine-tests.yaml
+++ b/.github/workflows/runtime-workflow-engine-tests.yaml
@@ -32,6 +32,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Spell check
+        uses: crate-ci/typos@7c572958218557a3272c2d6719629443b5cc26fd # v1.45.2
+        with:
+          config: src/Runtime/workflow-engine/typos.toml
+          files: src/Runtime/workflow-engine
+
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:
@@ -48,18 +54,3 @@ jobs:
 
       - name: Test
         run: dotnet test --no-build --blame-hang --blame-hang-timeout 5m
-
-  spell-check:
-    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
-    name: Spell check
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Run typos
-        uses: crate-ci/typos@7c572958218557a3272c2d6719629443b5cc26fd # v1.45.2
-        with:
-          config: src/Runtime/workflow-engine/typos.toml
-          files: src/Runtime/workflow-engine

--- a/src/Runtime/workflow-engine-app/Directory.Build.props
+++ b/src/Runtime/workflow-engine-app/Directory.Build.props
@@ -1,9 +1,8 @@
 <Project>
-  <!--  TEMP: Allow warnings for the time being-->
-  <!--  <PropertyGroup Condition="'$(DOTNET_TREATWARNINGSASERRORS)' == 'true' OR '$(CI)' == 'true'">-->
-  <!--    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>-->
-  <!--    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>-->
-  <!--  </PropertyGroup>-->
+  <PropertyGroup Condition="'$(DOTNET_TREATWARNINGSASERRORS)' == 'true' OR '$(CI)' == 'true'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+  </PropertyGroup>
 
   <PropertyGroup>
     <LangVersion>latest</LangVersion>

--- a/src/Runtime/workflow-engine-app/src/Directory.Build.props
+++ b/src/Runtime/workflow-engine-app/src/Directory.Build.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="../Directory.Build.props" />
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+</Project>

--- a/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/Commands/AppCommand/AppCommand.cs
+++ b/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/Commands/AppCommand/AppCommand.cs
@@ -175,7 +175,7 @@ internal sealed class AppCommand : Command<AppCommandData, AppWorkflowContext>
 internal static partial class AppCommandDescriptorLogs
 {
     [LoggerMessage(LogLevel.Information, "Sending AppCommand to {Endpoint} with payload: {Payload}")]
-    public static partial void SendingAppCommand(
+    internal static partial void SendingAppCommand(
         this ILogger<AppCommand> logger,
         Uri endpoint,
         AppCallbackPayload payload

--- a/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/Commands/AppCommand/AppCommand.cs
+++ b/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/Commands/AppCommand/AppCommand.cs
@@ -162,7 +162,9 @@ internal sealed class AppCommand : Command<AppCommandData, AppWorkflowContext>
 
     private HttpClient CreateAuthorizedClient(AppWorkflowContext workflowContext)
     {
+#pragma warning disable S1075
         var baseUrl = _settings.CommandEndpoint.FormatWith(workflowContext).TrimEnd('/') + '/';
+#pragma warning restore S1075
         var client = _httpClientFactory.CreateClient();
         client.BaseAddress = new Uri(baseUrl);
 

--- a/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/Program.cs
+++ b/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/Program.cs
@@ -28,6 +28,6 @@ await app.UseWorkflowEngine();
 await app.RunAsync();
 
 // Exposed for WebApplicationFactory<Program> in integration tests
-#pragma warning disable S1118
+#pragma warning disable S1118,CS1591,ASP0027
 public partial class Program;
-#pragma warning restore S1118
+#pragma warning restore S1118,CS1591,ASP0027

--- a/src/Runtime/workflow-engine-app/tests/Directory.Build.props
+++ b/src/Runtime/workflow-engine-app/tests/Directory.Build.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="../Directory.Build.props" />
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+</Project>

--- a/src/Runtime/workflow-engine-app/typos.toml
+++ b/src/Runtime/workflow-engine-app/typos.toml
@@ -8,6 +8,9 @@ extend-exclude = [
     "*.drawio*"
 ]
 
+[default]
+locale = "en-us"
+
 [default.extend-words]
 # Domain words and acronyms that should not be flagged.
 # Add entries as `word = "word"` to whitelist a token.

--- a/src/Runtime/workflow-engine-app/typos.toml
+++ b/src/Runtime/workflow-engine-app/typos.toml
@@ -1,0 +1,13 @@
+[files]
+extend-exclude = [
+    "**/wwwroot/**",
+    "**/.k6/**",
+    "**/bin/**",
+    "**/obj/**",
+    "*.svg",
+    "*.drawio*"
+]
+
+[default.extend-words]
+# Domain words and acronyms that should not be flagged.
+# Add entries as `word = "word"` to whitelist a token.

--- a/src/Runtime/workflow-engine/Directory.Build.props
+++ b/src/Runtime/workflow-engine/Directory.Build.props
@@ -1,9 +1,8 @@
 <Project>
-<!--  TEMP: Allow warnings for the time being-->
-<!--  <PropertyGroup Condition="'$(DOTNET_TREATWARNINGSASERRORS)' == 'true' OR '$(CI)' == 'true'">-->
-<!--    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>-->
-<!--    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>-->
-<!--  </PropertyGroup>-->
+  <PropertyGroup Condition="'$(DOTNET_TREATWARNINGSASERRORS)' == 'true' OR '$(CI)' == 'true'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+  </PropertyGroup>
 
   <PropertyGroup>
     <LangVersion>latest</LangVersion>

--- a/src/Runtime/workflow-engine/docs/proposals/recurring-workflows.md
+++ b/src/Runtime/workflow-engine/docs/proposals/recurring-workflows.md
@@ -44,18 +44,18 @@ A new `Recurrence` field on `WorkflowRequest`:
 
 At least one of `maxOccurrences` or `until` must be specified. Unbounded recurrence with no kill switch is not allowed.
 
-### Failure behaviour
+### Failure behavior
 
 "Failure" in this context means the workflow's retry strategy has been fully exhausted — not a transient blip, but a genuine failure.
 
-| Value        | Behaviour                                                                                                               |
+| Value        | Behavior                                                                                                               |
 | ------------ | ----------------------------------------------------------------------------------------------------------------------- |
 | **Stop**     | Chain ends. No successor is scheduled. This is the default.                                                             |
 | **Continue** | Schedule the next occurrence anyway. The failed workflow is recorded in the chain but does not block future executions. |
 
 Note: there is no "Retry" option. By the time recurrence failure handling kicks in, the retry strategy has already made multiple attempts with backoff. If the caller wants more resilience, they should configure a more aggressive retry strategy.
 
-### Engine behaviour
+### Engine behavior
 
 1. A workflow with a `Recurrence` spec is enqueued and processed normally.
 2. On terminal status (Completed, or Failed if `onFailure: Continue`):
@@ -69,7 +69,7 @@ Note: there is no "Retry" option. By the time recurrence failure handling kicks 
 
 ### Frozen spec
 
-The recurrence spec is frozen from the initial request. The engine always uses the predecessor's spec to compute the successor. There is no mechanism to modify the interval, steps, or failure behaviour mid-chain. This keeps the engine logic simple (clone + decrement) and avoids race conditions around in-flight modifications.
+The recurrence spec is frozen from the initial request. The engine always uses the predecessor's spec to compute the successor. There is no mechanism to modify the interval, steps, or failure behavior mid-chain. This keeps the engine logic simple (clone + decrement) and avoids race conditions around in-flight modifications.
 
 ### Cancellation
 

--- a/src/Runtime/workflow-engine/src/Directory.Build.props
+++ b/src/Runtime/workflow-engine/src/Directory.Build.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="../Directory.Build.props" />
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+</Project>

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Commands/Extensions/HttpResponseMessageExtensions.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Commands/Extensions/HttpResponseMessageExtensions.cs
@@ -1,9 +1,15 @@
 namespace WorkflowEngine.Commands.Extensions;
 
+/// <summary>
+/// Helpers over <see cref="HttpResponseMessage"/> used by command handlers when interpreting upstream responses.
+/// </summary>
 public static class HttpResponseMessageExtensions
 {
     extension(HttpResponseMessage response)
     {
+        /// <summary>
+        /// Reads the response body as a string, falling back to <paramref name="defaultValue"/> when the body is empty.
+        /// </summary>
         public async Task<string> GetContentOrDefault(
             string defaultValue,
             CancellationToken cancellationToken = default

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Commands/Extensions/StringExtensions.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Commands/Extensions/StringExtensions.cs
@@ -3,6 +3,9 @@ using System.Text.RegularExpressions;
 
 namespace WorkflowEngine.Commands.Extensions;
 
+/// <summary>
+/// String helpers used by command handlers (lightweight templating and URI parsing).
+/// </summary>
 public static partial class StringExtensions
 {
     private static readonly Regex _curlyBracedWordPattern = CurlyBracedWordPattern();

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Commands/Webhook/WebhookCommand.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Commands/Webhook/WebhookCommand.cs
@@ -142,8 +142,8 @@ public sealed class WebhookCommand : Command<WebhookCommandData>
 internal static partial class WebhookCommandDescriptorLogs
 {
     [LoggerMessage(LogLevel.Information, "[POST] Sending Webhook to {Endpoint} with payload: {Payload}")]
-    public static partial void SendingWebhookPost(this ILogger<WebhookCommand> logger, Uri endpoint, string payload);
+    internal static partial void SendingWebhookPost(this ILogger<WebhookCommand> logger, Uri endpoint, string payload);
 
     [LoggerMessage(LogLevel.Information, "[GET] Sending Webhook to {Endpoint} without payload")]
-    public static partial void SendingWebhookGet(this ILogger<WebhookCommand> logger, Uri endpoint);
+    internal static partial void SendingWebhookGet(this ILogger<WebhookCommand> logger, Uri endpoint);
 }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Commands/Webhook/WebhookCommand.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Commands/Webhook/WebhookCommand.cs
@@ -24,8 +24,13 @@ public sealed class WebhookCommand : Command<WebhookCommandData>
     private readonly ILogger<WebhookCommand> _logger;
 
     private const string CommandTypeId = "webhook";
+
+    /// <inheritdoc/>
     public override string CommandType => CommandTypeId;
 
+    /// <summary>
+    /// Creates a new <see cref="WebhookCommand"/> with the supplied HTTP client factory, concurrency limiter, and logger.
+    /// </summary>
     public WebhookCommand(
         IHttpClientFactory httpClientFactory,
         IConcurrencyLimiter limiter,

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Commands/Webhook/WebhookCommandData.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Commands/Webhook/WebhookCommandData.cs
@@ -5,14 +5,21 @@ using System.Text.Json.Serialization;
 
 namespace WorkflowEngine.Commands.Webhook;
 
+/// <summary>
+/// Data payload for the built-in webhook command. The engine sends an HTTP request to <see cref="Uri"/>;
+/// presence of <see cref="Payload"/> selects POST, absence selects GET.
+/// </summary>
 public sealed record WebhookCommandData
 {
+    /// <summary>Absolute URI to call.</summary>
     [JsonPropertyName("uri")]
     public required string Uri { get; init; }
 
+    /// <summary>Optional request body. Sent verbatim; format is the caller's responsibility.</summary>
     [JsonPropertyName("payload")]
     public string? Payload { get; init; }
 
+    /// <summary>Optional <c>Content-Type</c> header value applied when <see cref="Payload"/> is present.</summary>
     [JsonPropertyName("contentType")]
     public string? ContentType { get; init; }
 }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Commands/Webhook/WebhookCommandData.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Commands/Webhook/WebhookCommandData.cs
@@ -11,15 +11,21 @@ namespace WorkflowEngine.Commands.Webhook;
 /// </summary>
 public sealed record WebhookCommandData
 {
-    /// <summary>Absolute URI to call.</summary>
+    /// <summary>
+    /// Absolute URI to call.
+    /// </summary>
     [JsonPropertyName("uri")]
     public required string Uri { get; init; }
 
-    /// <summary>Optional request body. Sent verbatim; format is the caller's responsibility.</summary>
+    /// <summary>
+    /// Optional request body. Sent verbatim; format is the caller's responsibility.
+    /// </summary>
     [JsonPropertyName("payload")]
     public string? Payload { get; init; }
 
-    /// <summary>Optional <c>Content-Type</c> header value applied when <see cref="Payload"/> is present.</summary>
+    /// <summary>
+    /// Optional <c>Content-Type</c> header value applied when <see cref="Payload"/> is present.
+    /// </summary>
     [JsonPropertyName("contentType")]
     public string? ContentType { get; init; }
 }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Core/CommandRegistry.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Core/CommandRegistry.cs
@@ -8,14 +8,20 @@ namespace WorkflowEngine.Core;
 /// </summary>
 internal interface ICommandRegistry
 {
-    /// <summary>Get the command for the given command type.</summary>
+    /// <summary>
+    /// Get the command for the given command type.
+    /// </summary>
     /// <exception cref="CommandHandlerNotFoundException">No command registered for the given type.</exception>
     ICommand GetCommand(string commandType);
 
-    /// <summary>Check if a command is registered for the given command type.</summary>
+    /// <summary>
+    /// Check if a command is registered for the given command type.
+    /// </summary>
     bool HasCommand(string commandType);
 
-    /// <summary>Get all registered commands.</summary>
+    /// <summary>
+    /// Get all registered commands.
+    /// </summary>
     IEnumerable<ICommand> GetAllCommands();
 }
 

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Core/Extensions/ServiceCollectionExtensions.cs
@@ -9,6 +9,10 @@ using WorkflowEngine.Resilience;
 
 namespace WorkflowEngine.Core.Extensions;
 
+/// <summary>
+/// Service collection extensions for composing the workflow engine into a host (DI registration of
+/// core services, command plugins, settings binding, and engine health checks).
+/// </summary>
 public static class ServiceCollectionExtensions
 {
     extension(IServiceCollection services)
@@ -142,6 +146,9 @@ public static class ServiceCollectionExtensions
     }
 }
 
+/// <summary>
+/// Extensions over <see cref="OptionsBuilder{TOptions}"/> for <see cref="EngineSettings"/> default-fill and validation.
+/// </summary>
 public static class OptionsBuilderExtensions
 {
     extension(OptionsBuilder<EngineSettings> builder)

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Core/Extensions/WorkflowEngineAppExtensions.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Core/Extensions/WorkflowEngineAppExtensions.cs
@@ -4,6 +4,10 @@ using WorkflowEngine.Core.Endpoints;
 
 namespace WorkflowEngine.Core.Extensions;
 
+/// <summary>
+/// Top-level pipeline composition for the workflow engine. Hosts call <c>UseWorkflowEngine</c> on their
+/// <see cref="WebApplication"/> to wire middleware, endpoints, and database migrations in a single step.
+/// </summary>
 public static class WorkflowEngineAppExtensions
 {
     extension(WebApplication app)

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Core/Extensions/WorkflowEngineBuilderExtensions.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Core/Extensions/WorkflowEngineBuilderExtensions.cs
@@ -12,6 +12,10 @@ using WorkflowEngine.Telemetry.Extensions;
 
 namespace WorkflowEngine.Core.Extensions;
 
+/// <summary>
+/// Top-level host composition for the workflow engine. Hosts call <c>AddWorkflowEngine</c> on their
+/// <see cref="WebApplicationBuilder"/> to register all core services in a single step.
+/// </summary>
 public static class WorkflowEngineBuilderExtensions
 {
     extension(WebApplicationBuilder builder)

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Core/MetricsCollector.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Core/MetricsCollector.cs
@@ -85,15 +85,15 @@ internal sealed class MetricsCollector(
 internal static partial class MetricsCollectorLogs
 {
     [LoggerMessage(LogLevel.Information, "MetricsCollector starting")]
-    public static partial void StartingUp(this ILogger<MetricsCollector> logger);
+    internal static partial void StartingUp(this ILogger<MetricsCollector> logger);
 
     [LoggerMessage(LogLevel.Error, "Failed to collect workflow counts: {ErrorMessage}")]
-    public static partial void FailedToQueryCounts(
+    internal static partial void FailedToQueryCounts(
         this ILogger<MetricsCollector> logger,
         string errorMessage,
         Exception ex
     );
 
     [LoggerMessage(LogLevel.Information, "MetricsCollector shutting down")]
-    public static partial void ShuttingDown(this ILogger<MetricsCollector> logger);
+    internal static partial void ShuttingDown(this ILogger<MetricsCollector> logger);
 }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Core/WorkflowExecutor.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Core/WorkflowExecutor.cs
@@ -163,13 +163,17 @@ internal class WorkflowExecutor : IWorkflowExecutor
 internal static partial class WorkflowExecutorLogs
 {
     [LoggerMessage(LogLevel.Information, "Executing step {Step} for workflow {Workflow}")]
-    public static partial void ExecutingStep(this ILogger<WorkflowExecutor> logger, Step step, Workflow workflow);
+    internal static partial void ExecutingStep(this ILogger<WorkflowExecutor> logger, Step step, Workflow workflow);
 
     [LoggerMessage(LogLevel.Information, "Step {Step} executed with success in {Elapsed}")]
-    public static partial void SuccessfulExecution(this ILogger<WorkflowExecutor> logger, Step step, TimeSpan elapsed);
+    internal static partial void SuccessfulExecution(
+        this ILogger<WorkflowExecutor> logger,
+        Step step,
+        TimeSpan elapsed
+    );
 
     [LoggerMessage(LogLevel.Error, "Step {Step} executed with error in {Elapsed}: {Message}")]
-    public static partial void FailedExecution(
+    internal static partial void FailedExecution(
         this ILogger<WorkflowExecutor> logger,
         Step step,
         TimeSpan elapsed,
@@ -177,7 +181,7 @@ internal static partial class WorkflowExecutorLogs
     );
 
     [LoggerMessage(LogLevel.Error, "Execution of step {Step} failed after {Elapsed}: {Message}")]
-    public static partial void UnhandledExecutionError(
+    internal static partial void UnhandledExecutionError(
         this ILogger<WorkflowExecutor> logger,
         Step step,
         TimeSpan elapsed,

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Core/WorkflowHandler.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Core/WorkflowHandler.cs
@@ -31,7 +31,7 @@ internal sealed class WorkflowHandler(
     private readonly EngineSettings _settings = settings.Value;
 
     /// <summary>
-    /// Processes a workflow through all its steps. On return, the workflow's <see cref="Workflow.Status"/>
+    /// Processes a workflow through all its steps. On return, the workflow's <c>Status</c>
     /// reflects the final outcome (Completed, Failed, Canceled, or Requeued for retry).
     /// </summary>
     public async Task Handle(Workflow workflow, CancellationToken ct)

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Core/WorkflowHandler.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Core/WorkflowHandler.cs
@@ -55,7 +55,7 @@ internal sealed class WorkflowHandler(
     private void HandleLeaseLost(Workflow workflow)
     {
         logger.WorkflowLeaseLost(workflow);
-        Metrics.WorkflowsLeaseLost.Add(1, workflow.GetHistorgramTags());
+        Metrics.WorkflowsLeaseLost.Add(1, workflow.GetHistogramTags());
 
         // Steps run sequentially so at most one span is open, but a per-step Submit that
         // throws LeaseLostException unwinds past the per-step StopActivity. Loop to catch it.
@@ -409,7 +409,7 @@ internal sealed class WorkflowHandler(
     {
         var latest = workflow.BackoffUntil ?? workflow.CreatedAt;
         var queueDuration = timeProvider.GetUtcNow().Subtract(latest).TotalSeconds;
-        Metrics.WorkflowQueueTime.Record(queueDuration, workflow.GetHistorgramTags());
+        Metrics.WorkflowQueueTime.Record(queueDuration, workflow.GetHistogramTags());
     }
 
     private void RecordWorkflowServiceTime(Workflow workflow)
@@ -419,33 +419,33 @@ internal sealed class WorkflowHandler(
             .Subtract(workflow.ExecutionStartedAt ?? workflow.CreatedAt)
             .TotalSeconds;
 
-        Metrics.WorkflowServiceTime.Record(serviceDuration, workflow.GetHistorgramTags());
+        Metrics.WorkflowServiceTime.Record(serviceDuration, workflow.GetHistogramTags());
     }
 
     private void RecordWorkflowTotalTime(Workflow workflow)
     {
         var anchor = workflow.BackoffUntil ?? workflow.CreatedAt;
         var totalDuration = timeProvider.GetUtcNow().Subtract(anchor).TotalSeconds;
-        Metrics.WorkflowTotalTime.Record(totalDuration, workflow.GetHistorgramTags());
+        Metrics.WorkflowTotalTime.Record(totalDuration, workflow.GetHistogramTags());
     }
 
     private void RecordStepQueueTime(Step step, DateTimeOffset anchor)
     {
         var queueDuration = timeProvider.GetUtcNow().Subtract(anchor).TotalSeconds;
-        Metrics.StepQueueTime.Record(queueDuration, step.GetHistorgramTags());
+        Metrics.StepQueueTime.Record(queueDuration, step.GetHistogramTags());
     }
 
     private void RecordStepServiceTime(Step step)
     {
         var serviceDuration = timeProvider.GetUtcNow().Subtract(step.ExecutionStartedAt ?? step.CreatedAt).TotalSeconds;
 
-        Metrics.StepServiceTime.Record(serviceDuration, step.GetHistorgramTags());
+        Metrics.StepServiceTime.Record(serviceDuration, step.GetHistogramTags());
     }
 
     private void RecordStepTotalTime(Step step, DateTimeOffset anchor)
     {
         var totalDuration = timeProvider.GetUtcNow().Subtract(anchor).TotalSeconds;
-        Metrics.StepTotalTime.Record(totalDuration, step.GetHistorgramTags());
+        Metrics.StepTotalTime.Record(totalDuration, step.GetHistogramTags());
     }
 }
 

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Core/WorkflowHandler.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Core/WorkflowHandler.cs
@@ -449,9 +449,6 @@ internal sealed class WorkflowHandler(
     }
 }
 
-/// <summary>
-/// Source-generated log messages for <see cref="WorkflowHandler"/>.
-/// </summary>
 internal static partial class WorkflowHandlerLogs
 {
     [LoggerMessage(LogLevel.Debug, "Processing workflow: {Workflow}")]

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Core/WorkflowProcessor.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Core/WorkflowProcessor.cs
@@ -185,9 +185,6 @@ internal sealed class WorkflowProcessor(
     }
 }
 
-/// <summary>
-/// Source-generated log messages for <see cref="WorkflowProcessor"/>.
-/// </summary>
 internal static partial class WorkflowProcessorLogs
 {
     [LoggerMessage(LogLevel.Information, "WorkflowProcessor started (MaxWorkers={MaxWorkers})")]

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Core/WorkflowUpdateBuffer.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Core/WorkflowUpdateBuffer.cs
@@ -233,7 +233,7 @@ internal sealed class WorkflowUpdateBuffer : BackgroundService, IWorkflowUpdateB
     /// </summary>
     /// <remarks>
     /// Completing superseded entries with <c>TrySetResult()</c> before the final item is
-    /// flushed cannot mis-signal a real caller: the handler is single-threaded per workflow,
+    /// flushed cannot incorrectly signal a real caller: the handler is single-threaded per workflow,
     /// so an awaited <see cref="Submit"/> never has a concurrent second <see cref="Submit"/>
     /// in flight for the same workflow id. Only <see cref="SubmitAndForget"/> entries (which
     /// carry a null <c>Completion</c> and are safe under <c>?.TrySetResult</c>) can precede

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Data/Repository/EngineRepository.Writes.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Data/Repository/EngineRepository.Writes.cs
@@ -826,7 +826,7 @@ internal sealed partial class EngineRepository
 
                     var ids = new Guid[sorted.Count];
                     var statuses = new int[sorted.Count];
-                    var backoffUntils = new object[sorted.Count];
+                    var backoffDeadlines = new object[sorted.Count];
                     var engineTraceContexts = new object[sorted.Count];
                     var leaseTokens = new Guid[sorted.Count];
 
@@ -835,7 +835,7 @@ internal sealed partial class EngineRepository
                         var w = sorted[i].Workflow;
                         ids[i] = w.DatabaseId;
                         statuses[i] = (int)w.Status;
-                        backoffUntils[i] = w.BackoffUntil.HasValue ? w.BackoffUntil.Value : DBNull.Value;
+                        backoffDeadlines[i] = w.BackoffUntil.HasValue ? w.BackoffUntil.Value : DBNull.Value;
                         engineTraceContexts[i] = (object?)w.EngineTraceContext ?? DBNull.Value;
                         // FetchAndLockWorkflows always stamps a LeaseToken; the throw is an invariant check.
                         leaseTokens[i] =
@@ -862,7 +862,7 @@ internal sealed partial class EngineRepository
                         "EngineTraceContext" = v.engine_trace_context
                     FROM (
                         SELECT *
-                        FROM unnest(@ids, @statuses, @backoff_untils, @engine_trace_contexts, @lease_tokens)
+                        FROM unnest(@ids, @statuses, @backoff_deadlines, @engine_trace_contexts, @lease_tokens)
                             AS t(id, status, backoff_until, engine_trace_context, lease_token)
                         ORDER BY t.id
                     ) AS v
@@ -876,9 +876,9 @@ internal sealed partial class EngineRepository
                         cmd.Parameters.Add(new NpgsqlParameter<Guid[]>("ids", ids));
                         cmd.Parameters.Add(new NpgsqlParameter<int[]>("statuses", statuses));
                         cmd.Parameters.Add(
-                            new NpgsqlParameter("backoff_untils", NpgsqlDbType.Array | NpgsqlDbType.TimestampTz)
+                            new NpgsqlParameter("backoff_deadlines", NpgsqlDbType.Array | NpgsqlDbType.TimestampTz)
                             {
-                                Value = backoffUntils,
+                                Value = backoffDeadlines,
                             }
                         );
                         cmd.Parameters.Add(

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Data/Repository/IEngineRepository.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Data/Repository/IEngineRepository.cs
@@ -159,7 +159,7 @@ internal interface IEngineRepository
 
     /// <summary>
     /// Returns the subset of <paramref name="inFlightIds"/> that have a non-null <c>CancellationRequestedAt</c>.
-    /// Used by <see cref="WorkflowEngine.Core.CancellationWatcherService"/> for cross-pod cancellation propagation.
+    /// Used by <c>WorkflowEngine.Core.CancellationWatcherService</c> for cross-pod cancellation propagation.
     /// </summary>
     Task<IReadOnlyList<Guid>> GetPendingCancellations(
         IReadOnlyList<Guid> inFlightIds,

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Data/Services/DbConnectionResetService.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Data/Services/DbConnectionResetService.cs
@@ -37,13 +37,13 @@ internal sealed class DbConnectionResetService(ILogger<DbConnectionResetService>
 internal static partial class DbConnectionResetServiceLogs
 {
     [LoggerMessage(LogLevel.Information, "Terminating existing connections to database '{DatabaseName}'")]
-    public static partial void TerminatingConnections(
+    internal static partial void TerminatingConnections(
         this ILogger<DbConnectionResetService> logger,
         string databaseName
     );
 
     [LoggerMessage(LogLevel.Information, "Terminated {Count} connection(s) to database '{DatabaseName}'")]
-    public static partial void TerminatedConnections(
+    internal static partial void TerminatedConnections(
         this ILogger<DbConnectionResetService> logger,
         long count,
         string databaseName

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Data/Services/DbMaintenanceService.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Data/Services/DbMaintenanceService.cs
@@ -259,13 +259,13 @@ internal sealed class DbMaintenanceService(
 internal static partial class DbMaintenanceServiceLogs
 {
     [LoggerMessage(LogLevel.Information, "DbMaintenanceService starting")]
-    public static partial void StartingUp(this ILogger<DbMaintenanceService> logger);
+    internal static partial void StartingUp(this ILogger<DbMaintenanceService> logger);
 
     [LoggerMessage(
         LogLevel.Error,
         "Database maintenance failed (attempt {ConsecutiveFailures}, backing off {Delay}): {ErrorMessage}"
     )]
-    public static partial void MaintenanceFailed(
+    internal static partial void MaintenanceFailed(
         this ILogger<DbMaintenanceService> logger,
         int consecutiveFailures,
         TimeSpan delay,
@@ -274,20 +274,20 @@ internal static partial class DbMaintenanceServiceLogs
     );
 
     [LoggerMessage(LogLevel.Information, "DbMaintenanceService shutting down")]
-    public static partial void ShuttingDown(this ILogger<DbMaintenanceService> logger);
+    internal static partial void ShuttingDown(this ILogger<DbMaintenanceService> logger);
 
     [LoggerMessage(LogLevel.Information, "Retention: deleted {Count} terminal workflow(s)")]
-    public static partial void RetentionDeletedWorkflows(this ILogger<DbMaintenanceService> logger, int count);
+    internal static partial void RetentionDeletedWorkflows(this ILogger<DbMaintenanceService> logger, int count);
 
     [LoggerMessage(LogLevel.Information, "Retention: deleted {Count} orphaned idempotency key(s)")]
-    public static partial void RetentionDeletedKeys(this ILogger<DbMaintenanceService> logger, int count);
+    internal static partial void RetentionDeletedKeys(this ILogger<DbMaintenanceService> logger, int count);
 
     [LoggerMessage(LogLevel.Warning, "Reclaimed {Count} stale workflows from crashed/unresponsive workers")]
-    public static partial void ReclaimedStaleWorkflows(this ILogger<DbMaintenanceService> logger, int count);
+    internal static partial void ReclaimedStaleWorkflows(this ILogger<DbMaintenanceService> logger, int count);
 
     [LoggerMessage(
         LogLevel.Error,
         "Abandoned {Count} stale workflows that exceeded the reclaim limit — marked as Failed"
     )]
-    public static partial void AbandonedStaleWorkflows(this ILogger<DbMaintenanceService> logger, int count);
+    internal static partial void AbandonedStaleWorkflows(this ILogger<DbMaintenanceService> logger, int count);
 }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Data/Services/DbMigrationService.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Data/Services/DbMigrationService.cs
@@ -103,28 +103,28 @@ internal sealed class DbMigrationService
 internal static partial class DatabaseMigrationServiceLogs
 {
     [LoggerMessage(LogLevel.Information, "Applying {Count} pending migration(s): {Migrations}")]
-    public static partial void ApplyingPendingMigrations(
+    internal static partial void ApplyingPendingMigrations(
         this ILogger<DbMigrationService> logger,
         int count,
         string migrations
     );
 
     [LoggerMessage(LogLevel.Information, "Migrations applied successfully")]
-    public static partial void MigrationsAppliedSuccessfully(this ILogger<DbMigrationService> logger);
+    internal static partial void MigrationsAppliedSuccessfully(this ILogger<DbMigrationService> logger);
 
     [LoggerMessage(LogLevel.Information, "No pending migrations")]
-    public static partial void NoPendingMigrations(this ILogger<DbMigrationService> logger);
+    internal static partial void NoPendingMigrations(this ILogger<DbMigrationService> logger);
 
     [LoggerMessage(LogLevel.Critical, "Error applying migrations: {ErrorMessage}")]
-    public static partial void MigrationError(
+    internal static partial void MigrationError(
         this ILogger<DbMigrationService> logger,
         string errorMessage,
         Exception ex
     );
 
     [LoggerMessage(LogLevel.Information, "Registering SQL function: {ResourceName}")]
-    public static partial void RegisteringFunction(this ILogger<DbMigrationService> logger, string resourceName);
+    internal static partial void RegisteringFunction(this ILogger<DbMigrationService> logger, string resourceName);
 
     [LoggerMessage(LogLevel.Information, "SQL function registered: {ResourceName}")]
-    public static partial void FunctionRegistered(this ILogger<DbMigrationService> logger, string resourceName);
+    internal static partial void FunctionRegistered(this ILogger<DbMigrationService> logger, string resourceName);
 }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/CancelWorkflowResponse.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/CancelWorkflowResponse.cs
@@ -1,5 +1,14 @@
 namespace WorkflowEngine.Models;
 
+/// <summary>
+/// Response returned from a workflow cancellation request.
+/// </summary>
+/// <param name="WorkflowId">Database ID of the workflow that was targeted.</param>
+/// <param name="CancellationRequestedAt">When the cancellation was recorded.</param>
+/// <param name="CanceledImmediately">
+/// <c>true</c> when the workflow was already in a non-running state and could be canceled in-place,
+/// <c>false</c> when cancellation has been requested but is still propagating to the active worker.
+/// </param>
 public sealed record CancelWorkflowResponse(
     Guid WorkflowId,
     DateTimeOffset CancellationRequestedAt,

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Command.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Command.cs
@@ -13,10 +13,13 @@ public abstract class Command<TData, TContext> : ICommand
     where TData : class
     where TContext : class
 {
+    /// <inheritdoc/>
     public abstract string CommandType { get; }
 
+    /// <inheritdoc/>
     public Type CommandDataType => typeof(TData);
 
+    /// <inheritdoc/>
     public Type WorkflowContextType => typeof(TContext);
 
     CommandValidationResult ICommand.Validate(object? commandData, object? workflowContext) =>
@@ -50,10 +53,13 @@ public abstract class Command<TData, TContext> : ICommand
 public abstract class Command<TData> : ICommand
     where TData : class
 {
+    /// <inheritdoc/>
     public abstract string CommandType { get; }
 
+    /// <inheritdoc/>
     public Type CommandDataType => typeof(TData);
 
+    /// <inheritdoc/>
     public Type? WorkflowContextType => null;
 
     CommandValidationResult ICommand.Validate(object? commandData, object? workflowContext) =>

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/CommandExecutionContext.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/CommandExecutionContext.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text.Json;
+using WorkflowEngine.Models.Abstractions;
 using WorkflowEngine.Models.Exceptions;
 
 namespace WorkflowEngine.Models;

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/CommandExecutionContext.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/CommandExecutionContext.cs
@@ -9,13 +9,19 @@ namespace WorkflowEngine.Models;
 /// </summary>
 public sealed record CommandExecutionContext
 {
-    /// <summary>The parent workflow.</summary>
+    /// <summary>
+    /// The parent workflow.
+    /// </summary>
     public required Workflow Workflow { get; init; }
 
-    /// <summary>The step being executed.</summary>
+    /// <summary>
+    /// The step being executed.
+    /// </summary>
     public required Step Step { get; init; }
 
-    /// <summary>The raw command configuration (from <see cref="CommandDefinition.Data"/>), for logging/diagnostics.</summary>
+    /// <summary>
+    /// The raw command configuration (from <see cref="CommandDefinition.Data"/>), for logging/diagnostics.
+    /// </summary>
     public JsonElement? RawCommandData { get; init; }
 
     /// <summary>
@@ -28,10 +34,14 @@ public sealed record CommandExecutionContext
     /// </summary>
     public object? TypedWorkflowContext { get; init; }
 
-    /// <summary>State output from the previous step (or <see cref="Workflow.InitialState"/> for the first step).</summary>
+    /// <summary>
+    /// State output from the previous step (or <see cref="Workflow.InitialState"/> for the first step).
+    /// </summary>
     public string? StateIn { get; init; }
 
-    /// <summary>Parent trace context for distributed tracing.</summary>
+    /// <summary>
+    /// Parent trace context for distributed tracing.
+    /// </summary>
     public ActivityContext? ParentTraceContext { get; init; }
 
     /// <summary>

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/CommandValidationResult.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/CommandValidationResult.cs
@@ -1,5 +1,9 @@
 namespace WorkflowEngine.Models;
 
+/// <summary>
+/// Outcome of <see cref="Abstractions.ICommand.Validate"/>.
+/// A closed hierarchy with two cases: <see cref="Valid"/> and <see cref="Invalid"/>.
+/// </summary>
 public abstract record CommandValidationResult
 {
     private CommandValidationResult() { }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/EngineHealthLevel.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/EngineHealthLevel.cs
@@ -6,12 +6,18 @@ namespace WorkflowEngine.Models;
 /// </summary>
 public enum EngineHealthLevel
 {
-    /// <summary>The engine is operating normally.</summary>
+    /// <summary>
+    /// The engine is operating normally.
+    /// </summary>
     Healthy = 0,
 
-    /// <summary>The engine is operating but with reduced capacity or transient issues.</summary>
+    /// <summary>
+    /// The engine is operating but with reduced capacity or transient issues.
+    /// </summary>
     Degraded = 1,
 
-    /// <summary>The engine is unable to process work.</summary>
+    /// <summary>
+    /// The engine is unable to process work.
+    /// </summary>
     Unhealthy = 2,
 }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/EngineHealthLevel.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/EngineHealthLevel.cs
@@ -6,7 +6,12 @@ namespace WorkflowEngine.Models;
 /// </summary>
 public enum EngineHealthLevel
 {
+    /// <summary>The engine is operating normally.</summary>
     Healthy = 0,
+
+    /// <summary>The engine is operating but with reduced capacity or transient issues.</summary>
     Degraded = 1,
+
+    /// <summary>The engine is unable to process work.</summary>
     Unhealthy = 2,
 }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/EngineHealthStatus.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/EngineHealthStatus.cs
@@ -1,15 +1,36 @@
 namespace WorkflowEngine.Models;
 
+/// <summary>
+/// Bitwise flags describing the engine's runtime state.
+/// Aggregated by the health checks pipeline and projected to <see cref="EngineHealthLevel"/>.
+/// </summary>
 [Flags]
 public enum EngineHealthStatus
 {
+    /// <summary>No flags set. Status is unknown.</summary>
     None = 0,
+
+    /// <summary>The engine is healthy and able to process work.</summary>
     Healthy = 1 << 0,
+
+    /// <summary>The engine is unhealthy and may be unable to process work.</summary>
     Unhealthy = 1 << 1,
+
+    /// <summary>The engine background processor is running.</summary>
     Running = 1 << 2,
+
+    /// <summary>The engine background processor has stopped.</summary>
     Stopped = 1 << 3,
+
+    /// <summary>The active workflow inbox has reached its backpressure threshold.</summary>
     QueueFull = 1 << 4,
+
+    /// <summary>The engine has been administratively disabled and will not pick up new work.</summary>
     Disabled = 1 << 5,
+
+    /// <summary>The engine is running but has no in-flight work.</summary>
     Idle = 1 << 6,
+
+    /// <summary>The database is unreachable. The engine cannot process work.</summary>
     DatabaseUnavailable = 1 << 7,
 }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/EngineHealthStatus.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/EngineHealthStatus.cs
@@ -7,30 +7,48 @@ namespace WorkflowEngine.Models;
 [Flags]
 public enum EngineHealthStatus
 {
-    /// <summary>No flags set. Status is unknown.</summary>
+    /// <summary>
+    /// No flags set. Status is unknown.
+    /// </summary>
     None = 0,
 
-    /// <summary>The engine is healthy and able to process work.</summary>
+    /// <summary>
+    /// The engine is healthy and able to process work.
+    /// </summary>
     Healthy = 1 << 0,
 
-    /// <summary>The engine is unhealthy and may be unable to process work.</summary>
+    /// <summary>
+    /// The engine is unhealthy and may be unable to process work.
+    /// </summary>
     Unhealthy = 1 << 1,
 
-    /// <summary>The engine background processor is running.</summary>
+    /// <summary>
+    /// The engine background processor is running.
+    /// </summary>
     Running = 1 << 2,
 
-    /// <summary>The engine background processor has stopped.</summary>
+    /// <summary>
+    /// The engine background processor has stopped.
+    /// </summary>
     Stopped = 1 << 3,
 
-    /// <summary>The active workflow inbox has reached its backpressure threshold.</summary>
+    /// <summary>
+    /// The active workflow inbox has reached its backpressure threshold.
+    /// </summary>
     QueueFull = 1 << 4,
 
-    /// <summary>The engine has been administratively disabled and will not pick up new work.</summary>
+    /// <summary>
+    /// The engine has been administratively disabled and will not pick up new work.
+    /// </summary>
     Disabled = 1 << 5,
 
-    /// <summary>The engine is running but has no in-flight work.</summary>
+    /// <summary>
+    /// The engine is running but has no in-flight work.
+    /// </summary>
     Idle = 1 << 6,
 
-    /// <summary>The database is unreachable. The engine cannot process work.</summary>
+    /// <summary>
+    /// The database is unreachable. The engine cannot process work.
+    /// </summary>
     DatabaseUnavailable = 1 << 7,
 }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/EngineSettings.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/EngineSettings.cs
@@ -149,6 +149,9 @@ public sealed record EngineSettings
     public PaginationSettings Pagination { get; set; } = new();
 }
 
+/// <summary>
+/// Settings for the workflow enqueue write buffer (channel-based batched insert pipeline).
+/// </summary>
 public sealed record WriteBufferSettings
 {
     /// <summary>
@@ -170,6 +173,9 @@ public sealed record WriteBufferSettings
     public int FlushConcurrency { get; set; }
 }
 
+/// <summary>
+/// Settings for the in-flight status update buffer used by the processor write-back path.
+/// </summary>
 public sealed record UpdateBufferSettings
 {
     /// <summary>
@@ -185,6 +191,9 @@ public sealed record UpdateBufferSettings
     public int MaxQueueSize { get; set; }
 }
 
+/// <summary>
+/// Settings for the background data retention job that purges terminal workflows.
+/// </summary>
 public sealed record RetentionSettings
 {
     /// <summary>
@@ -206,6 +215,9 @@ public sealed record RetentionSettings
     public TimeSpan Interval { get; set; }
 }
 
+/// <summary>
+/// Settings for paginated list endpoints.
+/// </summary>
 public sealed record PaginationSettings
 {
     /// <summary>
@@ -221,6 +233,9 @@ public sealed record PaginationSettings
     public int MaxPageSize { get; set; } = 100;
 }
 
+/// <summary>
+/// Settings for the engine's concurrency limits across workers, database operations, and outbound HTTP calls.
+/// </summary>
 public sealed record ConcurrencySettings
 {
     /// <summary>

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Exceptions/CommandHandlerNotFoundException.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Exceptions/CommandHandlerNotFoundException.cs
@@ -8,10 +8,15 @@ namespace WorkflowEngine.Models.Exceptions;
 /// </summary>
 public sealed class CommandHandlerNotFoundException : EngineException
 {
+    /// <summary>The unresolved command type discriminator.</summary>
     public string CommandType { get; }
 
+    /// <summary>The command types that were registered when resolution failed, for diagnostics.</summary>
     public IReadOnlyList<string> RegisteredTypes { get; }
 
+    /// <summary>
+    /// Creates a new <see cref="CommandHandlerNotFoundException"/> for the given unresolved command type.
+    /// </summary>
     public CommandHandlerNotFoundException(string commandType, IEnumerable<string> registeredTypes)
         : base(
             $"No handler registered for command type '{commandType}'. "

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Exceptions/CommandHandlerNotFoundException.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Exceptions/CommandHandlerNotFoundException.cs
@@ -8,10 +8,14 @@ namespace WorkflowEngine.Models.Exceptions;
 /// </summary>
 public sealed class CommandHandlerNotFoundException : EngineException
 {
-    /// <summary>The unresolved command type discriminator.</summary>
+    /// <summary>
+    /// The unresolved command type discriminator.
+    /// </summary>
     public string CommandType { get; }
 
-    /// <summary>The command types that were registered when resolution failed, for diagnostics.</summary>
+    /// <summary>
+    /// The command types that were registered when resolution failed, for diagnostics.
+    /// </summary>
     public IReadOnlyList<string> RegisteredTypes { get; }
 
     /// <summary>

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Exceptions/EngineConfigurationException.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Exceptions/EngineConfigurationException.cs
@@ -1,12 +1,19 @@
 namespace WorkflowEngine.Models.Exceptions;
 
+/// <summary>
+/// Thrown when the engine cannot be initialized due to invalid or missing configuration.
+/// Hosts should treat this as a fatal startup error.
+/// </summary>
 public sealed class EngineConfigurationException : EngineException
 {
+    /// <inheritdoc/>
     public EngineConfigurationException(string message)
         : base(message) { }
 
+    /// <inheritdoc/>
     public EngineConfigurationException() { }
 
+    /// <inheritdoc/>
     public EngineConfigurationException(string message, Exception? innerException)
         : base(message, innerException) { }
 }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Exceptions/EngineException.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Exceptions/EngineException.cs
@@ -1,5 +1,9 @@
 namespace WorkflowEngine.Models.Exceptions;
 
+/// <summary>
+/// Base type for exceptions raised by the workflow engine. Hosts can use it as a coarse catch
+/// for engine-originated failures regardless of the specific cause.
+/// </summary>
 public class EngineException : Exception
 {
     /// <inheritdoc/>

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Exceptions/IdempotencyConflictException.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Exceptions/IdempotencyConflictException.cs
@@ -7,8 +7,12 @@ namespace WorkflowEngine.Models.Exceptions;
 /// </summary>
 public sealed class IdempotencyConflictException : EngineException
 {
+    /// <summary>The idempotency key that produced the conflict.</summary>
     public string IdempotencyKey { get; }
 
+    /// <summary>
+    /// Creates a new <see cref="IdempotencyConflictException"/> for the given idempotency key.
+    /// </summary>
     public IdempotencyConflictException(string idempotencyKey)
         : base($"Idempotency key '{idempotencyKey}' was already used with a different request body.")
     {

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Exceptions/IdempotencyConflictException.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Exceptions/IdempotencyConflictException.cs
@@ -7,7 +7,9 @@ namespace WorkflowEngine.Models.Exceptions;
 /// </summary>
 public sealed class IdempotencyConflictException : EngineException
 {
-    /// <summary>The idempotency key that produced the conflict.</summary>
+    /// <summary>
+    /// The idempotency key that produced the conflict.
+    /// </summary>
     public string IdempotencyKey { get; }
 
     /// <summary>

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Exceptions/LeaseLostException.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Exceptions/LeaseLostException.cs
@@ -10,7 +10,9 @@ namespace WorkflowEngine.Models.Exceptions;
 /// </summary>
 public sealed class LeaseLostException : EngineException
 {
-    /// <summary>Database ID of the workflow whose lease was revoked.</summary>
+    /// <summary>
+    /// Database ID of the workflow whose lease was revoked.
+    /// </summary>
     public Guid WorkflowId { get; }
 
     /// <summary>

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Exceptions/LeaseLostException.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Exceptions/LeaseLostException.cs
@@ -10,8 +10,12 @@ namespace WorkflowEngine.Models.Exceptions;
 /// </summary>
 public sealed class LeaseLostException : EngineException
 {
+    /// <summary>Database ID of the workflow whose lease was revoked.</summary>
     public Guid WorkflowId { get; }
 
+    /// <summary>
+    /// Creates a new <see cref="LeaseLostException"/> for the given workflow.
+    /// </summary>
     public LeaseLostException(Guid workflowId)
         : base($"Lease lost for workflow {workflowId} — another host has reclaimed it.")
     {

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/ExecutionResult.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/ExecutionResult.cs
@@ -1,5 +1,13 @@
 namespace WorkflowEngine.Models;
 
+/// <summary>
+/// The outcome of a single command execution. Returned by <see cref="Abstractions.ICommand.Execute"/>
+/// and consumed by the engine to decide whether to advance, retry, or fail the step.
+/// </summary>
+/// <param name="Status">The classification of the outcome.</param>
+/// <param name="Message">Optional message describing the outcome (used for logs and step error history).</param>
+/// <param name="Exception">Optional exception associated with a failed outcome.</param>
+/// <param name="HttpStatusCode">Optional HTTP status code captured from the underlying transport.</param>
 public record struct ExecutionResult(
     ExecutionStatus Status,
     string? Message = null,

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/ExecutionStatus.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/ExecutionStatus.cs
@@ -1,5 +1,8 @@
 namespace WorkflowEngine.Models;
 
+/// <summary>
+/// Classification of an <see cref="ExecutionResult"/>. Determines whether the engine advances, retries, or fails the step.
+/// </summary>
 public enum ExecutionStatus
 {
     /// <summary>

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Extensions/ExecutionStatusExtensions.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Extensions/ExecutionStatusExtensions.cs
@@ -1,5 +1,8 @@
 namespace WorkflowEngine.Models.Extensions;
 
+/// <summary>
+/// Convenience predicates over <see cref="ExecutionResult"/>.
+/// </summary>
 public static class ExecutionStatusExtensions
 {
     extension(ExecutionResult result)

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Extensions/HealthStatusExtensions.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Extensions/HealthStatusExtensions.cs
@@ -1,14 +1,26 @@
 namespace WorkflowEngine.Models.Extensions;
 
+/// <summary>
+/// Convenience predicates over the <see cref="EngineHealthStatus"/> bit field.
+/// </summary>
 public static class HealthStatusExtensions
 {
     extension(EngineHealthStatus status)
     {
+        /// <summary>
+        /// Returns <c>true</c> when <see cref="EngineHealthStatus.Disabled"/> is set.
+        /// </summary>
         public bool IsDisabled() => (status & EngineHealthStatus.Disabled) != 0;
 
+        /// <summary>
+        /// Returns <c>true</c> when the engine is <see cref="EngineHealthStatus.Running"/> and not flagged <see cref="EngineHealthStatus.Unhealthy"/>.
+        /// </summary>
         public bool IsHealthy() =>
             (status & EngineHealthStatus.Running) != 0 && (status & EngineHealthStatus.Unhealthy) == 0;
 
+        /// <summary>
+        /// Returns <c>true</c> when <see cref="EngineHealthStatus.QueueFull"/> is set.
+        /// </summary>
         public bool HasFullQueue() => (status & EngineHealthStatus.QueueFull) != 0;
     }
 }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Extensions/StepExtensions.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Extensions/StepExtensions.cs
@@ -1,5 +1,8 @@
 namespace WorkflowEngine.Models.Extensions;
 
+/// <summary>
+/// Helpers for projecting <see cref="Step"/> data into telemetry tags.
+/// </summary>
 public static class StepExtensions
 {
     extension(Step step)
@@ -17,7 +20,7 @@ public static class StepExtensions
         /// <summary>
         /// Step metadata useful for enriching telemetry histograms.
         /// </summary>
-        public (string key, object? value)[] GetHistorgramTags() =>
+        public (string key, object? value)[] GetHistogramTags() =>
             [
                 ("operation.type", step.Command.Type),
                 ("operation.id", step.OperationId),

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Extensions/WorkflowEngineItemStatusExtensions.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Extensions/WorkflowEngineItemStatusExtensions.cs
@@ -1,9 +1,15 @@
 namespace WorkflowEngine.Models.Extensions;
 
+/// <summary>
+/// Convenience predicates over <see cref="PersistentItemStatus"/>.
+/// </summary>
 public static class WorkflowEngineItemStatusExtensions
 {
     extension(PersistentItemStatus status)
     {
+        /// <summary>
+        /// Returns <c>true</c> when the status is terminal (completed, failed, canceled, or dependency-failed).
+        /// </summary>
         public bool IsDone() =>
             status
                 is PersistentItemStatus.Completed
@@ -11,6 +17,9 @@ public static class WorkflowEngineItemStatusExtensions
                     or PersistentItemStatus.Canceled
                     or PersistentItemStatus.DependencyFailed;
 
+        /// <summary>
+        /// Returns <c>true</c> when the status is <see cref="PersistentItemStatus.Completed"/>.
+        /// </summary>
         public bool IsSuccessful() => status is PersistentItemStatus.Completed;
     }
 }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Extensions/WorkflowExtensions.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Extensions/WorkflowExtensions.cs
@@ -1,5 +1,8 @@
 namespace WorkflowEngine.Models.Extensions;
 
+/// <summary>
+/// Helpers for inspecting and projecting <see cref="Workflow"/> data.
+/// </summary>
 public static class WorkflowExtensions
 {
     extension(Workflow workflow)
@@ -54,6 +57,6 @@ public static class WorkflowExtensions
         /// <summary>
         /// Step metadata useful for enriching telemetry histograms.
         /// </summary>
-        public (string key, object? value)[] GetHistorgramTags() => [("workflow.operation.id", workflow.OperationId)];
+        public (string key, object? value)[] GetHistogramTags() => [("workflow.operation.id", workflow.OperationId)];
     }
 }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/PersistentItem.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/PersistentItem.cs
@@ -2,16 +2,50 @@ using System.Diagnostics;
 
 namespace WorkflowEngine.Models;
 
+/// <summary>
+/// Base class for engine-persisted entities (<see cref="Workflow"/>, <see cref="Step"/>).
+/// Carries the identity, lifecycle, and observability fields shared by both.
+/// </summary>
 public abstract record PersistentItem
 {
+    /// <summary>
+    /// The database row identifier. Assigned by the engine on insert.
+    /// </summary>
     public Guid DatabaseId { get; internal set; }
+
+    /// <summary>
+    /// Caller-supplied identifier used in logs, telemetry, and idempotency keys.
+    /// </summary>
     public required string OperationId { get; init; }
 
+    /// <summary>
+    /// Current lifecycle status of this item.
+    /// </summary>
     public PersistentItemStatus Status { get; set; }
+
+    /// <summary>
+    /// When this item was first persisted.
+    /// </summary>
     public DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>
+    /// Last time this item's row was updated by the engine.
+    /// </summary>
     public DateTimeOffset? UpdatedAt { get; internal set; }
+
+    /// <summary>
+    /// Optional caller-supplied key/value labels. Stored verbatim and returned in responses.
+    /// </summary>
     public Dictionary<string, string>? Labels { get; init; }
+
+    /// <summary>
+    /// W3C trace context (traceparent/tracestate) of the engine activity that owns this item.
+    /// Used to stitch downstream spans back to the engine's parent activity.
+    /// </summary>
     public string? EngineTraceContext { get; set; }
 
+    /// <summary>
+    /// In-memory <see cref="Activity"/> handle for the engine span operating on this item. Not persisted.
+    /// </summary>
     public Activity? EngineActivity { get; set; }
 }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/PersistentItemStatus.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/PersistentItemStatus.cs
@@ -3,6 +3,9 @@ using WorkflowEngine.Resilience.JsonConverters;
 
 namespace WorkflowEngine.Models;
 
+/// <summary>
+/// Lifecycle status shared by <see cref="Workflow"/> and <see cref="Step"/>.
+/// </summary>
 [JsonConverter(typeof(FlexibleEnumConverter<PersistentItemStatus>))]
 public enum PersistentItemStatus
 {

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/ResumeWorkflowResponse.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/ResumeWorkflowResponse.cs
@@ -1,5 +1,11 @@
 namespace WorkflowEngine.Models;
 
+/// <summary>
+/// Response returned from a workflow resume request.
+/// </summary>
+/// <param name="WorkflowId">Database ID of the resumed workflow.</param>
+/// <param name="ResumedAt">When the workflow was resumed.</param>
+/// <param name="CascadeResumed">Database IDs of dependent workflows that were resumed alongside the target.</param>
 public sealed record ResumeWorkflowResponse(
     Guid WorkflowId,
     DateTimeOffset ResumedAt,

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Step.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Step.cs
@@ -5,23 +5,53 @@ using WorkflowEngine.Resilience.Models;
 
 namespace WorkflowEngine.Models;
 
+/// <summary>
+/// A single unit of work within a <see cref="Workflow"/>. Steps execute in ascending <see cref="ProcessingOrder"/>.
+/// </summary>
 public sealed record Step : PersistentItem
 {
+    /// <summary>
+    /// Zero-based execution order within the parent workflow.
+    /// </summary>
     public required int ProcessingOrder { get; init; }
+
+    /// <summary>
+    /// The command this step executes. Resolved against the engine's command registry at runtime.
+    /// </summary>
     public required CommandDefinition Command { get; init; }
 
+    /// <summary>
+    /// Optional per-step retry strategy. When <c>null</c>, the engine uses <see cref="EngineSettings.DefaultStepRetryStrategy"/>.
+    /// </summary>
     public RetryStrategy? RetryStrategy { get; init; }
+
+    /// <summary>
+    /// Number of times this step has been requeued after a retryable failure.
+    /// </summary>
     public int RequeueCount { get; set; }
+
 #pragma warning disable CA1002, CA2227 // Mutable domain entity — List<T> with setter is intentional
+    /// <summary>
+    /// Errors recorded across this step's execution attempts, in chronological order.
+    /// </summary>
     public List<ErrorEntry> ErrorHistory { get; set; } = [];
 #pragma warning restore CA1002, CA2227
+
+    /// <summary>
+    /// State produced by this step, passed as <see cref="CommandExecutionContext.StateIn"/> to the next step.
+    /// </summary>
     public string? StateOut { get; set; }
 
     internal DateTimeOffset? ExecutionStartedAt { get; set; }
 
+    /// <inheritdoc/>
     public override string ToString() => $"[{nameof(Step)}.{Command.Type}] {OperationId} ({Status})";
 
+    /// <inheritdoc/>
     public override int GetHashCode() => DatabaseId.GetHashCode();
 
+    /// <summary>
+    /// Records are equal when their <see cref="PersistentItem.DatabaseId"/> matches; the step row, not the in-memory snapshot, is the identity.
+    /// </summary>
     public bool Equals(Step? other) => other?.DatabaseId == DatabaseId;
 }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Step.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Step.cs
@@ -6,7 +6,8 @@ using WorkflowEngine.Resilience.Models;
 namespace WorkflowEngine.Models;
 
 /// <summary>
-/// A single unit of work within a <see cref="Workflow"/>. Steps execute in ascending <see cref="ProcessingOrder"/>.
+/// A Step is a single unit of work within a <see cref="Workflow"/>.
+/// Steps execute in ascending <see cref="ProcessingOrder"/>.
 /// </summary>
 public sealed record Step : PersistentItem
 {

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/StepStatusResponse.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/StepStatusResponse.cs
@@ -66,6 +66,9 @@ public sealed record StepStatusResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? StateOut { get; init; }
 
+    /// <summary>
+    /// Retry strategy applied to this step. Omitted when the step uses the engine default.
+    /// </summary>
     [JsonPropertyName("retryStrategy")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public RetryStrategy? RetryStrategy { get; init; }
@@ -93,6 +96,9 @@ public sealed record StepStatusResponse
             ErrorHistory = step.ErrorHistory.Count > 0 ? step.ErrorHistory : null,
         };
 
+    /// <summary>
+    /// Public-surface projection of <see cref="CommandDefinition"/>: only the type discriminator is exposed.
+    /// </summary>
     public sealed record CommandDetails
     {
         /// <summary>

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Workflow.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Workflow.cs
@@ -2,6 +2,10 @@ using System.Text.Json;
 
 namespace WorkflowEngine.Models;
 
+/// <summary>
+/// A persisted workflow: a sequence of steps executed by the engine in <see cref="Step.ProcessingOrder"/>.
+/// Identified by <see cref="IdempotencyKey"/> within a <see cref="Namespace"/>.
+/// </summary>
 public sealed record Workflow : PersistentItem
 {
     /// <summary>
@@ -28,9 +32,29 @@ public sealed record Workflow : PersistentItem
     /// </summary>
     public JsonElement? Context { get; init; }
 
+    /// <summary>
+    /// Optional earliest time at which the workflow may begin execution.
+    /// Workflows scheduled in the future are skipped by the fetch query until this time is reached.
+    /// </summary>
     public DateTimeOffset? StartAt { get; init; }
+
+    /// <summary>
+    /// Earliest time at which the workflow is eligible for re-fetch after a retryable failure.
+    /// Set by the engine based on the active <see cref="Step.RetryStrategy"/>.
+    /// </summary>
     public DateTimeOffset? BackoffUntil { get; set; }
+
+    /// <summary>
+    /// Last time the owning worker proved liveness for this workflow.
+    /// A workflow whose heartbeat falls outside <see cref="EngineSettings.StaleWorkflowThreshold"/>
+    /// is considered stale and may be reclaimed by another worker.
+    /// </summary>
     public DateTimeOffset? HeartbeatAt { get; set; }
+
+    /// <summary>
+    /// Number of times this workflow has been reclaimed from a stale worker.
+    /// Once <see cref="EngineSettings.MaxReclaimCount"/> is reached the workflow is treated as poisoned and failed.
+    /// </summary>
     public int ReclaimCount { get; set; }
 
     /// <summary>
@@ -43,18 +67,49 @@ public sealed record Workflow : PersistentItem
     /// </summary>
     public Guid? LeaseToken { get; set; }
 
+    /// <summary>
+    /// The workflow's steps, in declaration order. Execution order is determined by <see cref="Step.ProcessingOrder"/>.
+    /// </summary>
     public required IReadOnlyList<Step> Steps { get; init; }
+
+    /// <summary>
+    /// Captured W3C trace context (traceparent/tracestate) of the caller that enqueued this workflow.
+    /// Used to link engine-side activities back to the originating client trace.
+    /// </summary>
     public string? DistributedTraceContext { get; set; }
+
+    /// <summary>
+    /// When cancellation was requested for this workflow. <c>null</c> if no cancellation has been requested.
+    /// Polled by the cancellation watcher to propagate cancellation across pods.
+    /// </summary>
     public DateTimeOffset? CancellationRequestedAt { get; set; }
+
+    /// <summary>
+    /// Workflows that must complete before this one is eligible for execution.
+    /// </summary>
     public IEnumerable<Workflow>? Dependencies { get; init; }
+
+    /// <summary>
+    /// Soft-linked workflows associated with this one (for grouping and dashboard navigation, no execution effect).
+    /// </summary>
     public IEnumerable<Workflow>? Links { get; init; }
+
+    /// <summary>
+    /// Optional opaque state passed as <see cref="CommandExecutionContext.StateIn"/> to the first step.
+    /// Subsequent steps receive the previous step's <see cref="Step.StateOut"/>.
+    /// </summary>
     public string? InitialState { get; init; }
 
     internal DateTimeOffset? ExecutionStartedAt { get; set; }
 
+    /// <inheritdoc/>
     public override string ToString() => $"[{GetType().Name}] {OperationId} ({Status})";
 
+    /// <inheritdoc/>
     public override int GetHashCode() => DatabaseId.GetHashCode();
 
+    /// <summary>
+    /// Records are equal when their <see cref="PersistentItem.DatabaseId"/> matches; the workflow row, not the in-memory snapshot, is the identity.
+    /// </summary>
     public bool Equals(Workflow? other) => other?.DatabaseId == DatabaseId;
 }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Workflow.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/Workflow.cs
@@ -3,8 +3,8 @@ using System.Text.Json;
 namespace WorkflowEngine.Models;
 
 /// <summary>
-/// A persisted workflow: a sequence of steps executed by the engine in <see cref="Step.ProcessingOrder"/>.
-/// Identified by <see cref="IdempotencyKey"/> within a <see cref="Namespace"/>.
+/// A Workflow defines a logical collection of <see cref="Step">Steps</see> along with optional
+/// dependencies and links to other workflows.
 /// </summary>
 public sealed record Workflow : PersistentItem
 {

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/WorkflowCancellationInfo.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/WorkflowCancellationInfo.cs
@@ -1,3 +1,8 @@
 namespace WorkflowEngine.Models;
 
+/// <summary>
+/// Snapshot of a workflow's cancellation state, used by the cancellation watcher to decide whether to propagate cancellation.
+/// </summary>
+/// <param name="Status">Current lifecycle status of the workflow.</param>
+/// <param name="CancellationRequestedAt">When cancellation was requested, or <c>null</c> if no request is pending.</param>
 public sealed record WorkflowCancellationInfo(PersistentItemStatus Status, DateTimeOffset? CancellationRequestedAt);

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/WorkflowEnqueueResponse.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/WorkflowEnqueueResponse.cs
@@ -52,12 +52,21 @@ public abstract record WorkflowEnqueueResponse
     /// </summary>
     public sealed record WorkflowResult
     {
+        /// <summary>
+        /// Echo of the request-scoped <see cref="WorkflowRequest.Ref"/>, when one was supplied.
+        /// </summary>
         [JsonPropertyName("ref")]
         public string? Ref { get; init; }
 
+        /// <summary>
+        /// Database ID assigned to the workflow row.
+        /// </summary>
         [JsonPropertyName("databaseId")]
         public required Guid DatabaseId { get; init; }
 
+        /// <summary>
+        /// Namespace the workflow was registered in.
+        /// </summary>
         [JsonPropertyName("namespace")]
         public required string Namespace { get; init; }
     }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/WorkflowMetadataConstants.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/WorkflowMetadataConstants.cs
@@ -9,18 +9,32 @@ namespace WorkflowEngine.Models;
 /// </summary>
 public static class WorkflowMetadataConstants
 {
+    /// <summary>HTTP header names carrying workflow metadata on inbound and outbound calls.</summary>
     public static class Headers
     {
+        /// <summary>Header carrying the workflow namespace.</summary>
         public const string Namespace = "Namespace";
+
+        /// <summary>Header carrying the idempotency key used to deduplicate enqueue requests.</summary>
         public const string IdempotencyKey = "Idempotency-Key";
+
+        /// <summary>Header carrying the correlation ID shared by all workflows in a batch.</summary>
         public const string CorrelationId = "Correlation-Id";
+
+        /// <summary>Header carrying the workflow database ID.</summary>
         public const string WorkflowId = "Workflow-Id";
+
+        /// <summary>Header carrying the operation ID of a workflow or step.</summary>
         public const string OperationId = "Operation-Id";
     }
 
+    /// <summary>Query parameter names accepted on engine endpoints.</summary>
     public static class QueryParams
     {
+        /// <summary>Query parameter carrying the idempotency key (alternative to the header).</summary>
         public const string IdempotencyKey = "idempotencyKey";
+
+        /// <summary>Query parameter carrying the correlation ID used for filtering.</summary>
         public const string CorrelationId = "correlationId";
     }
 }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/WorkflowMetadataConstants.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/WorkflowMetadataConstants.cs
@@ -9,32 +9,50 @@ namespace WorkflowEngine.Models;
 /// </summary>
 public static class WorkflowMetadataConstants
 {
-    /// <summary>HTTP header names carrying workflow metadata on inbound and outbound calls.</summary>
+    /// <summary>
+    /// HTTP header names carrying workflow metadata on inbound and outbound calls.
+    /// </summary>
     public static class Headers
     {
-        /// <summary>Header carrying the workflow namespace.</summary>
+        /// <summary>
+        /// Header carrying the workflow namespace.
+        /// </summary>
         public const string Namespace = "Namespace";
 
-        /// <summary>Header carrying the idempotency key used to deduplicate enqueue requests.</summary>
+        /// <summary>
+        /// Header carrying the idempotency key used to deduplicate enqueue requests.
+        /// </summary>
         public const string IdempotencyKey = "Idempotency-Key";
 
-        /// <summary>Header carrying the correlation ID shared by all workflows in a batch.</summary>
+        /// <summary>
+        /// Header carrying the correlation ID shared by all workflows in a batch.
+        /// </summary>
         public const string CorrelationId = "Correlation-Id";
 
-        /// <summary>Header carrying the workflow database ID.</summary>
+        /// <summary>
+        /// Header carrying the workflow database ID.
+        /// </summary>
         public const string WorkflowId = "Workflow-Id";
 
-        /// <summary>Header carrying the operation ID of a workflow or step.</summary>
+        /// <summary>
+        /// Header carrying the operation ID of a workflow or step.
+        /// </summary>
         public const string OperationId = "Operation-Id";
     }
 
-    /// <summary>Query parameter names accepted on engine endpoints.</summary>
+    /// <summary>
+    /// Query parameter names accepted on engine endpoints.
+    /// </summary>
     public static class QueryParams
     {
-        /// <summary>Query parameter carrying the idempotency key (alternative to the header).</summary>
+        /// <summary>
+        /// Query parameter carrying the idempotency key (alternative to the header).
+        /// </summary>
         public const string IdempotencyKey = "idempotencyKey";
 
-        /// <summary>Query parameter carrying the correlation ID used for filtering.</summary>
+        /// <summary>
+        /// Query parameter carrying the correlation ID used for filtering.
+        /// </summary>
         public const string CorrelationId = "correlationId";
     }
 }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/WorkflowRef.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/WorkflowRef.cs
@@ -49,16 +49,24 @@ public readonly record struct WorkflowRef
     /// </summary>
     public Guid Id => _id ?? throw new InvalidOperationException("WorkflowRef is a ref string, not an ID.");
 
-    /// <summary>Implicit conversion from a batch-scoped alias string.</summary>
+    /// <summary>
+    /// Implicit conversion from a batch-scoped alias string.
+    /// </summary>
     public static implicit operator WorkflowRef(string @ref) => new(@ref);
 
-    /// <summary>Implicit conversion from a persisted database ID.</summary>
+    /// <summary>
+    /// Implicit conversion from a persisted database ID.
+    /// </summary>
     public static implicit operator WorkflowRef(Guid id) => new(id);
 
-    /// <summary>Creates a <see cref="WorkflowRef"/> from a batch-scoped alias string.</summary>
+    /// <summary>
+    /// Creates a <see cref="WorkflowRef"/> from a batch-scoped alias string.
+    /// </summary>
     public static WorkflowRef FromRefString(string @ref) => new(@ref);
 
-    /// <summary>Creates a <see cref="WorkflowRef"/> from a persisted database ID.</summary>
+    /// <summary>
+    /// Creates a <see cref="WorkflowRef"/> from a persisted database ID.
+    /// </summary>
     public static WorkflowRef FromDatabaseId(Guid id) => new(id);
 
     /// <inheritdoc/>

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/WorkflowRef.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/WorkflowRef.cs
@@ -49,13 +49,18 @@ public readonly record struct WorkflowRef
     /// </summary>
     public Guid Id => _id ?? throw new InvalidOperationException("WorkflowRef is a ref string, not an ID.");
 
+    /// <summary>Implicit conversion from a batch-scoped alias string.</summary>
     public static implicit operator WorkflowRef(string @ref) => new(@ref);
 
+    /// <summary>Implicit conversion from a persisted database ID.</summary>
     public static implicit operator WorkflowRef(Guid id) => new(id);
 
+    /// <summary>Creates a <see cref="WorkflowRef"/> from a batch-scoped alias string.</summary>
     public static WorkflowRef FromRefString(string @ref) => new(@ref);
 
+    /// <summary>Creates a <see cref="WorkflowRef"/> from a persisted database ID.</summary>
     public static WorkflowRef FromDatabaseId(Guid id) => new(id);
 
+    /// <inheritdoc/>
     public override string ToString() => IsRef ? $"ref:{_ref}" : $"id:{_id}";
 }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/WorkflowStatusResponse.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/WorkflowStatusResponse.cs
@@ -113,6 +113,9 @@ public sealed record WorkflowStatusResponse
     [JsonPropertyName("steps")]
     public required IReadOnlyList<StepStatusResponse> Steps { get; init; }
 
+    /// <summary>
+    /// Projects a <see cref="Workflow"/> to its public response representation.
+    /// </summary>
     public static WorkflowStatusResponse FromWorkflow(Workflow workflow) =>
         new()
         {

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Resilience/ConcurrencyLimiter.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Resilience/ConcurrencyLimiter.cs
@@ -4,6 +4,10 @@ using WorkflowEngine.Telemetry.Extensions;
 
 namespace WorkflowEngine.Resilience;
 
+/// <summary>
+/// Bounds concurrent access to scarce resources via three independent semaphore pools:
+/// database connections, outbound HTTP calls, and worker tasks.
+/// </summary>
 public interface IConcurrencyLimiter
 {
     /// <summary>
@@ -49,6 +53,9 @@ public interface IConcurrencyLimiter
     void ReleaseWorkerSlot();
 }
 
+/// <summary>
+/// Default <see cref="IConcurrencyLimiter"/> implementation backed by three <see cref="SemaphoreSlim"/> instances.
+/// </summary>
 public sealed class ConcurrencyLimiter : IDisposable, IConcurrencyLimiter
 {
     private readonly SemaphoreSlim _dbSemaphore;
@@ -78,6 +85,9 @@ public sealed class ConcurrencyLimiter : IDisposable, IConcurrencyLimiter
     public SlotStatus WorkerSlotStatus =>
         new(_workerSemaphore.CurrentCount, _maxWorkers - _workerSemaphore.CurrentCount, _maxWorkers);
 
+    /// <summary>
+    /// Creates a new <see cref="ConcurrencyLimiter"/> with the supplied per-pool capacities.
+    /// </summary>
     public ConcurrencyLimiter(int maxConcurrentDbOperations, int maxConcurrentHttpCalls, int maxWorkers)
     {
         _maxConcurrentDbOperations = maxConcurrentDbOperations;
@@ -131,6 +141,7 @@ public sealed class ConcurrencyLimiter : IDisposable, IConcurrencyLimiter
         _workerSemaphore.Release();
     }
 
+    /// <inheritdoc/>
     public void Dispose()
     {
         _dbSemaphore.Dispose();
@@ -151,5 +162,11 @@ public sealed class ConcurrencyLimiter : IDisposable, IConcurrencyLimiter
         }
     }
 
+    /// <summary>
+    /// Snapshot of a semaphore pool's slot accounting at a single point in time.
+    /// </summary>
+    /// <param name="Available">Slots currently free.</param>
+    /// <param name="Used">Slots currently in use.</param>
+    /// <param name="Total">Total slot capacity of the pool.</param>
     public sealed record SlotStatus(int Available, int Used, int Total);
 }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Resilience/Extensions/RetryStrategyExtensions.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Resilience/Extensions/RetryStrategyExtensions.cs
@@ -184,31 +184,19 @@ public static class RetryStrategyExtensions
     }
 }
 
-/// <summary>
-/// Source-generated logger messages emitted by <see cref="RetryStrategyExtensions"/> during a retry run.
-/// </summary>
-public static partial class RetryStrategyExtensionsLogging
+internal static partial class RetryStrategyExtensionsLogs
 {
-    /// <summary>
-    /// Logs that an operation is about to execute (attempt 1).
-    /// </summary>
     [LoggerMessage(LogLevel.Debug, "Starting execution of operation '{OperationName}'")]
-    public static partial void StartingExecution(this ILogger logger, string operationName);
+    internal static partial void StartingExecution(this ILogger logger, string operationName);
 
-    /// <summary>
-    /// Logs that an operation succeeded after the given attempt count.
-    /// </summary>
     [LoggerMessage(LogLevel.Debug, "Operation '{OperationName}' succeeded on attempt {Attempt}")]
-    public static partial void ExecutionSucceeded(this ILogger logger, string operationName, int attempt);
+    internal static partial void ExecutionSucceeded(this ILogger logger, string operationName, int attempt);
 
-    /// <summary>
-    /// Logs that an operation attempt threw, with the captured exception.
-    /// </summary>
     [LoggerMessage(
         LogLevel.Error,
         "Operation '{OperationName}' failed with error on attempt {Attempt}: {ErrorMessage}"
     )]
-    public static partial void ExecutionFailed(
+    internal static partial void ExecutionFailed(
         this ILogger logger,
         string operationName,
         int attempt,
@@ -216,38 +204,26 @@ public static partial class RetryStrategyExtensionsLogging
         Exception ex
     );
 
-    /// <summary>
-    /// Logs that the caller's error handler classified the exception as <see cref="RetryDecision.Abort"/>.
-    /// </summary>
     [LoggerMessage(LogLevel.Error, "Error {ErrorType} is unrecoverable, giving up")]
-    public static partial void UnrecoverableError(this ILogger logger, string errorType, Exception ex);
+    internal static partial void UnrecoverableError(this ILogger logger, string errorType, Exception ex);
 
-    /// <summary>
-    /// Logs that the strategy has exhausted its retry budget or hit its deadline.
-    /// </summary>
     [LoggerMessage(
         LogLevel.Error,
         "All available retries are exhausted or the deadline for this operation has been exceeded, giving up"
     )]
-    public static partial void MaxRetriesReached(this ILogger logger, Exception ex);
+    internal static partial void MaxRetriesReached(this ILogger logger, Exception ex);
 
-    /// <summary>
-    /// Logs that scheduling the next retry would push past the deadline.
-    /// </summary>
     [LoggerMessage(
         LogLevel.Error,
         "The next retry attempt is unreachable because it will exceed the deadline for this operation, giving up"
     )]
-    public static partial void NextRetryUnreachable(this ILogger logger, Exception ex);
+    internal static partial void NextRetryUnreachable(this ILogger logger, Exception ex);
 
-    /// <summary>
-    /// Logs that the strategy is sleeping before the next retry.
-    /// </summary>
     [LoggerMessage(
         LogLevel.Warning,
         "Operation '{OperationName}' failed on attempt {Attempt} of {MaxAttempts}, retrying in {Delay}ms"
     )]
-    public static partial void RetryDelay(
+    internal static partial void RetryDelay(
         this ILogger logger,
         string operationName,
         int attempt,

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Resilience/Extensions/RetryStrategyExtensions.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Resilience/Extensions/RetryStrategyExtensions.cs
@@ -9,6 +9,9 @@ using WorkflowEngine.Resilience.Models;
 
 namespace WorkflowEngine.Resilience.Extensions;
 
+/// <summary>
+/// Helpers that drive retry, backoff, and deadline logic from a <see cref="RetryStrategy"/>.
+/// </summary>
 public static class RetryStrategyExtensions
 {
     extension(RetryStrategy strategy)
@@ -181,14 +184,20 @@ public static class RetryStrategyExtensions
     }
 }
 
+/// <summary>
+/// Source-generated logger messages emitted by <see cref="RetryStrategyExtensions"/> during a retry run.
+/// </summary>
 public static partial class RetryStrategyExtensionsLogging
 {
+    /// <summary>Logs that an operation is about to execute (attempt 1).</summary>
     [LoggerMessage(LogLevel.Debug, "Starting execution of operation '{OperationName}'")]
     public static partial void StartingExecution(this ILogger logger, string operationName);
 
+    /// <summary>Logs that an operation succeeded after the given attempt count.</summary>
     [LoggerMessage(LogLevel.Debug, "Operation '{OperationName}' succeeded on attempt {Attempt}")]
     public static partial void ExecutionSucceeded(this ILogger logger, string operationName, int attempt);
 
+    /// <summary>Logs that an operation attempt threw, with the captured exception.</summary>
     [LoggerMessage(
         LogLevel.Error,
         "Operation '{OperationName}' failed with error on attempt {Attempt}: {ErrorMessage}"
@@ -201,21 +210,25 @@ public static partial class RetryStrategyExtensionsLogging
         Exception ex
     );
 
+    /// <summary>Logs that the caller's error handler classified the exception as <see cref="RetryDecision.Abort"/>.</summary>
     [LoggerMessage(LogLevel.Error, "Error {ErrorType} is unrecoverable, giving up")]
     public static partial void UnrecoverableError(this ILogger logger, string errorType, Exception ex);
 
+    /// <summary>Logs that the strategy has exhausted its retry budget or hit its deadline.</summary>
     [LoggerMessage(
         LogLevel.Error,
         "All available retries are exhausted or the deadline for this operation has been exceeded, giving up"
     )]
     public static partial void MaxRetriesReached(this ILogger logger, Exception ex);
 
+    /// <summary>Logs that scheduling the next retry would push past the deadline.</summary>
     [LoggerMessage(
         LogLevel.Error,
         "The next retry attempt is unreachable because it will exceed the deadline for this operation, giving up"
     )]
     public static partial void NextRetryUnreachable(this ILogger logger, Exception ex);
 
+    /// <summary>Logs that the strategy is sleeping before the next retry.</summary>
     [LoggerMessage(
         LogLevel.Warning,
         "Operation '{OperationName}' failed on attempt {Attempt} of {MaxAttempts}, retrying in {Delay}ms"

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Resilience/Extensions/RetryStrategyExtensions.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Resilience/Extensions/RetryStrategyExtensions.cs
@@ -189,15 +189,21 @@ public static class RetryStrategyExtensions
 /// </summary>
 public static partial class RetryStrategyExtensionsLogging
 {
-    /// <summary>Logs that an operation is about to execute (attempt 1).</summary>
+    /// <summary>
+    /// Logs that an operation is about to execute (attempt 1).
+    /// </summary>
     [LoggerMessage(LogLevel.Debug, "Starting execution of operation '{OperationName}'")]
     public static partial void StartingExecution(this ILogger logger, string operationName);
 
-    /// <summary>Logs that an operation succeeded after the given attempt count.</summary>
+    /// <summary>
+    /// Logs that an operation succeeded after the given attempt count.
+    /// </summary>
     [LoggerMessage(LogLevel.Debug, "Operation '{OperationName}' succeeded on attempt {Attempt}")]
     public static partial void ExecutionSucceeded(this ILogger logger, string operationName, int attempt);
 
-    /// <summary>Logs that an operation attempt threw, with the captured exception.</summary>
+    /// <summary>
+    /// Logs that an operation attempt threw, with the captured exception.
+    /// </summary>
     [LoggerMessage(
         LogLevel.Error,
         "Operation '{OperationName}' failed with error on attempt {Attempt}: {ErrorMessage}"
@@ -210,25 +216,33 @@ public static partial class RetryStrategyExtensionsLogging
         Exception ex
     );
 
-    /// <summary>Logs that the caller's error handler classified the exception as <see cref="RetryDecision.Abort"/>.</summary>
+    /// <summary>
+    /// Logs that the caller's error handler classified the exception as <see cref="RetryDecision.Abort"/>.
+    /// </summary>
     [LoggerMessage(LogLevel.Error, "Error {ErrorType} is unrecoverable, giving up")]
     public static partial void UnrecoverableError(this ILogger logger, string errorType, Exception ex);
 
-    /// <summary>Logs that the strategy has exhausted its retry budget or hit its deadline.</summary>
+    /// <summary>
+    /// Logs that the strategy has exhausted its retry budget or hit its deadline.
+    /// </summary>
     [LoggerMessage(
         LogLevel.Error,
         "All available retries are exhausted or the deadline for this operation has been exceeded, giving up"
     )]
     public static partial void MaxRetriesReached(this ILogger logger, Exception ex);
 
-    /// <summary>Logs that scheduling the next retry would push past the deadline.</summary>
+    /// <summary>
+    /// Logs that scheduling the next retry would push past the deadline.
+    /// </summary>
     [LoggerMessage(
         LogLevel.Error,
         "The next retry attempt is unreachable because it will exceed the deadline for this operation, giving up"
     )]
     public static partial void NextRetryUnreachable(this ILogger logger, Exception ex);
 
-    /// <summary>Logs that the strategy is sleeping before the next retry.</summary>
+    /// <summary>
+    /// Logs that the strategy is sleeping before the next retry.
+    /// </summary>
     [LoggerMessage(
         LogLevel.Warning,
         "Operation '{OperationName}' failed on attempt {Attempt} of {MaxAttempts}, retrying in {Delay}ms"

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Resilience/JsonConverters/FlexibleEnumConverter.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Resilience/JsonConverters/FlexibleEnumConverter.cs
@@ -10,6 +10,7 @@ namespace WorkflowEngine.Resilience.JsonConverters;
 public class FlexibleEnumConverter<TEnum> : JsonConverter<TEnum>
     where TEnum : struct, Enum
 {
+    /// <inheritdoc/>
     public override TEnum Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         return reader.TokenType switch
@@ -20,6 +21,7 @@ public class FlexibleEnumConverter<TEnum> : JsonConverter<TEnum>
         };
     }
 
+    /// <inheritdoc/>
     public override void Write(Utf8JsonWriter writer, TEnum value, JsonSerializerOptions options)
     {
         // Write as string by default for better readability

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Resilience/Models/RetryDecision.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Resilience/Models/RetryDecision.cs
@@ -1,7 +1,13 @@
 namespace WorkflowEngine.Resilience.Models;
 
+/// <summary>
+/// Returned by a caller-supplied error classifier to tell the retry pipeline whether to keep retrying or abort.
+/// </summary>
 public enum RetryDecision
 {
+    /// <summary>Stop retrying and rethrow the captured exception.</summary>
     Abort,
+
+    /// <summary>Continue retrying according to the active <see cref="RetryStrategy"/>.</summary>
     Retry,
 }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Resilience/Models/RetryDecision.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Resilience/Models/RetryDecision.cs
@@ -5,9 +5,13 @@ namespace WorkflowEngine.Resilience.Models;
 /// </summary>
 public enum RetryDecision
 {
-    /// <summary>Stop retrying and rethrow the captured exception.</summary>
+    /// <summary>
+    /// Stop retrying and rethrow the captured exception.
+    /// </summary>
     Abort,
 
-    /// <summary>Continue retrying according to the active <see cref="RetryStrategy"/>.</summary>
+    /// <summary>
+    /// Continue retrying according to the active <see cref="RetryStrategy"/>.
+    /// </summary>
     Retry,
 }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Telemetry/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Telemetry/Extensions/ServiceCollectionExtensions.cs
@@ -7,10 +7,20 @@ using OpenTelemetry.Trace;
 
 namespace WorkflowEngine.Telemetry.Extensions;
 
+/// <summary>
+/// Service collection extensions for registering the engine's OpenTelemetry pipeline.
+/// </summary>
 public static class ServiceCollectionExtensions
 {
     extension(IServiceCollection services)
     {
+        /// <summary>
+        /// Registers the engine's OpenTelemetry pipeline (tracing, metrics, logs) and the OTLP exporter.
+        /// </summary>
+        /// <param name="emitQueryParameters">Include EF Core SQL parameter values on database spans. Disable in production to avoid PII leakage.</param>
+        /// <param name="enableDatabaseInstrumentation">Enable EF Core and Npgsql tracing instrumentation. Implies <paramref name="enableDatabaseMetrics"/>.</param>
+        /// <param name="enableDatabaseMetrics">Enable Npgsql connection pool and command metrics.</param>
+        /// <param name="traceSamplingRate">Trace sampling rate between 0.0 (drop all) and 1.0 (keep all). Metrics and logs are always exported at full fidelity.</param>
         public IServiceCollection AddTelemetry(
             bool emitQueryParameters = false,
             bool enableDatabaseInstrumentation = false,

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Telemetry/Extensions/TelemetryExtensions.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Telemetry/Extensions/TelemetryExtensions.cs
@@ -6,6 +6,11 @@ using System.Diagnostics.Metrics;
 
 namespace WorkflowEngine.Telemetry.Extensions;
 
+/// <summary>
+/// Extensions over <see cref="ActivitySource"/>, <see cref="Activity"/>, <see cref="Counter{T}"/>,
+/// and <see cref="Histogram{T}"/> that adapt the engine's tuple-based tag conventions to the
+/// underlying OTEL key/value APIs.
+/// </summary>
 public static class TelemetryExtensions
 {
     extension(ActivitySource source)
@@ -126,22 +131,34 @@ public static class TelemetryExtensions
             activity.SetStatus(ActivityStatusCode.Ok);
         }
 
+        /// <summary>
+        /// Marks the activity as not requesting tag/event data, suppressing detail collection on this span.
+        /// </summary>
         public void NoData()
         {
             activity.IsAllDataRequested = false;
         }
 
+        /// <summary>
+        /// Marks the activity as requesting tag/event data, enabling detail collection on this span.
+        /// </summary>
         public void HasData()
         {
             activity.IsAllDataRequested = true;
         }
 
+        /// <summary>
+        /// Suppresses both data collection and the recorded flag, ensuring this span is not exported.
+        /// </summary>
         public void DontRecord()
         {
             activity.NoData();
             activity.ActivityTraceFlags &= ~ActivityTraceFlags.Recorded;
         }
 
+        /// <summary>
+        /// Enables data collection and the recorded flag, ensuring this span is exported.
+        /// </summary>
         public void Record()
         {
             activity.HasData();
@@ -151,11 +168,13 @@ public static class TelemetryExtensions
 
     extension(Counter<long> counter)
     {
+        /// <summary>Adds <paramref name="value"/> to the counter, attaching a single tuple-encoded tag.</summary>
         public void Add(long value, (string tag, object? value) tag)
         {
             counter.Add(value, new KeyValuePair<string, object?>(tag.tag, tag.value));
         }
 
+        /// <summary>Adds <paramref name="value"/> to the counter, attaching tuple-encoded tags.</summary>
         public void Add(long value, params (string tag, object? value)[] tags)
         {
             counter.Add(value, tags.Select(t => new KeyValuePair<string, object?>(t.tag, t.value)).ToArray());
@@ -164,11 +183,13 @@ public static class TelemetryExtensions
 
     extension(Histogram<double> histogram)
     {
+        /// <summary>Records <paramref name="value"/> on the histogram, attaching a single tuple-encoded tag.</summary>
         public void Record(double value, (string tag, object? value) tag)
         {
             histogram.Record(value, new KeyValuePair<string, object?>(tag.tag, tag.value));
         }
 
+        /// <summary>Records <paramref name="value"/> on the histogram, attaching tuple-encoded tags.</summary>
         public void Record(double value, params (string tag, object? value)[] tags)
         {
             histogram.Record(value, tags.Select(t => new KeyValuePair<string, object?>(t.tag, t.value)).ToArray());

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Telemetry/Extensions/TelemetryExtensions.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Telemetry/Extensions/TelemetryExtensions.cs
@@ -168,13 +168,17 @@ public static class TelemetryExtensions
 
     extension(Counter<long> counter)
     {
-        /// <summary>Adds <paramref name="value"/> to the counter, attaching a single tuple-encoded tag.</summary>
+        /// <summary>
+        /// Adds <paramref name="value"/> to the counter, attaching a single tuple-encoded tag.
+        /// </summary>
         public void Add(long value, (string tag, object? value) tag)
         {
             counter.Add(value, new KeyValuePair<string, object?>(tag.tag, tag.value));
         }
 
-        /// <summary>Adds <paramref name="value"/> to the counter, attaching tuple-encoded tags.</summary>
+        /// <summary>
+        /// Adds <paramref name="value"/> to the counter, attaching tuple-encoded tags.
+        /// </summary>
         public void Add(long value, params (string tag, object? value)[] tags)
         {
             counter.Add(value, tags.Select(t => new KeyValuePair<string, object?>(t.tag, t.value)).ToArray());
@@ -183,13 +187,17 @@ public static class TelemetryExtensions
 
     extension(Histogram<double> histogram)
     {
-        /// <summary>Records <paramref name="value"/> on the histogram, attaching a single tuple-encoded tag.</summary>
+        /// <summary>
+        /// Records <paramref name="value"/> on the histogram, attaching a single tuple-encoded tag.
+        /// </summary>
         public void Record(double value, (string tag, object? value) tag)
         {
             histogram.Record(value, new KeyValuePair<string, object?>(tag.tag, tag.value));
         }
 
-        /// <summary>Records <paramref name="value"/> on the histogram, attaching tuple-encoded tags.</summary>
+        /// <summary>
+        /// Records <paramref name="value"/> on the histogram, attaching tuple-encoded tags.
+        /// </summary>
         public void Record(double value, params (string tag, object? value)[] tags)
         {
             histogram.Record(value, tags.Select(t => new KeyValuePair<string, object?>(t.tag, t.value)).ToArray());

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Telemetry/Metrics.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Telemetry/Metrics.cs
@@ -6,134 +6,203 @@ using System.Diagnostics.Metrics;
 
 namespace WorkflowEngine.Telemetry;
 
+/// <summary>
+/// OpenTelemetry instrumentation for the workflow engine.
+/// Hosts all <see cref="ActivitySource"/> and <see cref="Meter"/> instruments and exposes
+/// the gauge setters used by the metrics collection background service.
+/// </summary>
 public static class Metrics
 {
+    /// <summary>The OpenTelemetry service name used by the engine's <see cref="ActivitySource"/> and <see cref="Meter"/>.</summary>
     public const string ServiceName = "WorkflowEngine";
+
+    /// <summary>Service version reported on the engine's resource attributes.</summary>
     public const string ServiceVersion = "1.0.0";
+
+    /// <summary>Activity source for engine-emitted spans (workflow lifecycle, step lifecycle, DB IO).</summary>
     public static readonly ActivitySource Source = new(ServiceName);
+
+    /// <summary>Meter that owns every engine-emitted counter, histogram, and observable gauge.</summary>
     public static readonly Meter Meter = new(ServiceName);
 
+    /// <summary>Counter of generic engine-side errors that don't have a more specific instrument.</summary>
     public static readonly Counter<long> Errors = Meter.CreateCounter<long>("engine.errors");
 
+    /// <summary>Counter incremented once per main-loop iteration. Useful for liveness alerts.</summary>
     public static readonly Counter<long> EngineMainLoopIterations = Meter.CreateCounter<long>(
         "engine.mainloop.iterations"
     );
+
+    /// <summary>Histogram of seconds the main loop spent waiting for tasks to complete and/or new workflows to arrive.</summary>
     public static readonly Histogram<double> EngineMainLoopQueueTime = Meter.CreateHistogram<double>(
         "engine.mainloop.time.queue",
         "s",
         "Amount of time the main loop spent waiting for tasks to complete and/or new workflows to arrive (seconds)."
     );
+
+    /// <summary>Histogram of seconds the main loop spent actively executing workflows and/or database IO.</summary>
     public static readonly Histogram<double> EngineMainLoopServiceTime = Meter.CreateHistogram<double>(
         "engine.mainloop.time.service",
         "s",
         "Amount of time the main loop spent actively executing workflows and/or database IO (seconds)."
     );
+
+    /// <summary>Histogram of seconds the main loop spent on a full execution (queue + service).</summary>
     public static readonly Histogram<double> EngineMainLoopTotalTime = Meter.CreateHistogram<double>(
         "engine.mainloop.time.total",
         "s",
         "Amount of time the main loop spent on a full execution (seconds)."
     );
 
+    /// <summary>Counter of inbound workflow query requests received (list/get endpoints).</summary>
     public static readonly Counter<long> WorkflowQueriesReceived = Meter.CreateCounter<long>(
         "engine.workflows.query.received"
     );
+
+    /// <summary>Counter of inbound workflow enqueue requests received (before validation).</summary>
     public static readonly Counter<long> WorkflowRequestsReceived = Meter.CreateCounter<long>(
         "engine.workflows.request.received"
     );
+
+    /// <summary>Counter of workflow enqueue requests that passed validation and were accepted for processing.</summary>
     public static readonly Counter<long> WorkflowRequestsAccepted = Meter.CreateCounter<long>(
         "engine.workflows.request.accepted"
     );
+
+    /// <summary>Counter of workflows that completed successfully.</summary>
     public static readonly Counter<long> WorkflowsSucceeded = Meter.CreateCounter<long>(
         "engine.workflows.execution.success"
     );
+
+    /// <summary>Counter of workflows requeued after a retryable failure.</summary>
     public static readonly Counter<long> WorkflowsRequeued = Meter.CreateCounter<long>(
         "engine.workflows.execution.requeued"
     );
+
+    /// <summary>Counter of workflows that terminated in <see cref="Models.PersistentItemStatus.Failed"/>.</summary>
     public static readonly Counter<long> WorkflowsFailed = Meter.CreateCounter<long>(
         "engine.workflows.execution.failed"
     );
+
+    /// <summary>Counter of workflows that terminated in <see cref="Models.PersistentItemStatus.Canceled"/>.</summary>
     public static readonly Counter<long> WorkflowsCanceled = Meter.CreateCounter<long>(
         "engine.workflows.execution.canceled"
     );
+
+    /// <summary>Counter of terminal workflows resumed for re-processing.</summary>
     public static readonly Counter<long> WorkflowsResumed = Meter.CreateCounter<long>(
         "engine.workflows.execution.resumed",
         description: "Number of terminal workflows resumed for re-processing"
     );
+
+    /// <summary>Counter of stale workflows reclaimed from crashed workers.</summary>
     public static readonly Counter<long> WorkflowsReclaimed = Meter.CreateCounter<long>(
         "engine.workflows.execution.reclaimed",
         description: "Number of stale workflows reclaimed from crashed workers"
     );
+
+    /// <summary>Counter of in-flight workflows this host abandoned because their lease was reclaimed by another host.</summary>
     public static readonly Counter<long> WorkflowsLeaseLost = Meter.CreateCounter<long>(
         "engine.workflows.execution.lease_lost",
         description: "Number of in-flight workflows this host abandoned because their lease was reclaimed by another host"
     );
+
+    /// <summary>Counter of fetched workflows skipped because they were already in-flight on this host (DbMaintenance reclaim race).</summary>
     public static readonly Counter<long> WorkflowFetchRaceDropped = Meter.CreateCounter<long>(
         "engine.workflows.fetch.race_dropped",
         description: "Number of fetched workflows skipped because they were already in-flight on this host (DbMaintenance reclaim race)"
     );
+
+    /// <summary>Histogram of seconds a workflow waited in the queue before this attempt was picked up.</summary>
     public static readonly Histogram<double> WorkflowQueueTime = Meter.CreateHistogram<double>(
         "engine.workflows.time.queue",
         "s",
         "Time the workflow waited in the queue before this attempt was picked up by a worker (seconds). Recorded once per attempt."
     );
+
+    /// <summary>Histogram of seconds spent actively processing a workflow attempt.</summary>
     public static readonly Histogram<double> WorkflowServiceTime = Meter.CreateHistogram<double>(
         "engine.workflows.time.service",
         "s",
         "Time spent actively processing this workflow attempt (seconds). Includes step execution and database IO. Recorded once per attempt."
     );
+
+    /// <summary>Histogram of total wall-clock seconds for a workflow attempt (queue + service).</summary>
     public static readonly Histogram<double> WorkflowTotalTime = Meter.CreateHistogram<double>(
         "engine.workflows.time.total",
         "s",
         "Total wall-clock time of this workflow attempt — queue + service (seconds). Recorded once per attempt."
     );
 
+    /// <summary>Counter of step requests accepted for execution.</summary>
     public static readonly Counter<long> StepRequestsAccepted = Meter.CreateCounter<long>(
         "engine.steps.request.accepted"
     );
+
+    /// <summary>Counter of steps that completed successfully.</summary>
     public static readonly Counter<long> StepsSucceeded = Meter.CreateCounter<long>("engine.steps.execution.success");
+
+    /// <summary>Counter of steps requeued after a retryable failure.</summary>
     public static readonly Counter<long> StepsRequeued = Meter.CreateCounter<long>("engine.steps.execution.requeued");
+
+    /// <summary>Counter of steps that terminated in failure.</summary>
     public static readonly Counter<long> StepsFailed = Meter.CreateCounter<long>("engine.steps.execution.failed");
 
+    /// <summary>Histogram of seconds between the prior step finishing and this step beginning execution.</summary>
     public static readonly Histogram<double> StepQueueTime = Meter.CreateHistogram<double>(
         "engine.steps.time.queue",
         "s",
         "Time between the prior step finishing (or the workflow attempt starting, for the first step) and this step beginning execution (seconds). Mostly captures engine-internal database IO. Recorded once per step per attempt."
     );
+
+    /// <summary>Histogram of seconds spent actively executing a step (command execution + DB IO).</summary>
     public static readonly Histogram<double> StepServiceTime = Meter.CreateHistogram<double>(
         "engine.steps.time.service",
         "s",
         "Time spent actively executing this step (seconds). Includes command execution and database IO. Recorded once per step per attempt."
     );
+
+    /// <summary>Histogram of total seconds for a step within the workflow attempt (queue + service).</summary>
     public static readonly Histogram<double> StepTotalTime = Meter.CreateHistogram<double>(
         "engine.steps.time.total",
         "s",
         "Total time for this step within the workflow attempt — queue + service (seconds). Recorded once per step per attempt."
     );
 
+    /// <summary>Counter of redundant status updates eliminated by deduplication in the update buffer.</summary>
     public static readonly Counter<long> UpdateBufferDeduplicatedItems = Meter.CreateCounter<long>(
         "engine.update_buffer.deduplicated",
         description: "Number of redundant status updates eliminated by deduplication in the update buffer"
     );
 
+    /// <summary>Counter of fire-and-forget status updates dropped because the update buffer channel was full.</summary>
     public static readonly Counter<long> UpdateBufferDroppedItems = Meter.CreateCounter<long>(
         "engine.update_buffer.dropped",
         description: "Number of fire-and-forget status updates dropped because the update buffer channel was full"
     );
 
+    /// <summary>Counter of workflow status updates actually written to the database after deduplication.</summary>
     public static readonly Counter<long> UpdateBufferFlushedItems = Meter.CreateCounter<long>(
         "engine.update_buffer.flushed",
         description: "Number of workflow status updates actually written to the database after deduplication"
     );
 
+    /// <summary>Counter of database operations that succeeded.</summary>
     public static readonly Counter<long> DbOperationsSucceeded = Meter.CreateCounter<long>(
         "engine.db.operations.success"
     );
+
+    /// <summary>Counter of database operations that were requeued for retry.</summary>
     public static readonly Counter<long> DbOperationsRequeued = Meter.CreateCounter<long>(
         "engine.db.operations.requeued"
     );
+
+    /// <summary>Counter of database operations that failed terminally.</summary>
     public static readonly Counter<long> DbOperationsFailed = Meter.CreateCounter<long>("engine.db.operations.failed");
 
     private static long _maintenanceConsecutiveFailures;
+
+    /// <summary>Gauge of consecutive database maintenance failures (0 = healthy).</summary>
     public static readonly ObservableGauge<long> MaintenanceConsecutiveFailures = Meter.CreateObservableGauge(
         "engine.maintenance.consecutive_failures",
         static () => _maintenanceConsecutiveFailures,
@@ -141,6 +210,8 @@ public static class Metrics
     );
 
     private static long _healthStatus; // 0=healthy, 1=degraded, 2=unhealthy
+
+    /// <summary>Gauge of overall engine health (0=healthy, 1=degraded, 2=unhealthy).</summary>
     public static readonly ObservableGauge<long> HealthStatus = Meter.CreateObservableGauge(
         "engine.health.status",
         static () => _healthStatus,
@@ -148,113 +219,158 @@ public static class Metrics
     );
 
     private static long _activeWorkflowsCount;
+
+    /// <summary>Gauge of currently active workflows (any non-terminal status).</summary>
     public static readonly ObservableGauge<long> ActiveWorkflows = Meter.CreateObservableGauge(
         "engine.workflows.active",
         static () => _activeWorkflowsCount
     );
 
     private static long _scheduledWorkflowsCount;
+
+    /// <summary>Gauge of workflows scheduled for future execution (<see cref="Models.Workflow.StartAt"/> in the future).</summary>
     public static readonly ObservableGauge<long> ScheduledWorkflows = Meter.CreateObservableGauge(
         "engine.workflows.scheduled",
         static () => _scheduledWorkflowsCount
     );
 
     private static long _failedWorkflowsCount;
+
+    /// <summary>Gauge of terminal failed workflows currently retained.</summary>
     public static readonly ObservableGauge<long> FailedWorkflows = Meter.CreateObservableGauge(
         "engine.workflows.failed",
         static () => _failedWorkflowsCount
     );
 
     private static long _successfulWorkflowsCount;
+
+    /// <summary>Gauge of terminal successful workflows currently retained.</summary>
     public static readonly ObservableGauge<long> SuccessfulWorkflows = Meter.CreateObservableGauge(
         "engine.workflows.successful",
         static () => _successfulWorkflowsCount
     );
 
     private static long _finishedWorkflowsCount;
+
+    /// <summary>Gauge of all terminal workflows currently retained (success + failure + canceled + dependency-failed).</summary>
     public static readonly ObservableGauge<long> FinishedWorkflows = Meter.CreateObservableGauge(
         "engine.workflows.finished",
         static () => _finishedWorkflowsCount
     );
 
     private static long _availableInboxSlotsCount;
+
+    /// <summary>Gauge of remaining inbox capacity before the engine reports backpressure.</summary>
     public static readonly ObservableGauge<long> AvailableInboxSlots = Meter.CreateObservableGauge(
         "engine.slots.inbox.available",
         static () => _availableInboxSlotsCount
     );
 
     private static long _usedInboxSlotsCount;
+
+    /// <summary>Gauge of currently consumed inbox slots.</summary>
     public static readonly ObservableGauge<long> UsedInboxSlots = Meter.CreateObservableGauge(
         "engine.slots.inbox.used",
         static () => _usedInboxSlotsCount
     );
 
     private static long _availableDbSlotsCount;
+
+    /// <summary>Gauge of available concurrency slots in the database semaphore pool.</summary>
     public static readonly ObservableGauge<long> AvailableDbSlots = Meter.CreateObservableGauge(
         "engine.slots.db.available",
         static () => _availableDbSlotsCount
     );
 
     private static long _usedDbSlotsCount;
+
+    /// <summary>Gauge of in-use concurrency slots in the database semaphore pool.</summary>
     public static readonly ObservableGauge<long> UsedDbSlots = Meter.CreateObservableGauge(
         "engine.slots.db.used",
         static () => _usedDbSlotsCount
     );
 
     private static long _availableHttpSlotsCount;
+
+    /// <summary>Gauge of available concurrency slots in the outbound-HTTP semaphore pool.</summary>
     public static readonly ObservableGauge<long> AvailableHttpSlots = Meter.CreateObservableGauge(
         "engine.slots.http.available",
         static () => _availableHttpSlotsCount
     );
 
     private static long _usedHttpSlotsCount;
+
+    /// <summary>Gauge of in-use concurrency slots in the outbound-HTTP semaphore pool.</summary>
     public static readonly ObservableGauge<long> UsedHttpSlots = Meter.CreateObservableGauge(
         "engine.slots.http.used",
         static () => _usedHttpSlotsCount
     );
 
     private static long _availableWorkerSlotsCount;
+
+    /// <summary>Gauge of available worker slots (concurrent workflow processors).</summary>
     public static readonly ObservableGauge<long> AvailableWorkerSlots = Meter.CreateObservableGauge(
         "engine.slots.workers.available",
         static () => _availableWorkerSlotsCount
     );
 
     private static long _usedWorkerSlotsCount;
+
+    /// <summary>Gauge of in-use worker slots.</summary>
     public static readonly ObservableGauge<long> UsedWorkerSlots = Meter.CreateObservableGauge(
         "engine.slots.workers.used",
         static () => _usedWorkerSlotsCount
     );
 
+    /// <summary>Sets the value reported by <see cref="MaintenanceConsecutiveFailures"/>.</summary>
     public static void SetMaintenanceConsecutiveFailures(int count) => _maintenanceConsecutiveFailures = count;
 
+    /// <summary>Sets the value reported by <see cref="HealthStatus"/>.</summary>
     public static void SetHealthStatus(long status) => _healthStatus = status;
 
+    /// <summary>Sets the value reported by <see cref="ActiveWorkflows"/>.</summary>
     public static void SetActiveWorkflowsCount(long count) => _activeWorkflowsCount = count;
 
+    /// <summary>Sets the value reported by <see cref="ScheduledWorkflows"/>.</summary>
     public static void SetScheduledWorkflowsCount(long count) => _scheduledWorkflowsCount = count;
 
+    /// <summary>Sets the value reported by <see cref="FailedWorkflows"/>.</summary>
     public static void SetFailedWorkflowsCount(long count) => _failedWorkflowsCount = count;
 
+    /// <summary>Sets the value reported by <see cref="SuccessfulWorkflows"/>.</summary>
     public static void SetSuccessfulWorkflowsCount(long count) => _successfulWorkflowsCount = count;
 
+    /// <summary>Sets the value reported by <see cref="FinishedWorkflows"/>.</summary>
     public static void SetFinishedWorkflowsCount(long count) => _finishedWorkflowsCount = count;
 
+    /// <summary>Sets the value reported by <see cref="AvailableInboxSlots"/>.</summary>
     public static void SetAvailableInboxSlots(int count) => _availableInboxSlotsCount = count;
 
+    /// <summary>Sets the value reported by <see cref="UsedInboxSlots"/>.</summary>
     public static void SetUsedInboxSlots(int count) => _usedInboxSlotsCount = count;
 
+    /// <summary>Sets the value reported by <see cref="AvailableDbSlots"/>.</summary>
     public static void SetAvailableDbSlots(int count) => _availableDbSlotsCount = count;
 
+    /// <summary>Sets the value reported by <see cref="UsedDbSlots"/>.</summary>
     public static void SetUsedDbSlots(int count) => _usedDbSlotsCount = count;
 
+    /// <summary>Sets the value reported by <see cref="AvailableHttpSlots"/>.</summary>
     public static void SetAvailableHttpSlots(int count) => _availableHttpSlotsCount = count;
 
+    /// <summary>Sets the value reported by <see cref="UsedHttpSlots"/>.</summary>
     public static void SetUsedHttpSlots(int count) => _usedHttpSlotsCount = count;
 
+    /// <summary>Sets the value reported by <see cref="AvailableWorkerSlots"/>.</summary>
     public static void SetAvailableWorkerSlots(int count) => _availableWorkerSlotsCount = count;
 
+    /// <summary>Sets the value reported by <see cref="UsedWorkerSlots"/>.</summary>
     public static void SetUsedWorkerSlots(int count) => _usedWorkerSlotsCount = count;
 
+    /// <summary>
+    /// Parses a W3C traceparent string into an <see cref="ActivityContext"/>.
+    /// Returns <c>null</c> when the input is null; returns the default context when parsing fails.
+    /// </summary>
     public static ActivityContext? ParseTraceContext(string? traceContext)
     {
         if (traceContext is null)
@@ -264,9 +380,17 @@ public static class Metrics
         return context;
     }
 
+    /// <summary>
+    /// Projects a single optional <see cref="ActivityContext"/> to an enumerable of <see cref="ActivityLink"/>,
+    /// suitable for passing as <c>links</c> when starting a new activity.
+    /// </summary>
     public static IEnumerable<ActivityLink> ToActivityLinks(this ActivityContext? context) =>
         context is null ? [] : [new ActivityLink(context.Value)];
 
+    /// <summary>
+    /// Projects a sequence of optional <see cref="ActivityContext"/> values to <see cref="ActivityLink"/>,
+    /// dropping null entries.
+    /// </summary>
     public static IEnumerable<ActivityLink> ToActivityLinks(this IEnumerable<ActivityContext?> contexts) =>
         contexts.OfType<ActivityContext>().Select(x => new ActivityLink(x));
 }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Telemetry/Metrics.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Telemetry/Metrics.cs
@@ -13,196 +13,270 @@ namespace WorkflowEngine.Telemetry;
 /// </summary>
 public static class Metrics
 {
-    /// <summary>The OpenTelemetry service name used by the engine's <see cref="ActivitySource"/> and <see cref="Meter"/>.</summary>
+    /// <summary>
+    /// The OpenTelemetry service name used by the engine's <see cref="ActivitySource"/> and <see cref="Meter"/>.
+    /// </summary>
     public const string ServiceName = "WorkflowEngine";
 
-    /// <summary>Service version reported on the engine's resource attributes.</summary>
+    /// <summary>
+    /// Service version reported on the engine's resource attributes.
+    /// </summary>
     public const string ServiceVersion = "1.0.0";
 
-    /// <summary>Activity source for engine-emitted spans (workflow lifecycle, step lifecycle, DB IO).</summary>
+    /// <summary>
+    /// Activity source for engine-emitted spans (workflow lifecycle, step lifecycle, DB IO).
+    /// </summary>
     public static readonly ActivitySource Source = new(ServiceName);
 
-    /// <summary>Meter that owns every engine-emitted counter, histogram, and observable gauge.</summary>
+    /// <summary>
+    /// Meter that owns every engine-emitted counter, histogram, and observable gauge.
+    /// </summary>
     public static readonly Meter Meter = new(ServiceName);
 
-    /// <summary>Counter of generic engine-side errors that don't have a more specific instrument.</summary>
+    /// <summary>
+    /// Counter of generic engine-side errors that don't have a more specific instrument.
+    /// </summary>
     public static readonly Counter<long> Errors = Meter.CreateCounter<long>("engine.errors");
 
-    /// <summary>Counter incremented once per main-loop iteration. Useful for liveness alerts.</summary>
+    /// <summary>
+    /// Counter incremented once per main-loop iteration. Useful for liveness alerts.
+    /// </summary>
     public static readonly Counter<long> EngineMainLoopIterations = Meter.CreateCounter<long>(
         "engine.mainloop.iterations"
     );
 
-    /// <summary>Histogram of seconds the main loop spent waiting for tasks to complete and/or new workflows to arrive.</summary>
+    /// <summary>
+    /// Histogram of seconds the main loop spent waiting for tasks to complete and/or new workflows to arrive.
+    /// </summary>
     public static readonly Histogram<double> EngineMainLoopQueueTime = Meter.CreateHistogram<double>(
         "engine.mainloop.time.queue",
         "s",
         "Amount of time the main loop spent waiting for tasks to complete and/or new workflows to arrive (seconds)."
     );
 
-    /// <summary>Histogram of seconds the main loop spent actively executing workflows and/or database IO.</summary>
+    /// <summary>
+    /// Histogram of seconds the main loop spent actively executing workflows and/or database IO.
+    /// </summary>
     public static readonly Histogram<double> EngineMainLoopServiceTime = Meter.CreateHistogram<double>(
         "engine.mainloop.time.service",
         "s",
         "Amount of time the main loop spent actively executing workflows and/or database IO (seconds)."
     );
 
-    /// <summary>Histogram of seconds the main loop spent on a full execution (queue + service).</summary>
+    /// <summary>
+    /// Histogram of seconds the main loop spent on a full execution (queue + service).
+    /// </summary>
     public static readonly Histogram<double> EngineMainLoopTotalTime = Meter.CreateHistogram<double>(
         "engine.mainloop.time.total",
         "s",
         "Amount of time the main loop spent on a full execution (seconds)."
     );
 
-    /// <summary>Counter of inbound workflow query requests received (list/get endpoints).</summary>
+    /// <summary>
+    /// Counter of inbound workflow query requests received (list/get endpoints).
+    /// </summary>
     public static readonly Counter<long> WorkflowQueriesReceived = Meter.CreateCounter<long>(
         "engine.workflows.query.received"
     );
 
-    /// <summary>Counter of inbound workflow enqueue requests received (before validation).</summary>
+    /// <summary>
+    /// Counter of inbound workflow enqueue requests received (before validation).
+    /// </summary>
     public static readonly Counter<long> WorkflowRequestsReceived = Meter.CreateCounter<long>(
         "engine.workflows.request.received"
     );
 
-    /// <summary>Counter of workflow enqueue requests that passed validation and were accepted for processing.</summary>
+    /// <summary>
+    /// Counter of workflow enqueue requests that passed validation and were accepted for processing.
+    /// </summary>
     public static readonly Counter<long> WorkflowRequestsAccepted = Meter.CreateCounter<long>(
         "engine.workflows.request.accepted"
     );
 
-    /// <summary>Counter of workflows that completed successfully.</summary>
+    /// <summary>
+    /// Counter of workflows that completed successfully.
+    /// </summary>
     public static readonly Counter<long> WorkflowsSucceeded = Meter.CreateCounter<long>(
         "engine.workflows.execution.success"
     );
 
-    /// <summary>Counter of workflows requeued after a retryable failure.</summary>
+    /// <summary>
+    /// Counter of workflows requeued after a retryable failure.
+    /// </summary>
     public static readonly Counter<long> WorkflowsRequeued = Meter.CreateCounter<long>(
         "engine.workflows.execution.requeued"
     );
 
-    /// <summary>Counter of workflows that terminated in <see cref="Models.PersistentItemStatus.Failed"/>.</summary>
+    /// <summary>
+    /// Counter of workflows that terminated in <see cref="Models.PersistentItemStatus.Failed"/>.
+    /// </summary>
     public static readonly Counter<long> WorkflowsFailed = Meter.CreateCounter<long>(
         "engine.workflows.execution.failed"
     );
 
-    /// <summary>Counter of workflows that terminated in <see cref="Models.PersistentItemStatus.Canceled"/>.</summary>
+    /// <summary>
+    /// Counter of workflows that terminated in <see cref="Models.PersistentItemStatus.Canceled"/>.
+    /// </summary>
     public static readonly Counter<long> WorkflowsCanceled = Meter.CreateCounter<long>(
         "engine.workflows.execution.canceled"
     );
 
-    /// <summary>Counter of terminal workflows resumed for re-processing.</summary>
+    /// <summary>
+    /// Counter of terminal workflows resumed for re-processing.
+    /// </summary>
     public static readonly Counter<long> WorkflowsResumed = Meter.CreateCounter<long>(
         "engine.workflows.execution.resumed",
         description: "Number of terminal workflows resumed for re-processing"
     );
 
-    /// <summary>Counter of stale workflows reclaimed from crashed workers.</summary>
+    /// <summary>
+    /// Counter of stale workflows reclaimed from crashed workers.
+    /// </summary>
     public static readonly Counter<long> WorkflowsReclaimed = Meter.CreateCounter<long>(
         "engine.workflows.execution.reclaimed",
         description: "Number of stale workflows reclaimed from crashed workers"
     );
 
-    /// <summary>Counter of in-flight workflows this host abandoned because their lease was reclaimed by another host.</summary>
+    /// <summary>
+    /// Counter of in-flight workflows this host abandoned because their lease was reclaimed by another host.
+    /// </summary>
     public static readonly Counter<long> WorkflowsLeaseLost = Meter.CreateCounter<long>(
         "engine.workflows.execution.lease_lost",
         description: "Number of in-flight workflows this host abandoned because their lease was reclaimed by another host"
     );
 
-    /// <summary>Counter of fetched workflows skipped because they were already in-flight on this host (DbMaintenance reclaim race).</summary>
+    /// <summary>
+    /// Counter of fetched workflows skipped because they were already in-flight on this host (DbMaintenance reclaim race).
+    /// </summary>
     public static readonly Counter<long> WorkflowFetchRaceDropped = Meter.CreateCounter<long>(
         "engine.workflows.fetch.race_dropped",
         description: "Number of fetched workflows skipped because they were already in-flight on this host (DbMaintenance reclaim race)"
     );
 
-    /// <summary>Histogram of seconds a workflow waited in the queue before this attempt was picked up.</summary>
+    /// <summary>
+    /// Histogram of seconds a workflow waited in the queue before this attempt was picked up.
+    /// </summary>
     public static readonly Histogram<double> WorkflowQueueTime = Meter.CreateHistogram<double>(
         "engine.workflows.time.queue",
         "s",
         "Time the workflow waited in the queue before this attempt was picked up by a worker (seconds). Recorded once per attempt."
     );
 
-    /// <summary>Histogram of seconds spent actively processing a workflow attempt.</summary>
+    /// <summary>
+    /// Histogram of seconds spent actively processing a workflow attempt.
+    /// </summary>
     public static readonly Histogram<double> WorkflowServiceTime = Meter.CreateHistogram<double>(
         "engine.workflows.time.service",
         "s",
         "Time spent actively processing this workflow attempt (seconds). Includes step execution and database IO. Recorded once per attempt."
     );
 
-    /// <summary>Histogram of total wall-clock seconds for a workflow attempt (queue + service).</summary>
+    /// <summary>
+    /// Histogram of total wall-clock seconds for a workflow attempt (queue + service).
+    /// </summary>
     public static readonly Histogram<double> WorkflowTotalTime = Meter.CreateHistogram<double>(
         "engine.workflows.time.total",
         "s",
         "Total wall-clock time of this workflow attempt — queue + service (seconds). Recorded once per attempt."
     );
 
-    /// <summary>Counter of step requests accepted for execution.</summary>
+    /// <summary>
+    /// Counter of step requests accepted for execution.
+    /// </summary>
     public static readonly Counter<long> StepRequestsAccepted = Meter.CreateCounter<long>(
         "engine.steps.request.accepted"
     );
 
-    /// <summary>Counter of steps that completed successfully.</summary>
+    /// <summary>
+    /// Counter of steps that completed successfully.
+    /// </summary>
     public static readonly Counter<long> StepsSucceeded = Meter.CreateCounter<long>("engine.steps.execution.success");
 
-    /// <summary>Counter of steps requeued after a retryable failure.</summary>
+    /// <summary>
+    /// Counter of steps requeued after a retryable failure.
+    /// </summary>
     public static readonly Counter<long> StepsRequeued = Meter.CreateCounter<long>("engine.steps.execution.requeued");
 
-    /// <summary>Counter of steps that terminated in failure.</summary>
+    /// <summary>
+    /// Counter of steps that terminated in failure.
+    /// </summary>
     public static readonly Counter<long> StepsFailed = Meter.CreateCounter<long>("engine.steps.execution.failed");
 
-    /// <summary>Histogram of seconds between the prior step finishing and this step beginning execution.</summary>
+    /// <summary>
+    /// Histogram of seconds between the prior step finishing and this step beginning execution.
+    /// </summary>
     public static readonly Histogram<double> StepQueueTime = Meter.CreateHistogram<double>(
         "engine.steps.time.queue",
         "s",
         "Time between the prior step finishing (or the workflow attempt starting, for the first step) and this step beginning execution (seconds). Mostly captures engine-internal database IO. Recorded once per step per attempt."
     );
 
-    /// <summary>Histogram of seconds spent actively executing a step (command execution + DB IO).</summary>
+    /// <summary>
+    /// Histogram of seconds spent actively executing a step (command execution + DB IO).
+    /// </summary>
     public static readonly Histogram<double> StepServiceTime = Meter.CreateHistogram<double>(
         "engine.steps.time.service",
         "s",
         "Time spent actively executing this step (seconds). Includes command execution and database IO. Recorded once per step per attempt."
     );
 
-    /// <summary>Histogram of total seconds for a step within the workflow attempt (queue + service).</summary>
+    /// <summary>
+    /// Histogram of total seconds for a step within the workflow attempt (queue + service).
+    /// </summary>
     public static readonly Histogram<double> StepTotalTime = Meter.CreateHistogram<double>(
         "engine.steps.time.total",
         "s",
         "Total time for this step within the workflow attempt — queue + service (seconds). Recorded once per step per attempt."
     );
 
-    /// <summary>Counter of redundant status updates eliminated by deduplication in the update buffer.</summary>
+    /// <summary>
+    /// Counter of redundant status updates eliminated by deduplication in the update buffer.
+    /// </summary>
     public static readonly Counter<long> UpdateBufferDeduplicatedItems = Meter.CreateCounter<long>(
         "engine.update_buffer.deduplicated",
         description: "Number of redundant status updates eliminated by deduplication in the update buffer"
     );
 
-    /// <summary>Counter of fire-and-forget status updates dropped because the update buffer channel was full.</summary>
+    /// <summary>
+    /// Counter of fire-and-forget status updates dropped because the update buffer channel was full.
+    /// </summary>
     public static readonly Counter<long> UpdateBufferDroppedItems = Meter.CreateCounter<long>(
         "engine.update_buffer.dropped",
         description: "Number of fire-and-forget status updates dropped because the update buffer channel was full"
     );
 
-    /// <summary>Counter of workflow status updates actually written to the database after deduplication.</summary>
+    /// <summary>
+    /// Counter of workflow status updates actually written to the database after deduplication.
+    /// </summary>
     public static readonly Counter<long> UpdateBufferFlushedItems = Meter.CreateCounter<long>(
         "engine.update_buffer.flushed",
         description: "Number of workflow status updates actually written to the database after deduplication"
     );
 
-    /// <summary>Counter of database operations that succeeded.</summary>
+    /// <summary>
+    /// Counter of database operations that succeeded.
+    /// </summary>
     public static readonly Counter<long> DbOperationsSucceeded = Meter.CreateCounter<long>(
         "engine.db.operations.success"
     );
 
-    /// <summary>Counter of database operations that were requeued for retry.</summary>
+    /// <summary>
+    /// Counter of database operations that were requeued for retry.
+    /// </summary>
     public static readonly Counter<long> DbOperationsRequeued = Meter.CreateCounter<long>(
         "engine.db.operations.requeued"
     );
 
-    /// <summary>Counter of database operations that failed terminally.</summary>
+    /// <summary>
+    /// Counter of database operations that failed terminally.
+    /// </summary>
     public static readonly Counter<long> DbOperationsFailed = Meter.CreateCounter<long>("engine.db.operations.failed");
 
     private static long _maintenanceConsecutiveFailures;
 
-    /// <summary>Gauge of consecutive database maintenance failures (0 = healthy).</summary>
+    /// <summary>
+    /// Gauge of consecutive database maintenance failures (0 = healthy).
+    /// </summary>
     public static readonly ObservableGauge<long> MaintenanceConsecutiveFailures = Meter.CreateObservableGauge(
         "engine.maintenance.consecutive_failures",
         static () => _maintenanceConsecutiveFailures,
@@ -211,7 +285,9 @@ public static class Metrics
 
     private static long _healthStatus; // 0=healthy, 1=degraded, 2=unhealthy
 
-    /// <summary>Gauge of overall engine health (0=healthy, 1=degraded, 2=unhealthy).</summary>
+    /// <summary>
+    /// Gauge of overall engine health (0=healthy, 1=degraded, 2=unhealthy).
+    /// </summary>
     public static readonly ObservableGauge<long> HealthStatus = Meter.CreateObservableGauge(
         "engine.health.status",
         static () => _healthStatus,
@@ -220,7 +296,9 @@ public static class Metrics
 
     private static long _activeWorkflowsCount;
 
-    /// <summary>Gauge of currently active workflows (any non-terminal status).</summary>
+    /// <summary>
+    /// Gauge of currently active workflows (any non-terminal status).
+    /// </summary>
     public static readonly ObservableGauge<long> ActiveWorkflows = Meter.CreateObservableGauge(
         "engine.workflows.active",
         static () => _activeWorkflowsCount
@@ -228,7 +306,9 @@ public static class Metrics
 
     private static long _scheduledWorkflowsCount;
 
-    /// <summary>Gauge of workflows scheduled for future execution (<see cref="Models.Workflow.StartAt"/> in the future).</summary>
+    /// <summary>
+    /// Gauge of workflows scheduled for future execution (<see cref="Models.Workflow.StartAt"/> in the future).
+    /// </summary>
     public static readonly ObservableGauge<long> ScheduledWorkflows = Meter.CreateObservableGauge(
         "engine.workflows.scheduled",
         static () => _scheduledWorkflowsCount
@@ -236,7 +316,9 @@ public static class Metrics
 
     private static long _failedWorkflowsCount;
 
-    /// <summary>Gauge of terminal failed workflows currently retained.</summary>
+    /// <summary>
+    /// Gauge of terminal failed workflows currently retained.
+    /// </summary>
     public static readonly ObservableGauge<long> FailedWorkflows = Meter.CreateObservableGauge(
         "engine.workflows.failed",
         static () => _failedWorkflowsCount
@@ -244,7 +326,9 @@ public static class Metrics
 
     private static long _successfulWorkflowsCount;
 
-    /// <summary>Gauge of terminal successful workflows currently retained.</summary>
+    /// <summary>
+    /// Gauge of terminal successful workflows currently retained.
+    /// </summary>
     public static readonly ObservableGauge<long> SuccessfulWorkflows = Meter.CreateObservableGauge(
         "engine.workflows.successful",
         static () => _successfulWorkflowsCount
@@ -252,7 +336,9 @@ public static class Metrics
 
     private static long _finishedWorkflowsCount;
 
-    /// <summary>Gauge of all terminal workflows currently retained (success + failure + canceled + dependency-failed).</summary>
+    /// <summary>
+    /// Gauge of all terminal workflows currently retained (success + failure + canceled + dependency-failed).
+    /// </summary>
     public static readonly ObservableGauge<long> FinishedWorkflows = Meter.CreateObservableGauge(
         "engine.workflows.finished",
         static () => _finishedWorkflowsCount
@@ -260,7 +346,9 @@ public static class Metrics
 
     private static long _availableInboxSlotsCount;
 
-    /// <summary>Gauge of remaining inbox capacity before the engine reports backpressure.</summary>
+    /// <summary>
+    /// Gauge of remaining inbox capacity before the engine reports backpressure.
+    /// </summary>
     public static readonly ObservableGauge<long> AvailableInboxSlots = Meter.CreateObservableGauge(
         "engine.slots.inbox.available",
         static () => _availableInboxSlotsCount
@@ -268,7 +356,9 @@ public static class Metrics
 
     private static long _usedInboxSlotsCount;
 
-    /// <summary>Gauge of currently consumed inbox slots.</summary>
+    /// <summary>
+    /// Gauge of currently consumed inbox slots.
+    /// </summary>
     public static readonly ObservableGauge<long> UsedInboxSlots = Meter.CreateObservableGauge(
         "engine.slots.inbox.used",
         static () => _usedInboxSlotsCount
@@ -276,7 +366,9 @@ public static class Metrics
 
     private static long _availableDbSlotsCount;
 
-    /// <summary>Gauge of available concurrency slots in the database semaphore pool.</summary>
+    /// <summary>
+    /// Gauge of available concurrency slots in the database semaphore pool.
+    /// </summary>
     public static readonly ObservableGauge<long> AvailableDbSlots = Meter.CreateObservableGauge(
         "engine.slots.db.available",
         static () => _availableDbSlotsCount
@@ -284,7 +376,9 @@ public static class Metrics
 
     private static long _usedDbSlotsCount;
 
-    /// <summary>Gauge of in-use concurrency slots in the database semaphore pool.</summary>
+    /// <summary>
+    /// Gauge of in-use concurrency slots in the database semaphore pool.
+    /// </summary>
     public static readonly ObservableGauge<long> UsedDbSlots = Meter.CreateObservableGauge(
         "engine.slots.db.used",
         static () => _usedDbSlotsCount
@@ -292,7 +386,9 @@ public static class Metrics
 
     private static long _availableHttpSlotsCount;
 
-    /// <summary>Gauge of available concurrency slots in the outbound-HTTP semaphore pool.</summary>
+    /// <summary>
+    /// Gauge of available concurrency slots in the outbound-HTTP semaphore pool.
+    /// </summary>
     public static readonly ObservableGauge<long> AvailableHttpSlots = Meter.CreateObservableGauge(
         "engine.slots.http.available",
         static () => _availableHttpSlotsCount
@@ -300,7 +396,9 @@ public static class Metrics
 
     private static long _usedHttpSlotsCount;
 
-    /// <summary>Gauge of in-use concurrency slots in the outbound-HTTP semaphore pool.</summary>
+    /// <summary>
+    /// Gauge of in-use concurrency slots in the outbound-HTTP semaphore pool.
+    /// </summary>
     public static readonly ObservableGauge<long> UsedHttpSlots = Meter.CreateObservableGauge(
         "engine.slots.http.used",
         static () => _usedHttpSlotsCount
@@ -308,7 +406,9 @@ public static class Metrics
 
     private static long _availableWorkerSlotsCount;
 
-    /// <summary>Gauge of available worker slots (concurrent workflow processors).</summary>
+    /// <summary>
+    /// Gauge of available worker slots (concurrent workflow processors).
+    /// </summary>
     public static readonly ObservableGauge<long> AvailableWorkerSlots = Meter.CreateObservableGauge(
         "engine.slots.workers.available",
         static () => _availableWorkerSlotsCount
@@ -316,55 +416,87 @@ public static class Metrics
 
     private static long _usedWorkerSlotsCount;
 
-    /// <summary>Gauge of in-use worker slots.</summary>
+    /// <summary>
+    /// Gauge of in-use worker slots.
+    /// </summary>
     public static readonly ObservableGauge<long> UsedWorkerSlots = Meter.CreateObservableGauge(
         "engine.slots.workers.used",
         static () => _usedWorkerSlotsCount
     );
 
-    /// <summary>Sets the value reported by <see cref="MaintenanceConsecutiveFailures"/>.</summary>
+    /// <summary>
+    /// Sets the value reported by <see cref="MaintenanceConsecutiveFailures"/>.
+    /// </summary>
     public static void SetMaintenanceConsecutiveFailures(int count) => _maintenanceConsecutiveFailures = count;
 
-    /// <summary>Sets the value reported by <see cref="HealthStatus"/>.</summary>
+    /// <summary>
+    /// Sets the value reported by <see cref="HealthStatus"/>.
+    /// </summary>
     public static void SetHealthStatus(long status) => _healthStatus = status;
 
-    /// <summary>Sets the value reported by <see cref="ActiveWorkflows"/>.</summary>
+    /// <summary>
+    /// Sets the value reported by <see cref="ActiveWorkflows"/>.
+    /// </summary>
     public static void SetActiveWorkflowsCount(long count) => _activeWorkflowsCount = count;
 
-    /// <summary>Sets the value reported by <see cref="ScheduledWorkflows"/>.</summary>
+    /// <summary>
+    /// Sets the value reported by <see cref="ScheduledWorkflows"/>.
+    /// </summary>
     public static void SetScheduledWorkflowsCount(long count) => _scheduledWorkflowsCount = count;
 
-    /// <summary>Sets the value reported by <see cref="FailedWorkflows"/>.</summary>
+    /// <summary>
+    /// Sets the value reported by <see cref="FailedWorkflows"/>.
+    /// </summary>
     public static void SetFailedWorkflowsCount(long count) => _failedWorkflowsCount = count;
 
-    /// <summary>Sets the value reported by <see cref="SuccessfulWorkflows"/>.</summary>
+    /// <summary>
+    /// Sets the value reported by <see cref="SuccessfulWorkflows"/>.
+    /// </summary>
     public static void SetSuccessfulWorkflowsCount(long count) => _successfulWorkflowsCount = count;
 
-    /// <summary>Sets the value reported by <see cref="FinishedWorkflows"/>.</summary>
+    /// <summary>
+    /// Sets the value reported by <see cref="FinishedWorkflows"/>.
+    /// </summary>
     public static void SetFinishedWorkflowsCount(long count) => _finishedWorkflowsCount = count;
 
-    /// <summary>Sets the value reported by <see cref="AvailableInboxSlots"/>.</summary>
+    /// <summary>
+    /// Sets the value reported by <see cref="AvailableInboxSlots"/>.
+    /// </summary>
     public static void SetAvailableInboxSlots(int count) => _availableInboxSlotsCount = count;
 
-    /// <summary>Sets the value reported by <see cref="UsedInboxSlots"/>.</summary>
+    /// <summary>
+    /// Sets the value reported by <see cref="UsedInboxSlots"/>.
+    /// </summary>
     public static void SetUsedInboxSlots(int count) => _usedInboxSlotsCount = count;
 
-    /// <summary>Sets the value reported by <see cref="AvailableDbSlots"/>.</summary>
+    /// <summary>
+    /// Sets the value reported by <see cref="AvailableDbSlots"/>.
+    /// </summary>
     public static void SetAvailableDbSlots(int count) => _availableDbSlotsCount = count;
 
-    /// <summary>Sets the value reported by <see cref="UsedDbSlots"/>.</summary>
+    /// <summary>
+    /// Sets the value reported by <see cref="UsedDbSlots"/>.
+    /// </summary>
     public static void SetUsedDbSlots(int count) => _usedDbSlotsCount = count;
 
-    /// <summary>Sets the value reported by <see cref="AvailableHttpSlots"/>.</summary>
+    /// <summary>
+    /// Sets the value reported by <see cref="AvailableHttpSlots"/>.
+    /// </summary>
     public static void SetAvailableHttpSlots(int count) => _availableHttpSlotsCount = count;
 
-    /// <summary>Sets the value reported by <see cref="UsedHttpSlots"/>.</summary>
+    /// <summary>
+    /// Sets the value reported by <see cref="UsedHttpSlots"/>.
+    /// </summary>
     public static void SetUsedHttpSlots(int count) => _usedHttpSlotsCount = count;
 
-    /// <summary>Sets the value reported by <see cref="AvailableWorkerSlots"/>.</summary>
+    /// <summary>
+    /// Sets the value reported by <see cref="AvailableWorkerSlots"/>.
+    /// </summary>
     public static void SetAvailableWorkerSlots(int count) => _availableWorkerSlotsCount = count;
 
-    /// <summary>Sets the value reported by <see cref="UsedWorkerSlots"/>.</summary>
+    /// <summary>
+    /// Sets the value reported by <see cref="UsedWorkerSlots"/>.
+    /// </summary>
     public static void SetUsedWorkerSlots(int count) => _usedWorkerSlotsCount = count;
 
     /// <summary>

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Telemetry/Metrics.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Telemetry/Metrics.cs
@@ -108,14 +108,14 @@ public static class Metrics
     );
 
     /// <summary>
-    /// Counter of workflows that terminated in <see cref="Models.PersistentItemStatus.Failed"/>.
+    /// Counter of workflows that terminated in a <c>Failed</c> state.
     /// </summary>
     public static readonly Counter<long> WorkflowsFailed = Meter.CreateCounter<long>(
         "engine.workflows.execution.failed"
     );
 
     /// <summary>
-    /// Counter of workflows that terminated in <see cref="Models.PersistentItemStatus.Canceled"/>.
+    /// Counter of workflows that terminated in a <c>Canceled</c> state.
     /// </summary>
     public static readonly Counter<long> WorkflowsCanceled = Meter.CreateCounter<long>(
         "engine.workflows.execution.canceled"
@@ -307,7 +307,7 @@ public static class Metrics
     private static long _scheduledWorkflowsCount;
 
     /// <summary>
-    /// Gauge of workflows scheduled for future execution (<see cref="Models.Workflow.StartAt"/> in the future).
+    /// Gauge of workflows scheduled for future execution.
     /// </summary>
     public static readonly ObservableGauge<long> ScheduledWorkflows = Meter.CreateObservableGauge(
         "engine.workflows.scheduled",

--- a/src/Runtime/workflow-engine/tests/Directory.Build.props
+++ b/src/Runtime/workflow-engine/tests/Directory.Build.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="../Directory.Build.props" />
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+</Project>

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Core.Tests/CancellationTests.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Core.Tests/CancellationTests.cs
@@ -101,7 +101,7 @@ public class CancellationTests
     /// Creates a mock executor where the specified step index cancels the CTS and throws
     /// <see cref="OperationCanceledException"/>. If a <paramref name="workflow"/> is provided,
     /// its <see cref="Workflow.CancellationRequestedAt"/> is stamped before cancellation
-    /// (simulating <see cref="InFlightTracker.TryCancel"/>). If null, only the CTS is
+    /// (simulating <see cref="InFlightTracker.TryCancel(System.Guid)"/>). If null, only the CTS is
     /// cancelled (simulating host shutdown).
     /// </summary>
     private static Mock<IWorkflowExecutor> MockExecutorWithCancellation(

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Core.Tests/Extensions/EngineSettingsConfigurationTests.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Core.Tests/Extensions/EngineSettingsConfigurationTests.cs
@@ -400,7 +400,7 @@ public class EngineSettingsConfigurationTests
 }
 
 /// <summary>
-/// Helper to convert a JSON string to a stream for <see cref="ConfigurationBuilder.AddJsonStream"/>.
+/// Helper to convert a JSON string to a stream for <c>ConfigurationBuilder.AddJsonStream</c>.
 /// </summary>
 internal static class JsonStreamHelper
 {

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Integration.Tests/TelemetryTests.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Integration.Tests/TelemetryTests.cs
@@ -368,7 +368,9 @@ public sealed class TelemetryTests(EngineAppFixture<Program> fixture) : IAsyncLi
 
     // ─── Span hierarchy helpers ────────────────────────────────────
 
-    /// <summary>Asserts that <paramref name="child"/> is a direct child of <paramref name="parent"/>.</summary>
+    /// <summary>
+    /// Asserts that <paramref name="child"/> is a direct child of <paramref name="parent"/>.
+    /// </summary>
     private static void AssertChildOf(Activity parent, Activity child)
     {
         Assert.Equal(parent.TraceId, child.TraceId);
@@ -393,7 +395,9 @@ public sealed class TelemetryTests(EngineAppFixture<Program> fixture) : IAsyncLi
         return matches[0];
     }
 
-    /// <summary>Returns the single activity matching <paramref name="operationName"/> within the given trace.</summary>
+    /// <summary>
+    /// Returns the single activity matching <paramref name="operationName"/> within the given trace.
+    /// </summary>
     private static Activity SingleInTrace(TelemetryCollector collector, ActivityTraceId traceId, string operationName)
     {
         var matches = collector.GetActivities(operationName).Where(a => a.TraceId == traceId).ToList();
@@ -404,7 +408,9 @@ public sealed class TelemetryTests(EngineAppFixture<Program> fixture) : IAsyncLi
         return matches[0];
     }
 
-    /// <summary>Returns the single activity whose name starts with <paramref name="prefix"/> within the given trace.</summary>
+    /// <summary>
+    /// Returns the single activity whose name starts with <paramref name="prefix"/> within the given trace.
+    /// </summary>
     private static Activity SingleStartingWith(TelemetryCollector collector, ActivityTraceId traceId, string prefix)
     {
         var matches = collector.GetActivitiesStartingWith(prefix).Where(a => a.TraceId == traceId).ToList();

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.TestKit/TestHelpers.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.TestKit/TestHelpers.cs
@@ -40,7 +40,9 @@ public sealed class TestHelpers(EngineAppFixture fixture)
             Labels = labels,
         };
 
-    /// <summary>Builds a <see cref="WorkflowRequest"/> with the supplied steps.</summary>
+    /// <summary>
+    /// Builds a <see cref="WorkflowRequest"/> with the supplied steps.
+    /// </summary>
     public WorkflowRequest CreateWorkflow(
         string wfRef,
         IEnumerable<StepRequest> steps,

--- a/src/Runtime/workflow-engine/typos.toml
+++ b/src/Runtime/workflow-engine/typos.toml
@@ -1,0 +1,15 @@
+[files]
+extend-exclude = [
+    "**/wwwroot/**",
+    "**/.k6/**",
+    "**/bin/**",
+    "**/obj/**",
+    "*.svg",
+    "*.drawio*",
+    "docs/presentation/**"
+]
+
+[default.extend-words]
+# Domain words and acronyms that should not be flagged.
+# Add entries as `word = "word"` to whitelist a token.
+OCE = "OCE" # OperationCanceledException

--- a/src/Runtime/workflow-engine/typos.toml
+++ b/src/Runtime/workflow-engine/typos.toml
@@ -6,7 +6,7 @@ extend-exclude = [
     "**/obj/**",
     "*.svg",
     "*.drawio*",
-    "docs/presentation/**"
+    "**/docs/presentation/**"
 ]
 
 [default.extend-words]

--- a/src/Runtime/workflow-engine/typos.toml
+++ b/src/Runtime/workflow-engine/typos.toml
@@ -9,6 +9,9 @@ extend-exclude = [
     "**/docs/presentation/**"
 ]
 
+[default]
+locale = "en-us"
+
 [default.extend-words]
 # Domain words and acronyms that should not be flagged.
 # Add entries as `word = "word"` to whitelist a token.


### PR DESCRIPTION
## Description
- Standardize XML docstrings across the workflow-engine production projects. The doc sweep covers `Models`, `Telemetry`, `Resilience`, `Commands`, and `Core`. Style is consistent throughout: one-sentence summaries by default, longer explanations only where behavior is non-obvious; `<inheritdoc/>` on trivial overrides; record primary-constructor parameters documented via `<param>` on the type.
- Re-enable the `TreatWarningsAsErrors` block in `src/Runtime/workflow-engine/Directory.Build.props`. The build was already warning-clean from prior incremental cleanup PRs; turning the gate back on keeps the bar from regressing.
- Rename `GetHistorgramTags()` to `GetHistogramTags()` on the `Workflow`/`Step` extensions and the 7 call sites in `WorkflowHandler.cs`. No public consumers yet, so the rename is safe.

## Related
- Closes #18585
- Closes #18319

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workflow model identity, lifecycle and observability fields; step status now exposes retry strategy.

* **Bug Fixes**
  * Fixed telemetry metric tag helper naming used in workflow and step metrics.

* **Documentation**
  * Vastly expanded XML documentation across the workflow engine and enabled in-build documentation generation for relevant subprojects.

* **Chores**
  * Enabled build-time warning-as-error enforcement (with specific exclusions) and added spell-check/typo checks to CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->