### PR TITLE
fix: fixed displaying of error message in component list

### DIFF
--- a/src/Designer/frontend/packages/ux-editor/src/components/config/editModal/EditBooleanValue.test.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/components/config/editModal/EditBooleanValue.test.tsx
@@ -81,4 +81,29 @@ describe('EditBooleanValue', () => {
       }),
     ).toBeInTheDocument();
   });
+
+  it('should update value when propertyPath is set', async () => {
+    const handleComponentChange = jest.fn();
+    renderEditBooleanValue({
+      handleComponentChange,
+      componentOverrides: {
+        propertyPath: 'definitions/inputComponent',
+      },
+    });
+    const inputElement = screen.getByLabelText(textMock('ux_editor.component_properties.required'));
+    await user.click(inputElement);
+    await waitFor(() => {
+      expect(handleComponentChange).toHaveBeenCalledWith({
+        id: 'c24d0812-0c34-4582-8f31-ff4ce9795e96',
+        type: ComponentType.Input,
+        textResourceBindings: {
+          title: 'ServiceName',
+        },
+        required: true,
+        itemType: 'COMPONENT',
+        dataModelBindings: { simpleBinding: { field: 'some-path', dataType: '' } },
+        propertyPath: 'definitions/inputComponent',
+      });
+    });
+  });
 });

--- a/src/Designer/frontend/packages/ux-editor/src/components/config/editModal/EditBooleanValue.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/components/config/editModal/EditBooleanValue.tsx
@@ -20,10 +20,10 @@ export const EditBooleanValue = ({
   const componentPropertyLabel = useComponentPropertyLabel();
   const componentPropertyHelpText = useComponentPropertyHelpText();
 
-  const handleChange = () => {
+  const handleChange = (newValue: boolean) => {
     handleComponentChange({
       ...component,
-      [propertyKey]: getNewBooleanValue(),
+      [propertyKey]: newValue,
     });
   };
 
@@ -31,18 +31,20 @@ export const EditBooleanValue = ({
     return Array.isArray(value);
   };
 
-  const getNewBooleanValue = () => !(component[propertyKey] ?? defaultValue);
-
   const helpText = isValueExpression(component[propertyKey])
     ? t('ux_editor.component_properties.config_is_expression_message')
     : componentPropertyHelpText(propertyKey);
+
+  const schemaPropertyPath = component.propertyPath
+    ? `${component.propertyPath}/properties/${propertyKey}`
+    : undefined;
 
   return (
     <FormField
       id={component.id}
       value={component[propertyKey]}
       onChange={handleChange}
-      propertyPath={component.propertyPath}
+      propertyPath={schemaPropertyPath}
       componentType={component.type}
       helpText={helpText}
       className={className}

--- a/src/Designer/frontend/packages/ux-editor/src/components/config/editModal/EditNumberValue.test.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/components/config/editModal/EditNumberValue.test.tsx
@@ -17,6 +17,7 @@ const renderEditNumberValue = async ({
   enumValues = null,
   maxLength = undefined,
   handleComponentChange = jest.fn(),
+  componentOverrides = {},
 } = {}) => {
   await waitForData();
 
@@ -34,6 +35,7 @@ const renderEditNumberValue = async ({
         maxLength,
         itemType: 'COMPONENT',
         dataModelBindings: { simpleBinding: { field: 'some-path', dataType: '' } },
+        ...componentOverrides,
       }}
     />,
   );
@@ -131,5 +133,26 @@ describe('EditNumberValue', () => {
     mockHandleComponentChange.mockClear();
     await user.clear(input);
     expect(mockHandleComponentChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('should update value when propertyPath is set', async () => {
+    const user = userEvent.setup();
+    const mockHandleComponentChange = jest.fn((componentProperties, _) => componentProperties);
+    await renderEditNumberValue({
+      handleComponentChange: mockHandleComponentChange,
+      componentOverrides: { propertyPath: 'definitions/inputComponent' },
+    });
+    await user.type(screen.getByRole('textbox'), '2');
+    expect(mockHandleComponentChange).toHaveReturnedWith({
+      id: 'c24d0812-0c34-4582-8f31-ff4ce9795e96',
+      type: ComponentType.Input,
+      textResourceBindings: {
+        title: 'ServiceName',
+      },
+      maxLength: 2,
+      itemType: 'COMPONENT',
+      dataModelBindings: { simpleBinding: { field: 'some-path', dataType: '' } },
+      propertyPath: 'definitions/inputComponent',
+    });
   });
 });

--- a/src/Designer/frontend/packages/ux-editor/src/components/config/editModal/EditNumberValue.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/components/config/editModal/EditNumberValue.tsx
@@ -48,13 +48,17 @@ export const EditNumberValue = <T extends ComponentType, K extends NumberKeys<Fo
     );
   };
 
+  const schemaPropertyPath = component.propertyPath
+    ? `${component.propertyPath}/properties/${String(propertyKey)}`
+    : undefined;
+
   return (
     <FormField
       id={component.id}
       label={componentPropertyLabel(String(propertyKey))}
       value={component[propertyKey]}
       onChange={handleValueChange}
-      propertyPath={component.propertyPath}
+      propertyPath={schemaPropertyPath}
       helpText={componentPropertyHelpText(String(propertyKey))}
       renderField={({ fieldProps }) =>
         enumValues ? (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

  CLOSES: #18315 

https://github.com/user-attachments/assets/eba102c2-7769-46ff-97eb-d8b79c4803ef



## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable boolean handling in configuration forms to ensure accurate state updates.
  * Improved property-path derivation for number and boolean fields so form fields align better with schema locations.
* **Tests**
  * Added tests verifying property-path is preserved when editing numeric and boolean configuration fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->