### PR TITLE
fix(admin): add beta tag to admin menu links

### DIFF
--- a/src/Designer/frontend/dashboard/utils/headerUtils/headerUtils.ts
+++ b/src/Designer/frontend/dashboard/utils/headerUtils/headerUtils.ts
@@ -24,6 +24,7 @@ export const dashboardHeaderMenuItems: HeaderMenuItem[] = [
     group: HeaderMenuGroupKey.Tools,
     featureFlag: FeatureFlag.Admin,
     isExternalLink: true,
+    isBeta: true,
   },
   {
     key: HeaderMenuItemKey.OrgLibrary,

--- a/src/Designer/frontend/packages/shared/src/components/PageHeader/PageHeader.tsx
+++ b/src/Designer/frontend/packages/shared/src/components/PageHeader/PageHeader.tsx
@@ -44,6 +44,7 @@ export const PageHeader = ({ owner, onOrgSelect, onUserSelect }: PageHeaderProps
             href: `${ADMIN_BASENAME}/${owner ?? ''}`,
             textKey: 'admin.apps.title',
             isActive: isPathActive(pathname, ADMIN_BASENAME),
+            isBeta: true,
           },
         ]
       : []),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add a beta tag to admin links since it is still behind a feature flag and still contain some bugs, such as the first request that retrieves instances in production, which takes around 7 seconds to run.

| BEFORE | AFTER |
|--------|--------|
| <img width="859" height="187" alt="Screenshot from 2026-05-06 10-22-02" src="https://github.com/user-attachments/assets/b821274e-7acf-4828-a2cd-5741dd2af337" /> | <img width="859" height="187" alt="Screenshot from 2026-05-06 10-21-56" src="https://github.com/user-attachments/assets/0a2e8115-a28e-4291-9357-33a6b7a16ced" /> | 

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added beta designation support to header menu items, allowing certain navigation options to be marked as beta to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->