### PR TITLE
fix: only user api keys for bot users

### DIFF
--- a/src/Designer/backend/src/Designer/Services/Implementation/BotAccountService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/BotAccountService.cs
@@ -179,7 +179,7 @@ public class BotAccountService(
     )
     {
         var botAccount = await GetBotAccountModelAsync(botAccountId, org, cancellationToken);
-        return await apiKeyService.ListAsync(botAccount.Username, cancellationToken: cancellationToken);
+        return await apiKeyService.ListAsync(botAccount.Username, ApiKeyType.User, cancellationToken);
     }
 
     public async Task RevokeApiKeyAsync(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Filter user api keys in bot users list endpoint

<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
