### PR TITLE
chore: studioctl - create constants for OS identifier values

### DIFF
--- a/src/cli/cmd/dev/main.go
+++ b/src/cli/cmd/dev/main.go
@@ -225,11 +225,11 @@ func installWindowsHostMode() error {
 		return fmt.Errorf("create windows staging directory: %w", mkdirErr)
 	}
 
-	binaryPathWSL, err := buildStudioctl("windows", stageDirWSL)
+	binaryPathWSL, err := buildStudioctl(osutil.OSWindows, stageDirWSL)
 	if err != nil {
 		return err
 	}
-	appManagerPathWSL, err := publishAppManager("windows", runtime.GOARCH, stageDirWSL)
+	appManagerPathWSL, err := publishAppManager(osutil.OSWindows, runtime.GOARCH, stageDirWSL)
 	if err != nil {
 		return err
 	}
@@ -350,7 +350,7 @@ Removes build/ and bin/ directories.
 }
 
 func binaryNameWithExt(name, goos string) string {
-	if goos == "windows" {
+	if goos == osutil.OSWindows {
 		return name + ".exe"
 	}
 	return name
@@ -412,21 +412,21 @@ func publishAppManager(goos, goarch, outputDir string) (string, error) {
 
 func dotnetRuntimeIdentifier(goos, goarch string) (string, error) {
 	switch goos {
-	case "linux":
+	case osutil.OSLinux:
 		switch goarch {
 		case goArchAMD64:
 			return "linux-x64", nil
 		case goArchARM64:
 			return "linux-arm64", nil
 		}
-	case "darwin":
+	case osutil.OSDarwin:
 		switch goarch {
 		case goArchAMD64:
 			return "osx-x64", nil
 		case goArchARM64:
 			return "osx-arm64", nil
 		}
-	case "windows":
+	case osutil.OSWindows:
 		switch goarch {
 		case goArchAMD64:
 			return "win-x64", nil

--- a/src/cli/internal/auth/credentials_test.go
+++ b/src/cli/internal/auth/credentials_test.go
@@ -60,7 +60,7 @@ func TestSaveAndLoadCredentials(t *testing.T) {
 	}
 	// Check file mode (permissions) - Unix only
 	// On Windows, permissions are enforced via ACLs, not Unix mode bits
-	if runtime.GOOS != "windows" {
+	if runtime.GOOS != osutil.OSWindows {
 		if info.Mode().Perm() != osutil.FilePermOwnerOnly {
 			t.Errorf("expected permissions 0600, got %o", info.Mode().Perm())
 		}

--- a/src/cli/internal/cmd/doctor/disk.go
+++ b/src/cli/internal/cmd/doctor/disk.go
@@ -13,6 +13,7 @@ import (
 	"altinn.studio/studioctl/internal/auth"
 	"altinn.studio/studioctl/internal/config"
 	"altinn.studio/studioctl/internal/install"
+	"altinn.studio/studioctl/internal/osutil"
 )
 
 func (s *Service) buildDisk() *Disk {
@@ -407,7 +408,7 @@ func (s *Service) checkAppManagerBinaryState() DiskCheck {
 			Message: "path exists but is a directory",
 		}
 	}
-	if runtime.GOOS != osWindows && info.Mode()&0o111 == 0 {
+	if runtime.GOOS != osutil.OSWindows && info.Mode()&0o111 == 0 {
 		return DiskCheck{
 			ID:      "appmgr_binary",
 			Level:   diskLevelWarn,
@@ -426,7 +427,7 @@ func (s *Service) checkAppManagerBinaryState() DiskCheck {
 
 func (s *Service) checkAppManagerRuntimeState() DiskCheck {
 	pidPath := s.cfg.AppManagerPIDPath()
-	if runtime.GOOS == osWindows {
+	if runtime.GOOS == osutil.OSWindows {
 		return checkAppManagerRuntimeStateWindows(s.cfg.Home, pidPath)
 	}
 
@@ -458,7 +459,7 @@ func (s *Service) checkAppManagerRuntimeState() DiskCheck {
 		return *check
 	}
 
-	if runtime.GOOS != osWindows && socketInfo.Mode()&os.ModeSocket == 0 {
+	if runtime.GOOS != osutil.OSWindows && socketInfo.Mode()&os.ModeSocket == 0 {
 		return DiskCheck{
 			ID:      "appmgr_state",
 			Level:   diskLevelWarn,
@@ -677,7 +678,7 @@ func readTrustedFile(path string) ([]byte, error) {
 }
 
 func ownerOnlyPermissionsWarning(mode os.FileMode) string {
-	if runtime.GOOS == osWindows {
+	if runtime.GOOS == osutil.OSWindows {
 		return ""
 	}
 	if mode.Perm()&0o077 != 0 {

--- a/src/cli/internal/cmd/doctor/prereq.go
+++ b/src/cli/internal/cmd/doctor/prereq.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"altinn.studio/devenv/pkg/container"
+	"altinn.studio/studioctl/internal/osutil"
 )
 
 func (s *Service) collectPrerequisites(ctx context.Context) *Prerequisites {
@@ -32,7 +33,7 @@ func (s *Service) collectPrerequisites(ctx context.Context) *Prerequisites {
 		OK:    containerErr == nil,
 	}
 
-	if runtime.GOOS == osWindows {
+	if runtime.GOOS == osutil.OSWindows {
 		windowsValue, windowsErr := s.probeWindowsVersion(ctx)
 		prerequisites.WindowsValue = windowsValue
 		prerequisites.Windows = &Check{

--- a/src/cli/internal/cmd/doctor/service.go
+++ b/src/cli/internal/cmd/doctor/service.go
@@ -27,9 +27,6 @@ const (
 	// minWindowsVersionParts is the minimum number of parts in a Windows version string (major.minor.build).
 	minWindowsVersionParts = 3
 
-	// osWindows is the runtime.GOOS value for Windows.
-	osWindows = "windows"
-
 	// On-disk state file names used by CLI components.
 	doctorConfigFileName       = "config.yaml"
 	doctorResourcesPlatformDir = "AltinnPlatformLocal"

--- a/src/cli/internal/cmd/doctor/system.go
+++ b/src/cli/internal/cmd/doctor/system.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"altinn.studio/devenv/pkg/processutil"
+	"altinn.studio/studioctl/internal/osutil"
 	"altinn.studio/studioctl/internal/ui"
 )
 
@@ -36,11 +37,11 @@ func buildSystem(ctx context.Context) *System {
 // getOSVersion returns the OS name and version.
 func getOSVersion(ctx context.Context) (osName, osVersion string) {
 	switch runtime.GOOS {
-	case "linux":
+	case osutil.OSLinux:
 		return getLinuxVersion(ctx)
-	case "darwin":
+	case osutil.OSDarwin:
 		return getDarwinVersion(ctx)
-	case osWindows:
+	case osutil.OSWindows:
 		return getWindowsVersion(ctx)
 	default:
 		return "", ""

--- a/src/cli/internal/cmd/env/localtest/env.go
+++ b/src/cli/internal/cmd/env/localtest/env.go
@@ -51,8 +51,6 @@ const stoppingEnvironmentMessage = "Stopping localtest environment..."
 // graphID scopes devenv ownership labels to studioctl's localtest graph.
 const graphID = "studioctl-localtest"
 
-const windowsGOOS = "windows"
-
 // Env implements envtypes.Env for the localtest runtime.
 type Env struct {
 	cfg    *config.Config
@@ -94,7 +92,7 @@ func (e *Env) Up(ctx context.Context, opts envtypes.UpOptions) error {
 
 	runtimeUser := ""
 	// Keep empty on Windows because os.Getuid/getgid are unsupported there.
-	if runtime.GOOS != windowsGOOS {
+	if runtime.GOOS != osutil.OSWindows {
 		runtimeUser = fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid())
 	}
 	topology := envtopology.NewLocal(envtopology.DefaultIngressPortString())

--- a/src/cli/internal/cmd/env/localtest/env_reset_test.go
+++ b/src/cli/internal/cmd/env/localtest/env_reset_test.go
@@ -17,6 +17,7 @@ import (
 	"altinn.studio/devenv/pkg/resource"
 	"altinn.studio/studioctl/internal/cmd/env/localtest/components"
 	"altinn.studio/studioctl/internal/config"
+	"altinn.studio/studioctl/internal/osutil"
 	"altinn.studio/studioctl/internal/ui"
 )
 
@@ -215,7 +216,7 @@ func TestReset_IgnoresLegacyWorkflowEngineDbDataCleanupFailure(t *testing.T) {
 }
 
 func TestRemoveResetDataPath_RejectsSymlink(t *testing.T) {
-	if runtime.GOOS == windowsGOOS {
+	if runtime.GOOS == osutil.OSWindows {
 		t.Skip("symlink creation requires elevated privileges on some Windows setups")
 	}
 

--- a/src/cli/internal/cmd/env/localtest/hostsfile.go
+++ b/src/cli/internal/cmd/env/localtest/hostsfile.go
@@ -659,7 +659,7 @@ func writeHostsFileAtomic(path, content string, mode fs.FileMode) (retErr error)
 }
 
 func replacePathAtomic(src, dst string) error {
-	if runtime.GOOS != windowsGOOS {
+	if runtime.GOOS != osutil.OSWindows {
 		if err := os.Rename(src, dst); err != nil {
 			return fmt.Errorf("rename %q to %q: %w", src, dst, err)
 		}
@@ -732,7 +732,7 @@ func reserveReplaceBackupPath(dst string) (string, error) {
 }
 
 func syncDirIfSupported(path string) error {
-	if runtime.GOOS == windowsGOOS {
+	if runtime.GOOS == osutil.OSWindows {
 		return nil
 	}
 

--- a/src/cli/internal/cmd/env/localtest/hostsfile_internal_test.go
+++ b/src/cli/internal/cmd/env/localtest/hostsfile_internal_test.go
@@ -7,6 +7,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"altinn.studio/studioctl/internal/osutil"
 )
 
 const testBlockName = "studioctl localtest"
@@ -397,7 +399,7 @@ func TestWriteHostsFileAtomicReplacesExistingFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("os.Stat() error = %v", err)
 	}
-	if runtime.GOOS != windowsGOOS {
+	if runtime.GOOS != osutil.OSWindows {
 		if info.Mode().Perm() != 0o600 {
 			t.Fatalf("perm = %o, want %o", info.Mode().Perm(), 0o600)
 		}

--- a/src/cli/internal/cmd/env/localtest/manifest_internal_test.go
+++ b/src/cli/internal/cmd/env/localtest/manifest_internal_test.go
@@ -268,7 +268,7 @@ func TestManifestPrepareWritesLocalFiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat pgpass: %v", err)
 	}
-	if runtime.GOOS != windowsGOOS && info.Mode().Perm() != osutil.FilePermDefault {
+	if runtime.GOOS != osutil.OSWindows && info.Mode().Perm() != osutil.FilePermDefault {
 		got := info.Mode().Perm()
 		t.Fatalf("pgpass mode = %v, want %v", got, osutil.FilePermDefault)
 	}

--- a/src/cli/internal/cmd/self.go
+++ b/src/cli/internal/cmd/self.go
@@ -18,7 +18,6 @@ import (
 
 const (
 	selfMigrateSubcmd = "__migrate"
-	osWindows         = "windows"
 )
 
 // SelfCommand implements the 'self' subcommand.
@@ -332,7 +331,7 @@ func (c *SelfCommand) runUpdate(ctx context.Context, args []string) error {
 		return fmt.Errorf("parsing flags: %w", err)
 	}
 
-	if runtime.GOOS == osWindows {
+	if runtime.GOOS == osutil.OSWindows {
 		return fmt.Errorf("%w: windows executable is locked while running", selfsvc.ErrUpdateUnsupported)
 	}
 
@@ -462,7 +461,7 @@ func (c *SelfCommand) runUninstall(ctx context.Context, args []string) error {
 		return fmt.Errorf("parsing flags: %w", err)
 	}
 
-	if runtime.GOOS == osWindows {
+	if runtime.GOOS == osutil.OSWindows {
 		c.out.Error("Self-uninstall while running is not supported on Windows.")
 		c.out.Println("Run this after studioctl has exited:")
 		c.out.Println(`  Remove-Item "<path-to-studioctl.exe>"`)

--- a/src/cli/internal/cmd/self/appmanager.go
+++ b/src/cli/internal/cmd/self/appmanager.go
@@ -11,6 +11,7 @@ import (
 
 	"altinn.studio/studioctl/internal/config"
 	installpkg "altinn.studio/studioctl/internal/install"
+	"altinn.studio/studioctl/internal/osutil"
 )
 
 const appManagerAssetBaseName = "app-manager"
@@ -138,7 +139,7 @@ func (s *Service) validatePayloadDir(payloadDir string) error {
 	if info.IsDir() {
 		return fmt.Errorf("%w: %s", errAppManagerExecutablePathDirectory, binaryPath)
 	}
-	if runtime.GOOS != "windows" && info.Mode()&0o111 == 0 {
+	if runtime.GOOS != osutil.OSWindows && info.Mode()&0o111 == 0 {
 		return fmt.Errorf("%w: %s", errAppManagerExecutableNotExecutable, binaryPath)
 	}
 	return nil

--- a/src/cli/internal/cmd/self/selfinstall.go
+++ b/src/cli/internal/cmd/self/selfinstall.go
@@ -15,10 +15,6 @@ import (
 )
 
 const (
-	osLinux   = "linux"
-	osWindows = "windows"
-	osDarwin  = "darwin"
-
 	exeSuffix = ".exe"
 
 	executablePerm = 0o755
@@ -87,9 +83,9 @@ func DetectCandidates(out *ui.Output) []Candidate {
 	var candidates []Candidate
 
 	switch runtime.GOOS {
-	case osLinux, osDarwin:
+	case osutil.OSLinux, osutil.OSDarwin:
 		candidates = unixCandidates(inPath, out)
-	case osWindows:
+	case osutil.OSWindows:
 		candidates = windowsCandidates(inPath, out)
 	default:
 		home, err := os.UserHomeDir()
@@ -261,7 +257,7 @@ func Install(targetDir string) (string, error) {
 	}
 
 	binaryName := "studioctl"
-	if runtime.GOOS == osWindows {
+	if runtime.GOOS == osutil.OSWindows {
 		binaryName += exeSuffix
 	}
 	targetPath := filepath.Join(targetDir, binaryName)
@@ -305,7 +301,7 @@ func InstallFile(srcPath, targetPath string) (string, error) {
 	if err := copyFile(absSource, absTarget); err != nil {
 		return "", fmt.Errorf("copy binary: %w", err)
 	}
-	if runtime.GOOS != osWindows {
+	if runtime.GOOS != osutil.OSWindows {
 		if err := os.Chmod(absTarget, executablePerm); err != nil {
 			return "", fmt.Errorf("make binary executable: %w", err)
 		}
@@ -352,7 +348,7 @@ func copyFile(src, dst string) (err error) {
 }
 
 func replacePath(src, dst string) error {
-	if runtime.GOOS == osWindows {
+	if runtime.GOOS == osutil.OSWindows {
 		return retryReplacePathWindows(src, dst)
 	}
 	return replacePathOnce(src, dst)
@@ -467,7 +463,7 @@ func PathInstructions(dir string) string {
 
 func pathInstructions(goos, dir string) string {
 	switch goos {
-	case "linux":
+	case osutil.OSLinux:
 		return joinLines(
 			fmt.Sprintf("Add %s to your PATH by adding this to your shell profile:", dir),
 			"",
@@ -483,7 +479,7 @@ func pathInstructions(goos, dir string) string {
 			"Then restart your shell or run: source ~/.bashrc (or equivalent)",
 		)
 
-	case "darwin":
+	case osutil.OSDarwin:
 		return joinLines(
 			fmt.Sprintf("Add %s to your PATH by adding this to your shell profile:", dir),
 			"",
@@ -496,7 +492,7 @@ func pathInstructions(goos, dir string) string {
 			"Then restart your shell or run: source ~/.zshrc",
 		)
 
-	case osWindows:
+	case osutil.OSWindows:
 		displayDir := strings.TrimRight(dir, `\/`) + `\`
 		return joinLines(
 			fmt.Sprintf("Add %s to your PATH:", displayDir),

--- a/src/cli/internal/cmd/self/selfinstall_test.go
+++ b/src/cli/internal/cmd/self/selfinstall_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 
 	"altinn.studio/studioctl/internal/cmd/self"
+	"altinn.studio/studioctl/internal/osutil"
 )
 
 func TestPathInstructionsWindowsUsesTrailingBackslash(t *testing.T) {
 	t.Parallel()
-	if runtime.GOOS != "windows" {
+	if runtime.GOOS != osutil.OSWindows {
 		t.Skip("windows-specific PATH instructions")
 	}
 

--- a/src/cli/internal/cmd/self/selfmanage.go
+++ b/src/cli/internal/cmd/self/selfmanage.go
@@ -89,7 +89,7 @@ func (s *Service) UpdateBinary(ctx context.Context, opts UpdateOptions) (result 
 		return UpdateResult{}, fmt.Errorf("resolve current executable path: %w", err)
 	}
 
-	if runtime.GOOS == osWindows {
+	if runtime.GOOS == osutil.OSWindows {
 		return UpdateResult{}, fmt.Errorf(
 			"%w: windows executable is locked while running",
 			ErrUpdateUnsupported,
@@ -394,7 +394,7 @@ func downloadUpdateBinary(
 	}
 
 	binaryPath = filepath.Join(tmpDir, "studioctl-download")
-	if runtime.GOOS == osWindows {
+	if runtime.GOOS == osutil.OSWindows {
 		binaryPath += exeSuffix
 	}
 
@@ -402,7 +402,7 @@ func downloadUpdateBinary(
 		return "", cleanup, err
 	}
 
-	if runtime.GOOS != osWindows {
+	if runtime.GOOS != osutil.OSWindows {
 		if err := os.Chmod(binaryPath, executablePerm); err != nil {
 			return "", cleanup, fmt.Errorf("make downloaded binary executable: %w", err)
 		}
@@ -415,7 +415,7 @@ func installFromDownloadedBinary(downloadedBinaryPath, targetPath string) error 
 	if err := copyFile(downloadedBinaryPath, targetPath); err != nil {
 		return fmt.Errorf("replace installed binary: %w", err)
 	}
-	if runtime.GOOS != osWindows {
+	if runtime.GOOS != osutil.OSWindows {
 		if err := os.Chmod(targetPath, executablePerm); err != nil {
 			return fmt.Errorf("make installed binary executable: %w", err)
 		}
@@ -430,7 +430,7 @@ func (s *Service) UninstallBinary() (UninstallResult, error) {
 		return UninstallResult{}, fmt.Errorf("resolve current executable path: %w", err)
 	}
 
-	if runtime.GOOS == osWindows {
+	if runtime.GOOS == osutil.OSWindows {
 		return UninstallResult{}, fmt.Errorf(
 			"%w: remove manually after process exits",
 			ErrUninstallUnsupported,
@@ -510,7 +510,7 @@ func isPathRoot(path string) bool {
 func samePath(left, right string) bool {
 	left = filepath.Clean(left)
 	right = filepath.Clean(right)
-	if runtime.GOOS == osWindows {
+	if runtime.GOOS == osutil.OSWindows {
 		return strings.EqualFold(left, right)
 	}
 	return left == right
@@ -571,7 +571,7 @@ func defaultAssetName(baseName, goos, goarch string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if goos == osWindows {
+	if goos == osutil.OSWindows {
 		asset += exeSuffix
 	}
 	return asset, nil
@@ -580,12 +580,12 @@ func defaultAssetName(baseName, goos, goarch string) (string, error) {
 func baseAssetName(baseName, goos, goarch string) (string, error) {
 	var osPart string
 	switch goos {
-	case osLinux:
-		osPart = osLinux
-	case osDarwin:
-		osPart = osDarwin
-	case osWindows:
-		osPart = osWindows
+	case osutil.OSLinux:
+		osPart = osutil.OSLinux
+	case osutil.OSDarwin:
+		osPart = osutil.OSDarwin
+	case osutil.OSWindows:
+		osPart = osutil.OSWindows
 	default:
 		return "", fmt.Errorf("%w: %s", ErrUnsupportedPlatform, goos)
 	}

--- a/src/cli/internal/cmd/self/selfmanage_test.go
+++ b/src/cli/internal/cmd/self/selfmanage_test.go
@@ -11,6 +11,7 @@ import (
 
 	self "altinn.studio/studioctl/internal/cmd/self"
 	"altinn.studio/studioctl/internal/config"
+	"altinn.studio/studioctl/internal/osutil"
 	"altinn.studio/studioctl/internal/ui"
 )
 
@@ -55,11 +56,11 @@ func TestDefaultAssetName(t *testing.T) {
 		goarch      string
 		want        string
 	}{
-		{name: "linux amd64", goos: "linux", goarch: "amd64", want: "studioctl-linux-amd64"},
-		{name: "darwin arm64", goos: "darwin", goarch: "arm64", want: "studioctl-darwin-arm64"},
-		{name: "windows amd64", goos: "windows", goarch: "amd64", want: "studioctl-windows-amd64.exe"},
+		{name: "linux amd64", goos: osutil.OSLinux, goarch: "amd64", want: "studioctl-linux-amd64"},
+		{name: "darwin arm64", goos: osutil.OSDarwin, goarch: "arm64", want: "studioctl-darwin-arm64"},
+		{name: "windows amd64", goos: osutil.OSWindows, goarch: "amd64", want: "studioctl-windows-amd64.exe"},
 		{name: "unsupported os", goos: "plan9", goarch: "amd64", wantErrType: self.ErrUnsupportedPlatform},
-		{name: "unsupported arch", goos: "linux", goarch: "386", wantErrType: self.ErrUnsupportedArchitecture},
+		{name: "unsupported arch", goos: osutil.OSLinux, goarch: "386", wantErrType: self.ErrUnsupportedArchitecture},
 	}
 
 	for _, tc := range tests {
@@ -86,7 +87,7 @@ func TestDefaultAssetName(t *testing.T) {
 func TestAppManagerAssetName(t *testing.T) {
 	t.Parallel()
 
-	got, err := self.AppManagerAssetName("windows", "amd64")
+	got, err := self.AppManagerAssetName(osutil.OSWindows, "amd64")
 	if err != nil {
 		t.Fatalf("AppManagerAssetName() unexpected error: %v", err)
 	}

--- a/src/cli/internal/cmd/self/staged_install.go
+++ b/src/cli/internal/cmd/self/staged_install.go
@@ -140,7 +140,7 @@ func copyDirectoryContents(srcDir, dstDir string) error {
 		if err := copyFile(srcPath, dstPath); err != nil {
 			return fmt.Errorf("copy payload file %q: %w", srcPath, err)
 		}
-		if runtime.GOOS != osWindows {
+		if runtime.GOOS != osutil.OSWindows {
 			//nolint:gosec // G304/G703: destination path is derived from the staged install directory.
 			if err := os.Chmod(dstPath, info.Mode().Perm()); err != nil {
 				return fmt.Errorf("set permissions on %q: %w", dstPath, err)

--- a/src/cli/internal/cmd/self_internal_test.go
+++ b/src/cli/internal/cmd/self_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"altinn.studio/studioctl/internal/osutil"
 	"altinn.studio/studioctl/internal/ui"
 )
 
@@ -36,7 +37,7 @@ func TestSelfUninstallConfirmationRequiresYesWithoutTerminal(t *testing.T) {
 }
 
 func TestSelfUninstallRunRequiresConfirmationBeforePrepare(t *testing.T) {
-	if runtime.GOOS == osWindows {
+	if runtime.GOOS == osutil.OSWindows {
 		t.Skip("self uninstall exits before confirmation on Windows")
 	}
 	command := &SelfCommand{

--- a/src/cli/internal/cmd/shell/service.go
+++ b/src/cli/internal/cmd/shell/service.go
@@ -17,8 +17,6 @@ import (
 )
 
 const (
-	osWindows = "windows"
-
 	shellBash       = "bash"
 	shellZsh        = "zsh"
 	shellFish       = "fish"
@@ -170,7 +168,7 @@ func getBinaryPath() (string, error) {
 }
 
 func detectShell() string {
-	if runtime.GOOS == osWindows {
+	if runtime.GOOS == osutil.OSWindows {
 		return shellPowerShell
 	}
 

--- a/src/cli/internal/config/config.go
+++ b/src/cli/internal/config/config.go
@@ -242,7 +242,7 @@ func (c *Config) AppLogDir(appID string) string {
 // On Windows, the .exe suffix is automatically appended.
 func (c *Config) AppManagerBinaryPath() string {
 	name := "app-manager"
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == osutil.OSWindows {
 		name += ".exe"
 	}
 	return filepath.Join(c.AppManagerInstallDir(), name)

--- a/src/cli/internal/install/install_test.go
+++ b/src/cli/internal/install/install_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"altinn.studio/studioctl/internal/config"
+	"altinn.studio/studioctl/internal/osutil"
 )
 
 const releaseMarkerV1 = "release-version:studioctl/v1.0.0\n"
@@ -536,7 +537,7 @@ func TestExtractTarGz_ReplacesWrongTypePaths(t *testing.T) {
 
 func TestExtractTarGz_PreservesFileModeWhenEnabled(t *testing.T) {
 	t.Parallel()
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == osutil.OSWindows {
 		t.Skip("Windows does not preserve POSIX executable bits")
 	}
 

--- a/src/cli/internal/osutil/browser.go
+++ b/src/cli/internal/osutil/browser.go
@@ -18,8 +18,6 @@ var (
 	errUnsupportedURLScheme  = errors.New("unsupported browser url scheme")
 )
 
-const goosLinux = "linux"
-
 // OpenContext opens the given URL in the default browser with context support.
 func OpenContext(ctx context.Context, rawURL string) error {
 	safeURL, err := validateBrowserURL(rawURL)
@@ -27,17 +25,17 @@ func OpenContext(ctx context.Context, rawURL string) error {
 		return err
 	}
 
-	if runtime.GOOS == goosLinux && IsWSL() {
+	if runtime.GOOS == OSLinux && IsWSL() {
 		return openWSL(ctx, safeURL)
 	}
 
 	var cmd *exec.Cmd
 	switch runtime.GOOS {
-	case goosLinux:
+	case OSLinux:
 		cmd = processutil.CommandContext(ctx, "xdg-open", safeURL)
-	case "darwin":
+	case OSDarwin:
 		cmd = processutil.CommandContext(ctx, "open", safeURL)
-	case "windows":
+	case OSWindows:
 		cmd = processutil.CommandContext(ctx, "cmd", "/c", "start", "", safeURL)
 	default:
 		return fmt.Errorf("%w: %s", ErrUnsupportedPlatform, runtime.GOOS)

--- a/src/cli/internal/osutil/hosts.go
+++ b/src/cli/internal/osutil/hosts.go
@@ -18,11 +18,11 @@ type HostsTarget struct {
 // LocalHostsFileTargets returns hosts files that should be updated on the current system.
 func LocalHostsFileTargets() ([]HostsTarget, error) {
 	switch runtime.GOOS {
-	case "darwin":
+	case OSDarwin:
 		return []HostsTarget{{Label: "macOS", Path: "/etc/hosts", Required: true}}, nil
-	case "linux":
+	case OSLinux:
 		return []HostsTarget{{Label: "Linux", Path: "/etc/hosts", Required: true}}, nil
-	case "windows":
+	case OSWindows:
 		path, err := windowsHostsPathNative()
 		if err != nil {
 			return nil, err

--- a/src/cli/internal/osutil/osutil.go
+++ b/src/cli/internal/osutil/osutil.go
@@ -9,6 +9,15 @@ import (
 
 const fallbackCommandName = "studioctl"
 
+const (
+	// OSLinux is the runtime.GOOS value for Linux.
+	OSLinux = "linux"
+	// OSDarwin is the runtime.GOOS value for macOS.
+	OSDarwin = "darwin"
+	// OSWindows is the runtime.GOOS value for Windows.
+	OSWindows = "windows"
+)
+
 // CurrentBin returns the invoked binary basename, with a stable fallback.
 func CurrentBin() string {
 	if len(os.Args) == 0 || os.Args[0] == "" {


### PR DESCRIPTION
## Description

create OS identifier constants in osutil instead of spread throughout

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal code consistency by standardising platform detection throughout the CLI tool. This update consolidates how the application identifies and handles different operating systems, enhancing code maintainability with no impact on user-facing functionality or behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->