### PR TITLE
chore: studioctl - logs `--follow` false by default

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -8,6 +8,10 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+### Changed
+
+- Breaking: make `--follow` default to `false` for log commands.
+
 ### Fixed
 
 - Keep running apps visible in localtest after restarting the localtest environment.

--- a/src/cli/internal/cmd/env.go
+++ b/src/cli/internal/cmd/env.go
@@ -1024,8 +1024,8 @@ func (c *EnvCommand) parseLogsFlags(args []string) (envLogsFlags, bool, error) {
 	fs.StringVar(&f.runtime, "runtime", runtimeLocaltest, "Runtime to use")
 	fs.StringVar(&f.component, "c", "", "Filter by component")
 	fs.StringVar(&f.component, "component", "", "Filter by component")
-	fs.BoolVar(&f.follow, "f", true, "Follow log output")
-	fs.BoolVar(&f.follow, "follow", true, "Follow log output")
+	fs.BoolVar(&f.follow, "f", defaultLogFollow, "Follow log output")
+	fs.BoolVar(&f.follow, "follow", defaultLogFollow, "Follow log output")
 	fs.BoolVar(&f.jsonOutput, "json", false, "Output as newline-delimited JSON")
 
 	if err := fs.Parse(args); err != nil {

--- a/src/cli/internal/cmd/logs.go
+++ b/src/cli/internal/cmd/logs.go
@@ -83,7 +83,7 @@ func (c *appLogsCommand) usageFor(commandPath string) string {
 		"Options:",
 		"  -p, --path PATH       Specify app directory (overrides auto-detect)",
 		"  --id ID              Select process ID or container ID from 'app ps'",
-		"  -f, --follow         Follow log output (default: true)",
+		"  -f, --follow         Follow log output (default: false)",
 		fmt.Sprintf("  --tail N|all        Number of log lines to show (default: %d)", defaultServersLogTailLines),
 		"  --json              Output as newline-delimited JSON",
 		"  -h, --help          Show this help",
@@ -142,14 +142,14 @@ func (c *appLogsCommand) parseFlags(args []string, commandPath string) (appLogsF
 		id:         "",
 		tail:       defaultServersLogTailLines,
 		tailAll:    false,
-		follow:     true,
+		follow:     defaultLogFollow,
 		jsonOutput: false,
 	}
 	fs.StringVar(&flags.appPath, "p", "", "App directory path")
 	fs.StringVar(&flags.appPath, "path", "", "App directory path")
 	fs.StringVar(&flags.id, "id", "", "Process ID or container ID from app ps")
-	fs.BoolVar(&flags.follow, "f", true, "Follow log output")
-	fs.BoolVar(&flags.follow, "follow", true, "Follow log output")
+	fs.BoolVar(&flags.follow, "f", defaultLogFollow, "Follow log output")
+	fs.BoolVar(&flags.follow, "follow", defaultLogFollow, "Follow log output")
 	fs.Var(appLogsTailFlag{all: &flags.tailAll, value: &flags.tail}, "tail", "Number of log lines to show")
 	fs.BoolVar(&flags.jsonOutput, "json", false, "Output as newline-delimited JSON")
 

--- a/src/cli/internal/cmd/root.go
+++ b/src/cli/internal/cmd/root.go
@@ -25,10 +25,11 @@ var (
 )
 
 const (
-	flagHelp      = "--help"
-	flagVersion   = "--version"
-	helpSubcmd    = "help"
-	versionSubcmd = "version"
+	defaultLogFollow = false
+	flagHelp         = "--help"
+	flagVersion      = "--version"
+	helpSubcmd       = "help"
+	versionSubcmd    = "version"
 )
 
 // Command represents a subcommand.

--- a/src/cli/internal/cmd/servers.go
+++ b/src/cli/internal/cmd/servers.go
@@ -149,7 +149,7 @@ func (c *ServersCommand) Usage() string {
 		"  logs    Stream server logs (app-manager)",
 		"",
 		"Options for 'servers logs':",
-		"  -f, --follow  Follow log output (default: true)",
+		"  -f, --follow  Follow log output (default: false)",
 		"  --tail        Number of log lines to show (default: 100)",
 		"  --json        Output as newline-delimited JSON",
 		"",
@@ -283,8 +283,8 @@ func (c *ServersCommand) runLogs(ctx context.Context, args []string) error {
 	var follow bool
 	var jsonOutput bool
 	var tail int
-	fs.BoolVar(&follow, "f", true, "Follow log output")
-	fs.BoolVar(&follow, "follow", true, "Follow log output")
+	fs.BoolVar(&follow, "f", defaultLogFollow, "Follow log output")
+	fs.BoolVar(&follow, "follow", defaultLogFollow, "Follow log output")
 	fs.BoolVar(&jsonOutput, "json", false, "Output as newline-delimited JSON")
 	fs.IntVar(&tail, "tail", defaultServersLogTailLines, "Number of log lines to show")
 	if err := fs.Parse(args); err != nil {


### PR DESCRIPTION
## Description

to match other tooling like docker cli, kubectl etc..

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * The `--follow` flag (`-f`) for log commands now defaults to `false` instead of `true`. Previously, log commands automatically streamed output. Users requiring streaming functionality must now explicitly specify `-f` or `--follow` when executing log commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->