### PR TITLE
refactor: moving `layoutOverrides` into `FormStore`

### DIFF
--- a/src/App/frontend/src/features/form/FormContext.tsx
+++ b/src/App/frontend/src/features/form/FormContext.tsx
@@ -2,16 +2,20 @@ import type { StoreApi } from 'zustand';
 
 import { ContextNotProvided, createContext } from 'src/core/contexts/context';
 import { createZustandHooks } from 'src/core/contexts/zustandContext';
+import { processLayouts } from 'src/features/form/layout/LayoutsContext';
+import { makeLayoutLookups } from 'src/features/form/layout/makeLayoutLookups';
 import { pageNavigationHooks } from 'src/features/form/layout/PageNavigationContext';
+import { getUiFolderSettings } from 'src/features/form/ui';
 import { formBootstrapHooks } from 'src/features/formBootstrap/FormBootstrap';
 import { formDataHooks } from 'src/features/formData/FormDataWrite';
 import { validationHooks } from 'src/features/validation/validationContext';
 import { nodesHooks } from 'src/utils/layout/NodesContext';
 import type { PageNavigationSliceState } from 'src/features/form/layout/PageNavigationContext';
-import type { FormBootstrapContextValue } from 'src/features/formBootstrap/types';
+import type { FormBootstrapBase, FormBootstrapContextValue } from 'src/features/formBootstrap/types';
 import type { FormDataMethods, FormDataSliceState } from 'src/features/formData/FormDataWriteStateMachine';
 import type { ValidationSliceState } from 'src/features/validation';
 import type { ValidationInternals } from 'src/features/validation/validationContext';
+import type { ILayoutCollection } from 'src/layout/layout';
 import type { NodesSliceState } from 'src/utils/layout/NodesContext';
 
 const { Provider, useLaxCtx, useCtx } = createContext<FormStoreApi>({
@@ -77,19 +81,45 @@ export type FormStoreSet = (
   replace?: boolean,
 ) => void;
 
-export interface FormBootstrapSliceState extends FormBootstrapContextValue {
-  update: (bootstrap: FormBootstrapContextValue) => void;
+interface FormBootstrapSliceState extends FormBootstrapContextValue {
+  initialLayouts: ILayoutCollection;
+  changeLayouts: (mutator: (existingLayouts: ILayoutCollection) => ILayoutCollection) => void;
+  resetLayouts: () => void;
 }
 
-export function createFormBootstrapSlice(
-  bootstrap: FormBootstrapContextValue,
-  set: FormStoreSet,
-): FormBootstrapSliceState {
+export function processBootstrap(bootstrap: FormBootstrapBase): FormBootstrapContextValue {
+  const defaultDataType = getUiFolderSettings(bootstrap.uiFolder)?.defaultDataType;
+  if (!defaultDataType) {
+    throw new Error(`Expected defaultDataType to be defined for uiFolder: ${bootstrap.uiFolder}`);
+  }
+
+  const processedLayouts = processLayouts(bootstrap.layouts, defaultDataType);
+  const layoutLookups = makeLayoutLookups(processedLayouts.processedLayouts);
+
   return {
     ...bootstrap,
-    update: (nextBootstrap) =>
+    ...processedLayouts,
+    layoutLookups,
+  };
+}
+
+export function createFormBootstrapSlice(bootstrap: FormBootstrapBase, set: FormStoreSet): FormBootstrapSliceState {
+  const processedBootstrap = processBootstrap(bootstrap);
+
+  return {
+    ...processedBootstrap,
+    initialLayouts: bootstrap.layouts,
+    changeLayouts: (mutator) =>
       set((state) => {
-        Object.assign(state.bootstrap, nextBootstrap);
+        const nextLayouts = mutator(structuredClone(state.bootstrap.initialLayouts));
+        Object.assign(state.bootstrap, processBootstrap({ ...state.bootstrap, layouts: nextLayouts }));
+      }),
+    resetLayouts: () =>
+      set((state) => {
+        Object.assign(
+          state.bootstrap,
+          processBootstrap({ ...state.bootstrap, layouts: state.bootstrap.initialLayouts }),
+        );
       }),
   };
 }

--- a/src/App/frontend/src/features/form/FormContext.tsx
+++ b/src/App/frontend/src/features/form/FormContext.tsx
@@ -111,7 +111,7 @@ export function createFormBootstrapSlice(bootstrap: FormBootstrapBase, set: Form
     initialLayouts: bootstrap.layouts,
     changeLayouts: (mutator) =>
       set((state) => {
-        const nextLayouts = mutator(structuredClone(state.bootstrap.initialLayouts));
+        const nextLayouts = mutator(structuredClone(state.bootstrap.layouts));
         Object.assign(state.bootstrap, processBootstrap({ ...state.bootstrap, layouts: nextLayouts }));
       }),
     resetLayouts: () =>

--- a/src/App/frontend/src/features/form/FormProvider.tsx
+++ b/src/App/frontend/src/features/form/FormProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { createStore } from 'zustand';
@@ -14,13 +14,15 @@ import { UpdateDataElementIdsForCypress } from 'src/features/form/DataElementIds
 import {
   createFormBootstrapSlice,
   FormStore,
+  type FormStoreApi,
   FormStoreProvider,
+  type FormStoreSet,
+  type FormStoreState,
   getRootFormStore,
+  processBootstrap,
 } from 'src/features/form/FormContext';
 import { getPrefillFromSessionStorage } from 'src/features/form/getPrefillFromSessionStorage';
 import { useLayoutOverrides } from 'src/features/form/layout/layoutOverrides';
-import { processLayouts } from 'src/features/form/layout/LayoutsContext';
-import { makeLayoutLookups } from 'src/features/form/layout/makeLayoutLookups';
 import { createPageNavigationSlice } from 'src/features/form/layout/PageNavigationContext';
 import { usePageSettings } from 'src/features/form/layoutSettings/processLayoutSettings';
 import { getUiFolderSettings } from 'src/features/form/ui';
@@ -42,8 +44,7 @@ import { useNavigationParam } from 'src/hooks/navigation';
 import { isAxiosError } from 'src/utils/isAxiosError';
 import { createNodesSlice, NodesProvider } from 'src/utils/layout/NodesContext';
 import { HttpStatusCodes } from 'src/utils/network/networking';
-import type { FormStoreApi, FormStoreSet, FormStoreState } from 'src/features/form/FormContext';
-import type { FormBootstrapBase, FormBootstrapContextValue } from 'src/features/formBootstrap/types';
+import type { FormBootstrapBase } from 'src/features/formBootstrap/types';
 import type { FormDataSliceProps } from 'src/features/formData/FormDataWrite';
 
 interface FormProviderProps {
@@ -59,28 +60,21 @@ export function FormProvider({ children, readOnly = false, ...props }: React.Pro
   const parentFromContext = FormStore.raw.useLaxStore();
   const parent = parentFromContext === ContextNotProvided ? undefined : parentFromContext;
   const hasProcess = useHasProcess();
-  const { error, bootstrap: bootstrapBase, layouts: bootstrapLayouts, enabled } = useBoostrapQuery(props);
-  const layouts = useLayoutOverrides(bootstrapLayouts);
-
-  const bootstrap = useMemo<FormBootstrapContextValue | null>(() => {
-    if (bootstrapBase && layouts) {
-      const defaultDataType = getUiFolderSettings(bootstrapBase.uiFolder)?.defaultDataType;
-      if (!defaultDataType) {
-        throw new Error(`Expected defaultDataType to be defined for uiFolder: ${bootstrapBase.uiFolder}`);
-      }
-
-      const processedLayouts = processLayouts(layouts, defaultDataType);
-      const layoutLookups = makeLayoutLookups(processedLayouts.processedLayouts);
-
-      return { ...bootstrapBase, ...processedLayouts, layoutLookups };
-    }
-
-    return null;
-  }, [bootstrapBase, layouts]);
+  const { error, bootstrap, enabled } = useBoostrapQuery(props);
+  const previousBootstrap = useRef<FormBootstrapBase | null>(bootstrap);
 
   const dataSliceProps = useFormDataSliceProps(bootstrap);
-  const bootstrapBaseRef = useRef(bootstrapBase);
   const storeRef = useRef<FormStoreApi | undefined>(undefined);
+
+  if (enabled && bootstrap && dataSliceProps && (!storeRef.current || previousBootstrap.current !== bootstrap)) {
+    // When the bootstrap query changes, or if it's the first render, we should wipe the store and restart. This usually
+    // means we're moved to another task while keeping a similar enough render-tree to cause this to be re-used. The
+    // layouts can change without all of this being reset, however.
+    storeRef.current = createFormStore({ parent, readOnly, data: dataSliceProps, bootstrap });
+    previousBootstrap.current = bootstrap;
+  }
+
+  useLayoutOverrides(storeRef);
 
   useEffect(() => {
     // This injects validations for subform data elements into the top-most form store. They are maintained by
@@ -96,12 +90,6 @@ export function FormProvider({ children, readOnly = false, ...props }: React.Pro
       }
     }
   }, [bootstrap, parent, props.dataElementIdOverride]);
-
-  useLayoutEffect(() => {
-    if (bootstrap) {
-      storeRef.current?.getState().bootstrap.update(bootstrap);
-    }
-  }, [bootstrap]);
 
   if (!enabled) {
     // No point in trying to render a form here, but this can still happen when FormProvider is applied for all tasks
@@ -122,16 +110,8 @@ export function FormProvider({ children, readOnly = false, ...props }: React.Pro
     return <Loader reason='bootstrap-form' />;
   }
 
-  if (!storeRef.current || bootstrapBaseRef.current !== bootstrapBase) {
-    // When the bootstrap query changes, or if it's the first render, we should wipe the store and restart. This usually
-    // means we're moved to another task while keeping a similar enough render-tree to cause this to be re-used. The
-    // layouts can change without all of this being reset, however.
-    storeRef.current = createFormStore({ parent, readOnly, data: dataSliceProps, bootstrap });
-    bootstrapBaseRef.current = bootstrapBase;
-  }
-
   return (
-    <FormStoreProvider value={storeRef.current}>
+    <FormStoreProvider value={storeRef.current!}>
       {window.Cypress && <UpdateDataElementIdsForCypress />}
       <FormDataWriteEffects />
       <ValidationEffects />
@@ -199,7 +179,7 @@ function useBoostrapQuery({ uiFolderOverride, dataElementIdOverride }: FormProvi
     [data, uiFolder],
   );
 
-  return { error, bootstrap, layouts: data?.layouts, enabled };
+  return { error, bootstrap, enabled };
 }
 
 function createFormStore({
@@ -211,14 +191,14 @@ function createFormStore({
   parent: FormStoreApi | undefined;
   data: FormDataSliceProps;
   readOnly: boolean;
-  bootstrap: FormBootstrapContextValue;
+  bootstrap: FormBootstrapBase;
 }): FormStoreApi {
   return createStore<FormStoreState>()(
     immer((set: FormStoreSet) => ({
       parent,
       readOnly,
       data: createFormDataWriteSlice(data, set),
-      validation: createValidationSlice(bootstrap, set),
+      validation: createValidationSlice(processBootstrap(bootstrap), set),
       nodes: createNodesSlice(set),
       pageNavigation: createPageNavigationSlice(set),
       bootstrap: createFormBootstrapSlice(bootstrap, set),
@@ -226,7 +206,7 @@ function createFormStore({
   );
 }
 
-export function useFormDataSliceProps(bootstrap: FormBootstrapContextValue | null): FormDataSliceProps | undefined {
+export function useFormDataSliceProps(bootstrap: FormBootstrapBase | null): FormDataSliceProps | undefined {
   const proxies = useFormDataWriteProxies();
   const selectFromInstance = useSelectFromInstanceData();
   const autoSaveBehavior = usePageSettings().autoSaveBehavior;

--- a/src/App/frontend/src/features/form/layout/layoutOverrides.ts
+++ b/src/App/frontend/src/features/form/layout/layoutOverrides.ts
@@ -7,14 +7,10 @@ const layoutOverrideStores: RefObject<FormStoreApi | undefined>[] = [];
 let windowLayoutOverridesInstalled = false;
 
 function getInnermostStore() {
-  for (let i = layoutOverrideStores.length - 1; i >= 0; i--) {
-    const store = layoutOverrideStores[i]?.current;
-    if (store) {
-      return store;
-    }
-  }
-
-  return undefined;
+  return [...layoutOverrideStores]
+    .reverse()
+    .map((ref) => ref?.current)
+    .find((store) => store !== undefined);
 }
 
 /**

--- a/src/App/frontend/src/features/form/layout/layoutOverrides.ts
+++ b/src/App/frontend/src/features/form/layout/layoutOverrides.ts
@@ -1,71 +1,60 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect } from 'react';
+import type { RefObject } from 'react';
 
-import type { ILayoutCollection } from 'src/layout/layout';
+import type { FormStoreApi } from 'src/features/form/FormContext';
 
-interface LayoutOverrideApi {
-  changeLayouts: (mutator: (existingLayouts: ILayoutCollection) => ILayoutCollection) => void;
-  resetLayouts: () => void;
-}
-
-const layoutOverrideApis: LayoutOverrideApi[] = [];
+const layoutOverrideStores: RefObject<FormStoreApi | undefined>[] = [];
 let windowLayoutOverridesInstalled = false;
 
-export function useLayoutOverrides(bootstrapLayouts: ILayoutCollection | undefined) {
-  const [overrideLayouts, setOverrideLayouts] = useState<ILayoutCollection | undefined>(undefined);
+function getInnermostStore() {
+  for (let i = layoutOverrideStores.length - 1; i >= 0; i--) {
+    const store = layoutOverrideStores[i]?.current;
+    if (store) {
+      return store;
+    }
+  }
 
-  const changeLayouts = useCallback(
-    (mutator: (existingLayouts: ILayoutCollection) => ILayoutCollection) => {
-      const existingLayouts = overrideLayouts ?? bootstrapLayouts;
-      if (!existingLayouts) {
-        throw new Error('Expected form bootstrap to exist before changing layouts');
-      }
+  return undefined;
+}
 
-      setOverrideLayouts(mutator(structuredClone(existingLayouts)));
-    },
-    [bootstrapLayouts, overrideLayouts],
-  );
-
-  const resetLayouts = useCallback(() => {
-    setOverrideLayouts(undefined);
-  }, []);
-
-  useEffect(() => {
-    setOverrideLayouts(undefined);
-  }, [bootstrapLayouts]);
-
+/**
+ * This hook manages the window.changeLayouts() function, which automatically accesses the innermost FormProvider and
+ * exposes a function to change layouts. This is used by:
+ *  - Cypress, in the cy.changeLayouts() command
+ *  - Studio, when changing layouts in the UI editor preview
+ *  - Our own LayoutInspector that lets you change layouts inside devtools
+ */
+export function useLayoutOverrides(storeRef: RefObject<FormStoreApi | undefined>) {
   useEffect(() => {
     if (!windowLayoutOverridesInstalled) {
       window.changeLayouts = (mutator) => {
-        const target = layoutOverrideApis.at(-1);
+        const target = getInnermostStore();
         if (!target) {
           throw new Error('Could not find an active FormProvider to change layouts for');
         }
 
-        target.changeLayouts(mutator);
+        target.getState().bootstrap.changeLayouts(mutator);
       };
 
       window.resetLayouts = () => {
-        const target = layoutOverrideApis.at(-1);
+        const target = getInnermostStore();
         if (!target) {
           throw new Error('Could not find an active FormProvider to reset layouts for');
         }
 
-        target.resetLayouts();
+        target.getState().bootstrap.resetLayouts();
       };
 
       windowLayoutOverridesInstalled = true;
     }
 
-    const api = { changeLayouts, resetLayouts };
-    layoutOverrideApis.push(api);
+    layoutOverrideStores.push(storeRef);
 
     return () => {
-      const idx = layoutOverrideApis.indexOf(api);
+      const idx = layoutOverrideStores.indexOf(storeRef);
       if (idx !== -1) {
-        layoutOverrideApis.splice(idx, 1);
+        layoutOverrideStores.splice(idx, 1);
       }
     };
-  }, [changeLayouts, resetLayouts]);
-
-  return overrideLayouts ?? bootstrapLayouts;
+  }, [storeRef]);
 }


### PR DESCRIPTION
## Description

To clean up and simplify things, I moved the form bootstrap data into `FormStore` in #18652, which also lays the groundwork for simpler selectors in `useExpressionDataSources()` in the future. However, this meant that the 'layout overrides' functionality was awkwardly bolted-on outside the `FormStore`. Instead of the simple-but-brutal 'update everything in the bootstrap slice' function, this now refactors to a more targeted 'update layouts' which is more targeted to what we needed.

Related to #18202, working towards the sub-tasks in #18020

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor

* **Refactor**
  * Improved internal form layout management architecture by restructuring how layouts are processed and modified, enabling more robust handling of layout overrides without affecting user-facing functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio/pull/18693)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->