### PR TITLE
chore: studioctl - refactor topology statekeeping

### DIFF
--- a/src/Shared/EnvTopology/BoundTopologyConfigurationExtensions.cs
+++ b/src/Shared/EnvTopology/BoundTopologyConfigurationExtensions.cs
@@ -10,7 +10,8 @@ public static class BoundTopologyConfigurationExtensions
 {
     public static IServiceCollection AddBoundTopology(
         this IServiceCollection services,
-        IConfiguration configuration
+        IConfiguration configuration,
+        bool optionalBoundConfig = false
     )
     {
         services.Configure<BoundTopologyOptions>(configuration.GetSection(BoundTopologyOptions.SectionName));
@@ -21,18 +22,18 @@ public static class BoundTopologyConfigurationExtensions
         );
         services.Configure<BoundTopologyConfig>(
             BoundTopologyOptions.BoundName,
-            BoundTopologyConfiguration(configuration[BoundTopologyOptions.ConfigPathConfigurationKey])
+            BoundTopologyConfiguration(configuration[BoundTopologyOptions.ConfigPathConfigurationKey], optionalBoundConfig)
         );
         services.AddSingleton<BoundTopologyIndexAccessor>();
         return services;
     }
 
-    private static IConfiguration BoundTopologyConfiguration(string? path)
+    private static IConfiguration BoundTopologyConfiguration(string? path, bool optional = false)
     {
         var builder = new ConfigurationBuilder();
         if (!string.IsNullOrWhiteSpace(path))
         {
-            builder.AddJsonFile(path, optional: false, reloadOnChange: true);
+            builder.AddJsonFile(path, optional, reloadOnChange: true);
         }
         return builder.Build();
     }

--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -10,6 +10,7 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ### Fixed
 
+- Keep running apps visible in localtest after restarting the localtest environment.
 - Improve localtest resource reconciliation so `env up` removes managed resources that are no longer requested, such as pgAdmin or monitoring, without restarting unchanged core containers.
 
 ## [0.1.0-preview.7] - 2026-04-29

--- a/src/cli/app-manager/Tunnel/ServiceCollectionExtensions.cs
+++ b/src/cli/app-manager/Tunnel/ServiceCollectionExtensions.cs
@@ -18,7 +18,7 @@ internal static class ServiceCollectionExtensions
                 }
             });
         services.AddSingleton(sp => sp.GetRequiredService<IOptions<TunnelOptions>>().Value);
-        services.AddBoundTopology(configuration);
+        services.AddBoundTopology(configuration, optionalBoundConfig: true);
         services.AddSingleton<TunnelState>();
         services.AddSingleton<BoundTopologyConfigReconciler>();
         services.AddHostedService(static sp => sp.GetRequiredService<BoundTopologyConfigReconciler>());

--- a/src/cli/internal/cmd/env/localtest/components/core.go
+++ b/src/cli/internal/cmd/env/localtest/components/core.go
@@ -87,7 +87,6 @@ func localtestEnv(topology envtopology.Local, ingressPort string) map[string]str
 		"GeneralSettings__HostName":                             topology.AppHostName(),
 		"LocalPlatformSettings__LocalTestingStorageBasePath":    "/AltinnPlatformLocal/",
 		"LocalPlatformSettings__LocalTestingStaticTestDataPath": "/testdata/",
-		envtopology.BoundTopologyOptionsBaseConfigPathEnv:       envtopology.BoundTopologyBaseConfigContainerPath,
 		envtopology.BoundTopologyOptionsConfigPathEnv:           envtopology.BoundTopologyConfigContainerPath,
 	}
 }

--- a/src/cli/internal/cmd/env/localtest/manifest_internal_test.go
+++ b/src/cli/internal/cmd/env/localtest/manifest_internal_test.go
@@ -324,12 +324,7 @@ func assertLocaltestCoreContainer(
 
 	assertEnvValue(t, spec.Environment, "ASPNETCORE_URLS", "http://*:5101/;http://*:8000/")
 	assertEnvValue(t, spec.Environment, "DOTNET_ENVIRONMENT", "Development")
-	assertEnvValue(
-		t,
-		spec.Environment,
-		envtopology.BoundTopologyOptionsBaseConfigPathEnv,
-		envtopology.BoundTopologyBaseConfigContainerPath,
-	)
+	assertEnvMissing(t, spec.Environment, envtopology.BoundTopologyOptionsBaseConfigPathEnv)
 	assertEnvValue(
 		t,
 		spec.Environment,

--- a/src/cli/internal/cmd/env/preconditions.go
+++ b/src/cli/internal/cmd/env/preconditions.go
@@ -17,11 +17,7 @@ func EnsureBoundTopology(
 	bindings []envtopology.RuntimeBinding,
 ) error {
 	if err := topology.WriteBoundTopologyBaseConfig(cfg.BoundTopologyBaseConfigPath(), bindings); err != nil {
-		return fmt.Errorf("write base bound topology config: %w", err)
-	}
-
-	if err := topology.WriteBoundTopologyConfig(cfg.BoundTopologyConfigPath(), bindings); err != nil {
-		return fmt.Errorf("write bound topology config: %w", err)
+		return fmt.Errorf("write environment topology config: %w", err)
 	}
 
 	if err := appmanager.EnsureStarted(ctx, cfg, topology.IngressPort()); err != nil {

--- a/src/cli/internal/config/config_test.go
+++ b/src/cli/internal/config/config_test.go
@@ -158,7 +158,7 @@ func TestNewWithEnvSocketDir(t *testing.T) {
 	if cfg.BoundTopologyConfigDir() != filepath.Join(cfg.DataDir, "generated", "topology") {
 		t.Errorf("BoundTopologyConfigDir() = %q, want generated topology dir in data dir", cfg.BoundTopologyConfigDir())
 	}
-	if cfg.BoundTopologyConfigPath() != filepath.Join(cfg.DataDir, "generated", "topology", "bound.json") {
+	if cfg.BoundTopologyConfigPath() != filepath.Join(cfg.DataDir, "generated", "topology", "result.json") {
 		t.Errorf(
 			"BoundTopologyConfigPath() = %q, want generated topology config in data dir",
 			cfg.BoundTopologyConfigPath(),
@@ -168,7 +168,7 @@ func TestNewWithEnvSocketDir(t *testing.T) {
 		cfg.DataDir,
 		"generated",
 		"topology",
-		"base.json",
+		"env.json",
 	) {
 		t.Errorf(
 			"BoundTopologyBaseConfigPath() = %q, want generated base topology config in data dir",

--- a/src/cli/internal/envtopology/bound_topology.go
+++ b/src/cli/internal/envtopology/bound_topology.go
@@ -18,10 +18,10 @@ const (
 	BoundTopologyConfigDirName = "generated/topology"
 
 	// BoundTopologyBaseConfigFileName is the app-manager input config file.
-	BoundTopologyBaseConfigFileName = "base.json"
+	BoundTopologyBaseConfigFileName = "env.json"
 
 	// BoundTopologyConfigFileName is the bound config consumed by localtest.
-	BoundTopologyConfigFileName = "bound.json"
+	BoundTopologyConfigFileName = "result.json"
 
 	// BoundTopologyContainerDir is the localtest mount point for generated topology config.
 	BoundTopologyContainerDir = "/studioctl/topology"

--- a/src/cli/internal/migrations/002_remove_legacy_topology_files.go
+++ b/src/cli/internal/migrations/002_remove_legacy_topology_files.go
@@ -1,0 +1,22 @@
+package migrations
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"altinn.studio/studioctl/internal/config"
+)
+
+func legacyTopologyFiles(_ context.Context, cfg *config.Config) error {
+	for _, name := range []string{"base.json", "bound.json", "base.json.tmp", "bound.json.tmp"} {
+		path := filepath.Join(cfg.BoundTopologyConfigDir(), name)
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("remove legacy topology file %s: %w", path, err)
+		}
+	}
+
+	return nil
+}

--- a/src/cli/internal/migrations/002_remove_legacy_topology_files_test.go
+++ b/src/cli/internal/migrations/002_remove_legacy_topology_files_test.go
@@ -1,0 +1,57 @@
+package migrations_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"altinn.studio/studioctl/internal/envtopology"
+	"altinn.studio/studioctl/internal/migrations"
+)
+
+func TestRunRemovesLegacyTopologyFiles(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig(t)
+	topologyDir := cfg.BoundTopologyConfigDir()
+	if err := os.MkdirAll(topologyDir, 0o700); err != nil {
+		t.Fatalf("create topology dir: %v", err)
+	}
+
+	legacyFiles := []string{"base.json", "bound.json", "base.json.tmp", "bound.json.tmp"}
+	for _, name := range legacyFiles {
+		if err := os.WriteFile(filepath.Join(topologyDir, name), []byte("{}\n"), 0o600); err != nil {
+			t.Fatalf("write legacy topology file %s: %v", name, err)
+		}
+	}
+
+	currentFiles := []string{
+		envtopology.BoundTopologyBaseConfigFileName,
+		envtopology.BoundTopologyConfigFileName,
+	}
+	for _, name := range currentFiles {
+		if err := os.WriteFile(filepath.Join(topologyDir, name), []byte("{}\n"), 0o600); err != nil {
+			t.Fatalf("write current topology file %s: %v", name, err)
+		}
+	}
+
+	if err := migrations.Run(t.Context(), cfg); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	for _, name := range legacyFiles {
+		if _, err := os.Stat(filepath.Join(topologyDir, name)); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("legacy topology file %s stat error = %v, want not exist", name, err)
+		}
+	}
+	for _, name := range currentFiles {
+		if _, err := os.Stat(filepath.Join(topologyDir, name)); err != nil {
+			t.Fatalf("current topology file %s stat error = %v, want exist", name, err)
+		}
+	}
+
+	if err := migrations.Run(t.Context(), cfg); err != nil {
+		t.Fatalf("second Run() error = %v", err)
+	}
+}

--- a/src/cli/internal/migrations/registered.go
+++ b/src/cli/internal/migrations/registered.go
@@ -6,5 +6,9 @@ func registeredMigrations() []Migration {
 			ID: "001-remove-legacy-network-metadata",
 			Up: legacyNetworkMetadata,
 		},
+		{
+			ID: "002-remove-legacy-topology-files",
+			Up: legacyTopologyFiles,
+		},
 	}
 }


### PR DESCRIPTION
## Description

Ensures single writer per topology file.
Previously were vulnerable to `env up` overwriting the bound.json file which could contain app paths. app-manager only updates the file when there is a diff in comparison to cached content. This replaces base.json with env.json, which includes the "runtime bindings", while result.json becomes runtime bindigs + app discovery.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic migration to remove legacy topology configuration files during system updates.

* **Chores**
  * Updated internal topology configuration file naming conventions.
  * Optimised environment configuration handling for topology setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->