### PR TITLE
chore: improve devenv resource graph reconciliation

### DIFF
--- a/src/Runtime/devenv/pkg/container/container.go
+++ b/src/Runtime/devenv/pkg/container/container.go
@@ -17,6 +17,7 @@ type (
 	PortMapping         = types.PortMapping
 	PublishedPort       = types.PublishedPort
 	ContainerListFilter = types.ContainerListFilter
+	NetworkListFilter   = types.NetworkListFilter
 	VolumeMount         = types.VolumeMount
 	ContainerConfig     = types.ContainerConfig
 	ImageInfo           = types.ImageInfo
@@ -130,6 +131,9 @@ type ContainerClient interface {
 	// NetworkInspect returns information about a network.
 	// Returns ErrNetworkNotFound if the network does not exist.
 	NetworkInspect(ctx context.Context, nameOrID string) (types.NetworkInfo, error)
+
+	// ListNetworks returns networks matching the provided filters.
+	ListNetworks(ctx context.Context, filter types.NetworkListFilter) ([]types.NetworkInfo, error)
 
 	// NetworkRemove removes a network.
 	NetworkRemove(ctx context.Context, nameOrID string) error

--- a/src/Runtime/devenv/pkg/container/dockerapi/docker_engine_api.go
+++ b/src/Runtime/devenv/pkg/container/dockerapi/docker_engine_api.go
@@ -828,6 +828,34 @@ func (c *Client) NetworkInspect(ctx context.Context, nameOrID string) (types.Net
 	}, nil
 }
 
+// ListNetworks returns networks matching the provided filters.
+func (c *Client) ListNetworks(ctx context.Context, filter types.NetworkListFilter) ([]types.NetworkInfo, error) {
+	args := filters.NewArgs()
+	for key, value := range filter.Labels {
+		label := key
+		if value != "" {
+			label += "=" + value
+		}
+		args.Add("label", label)
+	}
+
+	networks, err := c.cli.NetworkList(ctx, network.ListOptions{Filters: args})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list networks: %w", err)
+	}
+
+	result := make([]types.NetworkInfo, 0, len(networks))
+	for _, net := range networks {
+		result = append(result, types.NetworkInfo{
+			ID:     net.ID,
+			Name:   net.Name,
+			Driver: net.Driver,
+			Labels: net.Labels,
+		})
+	}
+	return result, nil
+}
+
 // NetworkRemove removes a network.
 func (c *Client) NetworkRemove(ctx context.Context, nameOrID string) error {
 	if err := c.cli.NetworkRemove(ctx, nameOrID); err != nil {

--- a/src/Runtime/devenv/pkg/container/mock/mock.go
+++ b/src/Runtime/devenv/pkg/container/mock/mock.go
@@ -42,6 +42,7 @@ type Client struct {
 	ContainerRemoveFunc  func(ctx context.Context, nameOrID string, force bool) error
 	NetworkCreateFunc    func(ctx context.Context, cfg types.NetworkConfig) (string, error)
 	NetworkInspectFunc   func(ctx context.Context, nameOrID string) (types.NetworkInfo, error)
+	ListNetworksFunc     func(ctx context.Context, filter types.NetworkListFilter) ([]types.NetworkInfo, error)
 	NetworkRemoveFunc    func(ctx context.Context, nameOrID string) error
 	VolumeRemoveFunc     func(ctx context.Context, name string, force bool) error
 	ContainerLogsFunc    func(ctx context.Context, nameOrID string, follow bool, tail string) (io.ReadCloser, error)
@@ -266,6 +267,15 @@ func (c *Client) NetworkInspect(ctx context.Context, nameOrID string) (types.Net
 		return c.NetworkInspectFunc(ctx, nameOrID)
 	}
 	return types.NetworkInfo{}, types.ErrNetworkNotFound
+}
+
+// ListNetworks implements ContainerClient.
+func (c *Client) ListNetworks(ctx context.Context, filter types.NetworkListFilter) ([]types.NetworkInfo, error) {
+	c.recordCall("ListNetworks", filter)
+	if c.ListNetworksFunc != nil {
+		return c.ListNetworksFunc(ctx, filter)
+	}
+	return nil, nil
 }
 
 // NetworkRemove implements ContainerClient.

--- a/src/Runtime/devenv/pkg/container/podman/podman.go
+++ b/src/Runtime/devenv/pkg/container/podman/podman.go
@@ -736,6 +736,60 @@ func (c *Client) NetworkInspect(ctx context.Context, nameOrID string) (types.Net
 	}, nil
 }
 
+type podmanNetworkListInfo struct {
+	Labels      map[string]string `json:"labels"`
+	LabelsTitle map[string]string `json:"Labels"`
+	ID          string            `json:"id"`
+	IDTitle     string            `json:"ID"`
+	Name        string            `json:"name"`
+	NameTitle   string            `json:"Name"`
+	Driver      string            `json:"driver"`
+	DriverTitle string            `json:"Driver"`
+}
+
+// ListNetworks returns networks matching the provided filters.
+func (c *Client) ListNetworks(ctx context.Context, filter types.NetworkListFilter) ([]types.NetworkInfo, error) {
+	args := make([]string, 0, 4+2*len(filter.Labels))
+	args = append(args, "network", "ls", "--format", "json")
+	for key, value := range filter.Labels {
+		label := key
+		if value != "" {
+			label += "=" + value
+		}
+		args = append(args, "--filter", "label="+label)
+	}
+
+	output, err := runPodmanCommand(ctx, args)
+	if err != nil {
+		return nil, fmt.Errorf("podman list networks failed: %w\nOutput: %s", err, string(output))
+	}
+
+	var networks []podmanNetworkListInfo
+	if err := json.Unmarshal(bytes.TrimSpace(output), &networks); err != nil {
+		return nil, fmt.Errorf("failed to parse podman network list output: %w", err)
+	}
+
+	result := make([]types.NetworkInfo, 0, len(networks))
+	for _, net := range networks {
+		result = append(result, types.NetworkInfo{
+			ID:     firstNonEmpty(net.ID, net.IDTitle),
+			Name:   firstNonEmpty(net.Name, net.NameTitle),
+			Driver: firstNonEmpty(net.Driver, net.DriverTitle),
+			Labels: firstNonNilMap(net.Labels, net.LabelsTitle),
+		})
+	}
+	return result, nil
+}
+
+func firstNonNilMap(values ...map[string]string) map[string]string {
+	for _, value := range values {
+		if value != nil {
+			return value
+		}
+	}
+	return nil
+}
+
 // NetworkRemove removes a network.
 func (c *Client) NetworkRemove(ctx context.Context, nameOrID string) error {
 	cmd := processutil.CommandContext(ctx, "podman", "network", "rm", nameOrID)

--- a/src/Runtime/devenv/pkg/container/types/types.go
+++ b/src/Runtime/devenv/pkg/container/types/types.go
@@ -210,6 +210,11 @@ type ContainerListFilter struct {
 	All    bool
 }
 
+// NetworkListFilter restricts network listing.
+type NetworkListFilter struct {
+	Labels map[string]string
+}
+
 // VolumeMountType defines the source type for a container volume mount.
 type VolumeMountType string
 

--- a/src/Runtime/devenv/pkg/resource/executor.go
+++ b/src/Runtime/devenv/pkg/resource/executor.go
@@ -26,6 +26,10 @@ type Executor struct {
 }
 
 const containerSpecHashLabel = "altinn.studio/devenv-spec-hash"
+
+// GraphIDLabel is the runtime label used to identify resources owned by a graph.
+const GraphIDLabel = "altinn.studio/devenv.graph"
+
 const networkResourceIDPrefix = "network:"
 const containerReadyTimeout = 2 * time.Minute
 const containerReadyPollInterval = 500 * time.Millisecond
@@ -33,13 +37,14 @@ const containerStatusExited = "exited"
 const containerStatusDead = "dead"
 
 var (
-	errUnknownResourceType      = errors.New("unknown resource type")
-	errImageNotResolved         = errors.New("image not resolved")
-	errNetworkNameUnresolvable  = errors.New("cannot resolve network name")
-	errImageMissingForPullNever = errors.New("image not found locally and pull policy is Never")
-	errContainerExited          = errors.New("container exited before becoming ready")
-	errContainerUnhealthy       = errors.New("container healthcheck failed")
-	errContainerReadyTimeout    = errors.New("container did not become ready before timeout")
+	errUnknownResourceType       = errors.New("unknown resource type")
+	errImageNotResolved          = errors.New("image not resolved")
+	errNetworkNameUnresolvable   = errors.New("cannot resolve network name")
+	errResourceOwnershipConflict = errors.New("resource exists but is not managed by this graph")
+	errImageMissingForPullNever  = errors.New("image not found locally and pull policy is Never")
+	errContainerExited           = errors.New("container exited before becoming ready")
+	errContainerUnhealthy        = errors.New("container healthcheck failed")
+	errContainerReadyTimeout     = errors.New("container did not become ready before timeout")
 )
 
 // NewExecutor creates an executor with the given container client.
@@ -57,20 +62,102 @@ func (e *Executor) SetObserver(o Observer) {
 
 // Apply creates/updates all resources in the graph in dependency order.
 // Resources at the same dependency level are applied in parallel.
-func (e *Executor) Apply(ctx context.Context, g *Graph) (Outputs, error) {
+func (e *Executor) Apply(ctx context.Context, g *Graph, opts ...ApplyOption) (Outputs, error) {
+	if err := validateGraphID(g); err != nil {
+		return Outputs{}, err
+	}
+	options := newApplyOptions(opts)
 	levels, err := g.TopologicalOrder()
 	if err != nil {
 		return Outputs{}, err
 	}
+	actual, err := e.Status(ctx, g)
+	if err != nil {
+		return Outputs{}, err
+	}
+	plan := buildApplyPlan(g, actual)
+	if err := validateNoOwnershipConflicts(plan, actual); err != nil {
+		return Outputs{}, err
+	}
+	if err := notifyApplyPlan(options, g, actual, plan); err != nil {
+		return Outputs{}, err
+	}
+	if err := e.executeDestroyPlan(ctx, actual, plan.destroy); err != nil {
+		return Outputs{}, err
+	}
+
+	return e.executeApplyPlan(ctx, g, levels, plan)
+}
+
+// Destroy removes all resources in the graph in reverse dependency order.
+// Resources at the same dependency level are destroyed in parallel.
+func (e *Executor) Destroy(ctx context.Context, g *Graph, opts ...DestroyOption) error {
+	if err := validateGraphID(g); err != nil {
+		return err
+	}
+	options := newDestroyOptions(opts)
+
+	actual, err := e.Status(ctx, g)
+	if err != nil {
+		return err
+	}
+	plan := buildDestroyPlan(g, actual)
+	if err := notifyDestroyPlan(options, g, actual, plan); err != nil {
+		return err
+	}
+	return e.executeDestroyPlan(ctx, actual, plan.destroy)
+}
+
+// Status returns observed state for the requested graph and any labelled runtime resources it owns.
+func (e *Executor) Status(ctx context.Context, g *Graph, opts ...StatusOption) (Snapshot, error) {
+	if err := validateGraphID(g); err != nil {
+		return Snapshot{}, err
+	}
+
+	options := newStatusOptions(opts)
+	resources := g.All()
+	snapshot := Snapshot{
+		GraphID:   g.ID(),
+		Resources: make(map[ResourceID]ObservedResource, len(resources)),
+	}
+
+	for _, r := range resources {
+		if options.skipResource(r) {
+			continue
+		}
+		observed, err := e.observeResource(ctx, g.ID(), r)
+		if err != nil {
+			return Snapshot{}, fmt.Errorf("status %s: %w", r.ID(), err)
+		}
+		snapshot.Resources[r.ID()] = observed
+	}
+
+	if err := e.discoverGraphResources(ctx, &snapshot); err != nil {
+		return Snapshot{}, err
+	}
+
+	return snapshot, nil
+}
+
+func (e *Executor) executeApplyPlan(
+	ctx context.Context,
+	g *Graph,
+	levels [][]Resource,
+	plan applyPlan,
+) (Outputs, error) {
+	applyIDs := resourceIDSet(plan.reconcile)
 
 	e.outputs.Reset()
 
 	for _, level := range levels {
 		eg, groupCtx := errgroup.WithContext(ctx)
 		for _, r := range level {
+			if _, ok := applyIDs[r.ID()]; !ok {
+				continue
+			}
 			eg.Go(func() error {
 				e.notify(EventApplyStart, r.ID(), nil)
-				output, err := e.applyResource(groupCtx, r)
+				output, err := e.applyResource(groupCtx, g.ID(), r)
 				if err != nil {
 					e.notify(EventApplyFailed, r.ID(), err)
 					return fmt.Errorf("apply %s: %w", r.ID(), err)
@@ -89,29 +176,27 @@ func (e *Executor) Apply(ctx context.Context, g *Graph) (Outputs, error) {
 	return e.outputs.Snapshot(), nil
 }
 
-// Destroy removes all resources in the graph in reverse dependency order.
-// Resources at the same dependency level are destroyed in parallel.
-func (e *Executor) Destroy(ctx context.Context, g *Graph) error {
-	levels, err := g.ReverseTopologicalOrder()
+func (e *Executor) executeDestroyPlan(ctx context.Context, actual Snapshot, ids []ResourceID) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	graph, err := buildObservedGraph(actual)
 	if err != nil {
 		return err
 	}
-
+	levels, err := graph.ReverseTopologicalOrderSubset(ids)
+	if err != nil {
+		return err
+	}
 	for _, level := range levels {
 		eg, groupCtx := errgroup.WithContext(ctx)
 		for _, r := range level {
 			eg.Go(func() error {
-				e.notify(EventDestroyStart, r.ID(), nil)
-				if err := e.destroyResource(groupCtx, r); err != nil {
-					if handleDestroyError(r, err) == ErrorDecisionIgnore {
-						e.notify(EventDestroyDone, r.ID(), nil)
-						return nil
-					}
-					e.notify(EventDestroyFailed, r.ID(), err)
-					return fmt.Errorf("destroy %s: %w", r.ID(), err)
+				observed, ok := actual.Resources[r.ID()]
+				if !ok {
+					return fmt.Errorf("%w: %q", errGraphResourceNotFound, r.ID())
 				}
-				e.notify(EventDestroyDone, r.ID(), nil)
-				return nil
+				return e.destroyObservedResource(groupCtx, r.ID(), observed)
 			})
 		}
 		if err := eg.Wait(); err != nil {
@@ -121,71 +206,240 @@ func (e *Executor) Destroy(ctx context.Context, g *Graph) error {
 	return nil
 }
 
-// Status returns the current status of all resources in the graph that are not skipped.
-func (e *Executor) Status(ctx context.Context, g *Graph, opts ...StatusOption) (map[ResourceID]Status, error) {
-	options := newStatusOptions(opts)
-	resources := g.Enabled()
-	result := make(map[ResourceID]Status, len(resources))
-
-	for _, r := range resources {
-		if options.skipResource(r) {
-			continue
-		}
-		status, err := e.resourceStatus(ctx, r)
-		if err != nil {
-			return nil, fmt.Errorf("status %s: %w", r.ID(), err)
-		}
-		result[r.ID()] = status
+func resourceIDSet(ids []ResourceID) map[ResourceID]struct{} {
+	set := make(map[ResourceID]struct{}, len(ids))
+	for _, id := range ids {
+		set[id] = struct{}{}
 	}
-
-	return result, nil
+	return set
 }
 
-func (e *Executor) applyResource(ctx context.Context, r Resource) (Output, error) {
+func validateGraphID(g *Graph) error {
+	if g == nil || g.ID() == "" {
+		return errGraphEmptyID
+	}
+	return nil
+}
+
+func (e *Executor) discoverGraphResources(ctx context.Context, snapshot *Snapshot) error {
+	containers, err := e.client.ListContainers(ctx, types.ContainerListFilter{
+		All:    true,
+		Labels: map[string]string{GraphIDLabel: snapshot.GraphID.String()},
+	})
+	if err != nil {
+		return fmt.Errorf("list graph containers: %w", err)
+	}
+	for _, info := range containers {
+		if info.Name == "" {
+			continue
+		}
+		id := ContainerID(info.Name)
+		if observed, ok := snapshot.Resources[id]; ok && observed.Resource != nil {
+			observed.RuntimeID = firstNonEmptyString(info.ID, info.Name)
+			observed.Managed = true
+			snapshot.Resources[id] = observed
+			continue
+		}
+		dependencies, depErr := e.discoveredContainerDependencies(ctx, info)
+		if depErr != nil {
+			return depErr
+		}
+		snapshot.Resources[id] = ObservedResource{
+			RuntimeID:    firstNonEmptyString(info.ID, info.Name),
+			Type:         resourceTypeContainer,
+			Status:       containerInfoStatus(info),
+			Managed:      true,
+			Dependencies: dependencies,
+		}
+	}
+
+	networks, err := e.client.ListNetworks(ctx, types.NetworkListFilter{
+		Labels: map[string]string{GraphIDLabel: snapshot.GraphID.String()},
+	})
+	if err != nil {
+		return fmt.Errorf("list graph networks: %w", err)
+	}
+	for _, network := range networks {
+		if network.Name == "" {
+			continue
+		}
+		id := ResourceID(networkResourceIDPrefix + network.Name)
+		if observed, ok := snapshot.Resources[id]; ok && observed.Resource != nil {
+			observed.Managed = true
+			snapshot.Resources[id] = observed
+			continue
+		}
+		snapshot.Resources[id] = ObservedResource{
+			RuntimeID: firstNonEmptyString(network.ID, network.Name),
+			Type:      resourceTypeNetwork,
+			Status:    StatusReady,
+			Managed:   true,
+		}
+	}
+	return nil
+}
+
+func (e *Executor) discoveredContainerDependencies(
+	ctx context.Context,
+	info types.ContainerInfo,
+) ([]ResourceRef, error) {
+	name := firstNonEmptyString(info.ID, info.Name)
+	networks, err := e.client.ContainerNetworks(ctx, name)
+	if errors.Is(err, types.ErrContainerNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("list container networks %s: %w", name, err)
+	}
+
+	dependencies := make([]ResourceRef, 0, len(networks))
+	for _, network := range networks {
+		if network != "" {
+			dependencies = append(dependencies, RefID(ResourceID(networkResourceIDPrefix+network)))
+		}
+	}
+	return dependencies, nil
+}
+
+func (e *Executor) destroyObservedRuntimeResource(
+	ctx context.Context,
+	id ResourceID,
+	observed ObservedResource,
+) error {
+	name := firstNonEmptyString(observed.RuntimeID, id.String())
+	switch observed.Type {
+	case resourceTypeContainer:
+		return e.stopAndRemoveContainer(ctx, name)
+	case resourceTypeNetwork:
+		err := e.client.NetworkRemove(ctx, name)
+		if err != nil && !errors.Is(err, types.ErrNetworkNotFound) {
+			return fmt.Errorf("remove network %s: %w", name, err)
+		}
+		return nil
+	case resourceTypeImage:
+		return nil
+	case resourceTypeUnknown:
+		return fmt.Errorf("%w: %v", errUnknownResourceType, observed.Type)
+	default:
+		return fmt.Errorf("%w: %v", errUnknownResourceType, observed.Type)
+	}
+}
+
+func (e *Executor) destroyObservedResource(ctx context.Context, id ResourceID, observed ObservedResource) error {
+	e.notify(EventDestroyStart, id, nil)
+	if err := e.destroyObservedRuntimeResource(ctx, id, observed); err != nil {
+		if observed.Resource != nil && handleDestroyError(observed.Resource, err) == ErrorDecisionIgnore {
+			e.notify(EventDestroyDone, id, nil)
+			return nil
+		}
+		e.notify(EventDestroyFailed, id, err)
+		return fmt.Errorf("destroy %s: %w", id, err)
+	}
+	e.notify(EventDestroyDone, id, nil)
+	return nil
+}
+
+func resourceManagedByGraph(labels map[string]string, graphID GraphID) bool {
+	return labels[GraphIDLabel] == graphID.String()
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func (e *Executor) applyResource(ctx context.Context, graphID GraphID, r Resource) (Output, error) {
 	switch res := r.(type) {
 	case *RemoteImage:
 		return e.applyRemoteImage(ctx, res)
 	case *LocalImage:
 		return e.applyLocalImage(ctx, res)
 	case *Network:
-		return e.applyNetwork(ctx, res)
+		return e.applyNetwork(ctx, graphID, res)
 	case *Container:
-		return e.applyContainer(ctx, res)
+		return e.applyContainer(ctx, graphID, res)
 	default:
 		return nil, fmt.Errorf("%w: %T", errUnknownResourceType, r)
 	}
 }
 
-func (e *Executor) destroyResource(ctx context.Context, r Resource) error {
+func (e *Executor) observeResource(ctx context.Context, graphID GraphID, r Resource) (ObservedResource, error) {
 	switch res := r.(type) {
 	case *RemoteImage:
-		// Images are shared, don't delete
-		return nil
+		status, err := e.imageStatus(ctx, res.Ref)
+		return ObservedResource{
+			Resource:  r,
+			Type:      resourceTypeImage,
+			RuntimeID: res.Ref,
+			Status:    status,
+			Managed:   false,
+		}, err
 	case *LocalImage:
-		// Images are shared, don't delete
-		return nil
+		status, err := e.imageStatus(ctx, res.Tag)
+		return ObservedResource{
+			Resource:  r,
+			Type:      resourceTypeImage,
+			RuntimeID: res.Tag,
+			Status:    status,
+			Managed:   false,
+		}, err
 	case *Network:
-		return e.destroyNetwork(ctx, res)
+		return e.observeNetwork(ctx, graphID, res)
 	case *Container:
-		return e.destroyContainer(ctx, res)
+		return e.observeContainer(ctx, graphID, res)
 	default:
-		return fmt.Errorf("%w: %T", errUnknownResourceType, r)
+		return ObservedResource{}, fmt.Errorf("%w: %T", errUnknownResourceType, r)
 	}
 }
 
-func (e *Executor) resourceStatus(ctx context.Context, r Resource) (Status, error) {
-	switch res := r.(type) {
-	case *RemoteImage:
-		return e.imageStatus(ctx, res.Ref)
-	case *LocalImage:
-		return e.imageStatus(ctx, res.Tag)
-	case *Network:
-		return e.networkStatus(ctx, res)
-	case *Container:
-		return e.containerStatus(ctx, res)
-	default:
-		return StatusUnknown, fmt.Errorf("%w: %T", errUnknownResourceType, r)
+func (e *Executor) observeNetwork(ctx context.Context, graphID GraphID, net *Network) (ObservedResource, error) {
+	observed := ObservedResource{
+		Resource:  net,
+		Type:      resourceTypeNetwork,
+		RuntimeID: net.Name,
+		Status:    StatusDestroyed,
+		Managed:   false,
 	}
+
+	info, err := e.client.NetworkInspect(ctx, net.Name)
+	if errors.Is(err, types.ErrNetworkNotFound) {
+		return observed, nil
+	}
+	if err != nil {
+		return observed, fmt.Errorf("inspect network %s: %w", net.Name, err)
+	}
+
+	observed.Status = StatusReady
+	observed.RuntimeID = firstNonEmptyString(info.ID, net.Name)
+	observed.Managed = resourceManagedByGraph(info.Labels, graphID)
+	return observed, nil
+}
+
+func (e *Executor) observeContainer(ctx context.Context, graphID GraphID, c *Container) (ObservedResource, error) {
+	observed := ObservedResource{
+		Resource:  c,
+		Type:      resourceTypeContainer,
+		RuntimeID: c.Name,
+		Status:    StatusDestroyed,
+		Managed:   false,
+	}
+
+	info, err := e.client.ContainerInspect(ctx, c.Name)
+	if errors.Is(err, types.ErrContainerNotFound) {
+		return observed, nil
+	}
+	if err != nil {
+		return observed, fmt.Errorf("inspect container %s: %w", c.Name, err)
+	}
+
+	observed.RuntimeID = firstNonEmptyString(info.ID, info.Name, c.Name)
+	observed.Status = containerInfoStatus(info)
+	observed.Managed = resourceManagedByGraph(info.Labels, graphID)
+	return observed, nil
 }
 
 // Image operations
@@ -262,7 +516,7 @@ func (e *Executor) imageStatus(ctx context.Context, ref string) (Status, error) 
 
 // Network operations
 
-func (e *Executor) applyNetwork(ctx context.Context, net *Network) (Output, error) {
+func (e *Executor) applyNetwork(ctx context.Context, graphID GraphID, net *Network) (Output, error) {
 	_, err := e.client.NetworkInspect(ctx, net.Name)
 	if err == nil {
 		// Network exists
@@ -283,7 +537,7 @@ func (e *Executor) applyNetwork(ctx context.Context, net *Network) (Output, erro
 	cfg := types.NetworkConfig{
 		Name:   net.Name,
 		Driver: driver,
-		Labels: net.Labels,
+		Labels: normalizedResourceLabels(net.Labels, graphID),
 	}
 
 	if _, err := e.client.NetworkCreate(ctx, cfg); err != nil {
@@ -291,14 +545,6 @@ func (e *Executor) applyNetwork(ctx context.Context, net *Network) (Output, erro
 	}
 
 	return noOutput{}, nil
-}
-
-func (e *Executor) destroyNetwork(ctx context.Context, net *Network) error {
-	err := e.client.NetworkRemove(ctx, net.Name)
-	if err != nil && !errors.Is(err, types.ErrNetworkNotFound) {
-		return fmt.Errorf("remove network %s: %w", net.Name, err)
-	}
-	return nil
 }
 
 func handleDestroyError(r Resource, err error) ErrorDecision {
@@ -315,20 +561,26 @@ func handleDestroyError(r Resource, err error) ErrorDecision {
 	return options.HandleDestroyError(err)
 }
 
-func (e *Executor) networkStatus(ctx context.Context, net *Network) (Status, error) {
-	_, err := e.client.NetworkInspect(ctx, net.Name)
-	if err != nil {
-		if errors.Is(err, types.ErrNetworkNotFound) {
-			return StatusDestroyed, nil
-		}
-		return StatusUnknown, fmt.Errorf("inspect network %s: %w", net.Name, err)
+func retainOnDestroy(r Resource) bool {
+	provider, ok := r.(LifecycleOptionsProvider)
+	if !ok {
+		return defaultRetainOnDestroy(r)
 	}
-	return StatusReady, nil
+	return provider.LifecycleOptions().RetainOnDestroy
+}
+
+func defaultRetainOnDestroy(r Resource) bool {
+	switch r.(type) {
+	case *RemoteImage, *LocalImage:
+		return true
+	default:
+		return false
+	}
 }
 
 // Container operations
 
-func (e *Executor) applyContainer(ctx context.Context, c *Container) (Output, error) {
+func (e *Executor) applyContainer(ctx context.Context, graphID GraphID, c *Container) (Output, error) {
 	imageOutput, ok := e.outputs.Image(c.Image.ID())
 	if !ok {
 		return nil, fmt.Errorf("%w: %s", errImageNotResolved, c.Image.ID())
@@ -340,7 +592,7 @@ func (e *Executor) applyContainer(ctx context.Context, c *Container) (Output, er
 		return nil, err
 	}
 
-	desiredLabels := normalizedContainerLabels(c, imageID, networks)
+	desiredLabels := normalizedContainerLabels(c, graphID, imageID, networks)
 
 	needsCreate, err := e.reconcileExistingContainer(ctx, c.Name, imageID, desiredLabels, networks)
 	if err != nil {
@@ -445,10 +697,6 @@ func (e *Executor) reconcileExistingContainer(
 	return false, nil
 }
 
-func (e *Executor) destroyContainer(ctx context.Context, c *Container) error {
-	return e.stopAndRemoveContainer(ctx, c.Name)
-}
-
 func (e *Executor) stopAndRemoveContainer(ctx context.Context, name string) error {
 	timeout := 10
 	stopErr := e.client.ContainerStop(ctx, name, &timeout)
@@ -477,28 +725,20 @@ func (e *Executor) stopAndRemoveContainer(ctx context.Context, name string) erro
 	return nil
 }
 
-func (e *Executor) containerStatus(ctx context.Context, c *Container) (Status, error) {
-	info, err := e.client.ContainerInspect(ctx, c.Name)
-	if err != nil {
-		if errors.Is(err, types.ErrContainerNotFound) {
-			return StatusDestroyed, nil
-		}
-		return StatusUnknown, fmt.Errorf("inspect container %s: %w", c.Name, err)
-	}
-
+func containerInfoStatus(info types.ContainerInfo) Status {
 	switch {
 	case info.State.Running && containerHealthReady(info.State.HealthStatus):
-		return StatusReady, nil
+		return StatusReady
 	case info.State.Running && containerHealthFailed(info.State.HealthStatus):
-		return StatusFailed, nil
+		return StatusFailed
 	case info.State.Running:
-		return StatusPending, nil
+		return StatusPending
 	case info.State.Status == "created":
-		return StatusPending, nil
+		return StatusPending
 	case info.State.Status == containerStatusExited:
-		return StatusFailed, nil
+		return StatusFailed
 	default:
-		return StatusUnknown, nil
+		return StatusUnknown
 	}
 }
 
@@ -627,11 +867,17 @@ func networksMatch(desired, actual []string) bool {
 	return slices.Equal(sortedDesired, sortedActual)
 }
 
-func normalizedContainerLabels(c *Container, imageID string, networks []string) map[string]string {
-	labels := make(map[string]string, len(c.Labels)+1)
-	maps.Copy(labels, c.Labels)
+func normalizedContainerLabels(c *Container, graphID GraphID, imageID string, networks []string) map[string]string {
+	labels := normalizedResourceLabels(c.Labels, graphID)
 	labels[containerSpecHashLabel] = containerSpecHash(c, imageID, networks)
 	return labels
+}
+
+func normalizedResourceLabels(labels map[string]string, graphID GraphID) map[string]string {
+	normalized := make(map[string]string, len(labels)+1)
+	maps.Copy(normalized, labels)
+	normalized[GraphIDLabel] = graphID.String()
+	return normalized
 }
 
 func containerSpecHash(c *Container, imageID string, networks []string) string {

--- a/src/Runtime/devenv/pkg/resource/executor_test.go
+++ b/src/Runtime/devenv/pkg/resource/executor_test.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"context"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 
@@ -25,10 +26,13 @@ func TestNormalizedContainerLabels_DoesNotMutateInput(t *testing.T) {
 		Labels: map[string]string{"altinn.studio/cli": "localtest"},
 	}
 
-	labels := normalizedContainerLabels(container, "sha256:image", []string{"net-a"})
+	labels := normalizedContainerLabels(container, testGraphID, "sha256:image", []string{"net-a"})
 
 	if labels[containerSpecHashLabel] == "" {
 		t.Fatalf("missing %q label", containerSpecHashLabel)
+	}
+	if labels[GraphIDLabel] != testGraphID.String() {
+		t.Fatalf("graph label = %q, want %q", labels[GraphIDLabel], testGraphID)
 	}
 
 	if _, exists := container.Labels[containerSpecHashLabel]; exists {
@@ -260,7 +264,7 @@ func TestExecutor_ApplyContainer_DoesNotWaitForReadyByDefault(t *testing.T) {
 		}, nil
 	}
 
-	graph := NewGraph()
+	graph := NewGraph(testGraphID)
 	image := &RemoteImage{Ref: "localtest:latest"}
 	container := &Container{
 		Name:  "localtest",
@@ -277,8 +281,8 @@ func TestExecutor_ApplyContainer_DoesNotWaitForReadyByDefault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Apply() error = %v, want nil", err)
 	}
-	if inspectCalls != 2 {
-		t.Fatalf("ContainerInspect calls = %d, want 2", inspectCalls)
+	if inspectCalls != 3 {
+		t.Fatalf("ContainerInspect calls = %d, want 3", inspectCalls)
 	}
 }
 
@@ -299,7 +303,7 @@ func TestExecutor_ApplySkipsDisabledResources(t *testing.T) {
 		return nil
 	}
 
-	graph := NewGraph()
+	graph := NewGraph(testGraphID)
 	disabled := false
 	image := &LocalImage{
 		Enabled:     &disabled,
@@ -318,6 +322,274 @@ func TestExecutor_ApplySkipsDisabledResources(t *testing.T) {
 	}
 }
 
+func TestExecutor_ApplyDestroysStaleGraphResources(t *testing.T) {
+	t.Parallel()
+
+	client := containermock.New()
+	var removedContainer string
+	var removedNetwork string
+	var destroyCalls []string
+	client.ListContainersFunc = func(context.Context, types.ContainerListFilter) ([]types.ContainerInfo, error) {
+		return []types.ContainerInfo{{
+			ID:   "stale-container-id",
+			Name: "stale-container",
+			Labels: map[string]string{
+				GraphIDLabel: "test",
+			},
+		}}, nil
+	}
+	client.ListNetworksFunc = func(context.Context, types.NetworkListFilter) ([]types.NetworkInfo, error) {
+		return []types.NetworkInfo{{
+			ID:   "stale-network-id",
+			Name: "stale-network",
+			Labels: map[string]string{
+				GraphIDLabel: "test",
+			},
+		}}, nil
+	}
+	client.ContainerNetworksFunc = func(context.Context, string) ([]string, error) {
+		return []string{"stale-network"}, nil
+	}
+	client.ContainerRemoveFunc = func(_ context.Context, nameOrID string, _ bool) error {
+		destroyCalls = append(destroyCalls, "container")
+		removedContainer = nameOrID
+		return nil
+	}
+	client.NetworkRemoveFunc = func(_ context.Context, nameOrID string) error {
+		destroyCalls = append(destroyCalls, "network")
+		removedNetwork = nameOrID
+		return nil
+	}
+
+	graph := NewGraph(testGraphID)
+	if err := graph.Add(&RemoteImage{Ref: "localtest:latest"}); err != nil {
+		t.Fatalf("graph.Add() error = %v", err)
+	}
+
+	if _, err := NewExecutor(client).Apply(t.Context(), graph); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if removedContainer != "stale-container-id" {
+		t.Fatalf("removed container = %q, want stale-container-id", removedContainer)
+	}
+	if removedNetwork != "stale-network-id" {
+		t.Fatalf("removed network = %q, want stale-network-id", removedNetwork)
+	}
+	if !slices.Equal(destroyCalls, []string{"container", "network"}) {
+		t.Fatalf("destroy calls = %v, want container before network", destroyCalls)
+	}
+}
+
+func TestExecutor_ApplyRetainsDisabledResourceWithLifecycleOption(t *testing.T) {
+	t.Parallel()
+
+	client := containermock.New()
+	client.ListContainersFunc = func(context.Context, types.ContainerListFilter) ([]types.ContainerInfo, error) {
+		return []types.ContainerInfo{{
+			ID:     "retained-container-id",
+			Name:   "retained",
+			Labels: map[string]string{GraphIDLabel: "test"},
+		}}, nil
+	}
+	client.ListNetworksFunc = func(context.Context, types.NetworkListFilter) ([]types.NetworkInfo, error) {
+		return nil, nil
+	}
+	client.ContainerInspectFunc = func(context.Context, string) (types.ContainerInfo, error) {
+		return types.ContainerInfo{
+			ID:     "retained-container-id",
+			Name:   "retained",
+			Labels: map[string]string{GraphIDLabel: "test"},
+		}, nil
+	}
+	client.ContainerRemoveFunc = func(context.Context, string, bool) error {
+		t.Fatal("ContainerRemove called for retained container")
+		return nil
+	}
+	client.NetworkRemoveFunc = func(context.Context, string) error {
+		t.Fatal("NetworkRemove called")
+		return nil
+	}
+
+	graph := NewGraph(testGraphID)
+	disabled := false
+	if err := graph.Add(&Container{
+		Name:    "retained",
+		Image:   RefID("image:unused"),
+		Enabled: &disabled,
+		Lifecycle: ContainerLifecycleOptions{
+			LifecycleOptions: LifecycleOptions{RetainOnDestroy: true},
+		},
+	}); err != nil {
+		t.Fatalf("graph.Add() error = %v", err)
+	}
+
+	if _, err := NewExecutor(client).Apply(t.Context(), graph); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+}
+
+func TestExecutor_StatusPreservesInspectedContainerHealthWhenDiscoveredByGraphLabel(t *testing.T) {
+	t.Parallel()
+
+	client := containermock.New()
+	client.ContainerInspectFunc = func(context.Context, string) (types.ContainerInfo, error) {
+		return types.ContainerInfo{
+			ID:     "container-id",
+			Name:   "localtest-workflow-engine-db",
+			Labels: map[string]string{GraphIDLabel: testGraphID.String()},
+			State: types.ContainerState{
+				Status:       "running",
+				Running:      true,
+				HealthStatus: "unhealthy",
+			},
+		}, nil
+	}
+	client.ListContainersFunc = func(context.Context, types.ContainerListFilter) ([]types.ContainerInfo, error) {
+		return []types.ContainerInfo{{
+			ID:     "container-id",
+			Name:   "localtest-workflow-engine-db",
+			Labels: map[string]string{GraphIDLabel: testGraphID.String()},
+			State: types.ContainerState{
+				Status:  "running",
+				Running: true,
+			},
+		}}, nil
+	}
+	client.ListNetworksFunc = func(context.Context, types.NetworkListFilter) ([]types.NetworkInfo, error) {
+		return nil, nil
+	}
+
+	graph := NewGraph(testGraphID)
+	container := &Container{
+		Name:  "localtest-workflow-engine-db",
+		Image: RefID("image:unused"),
+	}
+	mustAddResource(t, graph, container)
+
+	snapshot, err := NewExecutor(client).Status(t.Context(), graph)
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+	if got := snapshot.Resources[container.ID()].Status; got != StatusFailed {
+		t.Fatalf("container status = %v, want failed", got)
+	}
+}
+
+func TestExecutor_ApplyValidatesGraphBeforeDestroyingStaleResources(t *testing.T) {
+	t.Parallel()
+
+	client := containermock.New()
+	client.ListContainersFunc = func(context.Context, types.ContainerListFilter) ([]types.ContainerInfo, error) {
+		t.Fatal("ListContainers called before graph validation")
+		return nil, nil
+	}
+	client.ContainerRemoveFunc = func(context.Context, string, bool) error {
+		t.Fatal("ContainerRemove called before graph validation")
+		return nil
+	}
+
+	graph := NewGraph(testGraphID)
+	container := &Container{
+		Name:  "invalid",
+		Image: RefID("image:missing"),
+	}
+	mustAddResource(t, graph, container)
+
+	if _, err := NewExecutor(client).Apply(t.Context(), graph); err == nil {
+		t.Fatal("Apply() error = nil, want graph validation error")
+	}
+}
+
+func TestExecutor_ApplyFailsOnUnmanagedContainerNameCollision(t *testing.T) {
+	t.Parallel()
+
+	client := containermock.New()
+	client.ContainerInspectFunc = func(context.Context, string) (types.ContainerInfo, error) {
+		return types.ContainerInfo{
+			ID:      "unmanaged-container-id",
+			ImageID: "sha256:other-image",
+			State:   types.ContainerState{Status: "running", Running: true},
+			Labels:  map[string]string{},
+		}, nil
+	}
+	client.ContainerRemoveFunc = func(context.Context, string, bool) error {
+		t.Fatal("ContainerRemove called for unmanaged container")
+		return nil
+	}
+
+	graph := NewGraph(testGraphID)
+	image := &RemoteImage{Ref: "localtest:latest"}
+	container := &Container{
+		Name:  "localtest",
+		Image: Ref(image),
+	}
+	mustAddResource(t, graph, image)
+	mustAddResource(t, graph, container)
+
+	_, err := NewExecutor(client).Apply(t.Context(), graph)
+	if !errors.Is(err, errResourceOwnershipConflict) {
+		t.Fatalf("Apply() error = %v, want errResourceOwnershipConflict", err)
+	}
+}
+
+func TestExecutor_ApplyFailsOnUnmanagedContainerNameCollisionWithMatchingLabels(t *testing.T) {
+	t.Parallel()
+
+	client := containermock.New()
+	client.ContainerInspectFunc = func(context.Context, string) (types.ContainerInfo, error) {
+		return types.ContainerInfo{
+			ID:      "unmanaged-container-id",
+			ImageID: "sha256:other-image",
+			State:   types.ContainerState{Status: "running", Running: true},
+			Labels:  map[string]string{"app": "localtest"},
+		}, nil
+	}
+	client.ContainerRemoveFunc = func(context.Context, string, bool) error {
+		t.Fatal("ContainerRemove called for unmanaged container")
+		return nil
+	}
+
+	graph := NewGraph(testGraphID)
+	image := &RemoteImage{Ref: "localtest:latest"}
+	container := &Container{
+		Name:   "localtest",
+		Image:  Ref(image),
+		Labels: map[string]string{"app": "localtest"},
+	}
+	mustAddResource(t, graph, image)
+	mustAddResource(t, graph, container)
+
+	_, err := NewExecutor(client).Apply(t.Context(), graph)
+	if !errors.Is(err, errResourceOwnershipConflict) {
+		t.Fatalf("Apply() error = %v, want errResourceOwnershipConflict", err)
+	}
+}
+
+func TestExecutor_ApplyFailsOnUnmanagedNetworkNameCollision(t *testing.T) {
+	t.Parallel()
+
+	client := containermock.New()
+	client.NetworkInspectFunc = func(context.Context, string) (types.NetworkInfo, error) {
+		return types.NetworkInfo{
+			ID:     "unmanaged-network-id",
+			Name:   "altinntestlocal_network",
+			Labels: map[string]string{},
+		}, nil
+	}
+	client.NetworkCreateFunc = func(context.Context, types.NetworkConfig) (string, error) {
+		t.Fatal("NetworkCreate called for unmanaged network collision")
+		return "", nil
+	}
+
+	graph := NewGraph(testGraphID)
+	mustAddResource(t, graph, &Network{Name: "altinntestlocal_network"})
+
+	_, err := NewExecutor(client).Apply(t.Context(), graph)
+	if !errors.Is(err, errResourceOwnershipConflict) {
+		t.Fatalf("Apply() error = %v, want errResourceOwnershipConflict", err)
+	}
+}
+
 func TestExecutor_ApplyReturnsImageOutputs(t *testing.T) {
 	t.Parallel()
 
@@ -326,7 +598,7 @@ func TestExecutor_ApplyReturnsImageOutputs(t *testing.T) {
 		return types.ImageInfo{ID: "sha256:image-id"}, nil
 	}
 
-	graph := NewGraph()
+	graph := NewGraph(testGraphID)
 	image := &RemoteImage{Ref: "ghcr.io/altinn/test:latest", PullPolicy: PullIfNotPresent}
 	if err := graph.Add(image); err != nil {
 		t.Fatalf("graph.Add(image) error = %v", err)
@@ -373,7 +645,7 @@ func TestExecutor_ApplyReturnsContainerOutputs(t *testing.T) {
 		return "container-id", nil
 	}
 
-	graph := NewGraph()
+	graph := NewGraph(testGraphID)
 	image := &RemoteImage{Ref: "ghcr.io/altinn/test:latest", PullPolicy: PullIfNotPresent}
 	container := &Container{Name: "app", Image: Ref(image)}
 	if err := graph.Add(image); err != nil {
@@ -421,7 +693,7 @@ func TestExecutor_ApplyContainer_WaitsForReadyWhenEnabled(t *testing.T) {
 		return types.ContainerInfo{State: state}, nil
 	}
 
-	graph := NewGraph()
+	graph := NewGraph(testGraphID)
 	image := &RemoteImage{Ref: "localtest:latest"}
 	container := &Container{
 		Name:  "localtest",
@@ -495,17 +767,9 @@ func TestExecutor_ContainerStatus_UsesHealth(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			client := containermock.New()
-			client.ContainerInspectFunc = func(context.Context, string) (types.ContainerInfo, error) {
-				return types.ContainerInfo{State: tt.state}, nil
-			}
-
-			got, err := NewExecutor(client).containerStatus(t.Context(), &Container{Name: "localtest"})
-			if err != nil {
-				t.Fatalf("containerStatus() error = %v", err)
-			}
+			got := containerInfoStatus(types.ContainerInfo{State: tt.state})
 			if got != tt.want {
-				t.Fatalf("containerStatus() = %v, want %v", got, tt.want)
+				t.Fatalf("containerInfoStatus() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -530,17 +794,18 @@ func TestExecutor_Status_SkipsResources(t *testing.T) {
 
 	image := &RemoteImage{Ref: "localtest:latest"}
 	container := &Container{Name: "localtest", Image: Ref(image)}
-	graph := NewGraph()
+	graph := NewGraph(testGraphID)
 	mustAddResource(t, graph, image)
 	mustAddResource(t, graph, container)
 
-	statuses, err := NewExecutor(client).Status(t.Context(), graph, SkipResource(func(r Resource) bool {
+	snapshot, err := NewExecutor(client).Status(t.Context(), graph, SkipResource(func(r Resource) bool {
 		_, ok := r.(ImageResource)
 		return ok
 	}))
 	if err != nil {
 		t.Fatalf("Status() error = %v, want nil", err)
 	}
+	statuses := snapshot.Statuses()
 	if _, ok := statuses[image.ID()]; ok {
 		t.Fatalf("Status() included skipped image %q", image.ID())
 	}
@@ -553,11 +818,17 @@ func TestExecutor_DestroyNetwork_PropagatesNetworkInUseByDefault(t *testing.T) {
 	t.Parallel()
 
 	client := containermock.New()
+	client.NetworkInspectFunc = func(context.Context, string) (types.NetworkInfo, error) {
+		return types.NetworkInfo{
+			Name:   "localtest",
+			Labels: map[string]string{GraphIDLabel: testGraphID.String()},
+		}, nil
+	}
 	client.NetworkRemoveFunc = func(context.Context, string) error {
 		return types.ErrNetworkInUse
 	}
 
-	graph := NewGraph()
+	graph := NewGraph(testGraphID)
 	if err := graph.Add(&Network{Name: "localtest"}); err != nil {
 		t.Fatalf("graph.Add() error = %v", err)
 	}
@@ -572,11 +843,17 @@ func TestExecutor_DestroyNetwork_UsesLifecycleErrorHandler(t *testing.T) {
 	t.Parallel()
 
 	client := containermock.New()
+	client.NetworkInspectFunc = func(context.Context, string) (types.NetworkInfo, error) {
+		return types.NetworkInfo{
+			Name:   "localtest",
+			Labels: map[string]string{GraphIDLabel: testGraphID.String()},
+		}, nil
+	}
 	client.NetworkRemoveFunc = func(context.Context, string) error {
 		return types.ErrNetworkInUse
 	}
 
-	graph := NewGraph()
+	graph := NewGraph(testGraphID)
 	if err := graph.Add(&Network{
 		Name: "localtest",
 		Lifecycle: LifecycleOptions{
@@ -623,7 +900,7 @@ func TestExecutor_ApplyRemoteImage_EmitsProgressEvents(t *testing.T) {
 		PullPolicy: PullAlways,
 	}
 
-	graph := NewGraph()
+	graph := NewGraph(testGraphID)
 	if err := graph.Add(img); err != nil {
 		t.Fatalf("graph.Add() error = %v", err)
 	}

--- a/src/Runtime/devenv/pkg/resource/graph.go
+++ b/src/Runtime/devenv/pkg/resource/graph.go
@@ -18,20 +18,31 @@ var (
 	errGraphDisabledDependency = errors.New("enabled resource depends on disabled resource")
 	errGraphNilDependency      = errors.New("resource depends on nil resource")
 	errGraphDependencyCycle    = errors.New("dependency cycle detected")
+	errGraphEmptyID            = errors.New("resource graph ID is empty")
 )
 
 // Graph manages a DAG of resources with dependency tracking.
 // Graph is a pure data structure - use Executor to apply resources.
 type Graph struct {
 	resources map[ResourceID]Resource
+	id        GraphID
 	mu        sync.RWMutex
 }
 
 // NewGraph creates an empty resource graph.
-func NewGraph() *Graph {
+func NewGraph(id GraphID) *Graph {
 	return &Graph{
+		id:        id,
 		resources: make(map[ResourceID]Resource),
 	}
+}
+
+// ID returns the stable graph identity.
+func (g *Graph) ID() GraphID {
+	if g == nil {
+		return ""
+	}
+	return g.id
 }
 
 // Add registers a resource in the graph.
@@ -131,10 +142,33 @@ func (g *Graph) TopologicalOrder() ([][]Resource, error) {
 	return topologicalLevels(resources, order)
 }
 
+// TopologicalOrderSubset returns selected resources in dependency order.
+// Dependencies outside the selected set are ignored.
+func (g *Graph) TopologicalOrderSubset(ids []ResourceID) ([][]Resource, error) {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+
+	resources, err := g.subsetLocked(ids)
+	if err != nil {
+		return nil, err
+	}
+	return topologicalLevels(resources, sortedResourceIDs(resources))
+}
+
 // ReverseTopologicalOrder returns resources in reverse dependency order.
 // Used for destroy operations (dependents before dependencies).
 func (g *Graph) ReverseTopologicalOrder() ([][]Resource, error) {
 	levels, err := g.TopologicalOrder()
+	if err != nil {
+		return nil, err
+	}
+	slices.Reverse(levels)
+	return levels, nil
+}
+
+// ReverseTopologicalOrderSubset returns selected resources in reverse dependency order.
+func (g *Graph) ReverseTopologicalOrderSubset(ids []ResourceID) ([][]Resource, error) {
+	levels, err := g.TopologicalOrderSubset(ids)
 	if err != nil {
 		return nil, err
 	}
@@ -150,6 +184,18 @@ func (g *Graph) enabledResourcesLocked() map[ResourceID]Resource {
 		}
 	}
 	return result
+}
+
+func (g *Graph) subsetLocked(ids []ResourceID) (map[ResourceID]Resource, error) {
+	resources := make(map[ResourceID]Resource, len(ids))
+	for _, id := range ids {
+		r, exists := g.resources[id]
+		if !exists {
+			return nil, fmt.Errorf("%w: %q", errGraphResourceNotFound, id)
+		}
+		resources[id] = r
+	}
+	return resources, nil
 }
 
 func sortedResources(resources map[ResourceID]Resource) []Resource {
@@ -295,9 +341,13 @@ func topologicalLevels(resources map[ResourceID]Resource, order []ResourceID) ([
 	for _, id := range order {
 		resource := resources[id]
 		deps := resource.Dependencies()
-		inDegree[id] = len(deps)
+		inDegree[id] = 0
 		for _, dep := range deps {
 			depID := dep.ID()
+			if _, exists := resources[depID]; !exists {
+				continue
+			}
+			inDegree[id]++
 			dependents[depID] = append(dependents[depID], id)
 		}
 	}

--- a/src/Runtime/devenv/pkg/resource/graph_test.go
+++ b/src/Runtime/devenv/pkg/resource/graph_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 )
 
+const testGraphID GraphID = "test"
+
 // mockResource is a test implementation of Resource.
 type mockResource struct {
 	id      ResourceID
@@ -28,7 +30,7 @@ func buildLinearGraph() (*Graph, []Resource) {
 	b := &mockResource{id: "b", deps: DepIDs("a")}
 	c := &mockResource{id: "c", deps: DepIDs("b")}
 
-	g := NewGraph()
+	g := NewGraph(testGraphID)
 	return g, []Resource{a, b, c}
 }
 
@@ -66,7 +68,7 @@ func TestGraph_Add(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g := NewGraph()
+			g := NewGraph(testGraphID)
 			if tt.setup != nil {
 				tt.setup(g)
 			}
@@ -79,7 +81,7 @@ func TestGraph_Add(t *testing.T) {
 }
 
 func TestGraph_Get(t *testing.T) {
-	g := NewGraph()
+	g := NewGraph(testGraphID)
 	r := &mockResource{id: "a"}
 	mustAddResource(t, g, r)
 
@@ -92,7 +94,7 @@ func TestGraph_Get(t *testing.T) {
 }
 
 func TestGraph_All(t *testing.T) {
-	g := NewGraph()
+	g := NewGraph(testGraphID)
 	mustAddResource(t, g, &mockResource{id: "b"})
 	mustAddResource(t, g, &mockResource{id: "a"})
 
@@ -184,7 +186,7 @@ func TestGraph_Validate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g := NewGraph()
+			g := NewGraph(testGraphID)
 			for _, r := range tt.resources {
 				mustAddResource(t, g, r)
 			}
@@ -205,7 +207,7 @@ func TestGraph_Validate(t *testing.T) {
 }
 
 func TestGraph_Enabled(t *testing.T) {
-	g := NewGraph()
+	g := NewGraph(testGraphID)
 	mustAddResource(t, g, &mockResource{id: "c"})
 	mustAddResource(t, g, &mockResource{id: "b", enabled: new(bool)})
 	mustAddResource(t, g, &mockResource{id: "a"})
@@ -252,7 +254,7 @@ func TestGraph_TopologicalOrder_SkipsDisabledResources(t *testing.T) {
 	b := &mockResource{id: "b", enabled: new(bool)}
 	c := &mockResource{id: "c", deps: DepIDs("a")}
 
-	g := NewGraph()
+	g := NewGraph(testGraphID)
 	mustAddResource(t, g, a)
 	mustAddResource(t, g, b)
 	mustAddResource(t, g, c)
@@ -275,7 +277,7 @@ func TestGraph_TopologicalOrder_ParallelLevel(t *testing.T) {
 	b := &mockResource{id: "b"}
 	c := &mockResource{id: "c", deps: DepIDs("a", "b")}
 
-	g := NewGraph()
+	g := NewGraph(testGraphID)
 	mustAddResource(t, g, a)
 	mustAddResource(t, g, b)
 	mustAddResource(t, g, c)
@@ -331,12 +333,35 @@ func TestGraph_ReverseTopologicalOrder(t *testing.T) {
 	}
 }
 
+func TestGraph_ReverseTopologicalOrderSubset_IgnoresDependenciesOutsideSubset(t *testing.T) {
+	a := &mockResource{id: "a"}
+	b := &mockResource{id: "b", deps: DepIDs("a")}
+	c := &mockResource{id: "c", deps: DepIDs("b")}
+
+	g := NewGraph(testGraphID)
+	mustAddResource(t, g, a)
+	mustAddResource(t, g, b)
+	mustAddResource(t, g, c)
+
+	levels, err := g.ReverseTopologicalOrderSubset([]ResourceID{"b", "c"})
+	if err != nil {
+		t.Fatalf("ReverseTopologicalOrderSubset() error = %v", err)
+	}
+
+	if len(levels) != 2 {
+		t.Fatalf("ReverseTopologicalOrderSubset() returned %d levels, want 2", len(levels))
+	}
+	if levels[0][0].ID() != "c" || levels[1][0].ID() != "b" {
+		t.Fatalf("ReverseTopologicalOrderSubset() = %v, want c then b", levels)
+	}
+}
+
 func TestGraph_TopologicalOrder_WithDirectRefs(t *testing.T) {
 	a := &mockResource{id: "a"}
 	b := &mockResource{id: "b", deps: Deps(a)} // Direct ref
 	c := &mockResource{id: "c", deps: DepIDs("b")}
 
-	g := NewGraph()
+	g := NewGraph(testGraphID)
 	mustAddResource(t, g, a)
 	mustAddResource(t, g, b)
 	mustAddResource(t, g, c)
@@ -352,7 +377,7 @@ func TestGraph_TopologicalOrder_WithDirectRefs(t *testing.T) {
 }
 
 func TestGraph_TopologicalOrder_EmptyGraph(t *testing.T) {
-	g := NewGraph()
+	g := NewGraph(testGraphID)
 
 	levels, err := g.TopologicalOrder()
 	if err != nil {
@@ -368,7 +393,7 @@ func TestGraph_TopologicalOrder_CycleError(t *testing.T) {
 	a := &mockResource{id: "a", deps: DepIDs("b")}
 	b := &mockResource{id: "b", deps: DepIDs("a")}
 
-	g := NewGraph()
+	g := NewGraph(testGraphID)
 	mustAddResource(t, g, a)
 	mustAddResource(t, g, b)
 

--- a/src/Runtime/devenv/pkg/resource/plan.go
+++ b/src/Runtime/devenv/pkg/resource/plan.go
@@ -1,0 +1,205 @@
+package resource
+
+import (
+	"fmt"
+	"slices"
+)
+
+type applyPlan struct {
+	destroy   []ResourceID
+	conflict  []ResourceID
+	reconcile []ResourceID
+}
+
+type destroyPlan struct {
+	destroy []ResourceID
+}
+
+// PlannedResource is one resource operation selected by Apply or Destroy.
+type PlannedResource struct {
+	Resource Resource
+	ID       ResourceID
+}
+
+// ApplyPlan describes the operations Apply selected before execution starts.
+type ApplyPlan struct {
+	Snapshot  Snapshot
+	Destroy   []PlannedResource
+	Reconcile []PlannedResource
+}
+
+// DestroyPlan describes the operations Destroy selected before execution starts.
+type DestroyPlan struct {
+	Snapshot Snapshot
+	Destroy  []PlannedResource
+}
+
+// ApplyOption customizes Apply execution.
+type ApplyOption func(*applyOptions)
+
+type applyOptions struct {
+	onPlan func(ApplyPlan) error
+}
+
+// WithApplyPlan observes the plan Apply selected before execution starts.
+func WithApplyPlan(fn func(ApplyPlan) error) ApplyOption {
+	return func(opts *applyOptions) {
+		opts.onPlan = fn
+	}
+}
+
+func newApplyOptions(opts []ApplyOption) applyOptions {
+	options := applyOptions{onPlan: nil}
+	for _, opt := range opts {
+		opt(&options)
+	}
+	return options
+}
+
+func notifyApplyPlan(opts applyOptions, g *Graph, snapshot Snapshot, plan applyPlan) error {
+	if opts.onPlan == nil {
+		return nil
+	}
+	return opts.onPlan(ApplyPlan{
+		Snapshot:  snapshot,
+		Destroy:   plannedResources(g, plan.destroy),
+		Reconcile: plannedResources(g, plan.reconcile),
+	})
+}
+
+// DestroyOption customizes Destroy execution.
+type DestroyOption func(*destroyOptions)
+
+type destroyOptions struct {
+	onPlan func(DestroyPlan) error
+}
+
+// WithDestroyPlan observes the plan Destroy selected before execution starts.
+func WithDestroyPlan(fn func(DestroyPlan) error) DestroyOption {
+	return func(opts *destroyOptions) {
+		opts.onPlan = fn
+	}
+}
+
+func newDestroyOptions(opts []DestroyOption) destroyOptions {
+	options := destroyOptions{onPlan: nil}
+	for _, opt := range opts {
+		opt(&options)
+	}
+	return options
+}
+
+func notifyDestroyPlan(opts destroyOptions, g *Graph, snapshot Snapshot, plan destroyPlan) error {
+	if opts.onPlan == nil {
+		return nil
+	}
+	return opts.onPlan(DestroyPlan{
+		Snapshot: snapshot,
+		Destroy:  plannedResources(g, plan.destroy),
+	})
+}
+
+func plannedResources(g *Graph, ids []ResourceID) []PlannedResource {
+	resources := make([]PlannedResource, 0, len(ids))
+	for _, id := range ids {
+		resources = append(resources, PlannedResource{
+			Resource: g.Get(id),
+			ID:       id,
+		})
+	}
+	return resources
+}
+
+func buildApplyPlan(g *Graph, actual Snapshot) applyPlan {
+	plan := applyPlan{
+		destroy:   make([]ResourceID, 0),
+		conflict:  make([]ResourceID, 0),
+		reconcile: make([]ResourceID, 0),
+	}
+	destroySet := make(map[ResourceID]struct{})
+
+	for _, r := range g.All() {
+		id := r.ID()
+		observed, exists := actual.Resources[id]
+		switch {
+		case resourceEnabled(r):
+			if exists && unmanagedCollisionBlocksApply(r, observed) {
+				plan.conflict = append(plan.conflict, id)
+				continue
+			}
+			plan.reconcile = append(plan.reconcile, id)
+		case retainOnDestroy(r):
+		case exists && observed.Managed && observed.Status != StatusDestroyed:
+			addResourceID(&plan.destroy, destroySet, id)
+		}
+	}
+
+	for id, observed := range actual.Resources {
+		if g.Get(id) != nil {
+			continue
+		}
+		if observed.Managed && observed.Status != StatusDestroyed {
+			addResourceID(&plan.destroy, destroySet, id)
+		}
+	}
+
+	slices.Sort(plan.destroy)
+	slices.Sort(plan.conflict)
+	slices.Sort(plan.reconcile)
+	return plan
+}
+
+func unmanagedCollisionBlocksApply(r Resource, observed ObservedResource) bool {
+	if observed.Status == StatusDestroyed || observed.Managed {
+		return false
+	}
+	switch r.(type) {
+	case *Container, *Network:
+		return true
+	default:
+		return false
+	}
+}
+
+func buildDestroyPlan(g *Graph, actual Snapshot) destroyPlan {
+	plan := destroyPlan{
+		destroy: make([]ResourceID, 0),
+	}
+	for id, observed := range actual.Resources {
+		if observed.Status == StatusDestroyed {
+			continue
+		}
+		if r := g.Get(id); r != nil {
+			if observed.Managed && !retainOnDestroy(r) {
+				plan.destroy = append(plan.destroy, id)
+			}
+			continue
+		}
+		if observed.Managed {
+			plan.destroy = append(plan.destroy, id)
+		}
+	}
+	slices.Sort(plan.destroy)
+	return plan
+}
+
+func validateNoOwnershipConflicts(plan applyPlan, actual Snapshot) error {
+	if len(plan.conflict) == 0 {
+		return nil
+	}
+	id := plan.conflict[0]
+	observed := actual.Resources[id]
+	return fmt.Errorf("%w: %s (%s)", errResourceOwnershipConflict, id, observed.RuntimeID)
+}
+
+func addResourceID(ids *[]ResourceID, seen map[ResourceID]struct{}, id ResourceID) {
+	if seen == nil {
+		*ids = append(*ids, id)
+		return
+	}
+	if _, ok := seen[id]; ok {
+		return
+	}
+	seen[id] = struct{}{}
+	*ids = append(*ids, id)
+}

--- a/src/Runtime/devenv/pkg/resource/plan_test.go
+++ b/src/Runtime/devenv/pkg/resource/plan_test.go
@@ -1,0 +1,232 @@
+package resource
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestBuildApplyPlan_DestroysDisabledManagedResource(t *testing.T) {
+	t.Parallel()
+
+	disabled := false
+	container := &Container{
+		Name:    "localtest-workflow-engine",
+		Image:   RefID("image:unused"),
+		Enabled: &disabled,
+	}
+	graph := NewGraph(testGraphID)
+	mustAddResource(t, graph, container)
+
+	plan := buildApplyPlan(graph, Snapshot{
+		GraphID: testGraphID,
+		Resources: map[ResourceID]ObservedResource{
+			container.ID(): {
+				Type:    resourceTypeContainer,
+				Status:  StatusReady,
+				Managed: true,
+			},
+		},
+	})
+
+	if !slices.Contains(plan.destroy, container.ID()) {
+		t.Fatalf("destroy = %v, want %s", plan.destroy, container.ID())
+	}
+}
+
+func TestBuildApplyPlan_DestroysDisabledManagedResourceOnce(t *testing.T) {
+	t.Parallel()
+
+	disabled := false
+	container := &Container{
+		Name:    "localtest-workflow-engine",
+		Image:   RefID("image:unused"),
+		Enabled: &disabled,
+	}
+	graph := NewGraph(testGraphID)
+	mustAddResource(t, graph, container)
+
+	plan := buildApplyPlan(graph, Snapshot{
+		GraphID: testGraphID,
+		Resources: map[ResourceID]ObservedResource{
+			container.ID(): {
+				Type:    resourceTypeContainer,
+				Status:  StatusReady,
+				Managed: true,
+			},
+		},
+	})
+
+	if got := countResourceID(plan.destroy, container.ID()); got != 1 {
+		t.Fatalf("destroy contains %s %d times, want 1: %v", container.ID(), got, plan.destroy)
+	}
+}
+
+func TestBuildApplyPlan_DestroysManagedResourceRemovedFromGraph(t *testing.T) {
+	t.Parallel()
+
+	graph := NewGraph(testGraphID)
+	staleID := ContainerID("stale")
+
+	plan := buildApplyPlan(graph, Snapshot{
+		GraphID: testGraphID,
+		Resources: map[ResourceID]ObservedResource{
+			staleID: {
+				Type:    resourceTypeContainer,
+				Status:  StatusReady,
+				Managed: true,
+			},
+		},
+	})
+
+	if !slices.Contains(plan.destroy, staleID) {
+		t.Fatalf("destroy = %v, want %s", plan.destroy, staleID)
+	}
+}
+
+func TestBuildApplyPlan_ConflictsOnUnmanagedEnabledResource(t *testing.T) {
+	t.Parallel()
+
+	container := &Container{
+		Name:  "localtest",
+		Image: RefID("image:unused"),
+	}
+	graph := NewGraph(testGraphID)
+	mustAddResource(t, graph, container)
+
+	plan := buildApplyPlan(graph, Snapshot{
+		GraphID: testGraphID,
+		Resources: map[ResourceID]ObservedResource{
+			container.ID(): {
+				RuntimeID: "unmanaged-container-id",
+				Type:      resourceTypeContainer,
+				Status:    StatusReady,
+				Managed:   false,
+			},
+		},
+	})
+
+	if !slices.Contains(plan.conflict, container.ID()) {
+		t.Fatalf("conflict = %v, want %s", plan.conflict, container.ID())
+	}
+	if slices.Contains(plan.reconcile, container.ID()) {
+		t.Fatalf("reconcile = %v, did not expect %s", plan.reconcile, container.ID())
+	}
+}
+
+func countResourceID(ids []ResourceID, want ResourceID) int {
+	count := 0
+	for _, id := range ids {
+		if id == want {
+			count++
+		}
+	}
+	return count
+}
+
+func TestBuildApplyPlan_RetainsDisabledResourceWithLifecycleOption(t *testing.T) {
+	t.Parallel()
+
+	disabled := false
+	container := &Container{
+		Name:    "retained",
+		Image:   RefID("image:unused"),
+		Enabled: &disabled,
+		Lifecycle: ContainerLifecycleOptions{
+			LifecycleOptions: LifecycleOptions{RetainOnDestroy: true},
+		},
+	}
+	graph := NewGraph(testGraphID)
+	mustAddResource(t, graph, container)
+
+	plan := buildApplyPlan(graph, Snapshot{
+		GraphID: testGraphID,
+		Resources: map[ResourceID]ObservedResource{
+			container.ID(): {
+				Type:    resourceTypeContainer,
+				Status:  StatusReady,
+				Managed: true,
+			},
+		},
+	})
+
+	if slices.Contains(plan.destroy, container.ID()) {
+		t.Fatalf("destroy = %v, did not expect %s", plan.destroy, container.ID())
+	}
+}
+
+func TestBuildDestroyPlan_RetainsResourceWithLifecycleOption(t *testing.T) {
+	t.Parallel()
+
+	container := &Container{
+		Name:  "retained",
+		Image: RefID("image:unused"),
+		Lifecycle: ContainerLifecycleOptions{
+			LifecycleOptions: LifecycleOptions{RetainOnDestroy: true},
+		},
+	}
+	graph := NewGraph(testGraphID)
+	mustAddResource(t, graph, container)
+
+	plan := buildDestroyPlan(graph, Snapshot{
+		GraphID: testGraphID,
+		Resources: map[ResourceID]ObservedResource{
+			container.ID(): {
+				Type:    resourceTypeContainer,
+				Status:  StatusReady,
+				Managed: true,
+			},
+		},
+	})
+
+	if slices.Contains(plan.destroy, container.ID()) {
+		t.Fatalf("destroy = %v, did not expect %s", plan.destroy, container.ID())
+	}
+}
+
+func TestBuildDestroyPlan_IgnoresUnmanagedResourceInGraph(t *testing.T) {
+	t.Parallel()
+
+	container := &Container{
+		Name:  "localtest",
+		Image: RefID("image:unused"),
+	}
+	graph := NewGraph(testGraphID)
+	mustAddResource(t, graph, container)
+
+	plan := buildDestroyPlan(graph, Snapshot{
+		GraphID: testGraphID,
+		Resources: map[ResourceID]ObservedResource{
+			container.ID(): {
+				Type:    resourceTypeContainer,
+				Status:  StatusReady,
+				Managed: false,
+			},
+		},
+	})
+
+	if slices.Contains(plan.destroy, container.ID()) {
+		t.Fatalf("destroy = %v, did not expect %s", plan.destroy, container.ID())
+	}
+}
+
+func TestBuildDestroyPlan_DestroysManagedResourceRemovedFromGraph(t *testing.T) {
+	t.Parallel()
+
+	graph := NewGraph(testGraphID)
+	staleID := ContainerID("stale")
+
+	plan := buildDestroyPlan(graph, Snapshot{
+		GraphID: testGraphID,
+		Resources: map[ResourceID]ObservedResource{
+			staleID: {
+				Type:    resourceTypeContainer,
+				Status:  StatusReady,
+				Managed: true,
+			},
+		},
+	})
+
+	if !slices.Contains(plan.destroy, staleID) {
+		t.Fatalf("destroy = %v, want %s", plan.destroy, staleID)
+	}
+}

--- a/src/Runtime/devenv/pkg/resource/resource.go
+++ b/src/Runtime/devenv/pkg/resource/resource.go
@@ -9,6 +9,14 @@ func (id ResourceID) String() string {
 	return string(id)
 }
 
+// GraphID identifies a desired-state resource graph across invocations.
+type GraphID string
+
+// String returns the string representation of the ID.
+func (id GraphID) String() string {
+	return string(id)
+}
+
 // ResourceRef references a resource either by ID or by direct reference.
 // Use Ref() or RefID() to construct.
 type ResourceRef struct {
@@ -106,6 +114,7 @@ type ErrorHandler func(error) ErrorDecision
 // LifecycleOptions customizes resource lifecycle behavior.
 type LifecycleOptions struct {
 	HandleDestroyError ErrorHandler
+	RetainOnDestroy    bool
 }
 
 // ContainerLifecycleOptions customizes container-specific lifecycle behavior.

--- a/src/Runtime/devenv/pkg/resource/snapshot.go
+++ b/src/Runtime/devenv/pkg/resource/snapshot.go
@@ -1,0 +1,106 @@
+package resource
+
+import "slices"
+
+type resourceType uint8
+
+const (
+	resourceTypeUnknown resourceType = iota
+	resourceTypeImage
+	resourceTypeNetwork
+	resourceTypeContainer
+)
+
+// ObservedResource describes actual runtime state for a desired or discovered resource.
+type ObservedResource struct {
+	Resource     Resource
+	RuntimeID    string
+	Dependencies []ResourceRef
+	Status       Status
+	Type         resourceType
+	Managed      bool
+}
+
+// Snapshot is the observed state for a graph.
+type Snapshot struct {
+	Resources map[ResourceID]ObservedResource
+	GraphID   GraphID
+}
+
+// Statuses returns the resource status map for callers that only need health state.
+func (s Snapshot) Statuses() map[ResourceID]Status {
+	statuses := make(map[ResourceID]Status, len(s.Resources))
+	for id, res := range s.Resources {
+		statuses[id] = res.Status
+	}
+	return statuses
+}
+
+type observedGraphResource struct {
+	id   ResourceID
+	deps []ResourceRef
+}
+
+func (r observedGraphResource) ID() ResourceID {
+	return r.id
+}
+
+func (r observedGraphResource) Dependencies() []ResourceRef {
+	return r.deps
+}
+
+func buildObservedGraph(snapshot Snapshot) (*Graph, error) {
+	resources := snapshot.Resources
+	graph := NewGraph(snapshot.GraphID)
+	existing := existingResourceIDs(resources)
+
+	for _, id := range sortedResourceIDSet(existing) {
+		observed := resources[id]
+		if err := graph.Add(observedGraphResource{
+			id:   id,
+			deps: observedDependencies(observed, existing),
+		}); err != nil {
+			return nil, err
+		}
+	}
+	return graph, nil
+}
+
+func existingResourceIDs(resources map[ResourceID]ObservedResource) map[ResourceID]struct{} {
+	existing := make(map[ResourceID]struct{}, len(resources))
+	for id, observed := range resources {
+		if observed.Status != StatusDestroyed && (observed.Managed || observed.Resource != nil) {
+			existing[id] = struct{}{}
+		}
+	}
+	return existing
+}
+
+func sortedResourceIDSet(resources map[ResourceID]struct{}) []ResourceID {
+	ids := make([]ResourceID, 0, len(resources))
+	for id := range resources {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+	return ids
+}
+
+func observedDependencies(
+	observed ObservedResource,
+	existing map[ResourceID]struct{},
+) []ResourceRef {
+	if observed.Resource != nil {
+		return filterExistingDependencies(observed.Resource.Dependencies(), existing)
+	}
+	return filterExistingDependencies(observed.Dependencies, existing)
+}
+
+func filterExistingDependencies(dependencies []ResourceRef, existing map[ResourceID]struct{}) []ResourceRef {
+	deps := make([]ResourceRef, 0, len(dependencies))
+	for _, dep := range dependencies {
+		if _, ok := existing[dep.ID()]; ok {
+			deps = append(deps, RefID(dep.ID()))
+		}
+	}
+	return deps
+}

--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -8,6 +8,10 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+### Fixed
+
+- Improve localtest resource reconciliation so `env up` removes managed resources that are no longer requested, such as pgAdmin or monitoring, without restarting unchanged core containers.
+
 ## [0.1.0-preview.7] - 2026-04-29
 
 ### Added

--- a/src/cli/internal/cmd/env/localtest/env.go
+++ b/src/cli/internal/cmd/env/localtest/env.go
@@ -176,12 +176,20 @@ func (e *Env) Reset(ctx context.Context) error {
 
 // Status returns the localtest environment status.
 func (e *Env) Status(ctx context.Context) (*Status, error) {
-	return e.status(ctx, false)
+	return e.status(ctx, statusOptions{
+		IncludeMonitoring: false,
+		IncludePgAdmin:    false,
+		RequireDesired:    false,
+	})
 }
 
 // StatusForUp returns status for the containers requested by env up.
 func (e *Env) StatusForUp(ctx context.Context, opts envtypes.UpOptions) (*Status, error) {
-	return e.status(ctx, opts.PgAdmin)
+	return e.status(ctx, statusOptions{
+		IncludeMonitoring: opts.Monitoring,
+		IncludePgAdmin:    opts.PgAdmin,
+		RequireDesired:    true,
+	})
 }
 
 // Logs streams localtest environment logs.
@@ -189,7 +197,13 @@ func (e *Env) Logs(ctx context.Context, opts envtypes.LogsOptions) error {
 	return e.logs.Stream(ctx, opts.Component, opts.Follow, opts.JSON)
 }
 
-func (e *Env) status(ctx context.Context, includePgAdmin bool) (*Status, error) {
+type statusOptions struct {
+	IncludeMonitoring bool
+	IncludePgAdmin    bool
+	RequireDesired    bool
+}
+
+func (e *Env) status(ctx context.Context, opts statusOptions) (*Status, error) {
 	resources := buildResources(ResourceBuildOptions{
 		DevConfig:         nil,
 		DataDir:           e.cfg.DataDir,
@@ -197,8 +211,8 @@ func (e *Env) status(ctx context.Context, includePgAdmin bool) (*Status, error) 
 		RuntimeConfig:     RuntimeConfig{User: ""},
 		Topology:          envtopology.NewLocal(envtopology.DefaultIngressPortString()),
 		ImageMode:         ReleaseMode,
-		IncludeMonitoring: false,
-		IncludePgAdmin:    includePgAdmin,
+		IncludeMonitoring: opts.IncludeMonitoring,
+		IncludePgAdmin:    opts.IncludePgAdmin,
 	})
 	graph, err := buildResourceGraph(resources)
 	if err != nil {
@@ -206,12 +220,12 @@ func (e *Env) status(ctx context.Context, includePgAdmin bool) (*Status, error) 
 	}
 
 	executor := resource.NewExecutor(e.client)
-	statuses, err := executor.Status(ctx, graph, resource.SkipResource(isImageResource))
+	snapshot, err := executor.Status(ctx, graph, resource.SkipResource(isImageResource))
 	if err != nil {
 		return nil, fmt.Errorf("get resource status: %w", err)
 	}
 
-	return localtestStatus(graph.Enabled(), statuses), nil
+	return localtestStatus(graph.All(), snapshot, opts.RequireDesired), nil
 }
 
 func (e *Env) hasManagedResources(ctx context.Context) (bool, error) {
@@ -222,22 +236,19 @@ func (e *Env) hasManagedResources(ctx context.Context) (bool, error) {
 	}
 
 	executor := resource.NewExecutor(e.client)
-	statuses, err := executor.Status(ctx, graph, resource.SkipResource(isImageResource))
+	snapshot, err := executor.Status(ctx, graph, resource.SkipResource(isImageResource))
 	if err != nil {
 		return false, fmt.Errorf("get resource status: %w", err)
 	}
 
-	for _, res := range graph.Enabled() {
-		if !isRuntimeResource(res) {
+	for _, observed := range snapshot.Resources {
+		if !observed.Managed || observed.Status == resource.StatusDestroyed {
 			continue
 		}
-		status, ok := statuses[res.ID()]
-		if !ok {
-			return true, nil
+		if observed.Resource != nil && !isRuntimeResource(observed.Resource) {
+			continue
 		}
-		if status != resource.StatusDestroyed {
-			return true, nil
-		}
+		return true, nil
 	}
 
 	return false, nil
@@ -286,24 +297,27 @@ func (e *Env) applyResources(ctx context.Context, opts ResourceBuildOptions) err
 	}
 
 	var renderer localtestrenderer.Renderer
-	switch localtestrenderer.DetectMode(e.out, e.cfg.Verbose) {
-	case localtestrenderer.ModeTable:
-		renderer = localtestrenderer.NewTable(e.out, graph.Enabled(), localtestrenderer.OperationApply)
-	case localtestrenderer.ModeCompact:
-		renderer = localtestrenderer.NewCompact(e.out, graph.Enabled(), localtestrenderer.OperationApply)
-	case localtestrenderer.ModeLog:
-		renderer = localtestrenderer.NewLog(e.out, graph.Enabled(), localtestrenderer.OperationApply, spinnerMsg)
-	}
-	renderer.Start()
-	executor.SetObserver(renderer)
-
-	if _, err := executor.Apply(ctx, graph); err != nil {
-		renderer.FailAll(err.Error())
-		renderer.Stop()
+	if _, err := executor.Apply(ctx, graph, resource.WithApplyPlan(func(plan resource.ApplyPlan) error {
+		e.startRenderer(
+			executor,
+			&renderer,
+			applyPlannedResources(plan),
+			localtestrenderer.OperationApply,
+			plan.Snapshot.Statuses(),
+			spinnerMsg,
+		)
+		return nil
+	})); err != nil {
+		if renderer != nil {
+			renderer.FailAll(err.Error())
+			renderer.Stop()
+		}
 		return fmt.Errorf("start environment: %w", err)
 	}
 
-	renderer.Stop()
+	if renderer != nil {
+		renderer.Stop()
+	}
 	e.out.Success("Environment started")
 	return nil
 }
@@ -315,54 +329,81 @@ func (e *Env) destroyResources(ctx context.Context, opts ResourceBuildOptions, l
 		return err
 	}
 
-	executor := resource.NewExecutor(e.client)
-	statuses, statusErr := executor.Status(ctx, graph, resource.SkipResource(isImageResource))
-	if statusErr != nil {
-		e.out.Verbosef("Failed to probe current resource status for destroy rendering: %v", statusErr)
-		statuses = nil
-	}
-	renderResources := graph.Enabled()
 	var renderer localtestrenderer.Renderer
-	switch localtestrenderer.DetectMode(e.out, e.cfg.Verbose) {
-	case localtestrenderer.ModeTable:
-		renderer = localtestrenderer.NewTableWithStatus(
-			e.out,
-			renderResources,
+	executor := resource.NewExecutor(e.client)
+	if err := executor.Destroy(ctx, graph, resource.WithDestroyPlan(func(plan resource.DestroyPlan) error {
+		e.startRenderer(
+			executor,
+			&renderer,
+			plan.Destroy,
 			localtestrenderer.OperationDestroy,
-			statuses,
-		)
-	case localtestrenderer.ModeCompact:
-		renderer = localtestrenderer.NewCompactWithStatus(
-			e.out,
-			renderResources,
-			localtestrenderer.OperationDestroy,
-			statuses,
-		)
-	case localtestrenderer.ModeLog:
-		renderer = localtestrenderer.NewLogWithStatus(
-			e.out,
-			renderResources,
-			localtestrenderer.OperationDestroy,
-			statuses,
+			plan.Snapshot.Statuses(),
 			logStartMessage,
 		)
-	}
-	renderer.Start()
-	executor.SetObserver(renderer)
-
-	if err := executor.Destroy(ctx, graph); err != nil {
-		renderer.FailAll(err.Error())
-		renderer.Stop()
+		return nil
+	})); err != nil {
+		if renderer != nil {
+			renderer.FailAll(err.Error())
+			renderer.Stop()
+		}
 		return fmt.Errorf("destroy resources: %w", err)
 	}
 
-	renderer.Stop()
+	if renderer != nil {
+		renderer.Stop()
+	}
 	return nil
+}
+
+func (e *Env) startRenderer(
+	executor *resource.Executor,
+	renderer *localtestrenderer.Renderer,
+	resources []resource.PlannedResource,
+	operation localtestrenderer.Operation,
+	statuses map[resource.ResourceID]resource.Status,
+	logStartMessage string,
+) {
+	switch localtestrenderer.DetectMode(e.out, e.cfg.Verbose) {
+	case localtestrenderer.ModeTable:
+		*renderer = localtestrenderer.NewTableWithPlan(
+			e.out,
+			resources,
+			operation,
+			statuses,
+		)
+	case localtestrenderer.ModeCompact:
+		*renderer = localtestrenderer.NewCompactWithPlan(
+			e.out,
+			resources,
+			operation,
+			statuses,
+		)
+	case localtestrenderer.ModeLog:
+		*renderer = localtestrenderer.NewLogWithPlan(
+			e.out,
+			resources,
+			operation,
+			statuses,
+			logStartMessage,
+		)
+	default:
+		*renderer = localtestrenderer.NewLogWithPlan(e.out, resources, operation, statuses, logStartMessage)
+	}
+	(*renderer).Start()
+	executor.SetObserver(*renderer)
+}
+
+func applyPlannedResources(plan resource.ApplyPlan) []resource.PlannedResource {
+	resources := make([]resource.PlannedResource, 0, len(plan.Destroy)+len(plan.Reconcile))
+	resources = append(resources, plan.Destroy...)
+	resources = append(resources, plan.Reconcile...)
+	return resources
 }
 
 func localtestStatus(
 	resources []resource.Resource,
-	statuses map[resource.ResourceID]resource.Status,
+	snapshot resource.Snapshot,
+	requireDesired bool,
 ) *Status {
 	status := Status{
 		Containers: []ContainerStatus{},
@@ -370,7 +411,7 @@ func localtestStatus(
 		AnyRunning: false,
 	}
 	containerCount := 0
-	readyContainers := 0
+	convergedContainers := 0
 
 	for _, res := range resources {
 		containerResource, ok := res.(*resource.Container)
@@ -378,22 +419,47 @@ func localtestStatus(
 			continue
 		}
 
-		resourceStatus := statuses[containerResource.ID()]
+		resourceStatus := managedResourceStatus(snapshot, containerResource.ID())
+		if !resource.IsEnabled(containerResource) && resourceStatus == resource.StatusDestroyed {
+			continue
+		}
 		status.Containers = append(
 			status.Containers,
 			ContainerStatus{Name: containerResource.Name, Status: localtestStatusString(resourceStatus)},
 		)
 		containerCount++
-		if resourceStatus.IsHealthy() {
-			readyContainers++
+		if containerConverged(containerResource, resourceStatus, requireDesired) {
+			convergedContainers++
 		}
 		if resourceStatus != resource.StatusDestroyed {
 			status.AnyRunning = true
 		}
 	}
 
-	status.Running = containerCount > 0 && readyContainers == containerCount
+	status.Running = containerCount > 0 && convergedContainers == containerCount
 	return &status
+}
+
+func managedResourceStatus(snapshot resource.Snapshot, id resource.ResourceID) resource.Status {
+	if !managedResourcePresent(snapshot, id) {
+		return resource.StatusDestroyed
+	}
+	return snapshot.Resources[id].Status
+}
+
+func managedResourcePresent(snapshot resource.Snapshot, id resource.ResourceID) bool {
+	observed, ok := snapshot.Resources[id]
+	return ok && observed.Managed && observed.Status != resource.StatusDestroyed
+}
+
+func containerConverged(containerResource *resource.Container, status resource.Status, requireDesired bool) bool {
+	if resource.IsEnabled(containerResource) {
+		return status.IsHealthy()
+	}
+	if !requireDesired {
+		return status.IsHealthy()
+	}
+	return status == resource.StatusDestroyed
 }
 
 func localtestStatusString(status resource.Status) string {
@@ -670,7 +736,7 @@ func ensurePgpass(dataDir string) error {
 }
 
 func buildResourceGraph(resources []resource.Resource) (*resource.Graph, error) {
-	graph := resource.NewGraph()
+	graph := resource.NewGraph(resource.GraphID(graphID))
 	for _, res := range resources {
 		if err := graph.Add(res); err != nil {
 			return nil, fmt.Errorf("add resource %q to graph: %w", res.ID(), err)

--- a/src/cli/internal/cmd/env/localtest/env_internal_test.go
+++ b/src/cli/internal/cmd/env/localtest/env_internal_test.go
@@ -1,0 +1,41 @@
+package localtest
+
+import (
+	"testing"
+
+	"altinn.studio/devenv/pkg/resource"
+)
+
+func TestApplyPlannedResourcesCombinesDestroyAndReconcile(t *testing.T) {
+	t.Parallel()
+
+	destroyed := plannedResource(resource.ContainerID("removed"))
+	reconciled := plannedResource(resource.ContainerID("started"))
+
+	got := applyPlannedResources(resource.ApplyPlan{
+		Snapshot:  resource.Snapshot{},
+		Destroy:   []resource.PlannedResource{destroyed},
+		Reconcile: []resource.PlannedResource{reconciled},
+	})
+
+	assertPlannedResourceIDs(t, got, []resource.ResourceID{destroyed.ID, reconciled.ID})
+}
+
+func plannedResource(id resource.ResourceID) resource.PlannedResource {
+	return resource.PlannedResource{
+		Resource: nil,
+		ID:       id,
+	}
+}
+
+func assertPlannedResourceIDs(t *testing.T, got []resource.PlannedResource, want []resource.ResourceID) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("len(resources) = %d, want %d", len(got), len(want))
+	}
+	for i, id := range want {
+		if got[i].ID != id {
+			t.Fatalf("resources[%d].ID = %q, want %q", i, got[i].ID, id)
+		}
+	}
+}

--- a/src/cli/internal/cmd/env/localtest/env_reset_test.go
+++ b/src/cli/internal/cmd/env/localtest/env_reset_test.go
@@ -14,6 +14,7 @@ import (
 
 	containermock "altinn.studio/devenv/pkg/container/mock"
 	containertypes "altinn.studio/devenv/pkg/container/types"
+	"altinn.studio/devenv/pkg/resource"
 	"altinn.studio/studioctl/internal/config"
 	"altinn.studio/studioctl/internal/ui"
 )
@@ -53,10 +54,14 @@ func TestReset_StopsManagedResourcesBeforeRemovingPersistedData(t *testing.T) {
 
 	client := containermock.New()
 	client.ContainerInspectFunc = func(context.Context, string) (containertypes.ContainerInfo, error) {
-		return containertypes.ContainerInfo{}, nil
+		return containertypes.ContainerInfo{
+			Labels: map[string]string{resource.GraphIDLabel: graphID},
+		}, nil
 	}
 	client.NetworkInspectFunc = func(context.Context, string) (containertypes.NetworkInfo, error) {
-		return containertypes.NetworkInfo{}, nil
+		return containertypes.NetworkInfo{
+			Labels: map[string]string{resource.GraphIDLabel: graphID},
+		}, nil
 	}
 
 	env := NewEnv(

--- a/src/cli/internal/cmd/env/localtest/env_test.go
+++ b/src/cli/internal/cmd/env/localtest/env_test.go
@@ -12,6 +12,7 @@ import (
 	"altinn.studio/devenv/pkg/container"
 	"altinn.studio/devenv/pkg/container/mock"
 	"altinn.studio/devenv/pkg/container/types"
+	"altinn.studio/devenv/pkg/resource"
 	envtypes "altinn.studio/studioctl/internal/cmd/env"
 	"altinn.studio/studioctl/internal/cmd/env/localtest"
 	"altinn.studio/studioctl/internal/config"
@@ -38,7 +39,7 @@ func TestStatus_RunningRequiresAllCoreContainers(t *testing.T) {
 			wantRunning:    true,
 			wantAnyRunning: true,
 		},
-		"all core containers running without pgadmin": {
+		"optional pgadmin stale": {
 			states: map[string]types.ContainerState{
 				localtest.ContainerLocaltest:        {Status: "running", Running: true},
 				localtest.ContainerPDF3:             {Status: "running", Running: true},
@@ -46,7 +47,7 @@ func TestStatus_RunningRequiresAllCoreContainers(t *testing.T) {
 				localtest.ContainerWorkflowEngine:   {Status: "running", Running: true},
 				localtest.ContainerPgAdmin:          {Status: "exited", Running: false},
 			},
-			wantRunning:    true,
+			wantRunning:    false,
 			wantAnyRunning: true,
 		},
 		"one running one exited": {
@@ -83,7 +84,7 @@ func TestStatus_RunningRequiresAllCoreContainers(t *testing.T) {
 				if !ok {
 					return types.ContainerInfo{}, types.ErrContainerNotFound
 				}
-				return types.ContainerInfo{State: state}, nil
+				return managedContainerInfo(state), nil
 			}
 
 			env := newTestEnv(client)
@@ -109,7 +110,7 @@ func TestStatus_ReturnsErrorForNonNotFoundStateError(t *testing.T) {
 		if nameOrID == localtest.ContainerPDF3 {
 			return types.ContainerInfo{}, errStateUnavailable
 		}
-		return types.ContainerInfo{State: types.ContainerState{Status: "running", Running: true}}, nil
+		return managedContainerInfo(types.ContainerState{Status: "running", Running: true}), nil
 	}
 
 	env := newTestEnv(client)
@@ -117,6 +118,32 @@ func TestStatus_ReturnsErrorForNonNotFoundStateError(t *testing.T) {
 	if !errors.Is(err, errStateUnavailable) {
 		t.Fatalf("Status() error = %v, want wrapped %v", err, errStateUnavailable)
 	}
+}
+
+func TestStatus_HidesAbsentOptionalContainers(t *testing.T) {
+	t.Parallel()
+
+	coreState := types.ContainerState{Status: "running", Running: true}
+	client := mock.New()
+	client.ContainerInspectFunc = func(_ context.Context, nameOrID string) (types.ContainerInfo, error) {
+		switch nameOrID {
+		case localtest.ContainerLocaltest,
+			localtest.ContainerPDF3,
+			localtest.ContainerWorkflowEngineDb,
+			localtest.ContainerWorkflowEngine:
+			return managedContainerInfo(coreState), nil
+		default:
+			return types.ContainerInfo{}, types.ErrContainerNotFound
+		}
+	}
+
+	env := newTestEnv(client)
+	status, err := env.Status(context.Background())
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+	assertContainerStatusAbsent(t, status, localtest.ContainerPgAdmin)
+	assertContainerStatusAbsent(t, status, localtest.ContainerMonitoringGrafana)
 }
 
 func TestStatusForUp_IncludesPgAdminWhenRequested(t *testing.T) {
@@ -127,7 +154,7 @@ func TestStatusForUp_IncludesPgAdminWhenRequested(t *testing.T) {
 		if nameOrID == localtest.ContainerPgAdmin {
 			return types.ContainerInfo{}, types.ErrContainerNotFound
 		}
-		return types.ContainerInfo{State: types.ContainerState{Status: "running", Running: true}}, nil
+		return managedContainerInfo(types.ContainerState{Status: "running", Running: true}), nil
 	}
 
 	env := newTestEnv(client)
@@ -137,6 +164,146 @@ func TestStatusForUp_IncludesPgAdminWhenRequested(t *testing.T) {
 	}
 	if status.Running {
 		t.Fatal("StatusForUp().Running = true, want false when pgadmin is requested but missing")
+	}
+}
+
+func TestStatusForUp_RequiresUnrequestedPgAdminDestroyed(t *testing.T) {
+	t.Parallel()
+
+	client := mock.New()
+	client.ContainerInspectFunc = func(_ context.Context, _ string) (types.ContainerInfo, error) {
+		return managedContainerInfo(types.ContainerState{Status: "running", Running: true}), nil
+	}
+
+	env := newTestEnv(client)
+	status, err := env.StatusForUp(context.Background(), envtypes.UpOptions{})
+	if err != nil {
+		t.Fatalf("StatusForUp() error = %v", err)
+	}
+	if status.Running {
+		t.Fatal("StatusForUp().Running = true, want false when unrequested pgadmin is running")
+	}
+}
+
+func TestStatus_TreatsPresentOptionalContainerAsRunning(t *testing.T) {
+	t.Parallel()
+
+	client := mock.New()
+	client.ContainerInspectFunc = func(_ context.Context, _ string) (types.ContainerInfo, error) {
+		return managedContainerInfo(types.ContainerState{Status: "running", Running: true}), nil
+	}
+
+	env := newTestEnv(client)
+	status, err := env.Status(context.Background())
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+	if !status.Running {
+		t.Fatal("Status().Running = false, want true when visible optional containers are running")
+	}
+	assertContainerStatus(t, status, localtest.ContainerPgAdmin, "running")
+}
+
+func TestStatusForUp_IncludesMonitoringWhenRequested(t *testing.T) {
+	t.Parallel()
+
+	coreState := types.ContainerState{Status: "running", Running: true}
+	client := mock.New()
+	client.ContainerInspectFunc = func(_ context.Context, nameOrID string) (types.ContainerInfo, error) {
+		switch nameOrID {
+		case localtest.ContainerLocaltest,
+			localtest.ContainerPDF3,
+			localtest.ContainerWorkflowEngineDb,
+			localtest.ContainerWorkflowEngine:
+			return managedContainerInfo(coreState), nil
+		default:
+			return types.ContainerInfo{}, types.ErrContainerNotFound
+		}
+	}
+
+	env := newTestEnv(client)
+	status, err := env.StatusForUp(context.Background(), envtypes.UpOptions{Monitoring: true})
+	if err != nil {
+		t.Fatalf("StatusForUp() error = %v", err)
+	}
+	if status.Running {
+		t.Fatal("StatusForUp().Running = true, want false when monitoring is requested but missing")
+	}
+	assertContainerStatus(t, status, localtest.ContainerMonitoringGrafana, "not found")
+}
+
+func TestStatus_IgnoresUnmanagedNameCollisions(t *testing.T) {
+	t.Parallel()
+
+	client := mock.New()
+	client.ContainerInspectFunc = func(context.Context, string) (types.ContainerInfo, error) {
+		return types.ContainerInfo{
+			State:  types.ContainerState{Status: "running", Running: true},
+			Labels: map[string]string{},
+		}, nil
+	}
+
+	env := newTestEnv(client)
+	status, err := env.Status(context.Background())
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+	if status.Running {
+		t.Fatal("Status().Running = true, want false")
+	}
+	if status.AnyRunning {
+		t.Fatal("Status().AnyRunning = true, want false")
+	}
+}
+
+func TestDown_IgnoresUnmanagedNameCollision(t *testing.T) {
+	t.Parallel()
+
+	client := mock.New()
+	client.ContainerInspectFunc = func(_ context.Context, nameOrID string) (types.ContainerInfo, error) {
+		if nameOrID != localtest.ContainerLocaltest {
+			return types.ContainerInfo{}, types.ErrContainerNotFound
+		}
+		return types.ContainerInfo{
+			State:  types.ContainerState{Status: "running", Running: true},
+			Labels: map[string]string{},
+		}, nil
+	}
+	client.ContainerRemoveFunc = func(context.Context, string, bool) error {
+		t.Fatal("ContainerRemove called for unmanaged container")
+		return nil
+	}
+
+	env := newTestEnv(client)
+	err := env.Down(context.Background())
+	if !errors.Is(err, envtypes.ErrAlreadyStopped) {
+		t.Fatalf("Down() error = %v, want ErrAlreadyStopped", err)
+	}
+}
+
+func TestDown_StopsStaleManagedResources(t *testing.T) {
+	t.Parallel()
+
+	client := mock.New()
+	var removedContainer string
+	client.ListContainersFunc = func(context.Context, types.ContainerListFilter) ([]types.ContainerInfo, error) {
+		return []types.ContainerInfo{{
+			ID:     "stale-container-id",
+			Name:   "stale-container",
+			Labels: map[string]string{resource.GraphIDLabel: testGraphID},
+		}}, nil
+	}
+	client.ContainerRemoveFunc = func(_ context.Context, nameOrID string, _ bool) error {
+		removedContainer = nameOrID
+		return nil
+	}
+
+	env := newTestEnv(client)
+	if err := env.Down(context.Background()); err != nil {
+		t.Fatalf("Down() error = %v", err)
+	}
+	if removedContainer != "stale-container-id" {
+		t.Fatalf("removed container = %q, want stale-container-id", removedContainer)
 	}
 }
 
@@ -194,6 +361,35 @@ func TestLogs_JSONOutputsOneObjectPerLine(t *testing.T) {
 	}
 }
 
+func managedContainerInfo(state types.ContainerState) types.ContainerInfo {
+	return types.ContainerInfo{
+		State:  state,
+		Labels: map[string]string{resource.GraphIDLabel: testGraphID},
+	}
+}
+
+func assertContainerStatus(t *testing.T, status *localtest.Status, name string, want string) {
+	t.Helper()
+	for _, entry := range status.Containers {
+		if entry.Name == name {
+			if entry.Status != want {
+				t.Fatalf("container %q status = %q, want %q", name, entry.Status, want)
+			}
+			return
+		}
+	}
+	t.Fatalf("container %q missing from status", name)
+}
+
+func assertContainerStatusAbsent(t *testing.T, status *localtest.Status, name string) {
+	t.Helper()
+	for _, entry := range status.Containers {
+		if entry.Name == name {
+			t.Fatalf("container %q present in status with status %q, want absent", name, entry.Status)
+		}
+	}
+}
+
 func newTestEnv(client container.ContainerClient) *localtest.Env {
 	return localtest.NewEnv(
 		&config.Config{Images: testImages()},
@@ -210,6 +406,13 @@ func testImages() config.ImagesConfig {
 			WorkflowEngineDb: config.ImageSpec{Image: "postgres", Tag: "18"},
 			WorkflowEngine:   config.ImageSpec{Image: "ghcr.io/altinn/test-workflow-engine", Tag: "latest"},
 			PgAdmin:          config.ImageSpec{Image: "dpage/pgadmin4", Tag: "latest"},
+		},
+		Monitoring: config.MonitoringImages{
+			Tempo:         config.ImageSpec{Image: "grafana/tempo", Tag: "latest"},
+			Mimir:         config.ImageSpec{Image: "grafana/mimir", Tag: "latest"},
+			Loki:          config.ImageSpec{Image: "grafana/loki", Tag: "latest"},
+			OtelCollector: config.ImageSpec{Image: "otel/opentelemetry-collector-contrib", Tag: "latest"},
+			Grafana:       config.ImageSpec{Image: "grafana/grafana", Tag: "latest"},
 		},
 	}
 }

--- a/src/cli/internal/cmd/env/localtest/renderer/compact.go
+++ b/src/cli/internal/cmd/env/localtest/renderer/compact.go
@@ -10,37 +10,37 @@ import (
 
 // NewCompact creates the narrow interactive row renderer.
 func NewCompact(out *ui.Output, resources []resource.Resource, operation Operation) *CompactRenderer {
-	return NewCompactWithStatus(out, resources, operation, nil)
+	return &CompactRenderer{
+		screenRenderer: newScreenRenderer(out, resources, operation, nil, compactLayout{}),
+	}
 }
 
-// NewCompactWithStatus creates the narrow interactive row renderer with initial resource status.
-func NewCompactWithStatus(
+// NewCompactWithPlan creates the narrow interactive row renderer from planned resources.
+func NewCompactWithPlan(
 	out *ui.Output,
-	resources []resource.Resource,
+	resources []resource.PlannedResource,
 	operation Operation,
 	statuses map[resource.ResourceID]resource.Status,
 ) *CompactRenderer {
 	return &CompactRenderer{
-		screenRenderer: newScreenRenderer(out, resources, operation, statuses, compactLayout{}),
+		screenRenderer: newScreenRendererPlanned(out, resources, operation, statuses, compactLayout{}),
 	}
 }
 
 func (compactLayout) renderLines(model *renderModel, width int, now time.Time) []string {
 	lines := make([]string, 0, len(model.order)+1)
 	readyCount, failedCount, canceledCount, activeCount := 0, 0, 0, 0
-	successState := model.operation.successState()
-
 	for _, name := range model.order {
 		row := model.rows[name]
 		if row == nil {
 			continue
 		}
-		switch row.state {
-		case successState:
+		switch {
+		case isSuccessfulState(row.state):
 			readyCount++
-		case stateFailed:
+		case row.state == stateFailed:
 			failedCount++
-		case stateCanceled:
+		case row.state == stateCanceled:
 			canceledCount++
 		}
 		if isActiveState(row.state) {

--- a/src/cli/internal/cmd/env/localtest/renderer/log.go
+++ b/src/cli/internal/cmd/env/localtest/renderer/log.go
@@ -16,20 +16,26 @@ func NewLog(
 	operation Operation,
 	startMessage string,
 ) *LogRenderer {
-	return NewLogWithStatus(out, resources, operation, nil, startMessage)
+	return &LogRenderer{
+		out:          out,
+		model:        newRenderModel(resources, operation, nil),
+		startMessage: startMessage,
+		emitted:      make(map[string]string),
+		mu:           sync.Mutex{},
+	}
 }
 
-// NewLogWithStatus creates the non-interactive line-based renderer with initial resource status.
-func NewLogWithStatus(
+// NewLogWithPlan creates the non-interactive line-based renderer from planned resources.
+func NewLogWithPlan(
 	out *ui.Output,
-	resources []resource.Resource,
+	resources []resource.PlannedResource,
 	operation Operation,
 	statuses map[resource.ResourceID]resource.Status,
 	startMessage string,
 ) *LogRenderer {
 	return &LogRenderer{
 		out:          out,
-		model:        newRenderModel(resources, operation, statuses),
+		model:        newRenderModelPlanned(resources, operation, statuses),
 		startMessage: startMessage,
 		emitted:      make(map[string]string),
 		mu:           sync.Mutex{},
@@ -84,7 +90,7 @@ func (r *LogRenderer) linesForNamesLocked(names []string) []string {
 		if row == nil {
 			continue
 		}
-		line, signature, ok := logLineForRow(r.model, row)
+		line, signature, ok := logLineForRow(row)
 		if !ok {
 			continue
 		}
@@ -97,7 +103,7 @@ func (r *LogRenderer) linesForNamesLocked(names []string) []string {
 	return lines
 }
 
-func logLineForRow(model *renderModel, row *progressRow) (string, string, bool) {
+func logLineForRow(row *progressRow) (string, string, bool) {
 	if row.state == statePending {
 		return "", "", false
 	}
@@ -118,7 +124,7 @@ func logLineForRow(model *renderModel, row *progressRow) (string, string, bool) 
 		signature += "|" + row.message
 	}
 
-	if row.state == model.operation.successState() ||
+	if isSuccessfulState(row.state) ||
 		isTerminalUnsuccessfulState(row.state) ||
 		isActiveState(row.state) {
 		return line, signature, true

--- a/src/cli/internal/cmd/env/localtest/renderer/model.go
+++ b/src/cli/internal/cmd/env/localtest/renderer/model.go
@@ -12,37 +12,96 @@ func newRenderModel(
 	operation Operation,
 	statuses map[resource.ResourceID]resource.Status,
 ) *renderModel {
+	return newRenderModelResources(renderResourcesFromResources(resources), operation, statuses)
+}
+
+func newRenderModelPlanned(
+	resources []resource.PlannedResource,
+	operation Operation,
+	statuses map[resource.ResourceID]resource.Status,
+) *renderModel {
+	return newRenderModelResources(renderResourcesFromPlan(resources), operation, statuses)
+}
+
+type renderResource struct {
+	id      resource.ResourceID
+	imageID resource.ResourceID
+	name    string
+}
+
+func renderResourcesFromResources(resources []resource.Resource) []renderResource {
+	rows := make([]renderResource, 0, len(resources))
+	for _, res := range resources {
+		if row, ok := renderResourceFromResource(res, res.ID()); ok {
+			rows = append(rows, row)
+		}
+	}
+	return rows
+}
+
+func renderResourcesFromPlan(resources []resource.PlannedResource) []renderResource {
+	rows := make([]renderResource, 0, len(resources))
+	for _, res := range resources {
+		if row, ok := renderResourceFromResource(res.Resource, res.ID); ok {
+			rows = append(rows, row)
+			continue
+		}
+		if res.Resource != nil {
+			continue
+		}
+		rows = append(rows, renderResource{
+			id:      res.ID,
+			imageID: "",
+			name:    renderNameFromID(res.ID),
+		})
+	}
+	return rows
+}
+
+func renderResourceFromResource(res resource.Resource, id resource.ResourceID) (renderResource, bool) {
+	switch res := res.(type) {
+	case *resource.Network:
+		return renderResource{id: id, imageID: "", name: res.Name}, true
+	case *resource.Container:
+		return renderResource{id: id, imageID: res.Image.ID(), name: res.Name}, true
+	default:
+		return renderResource{id: "", imageID: "", name: ""}, false
+	}
+}
+
+func renderNameFromID(id resource.ResourceID) string {
+	value := id.String()
+	if name, ok := strings.CutPrefix(value, "container:"); ok {
+		return name
+	}
+	if name, ok := strings.CutPrefix(value, "network:"); ok {
+		return name
+	}
+	return value
+}
+
+func newRenderModelResources(
+	resources []renderResource,
+	operation Operation,
+	statuses map[resource.ResourceID]resource.Status,
+) *renderModel {
 	rowMap := make(map[string]*progressRow)
 	order := make([]string, 0)
 	resourceToRows := make(map[resource.ResourceID][]string)
 	imageToContainers := make(map[resource.ResourceID][]string)
 
 	for _, res := range resources {
-		if skipInitialResource(res, operation, statuses) {
+		if skipInitialResource(res.id, operation, statuses) {
 			continue
 		}
 
-		switch res := res.(type) {
-		case *resource.Network:
-			if _, exists := rowMap[res.Name]; !exists {
-				rowMap[res.Name] = newProgressRow(res.Name)
-				order = append(order, res.Name)
-			}
-			resourceToRows[res.ID()] = append(resourceToRows[res.ID()], res.Name)
-		case *resource.Container:
-			if _, exists := rowMap[res.Name]; !exists {
-				rowMap[res.Name] = newProgressRow(res.Name)
-				order = append(order, res.Name)
-			}
-
-			resourceToRows[res.ID()] = append(
-				resourceToRows[res.ID()],
-				res.Name,
-			)
-			imageToContainers[res.Image.ID()] = append(
-				imageToContainers[res.Image.ID()],
-				res.Name,
-			)
+		if _, exists := rowMap[res.name]; !exists {
+			rowMap[res.name] = newProgressRowFromStatus(res.name, operation, statuses[res.id])
+			order = append(order, res.name)
+		}
+		resourceToRows[res.id] = append(resourceToRows[res.id], res.name)
+		if res.imageID != "" {
+			imageToContainers[res.imageID] = append(imageToContainers[res.imageID], res.name)
 		}
 	}
 
@@ -65,15 +124,31 @@ func newRenderModel(
 }
 
 func skipInitialResource(
-	res resource.Resource,
+	id resource.ResourceID,
 	operation Operation,
 	statuses map[resource.ResourceID]resource.Status,
 ) bool {
 	if operation != OperationDestroy || statuses == nil {
 		return false
 	}
-	status, ok := statuses[res.ID()]
+	status, ok := statuses[id]
 	return ok && status == resource.StatusDestroyed
+}
+
+func newProgressRowFromStatus(
+	name string,
+	operation Operation,
+	status resource.Status,
+) *progressRow {
+	row := newProgressRow(name)
+	if operation != OperationApply || status != resource.StatusReady {
+		return row
+	}
+
+	row.state = stateReady
+	row.current = rowProgressComplete
+	row.total = rowProgressComplete
+	return row
 }
 
 func newProgressRow(name string) *progressRow {
@@ -281,15 +356,12 @@ func isTerminalState(state string) bool {
 	return state == stateReady || state == stateRemoved || isTerminalUnsuccessfulState(state)
 }
 
-func isTerminalUnsuccessfulState(state string) bool {
-	return state == stateFailed || state == stateCanceled
+func isSuccessfulState(state string) bool {
+	return state == stateReady || state == stateRemoved
 }
 
-func (o Operation) successState() string {
-	if o == OperationDestroy {
-		return stateRemoved
-	}
-	return stateReady
+func isTerminalUnsuccessfulState(state string) bool {
+	return state == stateFailed || state == stateCanceled
 }
 
 func (o Operation) successLabel() string {

--- a/src/cli/internal/cmd/env/localtest/renderer/renderer_test.go
+++ b/src/cli/internal/cmd/env/localtest/renderer/renderer_test.go
@@ -244,13 +244,16 @@ func TestDestroyRenderer_OmitsAlreadyDestroyedRows(t *testing.T) {
 	image := &resource.RemoteImage{Ref: "ghcr.io/altinn/test:latest"}
 	running := &resource.Container{Name: "localtest", Image: resource.Ref(image)}
 	destroyed := &resource.Container{Name: "localtest-pgadmin", Image: resource.Ref(image)}
-	resources := []resource.Resource{image, running, destroyed}
+	resources := []resource.PlannedResource{
+		{Resource: running, ID: running.ID()},
+		{Resource: destroyed, ID: destroyed.ID()},
+	}
 	statuses := map[resource.ResourceID]resource.Status{
 		running.ID():   resource.StatusReady,
 		destroyed.ID(): resource.StatusDestroyed,
 	}
 
-	renderer := NewTableWithStatus(
+	renderer := NewTableWithPlan(
 		ui.NewOutput(io.Discard, io.Discard, false),
 		resources,
 		OperationDestroy,
@@ -262,6 +265,34 @@ func TestDestroyRenderer_OmitsAlreadyDestroyedRows(t *testing.T) {
 	}
 	if renderer.model.rows[destroyed.Name] != nil {
 		t.Fatalf("unexpected row for already destroyed resource %q", destroyed.Name)
+	}
+}
+
+func TestApplyRenderer_InitializesReadyRowsFromStatus(t *testing.T) {
+	t.Parallel()
+
+	image := &resource.RemoteImage{Ref: "ghcr.io/altinn/test:latest"}
+	container := &resource.Container{Name: "localtest", Image: resource.Ref(image)}
+	resources := []resource.PlannedResource{
+		{Resource: container, ID: container.ID()},
+	}
+	statuses := map[resource.ResourceID]resource.Status{
+		container.ID(): resource.StatusReady,
+	}
+
+	renderer := NewTableWithPlan(
+		ui.NewOutput(io.Discard, io.Discard, false),
+		resources,
+		OperationApply,
+		statuses,
+	)
+
+	row := renderer.model.rows[container.Name]
+	if row == nil {
+		t.Fatalf("expected row for %q", container.Name)
+	}
+	if row.state != stateReady || row.current != rowProgressComplete || row.total != rowProgressComplete {
+		t.Fatalf("unexpected initial row state: state=%q current=%d total=%d", row.state, row.current, row.total)
 	}
 }
 
@@ -408,6 +439,32 @@ func TestLogRenderer_DeduplicatesProgressMilestones(t *testing.T) {
 	rendered := out.String()
 	if strings.Count(rendered, "20%") != 1 {
 		t.Fatalf("log output %q should contain exactly one deduped 20%% milestone", rendered)
+	}
+}
+
+func TestLogRenderer_PrintsPlannedResourceWithoutDesiredResource(t *testing.T) {
+	id := resource.ContainerID("stale-container")
+	out := &bytes.Buffer{}
+	renderer := NewLogWithPlan(
+		ui.NewOutput(out, io.Discard, false),
+		[]resource.PlannedResource{{
+			Resource: nil,
+			ID:       id,
+		}},
+		OperationApply,
+		nil,
+		"",
+	)
+
+	renderer.OnEvent(resource.Event{Type: resource.EventDestroyStart, Resource: id})
+	renderer.OnEvent(resource.Event{Type: resource.EventDestroyDone, Resource: id})
+
+	rendered := out.String()
+	if !strings.Contains(rendered, "stale-container: stopping") {
+		t.Fatalf("log output %q missing stopping line", rendered)
+	}
+	if !strings.Contains(rendered, "stale-container: removed") {
+		t.Fatalf("log output %q missing removed line", rendered)
 	}
 }
 

--- a/src/cli/internal/cmd/env/localtest/renderer/screen.go
+++ b/src/cli/internal/cmd/env/localtest/renderer/screen.go
@@ -48,6 +48,25 @@ func newScreenRenderer(
 	}
 }
 
+func newScreenRendererPlanned(
+	out *ui.Output,
+	resources []resource.PlannedResource,
+	operation Operation,
+	statuses map[resource.ResourceID]resource.Status,
+	rendererLayout layout,
+) *screenRenderer {
+	return &screenRenderer{
+		out:           out,
+		model:         newRenderModelPlanned(resources, operation, statuses),
+		layout:        rendererLayout,
+		done:          nil,
+		mu:            sync.Mutex{},
+		renderedLines: 0,
+		running:       false,
+		dirty:         false,
+	}
+}
+
 func (r *screenRenderer) Start() {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/src/cli/internal/cmd/env/localtest/renderer/table.go
+++ b/src/cli/internal/cmd/env/localtest/renderer/table.go
@@ -11,18 +11,20 @@ import (
 
 // NewTable creates the wide interactive table renderer.
 func NewTable(out *ui.Output, resources []resource.Resource, operation Operation) *TableRenderer {
-	return NewTableWithStatus(out, resources, operation, nil)
+	return &TableRenderer{
+		screenRenderer: newScreenRenderer(out, resources, operation, nil, tableLayout{}),
+	}
 }
 
-// NewTableWithStatus creates the wide interactive table renderer with initial resource status.
-func NewTableWithStatus(
+// NewTableWithPlan creates the wide interactive table renderer from planned resources.
+func NewTableWithPlan(
 	out *ui.Output,
-	resources []resource.Resource,
+	resources []resource.PlannedResource,
 	operation Operation,
 	statuses map[resource.ResourceID]resource.Status,
 ) *TableRenderer {
 	return &TableRenderer{
-		screenRenderer: newScreenRenderer(out, resources, operation, statuses, tableLayout{}),
+		screenRenderer: newScreenRendererPlanned(out, resources, operation, statuses, tableLayout{}),
 	}
 }
 
@@ -34,19 +36,17 @@ func (tableLayout) renderLines(model *renderModel, width int, now time.Time) []s
 
 	lines := make([]string, 0, len(model.order)+1)
 	readyCount, failedCount, canceledCount, activeCount := 0, 0, 0, 0
-	successState := model.operation.successState()
-
 	for _, name := range model.order {
 		row := model.rows[name]
 		if row == nil {
 			continue
 		}
-		switch row.state {
-		case successState:
+		switch {
+		case isSuccessfulState(row.state):
 			readyCount++
-		case stateFailed:
+		case row.state == stateFailed:
 			failedCount++
-		case stateCanceled:
+		case row.state == stateCanceled:
 			canceledCount++
 		}
 		if isActiveState(row.state) {

--- a/src/cli/internal/cmd/env/localtest/renderer/util.go
+++ b/src/cli/internal/cmd/env/localtest/renderer/util.go
@@ -59,7 +59,7 @@ func rawStateLabel(model *renderModel, row *progressRow) string {
 	switch {
 	case isTerminalUnsuccessfulState(row.state):
 		return "[!!] " + row.state
-	case row.state == model.operation.successState():
+	case isSuccessfulState(row.state):
 		return "[ok] " + row.state
 	case row.state == stateImageReady:
 		return "[~] image"

--- a/src/cli/internal/cmd/env/localtest/resources.go
+++ b/src/cli/internal/cmd/env/localtest/resources.go
@@ -17,11 +17,8 @@ import (
 )
 
 const (
-	// LabelKey is the label used to identify studioctl-managed resources.
-	LabelKey = "altinn.studio/cli"
-
-	// LabelValue is the value for the localtest runtime.
-	LabelValue = "localtest"
+	// graphID scopes devenv ownership labels to studioctl's localtest graph.
+	graphID = "studioctl-localtest"
 
 	// NetworkName is the name of the localtest network.
 	NetworkName = "altinntestlocal_network"
@@ -512,7 +509,6 @@ func buildResources(opts ResourceBuildOptions) []resource.Resource {
 	mon := monitoringContainers(opts.DataDir, opts.Topology)
 	coreImages := buildCoreImages(opts)
 	monImages := monitoringImageRefs(opts.Images.Monitoring)
-	labels := map[string]string{LabelKey: LabelValue}
 
 	capacity := 1 + len(core)*2 + len(mon)*2
 	resources := make([]resource.Resource, 0, capacity)
@@ -521,7 +517,7 @@ func buildResources(opts ResourceBuildOptions) []resource.Resource {
 		Enabled: nil,
 		Name:    NetworkName,
 		Driver:  "bridge",
-		Labels:  labels,
+		Labels:  nil,
 		Lifecycle: resource.LifecycleOptions{
 			// When apps are started with `studioctl run --mode container ..`
 			// we might have active containers attached to the network
@@ -531,6 +527,7 @@ func buildResources(opts ResourceBuildOptions) []resource.Resource {
 				}
 				return resource.ErrorDecisionDefault
 			},
+			RetainOnDestroy: false,
 		},
 	}
 	resources = append(resources, network)
@@ -546,7 +543,6 @@ func buildResources(opts ResourceBuildOptions) []resource.Resource {
 			spec,
 			coreImages[spec.Name],
 			resource.Ref(network),
-			labels,
 			opts.RuntimeConfig.User,
 			resourceEnabledRef(enabled),
 		))
@@ -564,7 +560,6 @@ func buildResources(opts ResourceBuildOptions) []resource.Resource {
 			spec,
 			image,
 			resource.Ref(network),
-			labels,
 			"", // Monitoring containers use default user (config mounts are read-only)
 			resourceEnabledRef(opts.IncludeMonitoring),
 		))
@@ -595,7 +590,6 @@ func newContainerResource(
 	spec *ContainerSpec,
 	imageRes resource.ImageResource,
 	network resource.ResourceRef,
-	labels map[string]string,
 	user string,
 	enabled *bool,
 ) *resource.Container {
@@ -614,12 +608,13 @@ func newContainerResource(
 		Ports:       spec.Ports,
 		Volumes:     spec.Volumes,
 		Env:         toEnvSlice(spec.Environment),
-		Labels:      labels,
+		Labels:      nil,
 		Command:     spec.Command,
 		ExtraHosts:  spec.ExtraHosts,
 		Lifecycle: resource.ContainerLifecycleOptions{
 			LifecycleOptions: resource.LifecycleOptions{
 				HandleDestroyError: nil,
+				RetainOnDestroy:    false,
 			},
 			WaitForReady: true,
 		},

--- a/src/cli/internal/cmd/env/localtest/resources.go
+++ b/src/cli/internal/cmd/env/localtest/resources.go
@@ -152,23 +152,10 @@ func localtestListenURLs(loadBalancerPort string) string {
 func coreContainers(
 	dataDir string,
 	topology envtopology.Local,
-	includeMonitoring bool,
-	includePgAdmin bool,
 ) []ContainerSpec {
 	ingressPort := topology.IngressPort()
-	app := topology.MustComponent(envtopology.ComponentApp)
 	runtimeConfig := newLocaltestConfig(topology)
-	bindings := topology.ResolveBindings(RuntimeBindings(BindingOptions{
-		IncludeMonitoring: includeMonitoring,
-		IncludePgAdmin:    includePgAdmin,
-	}))
-	networkAliases := []string{app.Host()}
-	for _, binding := range bindings {
-		if !binding.Enabled || !binding.HasRoute() || binding.Host == app.Host() {
-			continue
-		}
-		networkAliases = append(networkAliases, binding.Host)
-	}
+	networkAliases := topology.LocaltestIngressHosts()
 
 	containers := []ContainerSpec{
 		newContainerSpec(
@@ -505,7 +492,7 @@ func buildRemoteCoreImages(core config.CoreImages, includePgAdmin bool) map[stri
 }
 
 func buildResources(opts ResourceBuildOptions) []resource.Resource {
-	core := coreContainers(opts.DataDir, opts.Topology, opts.IncludeMonitoring, opts.IncludePgAdmin)
+	core := coreContainers(opts.DataDir, opts.Topology)
 	mon := monitoringContainers(opts.DataDir, opts.Topology)
 	coreImages := buildCoreImages(opts)
 	monImages := monitoringImageRefs(opts.Images.Monitoring)

--- a/src/cli/internal/cmd/env/localtest/resources_internal_test.go
+++ b/src/cli/internal/cmd/env/localtest/resources_internal_test.go
@@ -103,7 +103,7 @@ func TestCoreContainers_ServiceCallbacksUseLocaltestNetworkAlias(t *testing.T) {
 	t.Setenv(config.EnvCI, "")
 
 	dataDir := t.TempDir()
-	containers := coreContainers(dataDir, testTopology(), false, true)
+	containers := coreContainers(dataDir, testTopology())
 	assertCoreContainerLayout(t, containers)
 	assertLocaltestContainerConfig(t, containers[0], dataDir)
 	assertPdf3ContainerConfig(t, containers[1])
@@ -231,6 +231,26 @@ func TestResourceBuilder_AddsPgAdminOnlyWhenRequested(t *testing.T) {
 	}
 }
 
+func TestResourceBuilder_LocaltestAliasesDoNotChangeWithPgAdmin(t *testing.T) {
+	t.Setenv(config.EnvCI, "")
+
+	withoutPgAdmin := buildResources(newResourceBuildOptions(t.TempDir(), false, false))
+	withPgAdmin := buildResources(newResourceBuildOptions(t.TempDir(), false, true))
+
+	without := findResource(withoutPgAdmin, resource.ContainerID(ContainerLocaltest))
+	with := findResource(withPgAdmin, resource.ContainerID(ContainerLocaltest))
+	if without == nil || with == nil {
+		t.Fatalf("buildResources() missing %q", ContainerLocaltest)
+	}
+	if !slices.Equal(without.NetworkAliases, with.NetworkAliases) {
+		t.Fatalf(
+			"localtest aliases changed with pgadmin: without=%v with=%v",
+			without.NetworkAliases,
+			with.NetworkAliases,
+		)
+	}
+}
+
 func TestMonitoringContainers_OtelUsesLocalDomainAlias(t *testing.T) {
 	containers := monitoringContainers(t.TempDir(), testTopology())
 
@@ -294,7 +314,7 @@ func TestCoreContainers_PgAdminUsesImportedPassfile(t *testing.T) {
 	t.Setenv(config.EnvCI, "")
 
 	dataDir := t.TempDir()
-	containers := coreContainers(dataDir, testTopology(), false, true)
+	containers := coreContainers(dataDir, testTopology())
 
 	index := slices.IndexFunc(containers, func(spec ContainerSpec) bool {
 		return spec.Name == ContainerPgAdmin

--- a/src/cli/internal/cmd/env/localtest/resources_internal_test.go
+++ b/src/cli/internal/cmd/env/localtest/resources_internal_test.go
@@ -270,12 +270,11 @@ func TestResourceBuilder_FailsForUnknownContainerDependency(t *testing.T) {
 		&specs[0],
 		images["localtest-dependent"],
 		network,
-		nil,
 		"",
 		nil,
 	)
 
-	graph := resource.NewGraph()
+	graph := resource.NewGraph(resource.GraphID(graphID))
 	if err := graph.Add(&resource.Network{Name: NetworkName}); err != nil {
 		t.Fatalf("graph.Add(network) error = %v", err)
 	}

--- a/src/cli/internal/cmd/env/localtest/validate.go
+++ b/src/cli/internal/cmd/env/localtest/validate.go
@@ -6,10 +6,14 @@ import (
 	"fmt"
 
 	"altinn.studio/devenv/pkg/container"
+	"altinn.studio/devenv/pkg/resource"
 )
 
 // CheckForLegacyLocaltest checks if legacy localtest containers are running.
 // Returns an error if containers exist without the studioctl management label.
+// TODO: we should do something else for this. Need a smooth migration path
+// and we can probably check docker/podman compose labels or something
+// instead of matching on container names.
 func CheckForLegacyLocaltest(ctx context.Context, client container.ContainerClient, includePgAdmin bool) error {
 	containers := coreContainerNames(includePgAdmin)
 	var legacyContainers []string
@@ -27,7 +31,7 @@ func CheckForLegacyLocaltest(ctx context.Context, client container.ContainerClie
 			continue
 		}
 
-		if info.Labels[LabelKey] == LabelValue {
+		if isStudioctlManagedContainer(info.Labels) {
 			continue
 		}
 
@@ -38,4 +42,8 @@ func CheckForLegacyLocaltest(ctx context.Context, client container.ContainerClie
 		return fmt.Errorf("%w: %v", ErrLegacyLocaltestRunning, legacyContainers)
 	}
 	return nil
+}
+
+func isStudioctlManagedContainer(labels map[string]string) bool {
+	return labels[resource.GraphIDLabel] == graphID
 }

--- a/src/cli/internal/cmd/env/localtest/validate_test.go
+++ b/src/cli/internal/cmd/env/localtest/validate_test.go
@@ -7,10 +7,13 @@ import (
 
 	"altinn.studio/devenv/pkg/container/mock"
 	"altinn.studio/devenv/pkg/container/types"
+	"altinn.studio/devenv/pkg/resource"
 	"altinn.studio/studioctl/internal/cmd/env/localtest"
 )
 
 var errConnRefused = errors.New("connection refused")
+
+const testGraphID = "studioctl-localtest"
 
 func TestCheckForLegacyLocaltest(t *testing.T) {
 	t.Parallel()
@@ -32,12 +35,12 @@ func TestCheckForLegacyLocaltest(t *testing.T) {
 			wantLegacy: false,
 		},
 		{
-			name: "containers exist with studioctl label",
+			name: "containers exist with graph label value",
 			setup: func(c *mock.Client) {
 				c.ContainerInspectFunc = func(_ context.Context, _ string) (types.ContainerInfo, error) {
 					return types.ContainerInfo{
 						State:  types.ContainerState{Running: true},
-						Labels: map[string]string{localtest.LabelKey: localtest.LabelValue},
+						Labels: map[string]string{resource.GraphIDLabel: testGraphID},
 					}, nil
 				}
 			},
@@ -63,7 +66,7 @@ func TestCheckForLegacyLocaltest(t *testing.T) {
 				c.ContainerInspectFunc = func(_ context.Context, _ string) (types.ContainerInfo, error) {
 					return types.ContainerInfo{
 						State:  types.ContainerState{Running: true},
-						Labels: map[string]string{localtest.LabelKey: "other-value"},
+						Labels: map[string]string{resource.GraphIDLabel: "other-value"},
 					}, nil
 				}
 			},
@@ -105,7 +108,7 @@ func TestCheckForLegacyLocaltest(t *testing.T) {
 					}
 					return types.ContainerInfo{
 						State:  types.ContainerState{Running: true},
-						Labels: map[string]string{localtest.LabelKey: localtest.LabelValue},
+						Labels: map[string]string{resource.GraphIDLabel: testGraphID},
 					}, nil
 				}
 			},

--- a/src/cli/internal/cmd/env_internal_test.go
+++ b/src/cli/internal/cmd/env_internal_test.go
@@ -12,6 +12,7 @@ import (
 
 	"altinn.studio/devenv/pkg/container/mock"
 	containertypes "altinn.studio/devenv/pkg/container/types"
+	"altinn.studio/devenv/pkg/resource"
 	envlocaltest "altinn.studio/studioctl/internal/cmd/env/localtest"
 	"altinn.studio/studioctl/internal/config"
 	"altinn.studio/studioctl/internal/envtopology"
@@ -23,16 +24,24 @@ func TestEnvUpJSON_AlreadyRunning(t *testing.T) {
 	t.Parallel()
 
 	client := mock.New()
-	client.ContainerInspectFunc = func(context.Context, string) (containertypes.ContainerInfo, error) {
+	client.ContainerInspectFunc = func(_ context.Context, nameOrID string) (containertypes.ContainerInfo, error) {
+		switch nameOrID {
+		case envlocaltest.ContainerLocaltest,
+			envlocaltest.ContainerPDF3,
+			envlocaltest.ContainerWorkflowEngineDb,
+			envlocaltest.ContainerWorkflowEngine:
+		default:
+			return containertypes.ContainerInfo{}, containertypes.ErrContainerNotFound
+		}
 		return containertypes.ContainerInfo{
-			Labels: map[string]string{envlocaltest.LabelKey: envlocaltest.LabelValue},
+			Labels: map[string]string{resource.GraphIDLabel: "studioctl-localtest"},
 			State:  containertypes.ContainerState{Status: "running", Running: true},
 		}, nil
 	}
 
 	var out bytes.Buffer
 	command := &EnvCommand{
-		cfg: &config.Config{Images: testLocaltestImages()},
+		cfg: testEnvCommandConfig(t),
 		out: ui.NewOutput(&out, io.Discard, false),
 	}
 	err := command.runLocaltestUp(context.Background(), client, envUpFlags{
@@ -50,6 +59,20 @@ func TestEnvUpJSON_AlreadyRunning(t *testing.T) {
 	}
 	if got.Runtime != runtimeLocaltest || !got.Running || got.Started || !got.AlreadyRunning {
 		t.Fatalf("output = %+v, want already running result", got)
+	}
+}
+
+func testEnvCommandConfig(t *testing.T) *config.Config {
+	t.Helper()
+
+	home := t.TempDir()
+	return &config.Config{
+		Home:      home,
+		SocketDir: home,
+		LogDir:    filepath.Join(home, "logs"),
+		DataDir:   filepath.Join(home, "data"),
+		BinDir:    filepath.Join(home, "bin"),
+		Images:    testLocaltestImages(),
 	}
 }
 


### PR DESCRIPTION
## Description

- add graph IDs and label-based ownership for devenv resources
- introduce apply/destroy plans from observed-vs-desired graph state
- destroy managed resources removed from the desired graph
- surface planned destroy/reconcile operations in localtest renderers
- keep localtest container networkaliases stable (bound topology is still writen elsewhere so doesnt affect proxy)

In the future we could do persistent state like terraform etc does... but for now we can do without I think

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added network listing capabilities with filtering support.
  * Introduced explicit resource destruction operations for improved lifecycle control.
  * Implemented resource operation planning with preview capability before execution.
  * Added option to conditionally retain resources during cleanup operations.

* **Improvements**
  * Enhanced resource status monitoring and observation capabilities.
  * Improved identification and tracking of managed resources.
  * Refined handling and visibility of optional components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->