### PR TITLE
feat: studioctl - `self uninstall` remove all resources

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -17,6 +17,7 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 - Make `--random-host-port` default to `true` for `run` and `app run`.
 - Stop running apps, localtest, and app-manager before `self update`, `self uninstall`, and installer replacement.
+- Make `self uninstall` remove studioctl home data and env runtime resources.
 
 ### Fixed
 

--- a/src/cli/internal/cmd/self.go
+++ b/src/cli/internal/cmd/self.go
@@ -466,13 +466,25 @@ func (c *SelfCommand) runUninstall(ctx context.Context, args []string) error {
 		}
 	}()
 
+	if resetErr := c.transition.ResetEnvs(ctx); resetErr != nil {
+		return fmt.Errorf("reset environments before uninstall: %w", resetErr)
+	}
+	if validateErr := c.service.ValidateHomeRemoval(); validateErr != nil {
+		return fmt.Errorf("validate home directory removal: %w", validateErr)
+	}
+
 	result, err := c.service.UninstallBinary()
 	if err != nil {
 		return fmt.Errorf("self uninstall: %w", err)
 	}
 	removed = true
 
+	removedHome, err := c.service.RemoveHome()
+	if err != nil {
+		return fmt.Errorf("remove home directory: %w", err)
+	}
+
 	c.out.Successf("Removed %s", result.RemovedPath)
-	c.out.Println("Localtest resources and configuration were not removed.")
+	c.out.Successf("Removed %s", removedHome)
 	return nil
 }

--- a/src/cli/internal/cmd/self.go
+++ b/src/cli/internal/cmd/self.go
@@ -473,16 +473,16 @@ func (c *SelfCommand) runUninstall(ctx context.Context, args []string) error {
 		return fmt.Errorf("validate home directory removal: %w", validateErr)
 	}
 
+	removedHome, err := c.service.RemoveHome()
+	if err != nil {
+		return fmt.Errorf("remove home directory: %w", err)
+	}
+
 	result, err := c.service.UninstallBinary()
 	if err != nil {
 		return fmt.Errorf("self uninstall: %w", err)
 	}
 	removed = true
-
-	removedHome, err := c.service.RemoveHome()
-	if err != nil {
-		return fmt.Errorf("remove home directory: %w", err)
-	}
 
 	c.out.Successf("Removed %s", result.RemovedPath)
 	c.out.Successf("Removed %s", removedHome)

--- a/src/cli/internal/cmd/self/self_transition.go
+++ b/src/cli/internal/cmd/self/self_transition.go
@@ -114,6 +114,44 @@ func (t *Transition) RunMigrations(ctx context.Context) error {
 	return nil
 }
 
+// ResetEnvs removes persisted environment data before uninstall.
+func (t *Transition) ResetEnvs(ctx context.Context) error {
+	containerClient := t.containerClient
+	if containerClient == nil {
+		containerClient = container.Detect
+	}
+	client, err := containerClient(ctx)
+	if err != nil {
+		return fmt.Errorf("connect to container runtime: %w", err)
+	}
+	defer func() {
+		if closeErr := client.Close(); closeErr != nil {
+			t.out.Verbosef("failed to close container client: %v", closeErr)
+		}
+	}()
+
+	envs, err := envregistry.Envs(
+		envregistry.WithConfig(t.cfg),
+		envregistry.WithOutput(t.out),
+		envregistry.WithContainerClient(client),
+	)
+	if err != nil {
+		return fmt.Errorf("build environment registry: %w", err)
+	}
+
+	for _, env := range envs {
+		resetter, ok := env.(envtypes.Resetter)
+		if !ok {
+			continue
+		}
+		if err := resetter.Reset(ctx); err != nil {
+			return fmt.Errorf("reset %s before uninstall: %w", env.Name(), err)
+		}
+	}
+
+	return nil
+}
+
 // Restore restarts app-manager after a failed self operation when it was previously running.
 func (t *Transition) Restore(
 	ctx context.Context,

--- a/src/cli/internal/cmd/self/self_transition_internal_test.go
+++ b/src/cli/internal/cmd/self/self_transition_internal_test.go
@@ -5,10 +5,13 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	containerruntime "altinn.studio/devenv/pkg/container"
+	containermock "altinn.studio/devenv/pkg/container/mock"
 	"altinn.studio/studioctl/internal/appmanager"
 	"altinn.studio/studioctl/internal/config"
 	"altinn.studio/studioctl/internal/ui"
@@ -189,6 +192,34 @@ func TestSelfTransitionRunsMigrationsBeforeRestart(t *testing.T) {
 	}
 }
 
+func TestSelfTransitionResetEnvsRemovesLocaltestData(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig(t)
+	localtestDataDir := filepath.Join(cfg.DataDir, "AltinnPlatformLocal")
+	if err := os.MkdirAll(localtestDataDir, 0o755); err != nil {
+		t.Fatalf("create localtest data dir: %v", err)
+	}
+
+	client := containermock.New()
+	transition := &Transition{
+		cfg: cfg,
+		out: ui.NewOutput(&bytes.Buffer{}, io.Discard, true),
+		containerClient: func(context.Context) (containerruntime.ContainerClient, error) {
+			return client, nil
+		},
+	}
+
+	if err := transition.ResetEnvs(t.Context()); err != nil {
+		t.Fatalf("ResetEnvs() error = %v", err)
+	}
+
+	if _, err := os.Stat(localtestDataDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("localtest data still exists after ResetEnvs(): %v", err)
+	}
+	assertSelfTransitionCallRecorded(t, client.Calls, "VolumeRemove")
+}
+
 func TestSelfTransitionMigrationFailureDoesNotRestart(t *testing.T) {
 	t.Parallel()
 
@@ -263,4 +294,14 @@ func testConfig(t *testing.T) *config.Config {
 		t.Fatalf("config.New() error = %v", err)
 	}
 	return cfg
+}
+
+func assertSelfTransitionCallRecorded(t *testing.T, calls []containermock.Call, method string) {
+	t.Helper()
+	for _, call := range calls {
+		if call.Method == method {
+			return
+		}
+	}
+	t.Fatalf("%s not recorded in calls: %+v", method, calls)
 }

--- a/src/cli/internal/cmd/self/selfmanage.go
+++ b/src/cli/internal/cmd/self/selfmanage.go
@@ -46,6 +46,8 @@ var (
 	ErrUpdateUnsupported = errors.New("self update not supported on this platform")
 	// ErrUninstallUnsupported is returned when uninstall cannot be performed safely on current OS.
 	ErrUninstallUnsupported = errors.New("self uninstall not supported on this platform")
+	// ErrUnsafeHomeRemoval is returned when the configured home path is unsafe to remove recursively.
+	ErrUnsafeHomeRemoval = errors.New("unsafe studioctl home directory")
 	// ErrUnexpectedHTTPStatus is returned when a release endpoint returns non-200 status.
 	ErrUnexpectedHTTPStatus = errors.New("unexpected HTTP status")
 	// ErrStudioctlReleaseNotFound is returned when no studioctl release tags are found.
@@ -440,6 +442,79 @@ func (s *Service) UninstallBinary() (UninstallResult, error) {
 	}
 
 	return UninstallResult{RemovedPath: execPath}, nil
+}
+
+// RemoveHome removes the studioctl home directory.
+func (s *Service) RemoveHome() (string, error) {
+	home, err := safeHomeRemovalPath(s.cfg.Home)
+	if err != nil {
+		return "", err
+	}
+	if err := os.RemoveAll(home); err != nil {
+		return "", fmt.Errorf("remove home directory %q: %w", home, err)
+	}
+	return home, nil
+}
+
+// ValidateHomeRemoval checks whether the studioctl home directory can be removed safely.
+func (s *Service) ValidateHomeRemoval() error {
+	_, err := safeHomeRemovalPath(s.cfg.Home)
+	return err
+}
+
+func safeHomeRemovalPath(home string) (string, error) {
+	if strings.TrimSpace(home) == "" {
+		return "", fmt.Errorf("%w: empty path", ErrUnsafeHomeRemoval)
+	}
+
+	absHome, err := filepath.Abs(home)
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory: %w", err)
+	}
+	cleanHome := filepath.Clean(absHome)
+	if isPathRoot(cleanHome) {
+		return "", fmt.Errorf("%w: %s", ErrUnsafeHomeRemoval, cleanHome)
+	}
+
+	if userHome, err := os.UserHomeDir(); err == nil && samePath(cleanHome, userHome) {
+		return "", fmt.Errorf("%w: %s", ErrUnsafeHomeRemoval, cleanHome)
+	}
+	if userConfigDir, err := os.UserConfigDir(); err == nil && samePath(cleanHome, userConfigDir) {
+		return "", fmt.Errorf("%w: %s", ErrUnsafeHomeRemoval, cleanHome)
+	}
+	if cwd, err := os.Getwd(); err == nil && pathContains(cleanHome, cwd) {
+		return "", fmt.Errorf("%w: %s contains current directory %s", ErrUnsafeHomeRemoval, cleanHome, cwd)
+	}
+
+	return cleanHome, nil
+}
+
+func isPathRoot(path string) bool {
+	volume := filepath.VolumeName(path)
+	root := volume + string(os.PathSeparator)
+	return path == root
+}
+
+func samePath(left, right string) bool {
+	left = filepath.Clean(left)
+	right = filepath.Clean(right)
+	if runtime.GOOS == osWindows {
+		return strings.EqualFold(left, right)
+	}
+	return left == right
+}
+
+func pathContains(parent, child string) bool {
+	parent = filepath.Clean(parent)
+	child = filepath.Clean(child)
+	if samePath(parent, child) {
+		return true
+	}
+	rel, err := filepath.Rel(parent, child)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))
 }
 
 func currentExecutablePath() (string, error) {

--- a/src/cli/internal/cmd/self/selfmanage.go
+++ b/src/cli/internal/cmd/self/selfmanage.go
@@ -476,13 +476,25 @@ func safeHomeRemovalPath(home string) (string, error) {
 		return "", fmt.Errorf("%w: %s", ErrUnsafeHomeRemoval, cleanHome)
 	}
 
-	if userHome, err := os.UserHomeDir(); err == nil && samePath(cleanHome, userHome) {
+	userHome, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("%w: resolve user home directory: %w", ErrUnsafeHomeRemoval, err)
+	}
+	if samePath(cleanHome, userHome) {
 		return "", fmt.Errorf("%w: %s", ErrUnsafeHomeRemoval, cleanHome)
 	}
-	if userConfigDir, err := os.UserConfigDir(); err == nil && samePath(cleanHome, userConfigDir) {
+	userConfigDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("%w: resolve user config directory: %w", ErrUnsafeHomeRemoval, err)
+	}
+	if samePath(cleanHome, userConfigDir) {
 		return "", fmt.Errorf("%w: %s", ErrUnsafeHomeRemoval, cleanHome)
 	}
-	if cwd, err := os.Getwd(); err == nil && pathContains(cleanHome, cwd) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("%w: resolve current directory: %w", ErrUnsafeHomeRemoval, err)
+	}
+	if pathContains(cleanHome, cwd) {
 		return "", fmt.Errorf("%w: %s contains current directory %s", ErrUnsafeHomeRemoval, cleanHome, cwd)
 	}
 

--- a/src/cli/internal/cmd/self/selfmanage_test.go
+++ b/src/cli/internal/cmd/self/selfmanage_test.go
@@ -223,9 +223,9 @@ func TestRemoveHomeRejectsUserHome(t *testing.T) {
 		t.Skipf("user home unavailable: %v", err)
 	}
 
-	_, err = self.NewService(&config.Config{Home: home}).RemoveHome()
+	err = self.NewService(&config.Config{Home: home}).ValidateHomeRemoval()
 	if !errors.Is(err, self.ErrUnsafeHomeRemoval) {
-		t.Fatalf("RemoveHome() error = %v, want ErrUnsafeHomeRemoval", err)
+		t.Fatalf("ValidateHomeRemoval() error = %v, want ErrUnsafeHomeRemoval", err)
 	}
 }
 
@@ -237,9 +237,9 @@ func TestRemoveHomeRejectsCurrentDirectory(t *testing.T) {
 		t.Fatalf("get cwd: %v", err)
 	}
 
-	_, err = self.NewService(&config.Config{Home: cwd}).RemoveHome()
+	err = self.NewService(&config.Config{Home: cwd}).ValidateHomeRemoval()
 	if !errors.Is(err, self.ErrUnsafeHomeRemoval) {
-		t.Fatalf("RemoveHome() error = %v, want ErrUnsafeHomeRemoval", err)
+		t.Fatalf("ValidateHomeRemoval() error = %v, want ErrUnsafeHomeRemoval", err)
 	}
 }
 

--- a/src/cli/internal/cmd/self/selfmanage_test.go
+++ b/src/cli/internal/cmd/self/selfmanage_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	self "altinn.studio/studioctl/internal/cmd/self"
+	"altinn.studio/studioctl/internal/config"
 	"altinn.studio/studioctl/internal/ui"
 )
 
@@ -185,6 +188,58 @@ func TestChecksumForAsset(t *testing.T) {
 	_, err = self.ChecksumForAsset(checksums, "missing")
 	if !errors.Is(err, self.ErrChecksumAssetNotFound) {
 		t.Fatalf("ChecksumForAsset() error = %v, want %v", err, self.ErrChecksumAssetNotFound)
+	}
+}
+
+func TestRemoveHomeRemovesConfiguredHome(t *testing.T) {
+	t.Parallel()
+
+	home := filepath.Join(t.TempDir(), "studioctl-home")
+	cfg, err := config.New(config.Flags{Home: home}, "test-version")
+	if err != nil {
+		t.Fatalf("config.New() error = %v", err)
+	}
+	if writeErr := os.WriteFile(filepath.Join(cfg.Home, "config.yaml"), []byte("test"), 0o600); writeErr != nil {
+		t.Fatalf("write config: %v", writeErr)
+	}
+
+	removed, err := self.NewService(cfg).RemoveHome()
+	if err != nil {
+		t.Fatalf("RemoveHome() error = %v", err)
+	}
+	if removed != home {
+		t.Fatalf("RemoveHome() = %q, want %q", removed, home)
+	}
+	if _, err := os.Stat(home); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("home still exists after RemoveHome(): %v", err)
+	}
+}
+
+func TestRemoveHomeRejectsUserHome(t *testing.T) {
+	t.Parallel()
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("user home unavailable: %v", err)
+	}
+
+	_, err = self.NewService(&config.Config{Home: home}).RemoveHome()
+	if !errors.Is(err, self.ErrUnsafeHomeRemoval) {
+		t.Fatalf("RemoveHome() error = %v, want ErrUnsafeHomeRemoval", err)
+	}
+}
+
+func TestRemoveHomeRejectsCurrentDirectory(t *testing.T) {
+	t.Parallel()
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get cwd: %v", err)
+	}
+
+	_, err = self.NewService(&config.Config{Home: cwd}).RemoveHome()
+	if !errors.Is(err, self.ErrUnsafeHomeRemoval) {
+		t.Fatalf("RemoveHome() error = %v, want ErrUnsafeHomeRemoval", err)
 	}
 }
 


### PR DESCRIPTION
## Description

Make `self uninstall`
- reset env resources
- remove homedir (studioctl home)

to properly cleanup the install

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * `self uninstall` now removes the studioctl home directory alongside binary uninstallation and resets environment configurations.

* **Bug Fixes**
  * Added safety validation during uninstall to prevent accidental removal of critical directories such as user home or system paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->