### PR TITLE
fix(gateway): retrieve designer environment from annotations

### DIFF
--- a/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Application/Alerts/HandleAlerts.cs
+++ b/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Application/Alerts/HandleAlerts.cs
@@ -49,10 +49,19 @@ internal static class HandleAlerts
         IOptionsMonitor<MetricsClientSettings> metricsClientSettings,
         DesignerClient designerClient,
         AlertPayload alertPayload,
-        CancellationToken cancellationToken,
-        string environment = "prod"
+        IOptionsMonitor<StudioEnvironments> environments,
+        CancellationToken cancellationToken
     )
     {
+        string? designerEnvironmentLabel = alertPayload
+            .Alerts.Select(a => a.Labels.GetValueOrDefault("DesignerEnvironment"))
+            .FirstOrDefault();
+        string designerEnvironment =
+            !string.IsNullOrWhiteSpace(designerEnvironmentLabel)
+            && environments.CurrentValue.ContainsKey(designerEnvironmentLabel)
+                ? designerEnvironmentLabel
+                : "prod";
+
         IMetricsClient metricsClient = serviceProvider.GetRequiredKeyedService<IMetricsClient>(
             metricsClientSettings.CurrentValue.Provider
         );
@@ -114,7 +123,7 @@ internal static class HandleAlerts
             LogsUrl = logsUrl,
         };
 
-        await designerClient.NotifyAlertsUpdated(alert, environment, cancellationToken);
+        await designerClient.NotifyAlertsUpdated(alert, designerEnvironment, cancellationToken);
 
         return Results.Ok();
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Allows routing alert notifications to the correct designer instance (dev/staging/prod) since a single Grafana is shared across all environments

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Refactor**
- Enhanced alert handling environment resolution for improved system flexibility and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->