### PR TITLE
fix(settings): filter api keys by user type

### DIFF
--- a/src/Designer/backend/src/Designer/Services/Implementation/BotAccountService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/BotAccountService.cs
@@ -91,7 +91,7 @@ public class BotAccountService(
     {
         return await dbContext
             .ApiKeys.AsNoTracking()
-            .Where(k => botAccountIds.Contains(k.UserAccount.Id) && !k.Revoked)
+            .Where(k => botAccountIds.Contains(k.UserAccount.Id) && !k.Revoked && k.TokenType == ApiKeyType.User)
             .GroupBy(k => k.UserAccount.Id)
             .ToDictionaryAsync(g => g.Key, g => g.Count(), cancellationToken);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`GetApiKeyCountsByBotIdsAsync` is counting all API keys regardless of type, while ``ListApiKeysAsync`` only returns User type keys, causing the counts to mismatch.

#### Show `5 nøkler` when api keys is collapsed

<img width="3081" height="220" alt="1a" src="https://github.com/user-attachments/assets/000fd84f-d384-4ccb-845f-f4beb9150257" />

#### Show `2 nøkler` when api keys is expanded

<img width="3081" height="842" alt="1b" src="https://github.com/user-attachments/assets/807f523a-cf1c-4511-b5d0-9df1303d8ff0" />


## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of API key count reporting for bot accounts by filtering to include user-type tokens only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->