### PR TITLE
chore: update version handling in Designer to support v9 apps

### DIFF
--- a/src/Designer/backend/src/Designer/Controllers/AppDevelopmentController.cs
+++ b/src/Designer/backend/src/Designer/Controllers/AppDevelopmentController.cs
@@ -1172,7 +1172,17 @@ public class AppDevelopmentController : Controller
         var editingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(org, app, developer);
 
         var backendVersion = _appDevelopmentService.GetAppLibVersion(editingContext);
-        _appDevelopmentService.TryGetFrontendVersion(editingContext, out string frontendVersion);
+        string frontendVersion;
+
+        // For v9 apps and onwards, Index.cshtml no longer exists and frontend major version aligns with backend major version.
+        if (backendVersion?.Major >= 9)
+        {
+            frontendVersion = backendVersion.Major.ToString();
+        }
+        else
+        {
+            _appDevelopmentService.TryGetFrontendVersion(editingContext, out frontendVersion);
+        }
 
         return new VersionResponse { BackendVersion = backendVersion, FrontendVersion = frontendVersion };
     }

--- a/src/Designer/frontend/app-development/layout/VersionDialog/VersionDialog.tsx
+++ b/src/Designer/frontend/app-development/layout/VersionDialog/VersionDialog.tsx
@@ -11,55 +11,44 @@ import {
 import { useTranslation } from 'react-i18next';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useLocalStorage } from '@studio/components-legacy';
-import {
-  MAXIMUM_SUPPORTED_BACKEND_VERSION,
-  MAXIMUM_SUPPORTED_FRONTEND_VERSION,
-  MINIMUM_SUPPORTED_BACKEND_VERSION,
-  MINIMUM_SUPPORTED_FRONTEND_VERSION,
-} from 'app-shared/constants';
 import { altinnDocsUrl } from 'app-shared/ext-urls';
 import classes from './VersionDialog.module.css';
 import cn from 'classnames';
 import type { AppVersion } from 'app-shared/types/AppVersion';
 import { RemindChoiceDialog } from 'app-shared/components/RemindChoiceDialog/RemindChoiceDialog';
-import { isBelowSupportedVersion } from 'app-shared/utils/compareFunctions';
 import { VersionDialogTableRow } from './VersionDialogTableRow';
+import { useVersionStatus, type VersionStatus } from './useVersionStatus';
 
 export const VersionDialog = () => {
   const { org, app } = useStudioEnvironmentParams();
   const { data } = useAppVersionQuery(org, app);
   const { t } = useTranslation();
+  const versionStatus = useVersionStatus(data);
 
-  if (!data) {
+  if (!versionStatus) {
     return;
   }
 
-  const isUnsupported =
-    isBelowSupportedVersion(data.frontendVersion, MINIMUM_SUPPORTED_FRONTEND_VERSION) ||
-    isBelowSupportedVersion(data.backendVersion, MINIMUM_SUPPORTED_BACKEND_VERSION);
-
-  if (isUnsupported) {
+  if (versionStatus.isUnsupported) {
     return (
       <Dialog
         title={t('version_dialog.unsupported_version_title')}
         frontendVersion={data.frontendVersion}
         backendVersion={data.backendVersion}
+        versionStatus={versionStatus}
       >
         {t('version_dialog.unsupported_version_content')}
       </Dialog>
     );
   }
 
-  const isOutdated =
-    isBelowSupportedVersion(data.frontendVersion, MAXIMUM_SUPPORTED_FRONTEND_VERSION) ||
-    isBelowSupportedVersion(data.backendVersion, MAXIMUM_SUPPORTED_BACKEND_VERSION);
-
-  if (isOutdated) {
+  if (versionStatus.isOutdated) {
     return (
       <Dialog
         title={t('version_dialog.outdated_version_title')}
         frontendVersion={data.frontendVersion}
         backendVersion={data.backendVersion}
+        versionStatus={versionStatus}
       >
         <StudioParagraph>{t('version_dialog.outdated_version_description')}</StudioParagraph>
         <StudioParagraph>{t('version_dialog.outdated_version_recommendation')}</StudioParagraph>
@@ -76,9 +65,17 @@ type DialogProps = {
   frontendVersion: string;
   backendVersion: string;
   className?: string;
+  versionStatus: VersionStatus;
 };
 
-const Dialog = ({ title, children, frontendVersion, backendVersion, className }: DialogProps) => {
+const Dialog = ({
+  title,
+  children,
+  frontendVersion,
+  backendVersion,
+  className,
+  versionStatus,
+}: DialogProps) => {
   const { org, app } = useStudioEnvironmentParams();
   const { t } = useTranslation();
 
@@ -105,15 +102,6 @@ const Dialog = ({ title, children, frontendVersion, backendVersion, className }:
     return;
   }
 
-  const isFrontendVersionOutdated = isBelowSupportedVersion(
-    frontendVersion,
-    MAXIMUM_SUPPORTED_FRONTEND_VERSION,
-  );
-  const isBackendVersionOutdated = isBelowSupportedVersion(
-    backendVersion,
-    MAXIMUM_SUPPORTED_BACKEND_VERSION,
-  );
-
   return (
     <StudioDialog data-color='warning' open={opened} className={classes.dialog} closeButton={false}>
       <RemindChoiceDialog closeDialog={handleCloseDialog} />
@@ -135,11 +123,11 @@ const Dialog = ({ title, children, frontendVersion, backendVersion, className }:
               </StudioTable.Row>
             </StudioTable.Head>
             <StudioTable.Body>
-              {isFrontendVersionOutdated && (
+              {versionStatus.isFrontendOutdated && (
                 <VersionDialogTableRow
                   devTypeLabel={t('version_dialog.frontend')}
                   currentVersion={frontendVersion}
-                  latestVersion={MAXIMUM_SUPPORTED_FRONTEND_VERSION}
+                  latestVersion={versionStatus.maxFrontendVersion}
                   link={{
                     href: altinnDocsUrl({
                       relativeUrl: 'community/changelog/app-frontend/',
@@ -148,11 +136,11 @@ const Dialog = ({ title, children, frontendVersion, backendVersion, className }:
                   }}
                 />
               )}
-              {isBackendVersionOutdated && (
+              {versionStatus.isBackendOutdated && (
                 <VersionDialogTableRow
                   devTypeLabel={t('version_dialog.backend')}
                   currentVersion={backendVersion}
-                  latestVersion={MAXIMUM_SUPPORTED_BACKEND_VERSION}
+                  latestVersion={versionStatus.maxBackendVersion}
                   link={{
                     href: altinnDocsUrl({
                       relativeUrl: 'community/changelog/app-nuget/',

--- a/src/Designer/frontend/app-development/layout/VersionDialog/useVersionStatus.test.tsx
+++ b/src/Designer/frontend/app-development/layout/VersionDialog/useVersionStatus.test.tsx
@@ -1,0 +1,53 @@
+import {
+  MAXIMUM_SUPPORTED_BACKEND_VERSION,
+  MAXIMUM_SUPPORTED_FRONTEND_VERSION,
+  NEXT_V9_VERSION,
+} from 'app-shared/constants';
+import { useVersionStatus } from './useVersionStatus';
+import { type FeatureFlag } from '@studio/feature-flags';
+
+const mockUseFeatureFlag = jest.fn();
+jest.mock('@studio/feature-flags', () => ({
+  ...jest.requireActual('@studio/feature-flags'),
+  useFeatureFlag: (flag: FeatureFlag) => mockUseFeatureFlag(flag),
+}));
+
+describe('useVersionStatus', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns correct version status when NextV9 flag is disabled', () => {
+    mockUseFeatureFlag.mockReturnValue(false);
+    const versionStatus = useVersionStatus({
+      frontendVersion: MAXIMUM_SUPPORTED_FRONTEND_VERSION.toString(),
+      backendVersion: MAXIMUM_SUPPORTED_BACKEND_VERSION.toString(),
+    });
+
+    expect(versionStatus).toEqual({
+      isUnsupported: false,
+      isOutdated: false,
+      isFrontendOutdated: false,
+      isBackendOutdated: false,
+      maxFrontendVersion: MAXIMUM_SUPPORTED_FRONTEND_VERSION,
+      maxBackendVersion: MAXIMUM_SUPPORTED_BACKEND_VERSION,
+    });
+  });
+
+  it('returns correct version status when NextV9 flag is enabled', () => {
+    mockUseFeatureFlag.mockReturnValue(true);
+    const versionStatus = useVersionStatus({
+      frontendVersion: MAXIMUM_SUPPORTED_FRONTEND_VERSION.toString(),
+      backendVersion: MAXIMUM_SUPPORTED_BACKEND_VERSION.toString(),
+    });
+
+    expect(versionStatus).toEqual({
+      isUnsupported: false,
+      isOutdated: true,
+      isFrontendOutdated: true,
+      isBackendOutdated: true,
+      maxFrontendVersion: NEXT_V9_VERSION,
+      maxBackendVersion: NEXT_V9_VERSION,
+    });
+  });
+});

--- a/src/Designer/frontend/app-development/layout/VersionDialog/useVersionStatus.tsx
+++ b/src/Designer/frontend/app-development/layout/VersionDialog/useVersionStatus.tsx
@@ -1,0 +1,55 @@
+import { useFeatureFlag, FeatureFlag } from '@studio/feature-flags';
+import {
+  MAXIMUM_SUPPORTED_BACKEND_VERSION,
+  MAXIMUM_SUPPORTED_FRONTEND_VERSION,
+  MINIMUM_SUPPORTED_BACKEND_VERSION,
+  MINIMUM_SUPPORTED_FRONTEND_VERSION,
+  NEXT_V9_VERSION,
+} from 'app-shared/constants';
+import type { AppVersion } from 'app-shared/types/AppVersion';
+import { isBelowSupportedVersion } from 'app-shared/utils/compareFunctions';
+
+export type VersionStatus = {
+  isUnsupported: boolean;
+  isOutdated: boolean;
+  isFrontendOutdated: boolean;
+  isBackendOutdated: boolean;
+  maxFrontendVersion: number;
+  maxBackendVersion: number;
+};
+
+export const useVersionStatus = (data?: AppVersion): VersionStatus | undefined => {
+  const isNextV9 = useFeatureFlag(FeatureFlag.NextV9);
+  if (!data) return undefined;
+
+  const { minFrontend, maxFrontend, minBackend, maxBackend } = getVersionLimits(isNextV9);
+
+  const isUnsupported =
+    isBelowSupportedVersion(data.frontendVersion, minFrontend) ||
+    isBelowSupportedVersion(data.backendVersion, minBackend);
+  const isFrontendOutdated = isBelowSupportedVersion(data.frontendVersion, maxFrontend);
+  const isBackendOutdated = isBelowSupportedVersion(data.backendVersion, maxBackend);
+
+  return {
+    isUnsupported,
+    isOutdated: isFrontendOutdated || isBackendOutdated,
+    isFrontendOutdated,
+    isBackendOutdated,
+    maxFrontendVersion: maxFrontend,
+    maxBackendVersion: maxBackend,
+  };
+};
+
+type VersionLimits = {
+  minFrontend: number;
+  minBackend: number;
+  maxFrontend: number;
+  maxBackend: number;
+};
+
+const getVersionLimits = (isNextV9: boolean): VersionLimits => ({
+  minFrontend: MINIMUM_SUPPORTED_FRONTEND_VERSION,
+  minBackend: MINIMUM_SUPPORTED_BACKEND_VERSION,
+  maxFrontend: isNextV9 ? NEXT_V9_VERSION : MAXIMUM_SUPPORTED_FRONTEND_VERSION,
+  maxBackend: isNextV9 ? NEXT_V9_VERSION : MAXIMUM_SUPPORTED_BACKEND_VERSION,
+});

--- a/src/Designer/frontend/libs/studio-feature-flags/src/FeatureFlag.ts
+++ b/src/Designer/frontend/libs/studio-feature-flags/src/FeatureFlag.ts
@@ -6,5 +6,6 @@ export enum FeatureFlag {
   CustomTemplates = 'customTemplates',
   Maskinporten = 'maskinporten',
   NewCodeLists = 'newCodeLists',
+  NextV9 = 'nextV9',
   ShouldOverrideAppLibCheck = 'shouldOverrideAppLibCheck',
 }

--- a/src/Designer/frontend/packages/shared/src/constants.js
+++ b/src/Designer/frontend/packages/shared/src/constants.js
@@ -26,6 +26,7 @@ export const MEDIA_QUERY_MAX_WIDTH = '(max-width: 1024px)';
 export const DATA_MODEL_NAME_REGEX = /^[a-zA-Z][a-zA-Z0-9_]*$/;
 export const MINIMUM_SUPPORTED_FRONTEND_VERSION = 3;
 export const MAXIMUM_SUPPORTED_FRONTEND_VERSION = 4;
+export const NEXT_V9_VERSION = 9;
 export const MINIMUM_SUPPORTED_BACKEND_VERSION = 7;
 export const MAXIMUM_SUPPORTED_BACKEND_VERSION = 8;
 export const CODE_LIST_FOLDER = 'CodeLists';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Backend:
Updated `GetAppVersion` controller to support v9 apps. If backend version is v9 or higher, frontend version is aligned to the same version. For older apps (v4 and below), `index.cshtml` is still used to get frontend version.


Frontend:
Created a feature flag for v9 to prepare Designer for upcoming version changes. Used it in `VersionDialog` in `app-developent` that alerts user if the app is an older app version. Refactored `VersionDialog` to move version status logic into a dedicated hook.


<!--- Describe your changes in detail -->

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for backend version 9 and later with improved version compatibility detection.

* **Improvements**
  * Enhanced version checking logic to provide more accurate version status reporting for frontend and backend components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->