### PR TITLE
chore: release studioctl v0.1.0-preview.7

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -8,6 +8,8 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+## [0.1.0-preview.7] - 2026-04-29
+
 ### Added
 
 - Add `env reset` for localtest to delete persisted localtest and workflow-engine database data, with interactive confirmation.


### PR DESCRIPTION
## Description

Prepare release v0.1.0-preview.7

- [Added] Add `env reset` for localtest to delete persisted localtest and workflow-engine database data, with interactive confirmation.
- [Added] Add `env hosts add`, `env hosts remove`, and `env hosts status` for localtest, including managed hosts-file blocks, backup creation, and `--json` output.
- [Changed] Make `--random-host-port` default to `true` for `run` and `app run`.
- [Changed] Stop running apps, localtest, and app-manager before `self update`, `self uninstall`, and installer replacement.
- [Fixed] Fix install and update flows when no interactive terminal prompt is available.
- [Fixed] Fix workflow-engine database persistence cross-platform support by using a named/managed volume instead of host bind mount.
- [Fixed] Fix app-manager shutdown waits incorrectly reporting that an exited process is still running on Linux systems.
- [Fixed] Reading password input when using `studioctl auth` now works on macOS with bracketed paste enabled.
- [Removed] Breaking: remove `--checks` from `studioctl doctor`; `studioctl doctor` now always runs localtest environment diagnostics and reports localtest, PDF, and workflow-engine health in text and JSON output.

@coderabbitai ignore

**Full Changelog**: https://github.com/Altinn/altinn-studio/compare/studioctl/v0.1.0-preview.6...studioctl/v0.1.0-preview.7