### PR TITLE
fix: studioctl self uninstall should ask for confirmation

### DIFF
--- a/src/cli/internal/cmd/self.go
+++ b/src/cli/internal/cmd/self.go
@@ -16,25 +16,28 @@ import (
 	"altinn.studio/studioctl/internal/ui"
 )
 
-const selfMigrateSubcmd = "__migrate"
-
-var selfInteractiveInput = ui.InteractiveInput
+const (
+	selfMigrateSubcmd = "__migrate"
+	osWindows         = "windows"
+)
 
 // SelfCommand implements the 'self' subcommand.
 type SelfCommand struct {
-	cfg        *config.Config
-	out        *ui.Output
-	service    *selfsvc.Service
-	transition *selfsvc.Transition
+	cfg              *config.Config
+	out              *ui.Output
+	service          *selfsvc.Service
+	transition       *selfsvc.Transition
+	interactiveInput func() (io.Reader, func() error, error)
 }
 
 // NewSelfCommand creates a new self command.
 func NewSelfCommand(cfg *config.Config, out *ui.Output) *SelfCommand {
 	return &SelfCommand{
-		cfg:        cfg,
-		out:        out,
-		service:    selfsvc.NewService(cfg),
-		transition: selfsvc.NewTransition(cfg, out),
+		cfg:              cfg,
+		out:              out,
+		service:          selfsvc.NewService(cfg),
+		transition:       selfsvc.NewTransition(cfg, out),
+		interactiveInput: ui.InteractiveInput,
 	}
 }
 
@@ -329,7 +332,7 @@ func (c *SelfCommand) runUpdate(ctx context.Context, args []string) error {
 		return fmt.Errorf("parsing flags: %w", err)
 	}
 
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == osWindows {
 		return fmt.Errorf("%w: windows executable is locked while running", selfsvc.ErrUpdateUnsupported)
 	}
 
@@ -459,7 +462,7 @@ func (c *SelfCommand) runUninstall(ctx context.Context, args []string) error {
 		return fmt.Errorf("parsing flags: %w", err)
 	}
 
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == osWindows {
 		c.out.Error("Self-uninstall while running is not supported on Windows.")
 		c.out.Println("Run this after studioctl has exited:")
 		c.out.Println(`  Remove-Item "<path-to-studioctl.exe>"`)
@@ -514,7 +517,7 @@ func (c *SelfCommand) confirmUninstallIfNeeded(
 		return true, nil
 	}
 
-	input, cleanup, err := selfInteractiveInput()
+	input, cleanup, err := c.interactiveInput()
 	if err != nil {
 		return false, fmt.Errorf(
 			"%w: --yes is required when no terminal input is available",

--- a/src/cli/internal/cmd/self.go
+++ b/src/cli/internal/cmd/self.go
@@ -18,6 +18,8 @@ import (
 
 const selfMigrateSubcmd = "__migrate"
 
+var selfInteractiveInput = ui.InteractiveInput
+
 // SelfCommand implements the 'self' subcommand.
 type SelfCommand struct {
 	cfg        *config.Config
@@ -428,6 +430,10 @@ func (c *SelfCommand) runMigrate(ctx context.Context, args []string) error {
 	return nil
 }
 
+type selfUninstallFlags struct {
+	yes bool
+}
+
 func (c *SelfCommand) runUninstall(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("self uninstall", flag.ContinueOnError)
 	fs.Usage = func() {
@@ -437,9 +443,14 @@ func (c *SelfCommand) runUninstall(ctx context.Context, args []string) error {
 			fmt.Sprintf("Remove the installed %s.", osutil.CurrentBin()),
 			"",
 			"Options:",
+			"  -y, --yes   Skip confirmation prompt",
 			"  -h, --help  Show this help message",
 		))
 	}
+
+	var flags selfUninstallFlags
+	fs.BoolVar(&flags.yes, "y", false, "Skip confirmation prompt")
+	fs.BoolVar(&flags.yes, "yes", false, "Skip confirmation prompt")
 
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -452,6 +463,12 @@ func (c *SelfCommand) runUninstall(ctx context.Context, args []string) error {
 		c.out.Error("Self-uninstall while running is not supported on Windows.")
 		c.out.Println("Run this after studioctl has exited:")
 		c.out.Println(`  Remove-Item "<path-to-studioctl.exe>"`)
+		return nil
+	}
+
+	if proceed, err := c.confirmUninstallIfNeeded(ctx, flags); err != nil {
+		return err
+	} else if !proceed {
 		return nil
 	}
 
@@ -487,4 +504,42 @@ func (c *SelfCommand) runUninstall(ctx context.Context, args []string) error {
 	c.out.Successf("Removed %s", result.RemovedPath)
 	c.out.Successf("Removed %s", removedHome)
 	return nil
+}
+
+func (c *SelfCommand) confirmUninstallIfNeeded(
+	ctx context.Context,
+	flags selfUninstallFlags,
+) (bool, error) {
+	if flags.yes {
+		return true, nil
+	}
+
+	input, cleanup, err := selfInteractiveInput()
+	if err != nil {
+		return false, fmt.Errorf(
+			"%w: --yes is required when no terminal input is available",
+			ErrInvalidFlagValue,
+		)
+	}
+	defer func() {
+		if cleanupErr := cleanup(); cleanupErr != nil {
+			c.out.Verbosef("failed to close terminal input: %v", cleanupErr)
+		}
+	}()
+
+	confirmed, err := ui.Confirm(
+		ctx,
+		c.out,
+		input,
+		fmt.Sprintf("Uninstall %s and delete local data? [y/N]: ", osutil.CurrentBin()),
+	)
+	if err != nil {
+		return false, fmt.Errorf("confirm uninstall: %w", err)
+	}
+	if !confirmed {
+		c.out.Println("Uninstall cancelled")
+		return false, nil
+	}
+
+	return true, nil
 }

--- a/src/cli/internal/cmd/self_internal_test.go
+++ b/src/cli/internal/cmd/self_internal_test.go
@@ -1,0 +1,118 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"runtime"
+	"strings"
+	"testing"
+
+	"altinn.studio/studioctl/internal/ui"
+)
+
+func TestSelfUninstallConfirmationRequiresYesWithoutTerminal(t *testing.T) {
+	withSelfInteractiveInput(t, func() (io.Reader, func() error, error) {
+		return nil, nil, errors.New("no terminal")
+	})
+
+	command := &SelfCommand{out: ui.NewOutput(io.Discard, io.Discard, false)}
+
+	proceed, err := command.confirmUninstallIfNeeded(context.Background(), selfUninstallFlags{})
+	if err == nil {
+		t.Fatal("confirmUninstallIfNeeded() error = nil, want error")
+	}
+	if !errors.Is(err, ErrInvalidFlagValue) {
+		t.Fatalf("confirmUninstallIfNeeded() error = %v, want %v", err, ErrInvalidFlagValue)
+	}
+	if !strings.Contains(err.Error(), "--yes is required when no terminal input is available") {
+		t.Fatalf("confirmUninstallIfNeeded() error = %v, want --yes message", err)
+	}
+	if proceed {
+		t.Fatal("confirmUninstallIfNeeded() proceed = true, want false")
+	}
+}
+
+func TestSelfUninstallRunRequiresConfirmationBeforePrepare(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("self uninstall exits before confirmation on Windows")
+	}
+	withSelfInteractiveInput(t, func() (io.Reader, func() error, error) {
+		return nil, nil, errors.New("no terminal")
+	})
+
+	command := &SelfCommand{out: ui.NewOutput(io.Discard, io.Discard, false)}
+
+	err := command.runUninstall(context.Background(), nil)
+	if err == nil {
+		t.Fatal("runUninstall() error = nil, want error")
+	}
+	if !errors.Is(err, ErrInvalidFlagValue) {
+		t.Fatalf("runUninstall() error = %v, want %v", err, ErrInvalidFlagValue)
+	}
+}
+
+func TestSelfUninstallConfirmationYesSkipsPrompt(t *testing.T) {
+	withSelfInteractiveInput(t, func() (io.Reader, func() error, error) {
+		t.Fatal("selfInteractiveInput() called with --yes")
+		return nil, nil, nil
+	})
+
+	command := &SelfCommand{out: ui.NewOutput(io.Discard, io.Discard, false)}
+
+	proceed, err := command.confirmUninstallIfNeeded(
+		context.Background(),
+		selfUninstallFlags{yes: true},
+	)
+	if err != nil {
+		t.Fatalf("confirmUninstallIfNeeded() error = %v", err)
+	}
+	if !proceed {
+		t.Fatal("confirmUninstallIfNeeded() proceed = false, want true")
+	}
+}
+
+func TestSelfUninstallConfirmationCancel(t *testing.T) {
+	cleanupCalled := false
+	withSelfInteractiveInput(t, func() (io.Reader, func() error, error) {
+		return strings.NewReader("n\n"), func() error {
+			cleanupCalled = true
+			return nil
+		}, nil
+	})
+
+	var out bytes.Buffer
+	command := &SelfCommand{out: ui.NewOutput(&out, io.Discard, false)}
+
+	proceed, err := command.confirmUninstallIfNeeded(context.Background(), selfUninstallFlags{})
+	if err != nil {
+		t.Fatalf("confirmUninstallIfNeeded() error = %v", err)
+	}
+	if proceed {
+		t.Fatal("confirmUninstallIfNeeded() proceed = true, want false")
+	}
+	if !cleanupCalled {
+		t.Fatal("interactive input cleanup was not called")
+	}
+	got := out.String()
+	if !strings.Contains(got, " and delete local data? [y/N]: ") {
+		t.Fatalf("output = %q, want confirmation prompt", got)
+	}
+	if !strings.Contains(got, "Uninstall cancelled") {
+		t.Fatalf("output = %q, want cancellation message", got)
+	}
+}
+
+func withSelfInteractiveInput(
+	t *testing.T,
+	input func() (io.Reader, func() error, error),
+) {
+	t.Helper()
+
+	old := selfInteractiveInput
+	selfInteractiveInput = input
+	t.Cleanup(func() {
+		selfInteractiveInput = old
+	})
+}

--- a/src/cli/internal/cmd/self_internal_test.go
+++ b/src/cli/internal/cmd/self_internal_test.go
@@ -13,11 +13,12 @@ import (
 )
 
 func TestSelfUninstallConfirmationRequiresYesWithoutTerminal(t *testing.T) {
-	withSelfInteractiveInput(t, func() (io.Reader, func() error, error) {
-		return nil, nil, errors.New("no terminal")
-	})
-
-	command := &SelfCommand{out: ui.NewOutput(io.Discard, io.Discard, false)}
+	command := &SelfCommand{
+		out: ui.NewOutput(io.Discard, io.Discard, false),
+		interactiveInput: func() (io.Reader, func() error, error) {
+			return nil, nil, io.ErrClosedPipe
+		},
+	}
 
 	proceed, err := command.confirmUninstallIfNeeded(context.Background(), selfUninstallFlags{})
 	if err == nil {
@@ -35,14 +36,15 @@ func TestSelfUninstallConfirmationRequiresYesWithoutTerminal(t *testing.T) {
 }
 
 func TestSelfUninstallRunRequiresConfirmationBeforePrepare(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == osWindows {
 		t.Skip("self uninstall exits before confirmation on Windows")
 	}
-	withSelfInteractiveInput(t, func() (io.Reader, func() error, error) {
-		return nil, nil, errors.New("no terminal")
-	})
-
-	command := &SelfCommand{out: ui.NewOutput(io.Discard, io.Discard, false)}
+	command := &SelfCommand{
+		out: ui.NewOutput(io.Discard, io.Discard, false),
+		interactiveInput: func() (io.Reader, func() error, error) {
+			return nil, nil, io.ErrClosedPipe
+		},
+	}
 
 	err := command.runUninstall(context.Background(), nil)
 	if err == nil {
@@ -54,12 +56,13 @@ func TestSelfUninstallRunRequiresConfirmationBeforePrepare(t *testing.T) {
 }
 
 func TestSelfUninstallConfirmationYesSkipsPrompt(t *testing.T) {
-	withSelfInteractiveInput(t, func() (io.Reader, func() error, error) {
-		t.Fatal("selfInteractiveInput() called with --yes")
-		return nil, nil, nil
-	})
-
-	command := &SelfCommand{out: ui.NewOutput(io.Discard, io.Discard, false)}
+	command := &SelfCommand{
+		out: ui.NewOutput(io.Discard, io.Discard, false),
+		interactiveInput: func() (io.Reader, func() error, error) {
+			t.Fatal("interactiveInput() called with --yes")
+			return nil, nil, nil
+		},
+	}
 
 	proceed, err := command.confirmUninstallIfNeeded(
 		context.Background(),
@@ -75,15 +78,17 @@ func TestSelfUninstallConfirmationYesSkipsPrompt(t *testing.T) {
 
 func TestSelfUninstallConfirmationCancel(t *testing.T) {
 	cleanupCalled := false
-	withSelfInteractiveInput(t, func() (io.Reader, func() error, error) {
-		return strings.NewReader("n\n"), func() error {
-			cleanupCalled = true
-			return nil
-		}, nil
-	})
 
 	var out bytes.Buffer
-	command := &SelfCommand{out: ui.NewOutput(&out, io.Discard, false)}
+	command := &SelfCommand{
+		out: ui.NewOutput(&out, io.Discard, false),
+		interactiveInput: func() (io.Reader, func() error, error) {
+			return strings.NewReader("n\n"), func() error {
+				cleanupCalled = true
+				return nil
+			}, nil
+		},
+	}
 
 	proceed, err := command.confirmUninstallIfNeeded(context.Background(), selfUninstallFlags{})
 	if err != nil {
@@ -102,17 +107,4 @@ func TestSelfUninstallConfirmationCancel(t *testing.T) {
 	if !strings.Contains(got, "Uninstall cancelled") {
 		t.Fatalf("output = %q, want cancellation message", got)
 	}
-}
-
-func withSelfInteractiveInput(
-	t *testing.T,
-	input func() (io.Reader, func() error, error),
-) {
-	t.Helper()
-
-	old := selfInteractiveInput
-	selfInteractiveInput = input
-	t.Cleanup(func() {
-		selfInteractiveInput = old
-	})
 }


### PR DESCRIPTION
## Description

since its destructive uninstallation should require confirmation, matches what is done for `env reset`

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The `self uninstall` command now supports `-y/--yes` flag to skip confirmation prompts.
  * Interactive confirmation is required when the flag is omitted; uninstall can be cancelled via the prompt.

* **Tests**
  * Added tests validating confirmation behaviour and interactive prompt handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->