### PR TITLE
fix: Designer Ansattporten login config

### DIFF
--- a/charts/altinn-designer/values.yaml
+++ b/charts/altinn-designer/values.yaml
@@ -75,15 +75,13 @@ environmentVariables:
     - name: StudioOidcLoginSettings__AccountLinkUrl
       value: https://dev.altinn.studio/repos/user/oauth2/ansattporten
     - name: StudioOidcLoginSettings__AuthorizationDetails__0__Type
-      value: "ansattporten:altinn:service"
+      value: "ansattporten:altinn:resource"
     - name: StudioOidcLoginSettings__AuthorizationDetails__0__Resource
-      value: "urn:altinn:resource:2480:40"
+      value: "urn:altinn:resource:digdir-selvbetjening-klienter"
     - name: StudioOidcLoginSettings__AuthorizationDetails__0__OrganizationForm
       value: "enterprise"
-    - name: StudioOidcLoginSettings__AuthorizationDetails__1__Type
-      value: "ansattporten:altinn:service"
-    - name: StudioOidcLoginSettings__AuthorizationDetails__1__Resource
-      value: "urn:altinn:resource:5613:1"
+    - name: StudioOidcLoginSettings__AuthorizationDetails__0__RepresentationIsRequired
+      value: "false"
     - name: MaskinPortenHttpClientSettings__BaseUrl
       value: "https://api.test.samarbeid.digdir.no"
     - name: FeatureManagement__StudioOidc
@@ -165,15 +163,13 @@ environmentVariables:
     - name: StudioOidcLoginSettings__AccountLinkUrl
       value: https://staging.altinn.studio/repos/user/oauth2/ansattporten
     - name: StudioOidcLoginSettings__AuthorizationDetails__0__Type
-      value: "ansattporten:altinn:service"
+      value: "ansattporten:altinn:resource"
     - name: StudioOidcLoginSettings__AuthorizationDetails__0__Resource
-      value: "urn:altinn:resource:2480:40"
+      value: "urn:altinn:resource:digdir-selvbetjening-klienter"
     - name: StudioOidcLoginSettings__AuthorizationDetails__0__OrganizationForm
       value: "enterprise"
-    - name: StudioOidcLoginSettings__AuthorizationDetails__1__Type
-      value: "ansattporten:altinn:service"
-    - name: StudioOidcLoginSettings__AuthorizationDetails__1__Resource
-      value: "urn:altinn:resource:5613:1"
+    - name: StudioOidcLoginSettings__AuthorizationDetails__0__RepresentationIsRequired
+      value: "false"
     - name: MaskinPortenHttpClientSettings__BaseUrl
       value: "https://api.test.samarbeid.digdir.no"
     - name: FeatureManagement__StudioOidc
@@ -253,15 +249,13 @@ environmentVariables:
     - name: StudioOidcLoginSettings__AccountLinkUrl
       value: https://altinn.studio/repos/user/oauth2/ansattporten
     - name: StudioOidcLoginSettings__AuthorizationDetails__0__Type
-      value: "ansattporten:altinn:service"
+      value: "ansattporten:altinn:resource"
     - name: StudioOidcLoginSettings__AuthorizationDetails__0__Resource
-      value: "urn:altinn:resource:2480:40"
+      value: "urn:altinn:resource:digdir-selvbetjening-klienter"
     - name: StudioOidcLoginSettings__AuthorizationDetails__0__OrganizationForm
       value: "enterprise"
-    - name: StudioOidcLoginSettings__AuthorizationDetails__1__Type
-      value: "ansattporten:altinn:service"
-    - name: StudioOidcLoginSettings__AuthorizationDetails__1__Resource
-      value: "urn:altinn:resource:5613:1"
+    - name: StudioOidcLoginSettings__AuthorizationDetails__0__RepresentationIsRequired
+      value: "false"
     - name: MaskinPortenHttpClientSettings__BaseUrl
       value: "https://api.samarbeid.digdir.no"
     - name: FeatureManagement__StudioOidc

--- a/src/Designer/backend/src/Designer/Configuration/StudioOidcLoginSettings.cs
+++ b/src/Designer/backend/src/Designer/Configuration/StudioOidcLoginSettings.cs
@@ -18,6 +18,11 @@ public class AuthorizationDetail
     [JsonPropertyName("resource")]
     public required string Resource { get; set; }
 
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("organizationform")]
     public string? OrganizationForm { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("representation_is_required")]
+    public bool? RepresentationIsRequired { get; set; }
 }

--- a/src/Designer/backend/src/Designer/Infrastructure/Authorization/OrgAccessHandler.cs
+++ b/src/Designer/backend/src/Designer/Infrastructure/Authorization/OrgAccessHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Text.Json;
@@ -15,7 +16,7 @@ using Microsoft.IdentityModel.Tokens;
 namespace Altinn.Studio.Designer.Infrastructure.Authorization;
 
 /// <summary>
-/// Authorization handler that validates authenticated users have reportee access
+/// Authorization handler that validates authenticated users have authorized party access
 /// to the organization for the current app.
 /// </summary>
 public sealed class OrgAccessHandler : AuthorizationHandler<OrgAccessRequirement>
@@ -70,10 +71,10 @@ public sealed class OrgAccessHandler : AuthorizationHandler<OrgAccessRequirement
             return;
         }
 
-        var reporteeOrgNumbers = ExtractReporteeOrgNumbers(accessToken);
-        if (reporteeOrgNumbers.Length == 0)
+        var authorizedPartyOrgNumbers = ExtractAuthorizedPartyOrgNumbers(accessToken);
+        if (authorizedPartyOrgNumbers.Length == 0)
         {
-            LogOrgAccessDecision(org, null, reporteeOrgNumbers, false, "MissingReportees", accessToken);
+            LogOrgAccessDecision(org, null, authorizedPartyOrgNumbers, false, "MissingAuthorizedParties", accessToken);
             context.Fail();
             return;
         }
@@ -81,24 +82,24 @@ public sealed class OrgAccessHandler : AuthorizationHandler<OrgAccessRequirement
         var orgNr = await _environmentsService.GetAltinnOrgNumber(org);
         if (orgNr is null)
         {
-            LogOrgAccessDecision(org, orgNr, reporteeOrgNumbers, false, "UnknownOrgNumber", accessToken);
+            LogOrgAccessDecision(org, orgNr, authorizedPartyOrgNumbers, false, "UnknownOrgNumber", accessToken);
             context.Fail();
             return;
         }
 
-        if (!string.IsNullOrWhiteSpace(orgNr) && reporteeOrgNumbers.Contains(orgNr))
+        if (!string.IsNullOrWhiteSpace(orgNr) && authorizedPartyOrgNumbers.Contains(orgNr))
         {
-            LogOrgAccessDecision(org, orgNr, reporteeOrgNumbers, true, "Granted", accessToken);
+            LogOrgAccessDecision(org, orgNr, authorizedPartyOrgNumbers, true, "Granted", accessToken);
             context.Succeed(requirement);
         }
         else
         {
-            LogOrgAccessDecision(org, orgNr, reporteeOrgNumbers, false, "OrgNumberMismatch", accessToken);
+            LogOrgAccessDecision(org, orgNr, authorizedPartyOrgNumbers, false, "OrgNumberMismatch", accessToken);
             context.Fail();
         }
     }
 
-    internal string[] ExtractReporteeOrgNumbers(string accessToken)
+    internal string[] ExtractAuthorizedPartyOrgNumbers(string accessToken)
     {
         try
         {
@@ -125,25 +126,7 @@ public sealed class OrgAccessHandler : AuthorizationHandler<OrgAccessRequirement
                     ? authDetailsElement.EnumerateArray()
                     : new[] { authDetailsElement }.AsEnumerable();
 
-            return detailsArray
-                .Where(detail => detail.TryGetProperty("reportees", out _))
-                .SelectMany(detail => detail.GetProperty("reportees").EnumerateArray())
-                .SelectMany(reportee =>
-                {
-                    // Try both "ID" (current standard) and "id" (fallback) for resilience
-                    if (
-                        (reportee.TryGetProperty("ID", out var id) || reportee.TryGetProperty("id", out id))
-                        && id.GetString() is string idStr
-                        && idStr.StartsWith(OrgNumberPrefix)
-                        && idStr.Length > PrefixLength
-                    )
-                    {
-                        return [idStr[PrefixLength..]];
-                    }
-                    return Array.Empty<string>();
-                })
-                .Distinct()
-                .ToArray();
+            return detailsArray.SelectMany(ExtractAuthorizedPartyIds).SelectMany(ExtractOrgNumber).Distinct().ToArray();
         }
         catch (SecurityTokenException)
         {
@@ -159,22 +142,61 @@ public sealed class OrgAccessHandler : AuthorizationHandler<OrgAccessRequirement
         }
     }
 
+    private static IEnumerable<string> ExtractAuthorizedPartyIds(JsonElement authorizationDetail)
+    {
+        if (authorizationDetail.TryGetProperty("authorized_parties", out var authorizedParties))
+        {
+            foreach (var authorizedParty in authorizedParties.EnumerateArray())
+            {
+                if (authorizedParty.TryGetProperty("orgno", out var orgNo) && TryGetId(orgNo, out var id))
+                {
+                    yield return id;
+                }
+            }
+        }
+    }
+
+    private static bool TryGetId(JsonElement element, out string id)
+    {
+        if (
+            (element.TryGetProperty("ID", out var idElement) || element.TryGetProperty("id", out idElement))
+            && idElement.GetString() is string idValue
+        )
+        {
+            id = idValue;
+            return true;
+        }
+
+        id = string.Empty;
+        return false;
+    }
+
+    private static IEnumerable<string> ExtractOrgNumber(string id)
+    {
+        if (id.StartsWith(OrgNumberPrefix) && id.Length > PrefixLength)
+        {
+            return [id[PrefixLength..]];
+        }
+
+        return [];
+    }
+
     private void LogOrgAccessDecision(
         string org,
         string? orgNumber,
-        string[] reporteeOrgNumbers,
+        string[] authorizedPartyOrgNumbers,
         bool granted,
         string reason,
         string? accessToken
     )
     {
         _logger.LogWarning(
-            "Org access decision. Granted={Granted}, Reason={Reason}, Org={Org}, OrgNumber={OrgNumber}, ReporteeOrgNumbers={ReporteeOrgNumbers}, JwtPayload={JwtPayload}",
+            "Org access decision. Granted={Granted}, Reason={Reason}, Org={Org}, OrgNumber={OrgNumber}, AuthorizedPartyOrgNumbers={AuthorizedPartyOrgNumbers}, JwtPayload={JwtPayload}",
             granted,
             reason,
             org,
             orgNumber,
-            FormatOrgNumbers(reporteeOrgNumbers),
+            FormatOrgNumbers(authorizedPartyOrgNumbers),
             GetJwtPayloadForLogging(accessToken)
         );
     }

--- a/src/Designer/backend/src/Designer/Infrastructure/Authorization/OrgAccessHandler.cs
+++ b/src/Designer/backend/src/Designer/Infrastructure/Authorization/OrgAccessHandler.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Tokens;
 
@@ -26,19 +25,16 @@ public sealed class OrgAccessHandler : AuthorizationHandler<OrgAccessRequirement
     private const int PrefixLength = 5;
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IEnvironmentsService _environmentsService;
-    private readonly IHostEnvironment _hostEnvironment;
     private readonly ILogger<OrgAccessHandler> _logger;
 
     public OrgAccessHandler(
         IHttpContextAccessor httpContextAccessor,
         IEnvironmentsService environmentsService,
-        IHostEnvironment hostEnvironment,
         ILogger<OrgAccessHandler> logger
     )
     {
         _httpContextAccessor = httpContextAccessor;
         _environmentsService = environmentsService;
-        _hostEnvironment = hostEnvironment;
         _logger = logger;
     }
 
@@ -69,42 +65,40 @@ public sealed class OrgAccessHandler : AuthorizationHandler<OrgAccessRequirement
 
         if (string.IsNullOrWhiteSpace(accessToken))
         {
+            LogOrgAccessDecision(org, null, [], false, "MissingAccessToken", accessToken);
             context.Fail();
             return;
         }
 
-        if (_hostEnvironment.IsProduction())
+        var reporteeOrgNumbers = ExtractReporteeOrgNumbers(accessToken);
+        if (reporteeOrgNumbers.Length == 0)
         {
-            var reporteeOrgNumbers = ExtractReporteeOrgNumbers(accessToken);
-            if (reporteeOrgNumbers.Length == 0)
-            {
-                context.Fail();
-                return;
-            }
+            LogOrgAccessDecision(org, null, reporteeOrgNumbers, false, "MissingReportees", accessToken);
+            context.Fail();
+            return;
+        }
 
-            var orgNr = await _environmentsService.GetAltinnOrgNumber(org);
-            if (orgNr is null)
-            {
-                context.Fail();
-                return;
-            }
+        var orgNr = await _environmentsService.GetAltinnOrgNumber(org);
+        if (orgNr is null)
+        {
+            LogOrgAccessDecision(org, orgNr, reporteeOrgNumbers, false, "UnknownOrgNumber", accessToken);
+            context.Fail();
+            return;
+        }
 
-            if (!string.IsNullOrWhiteSpace(orgNr) && reporteeOrgNumbers.Contains(orgNr))
-            {
-                context.Succeed(requirement);
-            }
-            else
-            {
-                context.Fail();
-            }
+        if (!string.IsNullOrWhiteSpace(orgNr) && reporteeOrgNumbers.Contains(orgNr))
+        {
+            LogOrgAccessDecision(org, orgNr, reporteeOrgNumbers, true, "Granted", accessToken);
+            context.Succeed(requirement);
         }
         else
         {
-            context.Succeed(requirement);
+            LogOrgAccessDecision(org, orgNr, reporteeOrgNumbers, false, "OrgNumberMismatch", accessToken);
+            context.Fail();
         }
     }
 
-    private string[] ExtractReporteeOrgNumbers(string accessToken)
+    internal string[] ExtractReporteeOrgNumbers(string accessToken)
     {
         try
         {
@@ -151,20 +145,56 @@ public sealed class OrgAccessHandler : AuthorizationHandler<OrgAccessRequirement
                 .Distinct()
                 .ToArray();
         }
-        catch (SecurityTokenException ex)
+        catch (SecurityTokenException)
         {
-            _logger.LogWarning(ex, "Invalid JWT token format in access token");
             return [];
         }
-        catch (JsonException ex)
+        catch (JsonException)
         {
-            _logger.LogWarning(ex, "Failed to parse authorization_details JSON from access token");
             return [];
         }
-        catch (Exception ex)
+        catch (Exception)
         {
-            _logger.LogError(ex, "Unexpected error extracting reportee organization numbers from access token");
             return [];
         }
     }
+
+    private void LogOrgAccessDecision(
+        string org,
+        string? orgNumber,
+        string[] reporteeOrgNumbers,
+        bool granted,
+        string reason,
+        string? accessToken
+    )
+    {
+        _logger.LogWarning(
+            "Org access decision. Granted={Granted}, Reason={Reason}, Org={Org}, OrgNumber={OrgNumber}, ReporteeOrgNumbers={ReporteeOrgNumbers}, JwtPayload={JwtPayload}",
+            granted,
+            reason,
+            org,
+            orgNumber,
+            FormatOrgNumbers(reporteeOrgNumbers),
+            GetJwtPayloadForLogging(accessToken)
+        );
+    }
+
+    private static string GetJwtPayloadForLogging(string? accessToken)
+    {
+        if (string.IsNullOrWhiteSpace(accessToken))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            return JsonSerializer.Serialize(new JwtSecurityTokenHandler().ReadJwtToken(accessToken).Payload);
+        }
+        catch
+        {
+            return "Unable to parse JWT payload";
+        }
+    }
+
+    private static string FormatOrgNumbers(string[] orgNumbers) => string.Join(",", orgNumbers);
 }

--- a/src/Designer/backend/src/Designer/Infrastructure/Authorization/OrgAccessHandler.cs
+++ b/src/Designer/backend/src/Designer/Infrastructure/Authorization/OrgAccessHandler.cs
@@ -10,7 +10,6 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Tokens;
 
 namespace Altinn.Studio.Designer.Infrastructure.Authorization;
@@ -26,17 +25,11 @@ public sealed class OrgAccessHandler : AuthorizationHandler<OrgAccessRequirement
     private const int PrefixLength = 5;
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IEnvironmentsService _environmentsService;
-    private readonly ILogger<OrgAccessHandler> _logger;
 
-    public OrgAccessHandler(
-        IHttpContextAccessor httpContextAccessor,
-        IEnvironmentsService environmentsService,
-        ILogger<OrgAccessHandler> logger
-    )
+    public OrgAccessHandler(IHttpContextAccessor httpContextAccessor, IEnvironmentsService environmentsService)
     {
         _httpContextAccessor = httpContextAccessor;
         _environmentsService = environmentsService;
-        _logger = logger;
     }
 
     /// <inheritdoc/>
@@ -66,7 +59,6 @@ public sealed class OrgAccessHandler : AuthorizationHandler<OrgAccessRequirement
 
         if (string.IsNullOrWhiteSpace(accessToken))
         {
-            LogOrgAccessDecision(org, null, [], false, "MissingAccessToken", accessToken);
             context.Fail();
             return;
         }
@@ -74,7 +66,6 @@ public sealed class OrgAccessHandler : AuthorizationHandler<OrgAccessRequirement
         var authorizedPartyOrgNumbers = ExtractAuthorizedPartyOrgNumbers(accessToken);
         if (authorizedPartyOrgNumbers.Length == 0)
         {
-            LogOrgAccessDecision(org, null, authorizedPartyOrgNumbers, false, "MissingAuthorizedParties", accessToken);
             context.Fail();
             return;
         }
@@ -82,19 +73,16 @@ public sealed class OrgAccessHandler : AuthorizationHandler<OrgAccessRequirement
         var orgNr = await _environmentsService.GetAltinnOrgNumber(org);
         if (orgNr is null)
         {
-            LogOrgAccessDecision(org, orgNr, authorizedPartyOrgNumbers, false, "UnknownOrgNumber", accessToken);
             context.Fail();
             return;
         }
 
         if (!string.IsNullOrWhiteSpace(orgNr) && authorizedPartyOrgNumbers.Contains(orgNr))
         {
-            LogOrgAccessDecision(org, orgNr, authorizedPartyOrgNumbers, true, "Granted", accessToken);
             context.Succeed(requirement);
         }
         else
         {
-            LogOrgAccessDecision(org, orgNr, authorizedPartyOrgNumbers, false, "OrgNumberMismatch", accessToken);
             context.Fail();
         }
     }
@@ -180,43 +168,4 @@ public sealed class OrgAccessHandler : AuthorizationHandler<OrgAccessRequirement
 
         return [];
     }
-
-    private void LogOrgAccessDecision(
-        string org,
-        string? orgNumber,
-        string[] authorizedPartyOrgNumbers,
-        bool granted,
-        string reason,
-        string? accessToken
-    )
-    {
-        _logger.LogWarning(
-            "Org access decision. Granted={Granted}, Reason={Reason}, Org={Org}, OrgNumber={OrgNumber}, AuthorizedPartyOrgNumbers={AuthorizedPartyOrgNumbers}, JwtPayload={JwtPayload}",
-            granted,
-            reason,
-            org,
-            orgNumber,
-            FormatOrgNumbers(authorizedPartyOrgNumbers),
-            GetJwtPayloadForLogging(accessToken)
-        );
-    }
-
-    private static string GetJwtPayloadForLogging(string? accessToken)
-    {
-        if (string.IsNullOrWhiteSpace(accessToken))
-        {
-            return string.Empty;
-        }
-
-        try
-        {
-            return JsonSerializer.Serialize(new JwtSecurityTokenHandler().ReadJwtToken(accessToken).Payload);
-        }
-        catch
-        {
-            return "Unable to parse JWT payload";
-        }
-    }
-
-    private static string FormatOrgNumbers(string[] orgNumbers) => string.Join(",", orgNumbers);
 }

--- a/src/Designer/backend/src/Designer/appsettings.json
+++ b/src/Designer/backend/src/Designer/appsettings.json
@@ -147,13 +147,10 @@
 //         "AcrValues": "substantial",
 //         "AuthorizationDetails": [
 //             {
-//                 "Type": "ansattporten:altinn:service",
-//                 "Resource": "urn:altinn:resource:2480:40",
-//                 "OrganizationForm": "enterprise"
-//             },
-//             {
-//                 "Type": "ansattporten:altinn:service",
-//                 "Resource": "urn:altinn:resource:5613:1"
+//                 "Type": "ansattporten:altinn:resource",
+//                 "Resource": "urn:altinn:resource:digdir-selvbetjening-klienter",
+//                 "OrganizationForm": "enterprise",
+//                 "RepresentationIsRequired": false
 //             }
 //         ],
 //         "FetchClientIdAndSecretFromRootEnvFile": true
@@ -169,13 +166,10 @@
         "AccountLinkUrl": "http://studio.localhost/repos/user/oauth2/fake-ansattporten",
         "AuthorizationDetails": [
             {
-                "Type": "ansattporten:altinn:service",
-                "Resource": "urn:altinn:resource:2480:40",
-                "OrganizationForm": "enterprise"
-            },
-            {
-                "Type": "ansattporten:altinn:service",
-                "Resource": "urn:altinn:resource:5613:1"
+                "Type": "ansattporten:altinn:resource",
+                "Resource": "urn:altinn:resource:digdir-selvbetjening-klienter",
+                "OrganizationForm": "enterprise",
+                "RepresentationIsRequired": false
             }
         ]
     },

--- a/src/Designer/backend/tests/Designer.Tests/Controllers/AppScopesController/Utils/TestOidcAuthHandler.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Controllers/AppScopesController/Utils/TestOidcAuthHandler.cs
@@ -26,9 +26,17 @@ public class TestOidcAuthHandler : AuthenticationHandler<AuthenticationSchemeOpt
         {
             new
             {
-                type = "ansattporten:altinn:service",
-                resource = "urn:altinn:resource:5613:1",
-                reportees = new[] { new { ID = "0192:991825827" } },
+                type = "ansattporten:altinn:resource",
+                resource = "urn:altinn:resource:digdir-selvbetjening-klienter",
+                authorized_parties = new[]
+                {
+                    new
+                    {
+                        orgno = new { authority = "iso6523-actorid-upis", ID = "0192:991825827" },
+                        resource = "digdir-selvbetjening-klienter",
+                        name = "Test org",
+                    },
+                },
             },
         };
 

--- a/src/Designer/backend/tests/Designer.Tests/Infrastructure/Authorization/OrgAccessHandlerTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Infrastructure/Authorization/OrgAccessHandlerTests.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
 using System.Security.Claims;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -24,10 +25,6 @@ public class OrgAccessHandlerTests
     private const string TestOrgIdentifier = "ttd";
     private const string TestOrgNumber = "991825827";
     private const string OtherOrgNumber = "310461598";
-    private const string AccessTokenWithReportee =
-        "eyJraWQiOiJiZFhMRVduRGpMSGpwRThPZnl5TUp4UlJLbVo3MUxCOHUxeUREbVBpdVQwIiwiYWxnIjoiUlMyNTYifQ."
-        + "eyJzdWIiOiIyOTkwNjI5Njc2MiIsImNsbSI6WyIhd0FBQyJdLCJpc3MiOiJodHRwczovL3Rlc3QuYW5zYXR0cG9ydGVuLm5vIiwiY2xpZW50X2FtciI6ImNsaWVudF9zZWNyZXRfYmFzaWMiLCJwaWQiOiIyOTkwNjI5Njc2MiIsImNsaWVudF9pZCI6IjlhOTllOTZkLWI1NmMtNGY3NC1hNjg5LWY5MzZmNzFjODgxOSIsImFjciI6InN1YnN0YW50aWFsIiwic2lrIjoiZk84NmpoaHNVU0t4YWRpTXgtSmJ2czFGdkdqNFI0emtkaEx6M0JEYng4MCIsImF1dGhvcml6YXRpb25fZGV0YWlscyI6W3sicmVzb3VyY2UiOiJ1cm46YWx0aW5uOnJlc291cmNlOjI0ODA6NDAiLCJ0eXBlIjoiYW5zYXR0cG9ydGVuOmFsdGlubjpzZXJ2aWNlIiwicmVzb3VyY2VfbmFtZSI6IlByb2R1a3RlciBvZyB0amVuZXN0ZXIgZnJhIEJyw7hubsO4eXN1bmRyZWdpc3RyZW5lIiwicmVwb3J0ZWVzIjpbeyJSaWdodHMiOlsiUmVhZCIsIkFyY2hpdmVEZWxldGUiLCJBcmNoaXZlUmVhZCJdLCJBdXRob3JpdHkiOiJpc282NTIzLWFjdG9yaWQtdXBpcyIsIklEIjoiMDE5MjozMTA4ODgxNjgiLCJOYW1lIjoiREVESUtFUlQgVkVOU1RSRSBUSUdFUiBBUyJ9XX1dLCJzY29wZSI6Im9wZW5pZCBwcm9maWxlIiwiZXhwIjoxNzc3OTY3Mzc5LCJpYXQiOjE3Nzc5NjY3NzksImp0aSI6IjNuQmJ2V0hwN19vIiwiY29uc3VtZXIiOnsiYXV0aG9yaXR5IjoiaXNvNjUyMy1hY3RvcmlkLXVwaXMiLCJJRCI6IjAxOTI6OTkxODI1ODI3In19."
-        + "NkvxfzaTkQ5EdfaBBFBedM1NFJSE7d7i4QSk9RLYsCNloUn4rKMZ0Itss3vesBqr-bx44iXqVHFqWPBXak0KcTdT7ZcSyyeAvzS5hLelrlb-h4hBn8X6cyatKp6yhYJ67BH0ZiAaxFAVSnZul3xjr49wmOQoIqU2au_xGW97P1GsTEzHvmxzHnIYRDdot6ueWOPtR89tKk1rY4W4MT9Rb_T6Ia5UhKYweywp0rc3An-UbxFVFf-idomx8ukzntk9Hh7a0vU0DGt-7YhwCNzjHyaN9ZD_ZWttUSJTBBcxMkFLF9DiMouXp9jrTSXcNmiY5CsNRxkR0mLT8C58LYWRAX2PjWkk_v7hqDQOwx70V0sO16trxuU-riN6ai72q-R7Sxw0ca7OIcjbtd4cFhcr0FFI2xgZ4csd-x7b9cKGvnZzQGOaQKo1aTfc7MLzZ_VWX_muMxUUnAIzRySSxuw-DvKMAUjHdVCi4HVPjZtWHvQU2ebUzO_xdNNT9_bWMw7J";
 
     [Fact]
     public async Task HandleRequirementAsync_ShouldFail_WhenHttpContextIsNull()
@@ -44,13 +41,25 @@ public class OrgAccessHandlerTests
     }
 
     [Fact]
-    public void ExtractReporteeOrgNumbers_ShouldReturnReportees_FromAnsattportenAccessToken()
+    public void ExtractAuthorizedPartyOrgNumbers_ShouldReturnAuthorizedParties_FromAnsattportenResourceAccessToken()
     {
+        var token = CreateJwtTokenWithAuthorizedParties([TestOrgNumber]);
         var handler = CreateHandler(null);
 
-        var orgNumbers = handler.ExtractReporteeOrgNumbers(AccessTokenWithReportee);
+        var orgNumbers = handler.ExtractAuthorizedPartyOrgNumbers(token);
 
-        Assert.Equal(["310888168"], orgNumbers);
+        Assert.Equal([TestOrgNumber], orgNumbers);
+    }
+
+    [Fact]
+    public void ExtractAuthorizedPartyOrgNumbers_ShouldReturnAuthorizedParties_WhenAuthorizationDetailsIsJsonString()
+    {
+        var token = CreateJwtTokenWithAuthorizationDetailsAsString([TestOrgNumber]);
+        var handler = CreateHandler(null);
+
+        var orgNumbers = handler.ExtractAuthorizedPartyOrgNumbers(token);
+
+        Assert.Equal([TestOrgNumber], orgNumbers);
     }
 
     [Fact]
@@ -86,7 +95,7 @@ public class OrgAccessHandlerTests
     }
 
     [Fact]
-    public async Task HandleRequirementAsync_ShouldFail_WhenTokenHasNoReportees()
+    public async Task HandleRequirementAsync_ShouldFail_WhenTokenHasNoAuthorizedParties()
     {
         var token = CreateJwtToken([]);
         var httpContextMock = CreateMockHttpContext(TestOrgIdentifier, token);
@@ -103,10 +112,27 @@ public class OrgAccessHandlerTests
     }
 
     [Fact]
+    public async Task HandleRequirementAsync_ShouldFail_WhenAuthorizationDetailsHasNoResourceOrAuthorizedParties()
+    {
+        var token = CreateJwtTokenWithoutAuthorizedParties();
+        var httpContextMock = CreateMockHttpContext(TestOrgIdentifier, token);
+        var handler = CreateHandler(httpContextMock);
+
+        var requirement = new OrgAccessRequirement();
+        var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[] { }, "TestAuth"));
+        var context = new AuthorizationHandlerContext(new[] { requirement }, user, resource: null);
+
+        await handler.HandleAsync(context);
+
+        Assert.False(context.HasSucceeded);
+        Assert.True(context.HasFailed);
+    }
+
+    [Fact]
     public async Task HandleRequirementAsync_ShouldFail_WhenOrgNotFoundInAltinnOrgs()
     {
-        var reportees = new[] { TestOrgNumber };
-        var token = CreateJwtToken(reportees);
+        var authorizedParties = new[] { TestOrgNumber };
+        var token = CreateJwtToken(authorizedParties);
         var httpContextMock = CreateMockHttpContext(TestOrgIdentifier, token);
         var handler = CreateHandler(
             httpContextMock,
@@ -127,10 +153,10 @@ public class OrgAccessHandlerTests
     }
 
     [Fact]
-    public async Task HandleRequirementAsync_ShouldSucceed_WhenUserHasMatchingReporteeOrgNumber()
+    public async Task HandleRequirementAsync_ShouldSucceed_WhenUserHasMatchingAuthorizedPartyOrgNumber()
     {
-        var reportees = new[] { TestOrgNumber };
-        var token = CreateJwtToken(reportees);
+        var authorizedParties = new[] { TestOrgNumber };
+        var token = CreateJwtToken(authorizedParties);
         var httpContextMock = CreateMockHttpContext(TestOrgIdentifier, token);
         var handler = CreateHandler(
             httpContextMock,
@@ -151,10 +177,10 @@ public class OrgAccessHandlerTests
     }
 
     [Fact]
-    public async Task HandleRequirementAsync_ShouldFail_WhenUserHasNoMatchingReporteeOrgNumber()
+    public async Task HandleRequirementAsync_ShouldFail_WhenUserHasNoMatchingAuthorizedPartyOrgNumber()
     {
-        var reportees = new[] { OtherOrgNumber };
-        var token = CreateJwtToken(reportees);
+        var authorizedParties = new[] { OtherOrgNumber };
+        var token = CreateJwtToken(authorizedParties);
         var httpContextMock = CreateMockHttpContext(TestOrgIdentifier, token);
         var handler = CreateHandler(
             httpContextMock,
@@ -175,10 +201,10 @@ public class OrgAccessHandlerTests
     }
 
     [Fact]
-    public async Task HandleRequirementAsync_ShouldSucceed_WhenUserHasMultipleReporteesWithMatch()
+    public async Task HandleRequirementAsync_ShouldSucceed_WhenUserHasMultipleAuthorizedPartiesWithMatch()
     {
-        var reportees = new[] { OtherOrgNumber, TestOrgNumber, "123456789" };
-        var token = CreateJwtToken(reportees);
+        var authorizedParties = new[] { OtherOrgNumber, TestOrgNumber, "123456789" };
+        var token = CreateJwtToken(authorizedParties);
         var httpContextMock = CreateMockHttpContext(TestOrgIdentifier, token);
         var handler = CreateHandler(
             httpContextMock,
@@ -202,8 +228,8 @@ public class OrgAccessHandlerTests
     public async Task HandleRequirementAsync_ShouldSucceed_ForTtdOrgUsingDigdirOrgNumber()
     {
         // ttd test org uses Digdir's org number (991825827)
-        var reportees = new[] { TestOrgNumber };
-        var token = CreateJwtToken(reportees);
+        var authorizedParties = new[] { TestOrgNumber };
+        var token = CreateJwtToken(authorizedParties);
         var httpContextMock = CreateMockHttpContext("ttd", token);
         var handler = CreateHandler(
             httpContextMock,
@@ -226,7 +252,7 @@ public class OrgAccessHandlerTests
     [Fact]
     public async Task HandleRequirementAsync_ShouldFail_WhenOrgNumberIsTooShort()
     {
-        var token = CreateJwtTokenWithCustomReportees(new[] { new { ID = "0192:" } });
+        var token = CreateJwtTokenWithCustomAuthorizedParties(["0192:"]);
         var httpContextMock = CreateMockHttpContext(TestOrgIdentifier, token);
         var handler = CreateHandler(httpContextMock);
 
@@ -243,7 +269,7 @@ public class OrgAccessHandlerTests
     [Fact]
     public async Task HandleRequirementAsync_ShouldFail_WhenOrgNumberMissingPrefix()
     {
-        var token = CreateJwtTokenWithCustomReportees(new[] { new { ID = "991825827" } });
+        var token = CreateJwtTokenWithCustomAuthorizedParties(["991825827"]);
         var httpContextMock = CreateMockHttpContext(TestOrgIdentifier, token);
         var handler = CreateHandler(httpContextMock);
 
@@ -306,7 +332,7 @@ public class OrgAccessHandlerTests
     [Fact]
     public async Task HandleRequirementAsync_ShouldFail_WhenOrgNumberIsEmptyString()
     {
-        var token = CreateJwtTokenWithCustomReportees(new[] { new { ID = "" } });
+        var token = CreateJwtTokenWithCustomAuthorizedParties([""]);
         var httpContextMock = CreateMockHttpContext(TestOrgIdentifier, token);
         var handler = CreateHandler(httpContextMock);
 
@@ -373,15 +399,23 @@ public class OrgAccessHandlerTests
 
     private static string CreateJwtToken(string[] orgNumbers)
     {
+        return CreateJwtTokenWithAuthorizedParties(orgNumbers);
+    }
+
+    private static string CreateJwtTokenWithCustomAuthorizedParties(string[] ids)
+    {
         var authorizationDetails = new[]
         {
             new
             {
-                type = "ansattporten:altinn:service",
-                resource = "urn:altinn:resource:5613:1",
-                reportees = orgNumbers.Length > 0
-                    ? Array.ConvertAll(orgNumbers, orgNo => new { ID = $"0192:{orgNo}" })
-                    : Array.Empty<object>(),
+                type = "ansattporten:altinn:resource",
+                resource = "urn:altinn:resource:digdir-selvbetjening-klienter",
+                authorized_parties = ids.Select(id => new
+                {
+                    orgno = new { authority = "iso6523-actorid-upis", ID = id },
+                    resource = "digdir-selvbetjening-klienter",
+                    name = "Test org",
+                }),
             },
         };
 
@@ -399,15 +433,38 @@ public class OrgAccessHandlerTests
         return handler.WriteToken(token);
     }
 
-    private static string CreateJwtTokenWithCustomReportees(object[] reportees)
+    private static string CreateJwtTokenWithoutAuthorizedParties()
+    {
+        var authorizationDetails = new[] { new { type = "ansattporten:altinn:resource" } };
+
+        var header = new JwtHeader();
+        var payload = new JwtPayload
+        {
+            { "iss", "test" },
+            { "aud", "test" },
+            { "exp", new DateTimeOffset(DateTime.UtcNow.AddHours(1)).ToUnixTimeSeconds() },
+            { "authorization_details", JsonSerializer.SerializeToElement(authorizationDetails) },
+        };
+
+        var token = new JwtSecurityToken(header, payload);
+        var handler = new JwtSecurityTokenHandler();
+        return handler.WriteToken(token);
+    }
+
+    private static string CreateJwtTokenWithAuthorizedParties(string[] orgNumbers)
     {
         var authorizationDetails = new[]
         {
             new
             {
-                type = "ansattporten:altinn:service",
-                resource = "urn:altinn:resource:5613:1",
-                reportees,
+                type = "ansattporten:altinn:resource",
+                resource = "urn:altinn:resource:digdir-selvbetjening-klienter",
+                authorized_parties = orgNumbers.Select(orgNo => new
+                {
+                    orgno = new { authority = "iso6523-actorid-upis", ID = $"0192:{orgNo}" },
+                    resource = "digdir-selvbetjening-klienter",
+                    name = "Test org",
+                }),
             },
         };
 
@@ -418,6 +475,37 @@ public class OrgAccessHandlerTests
             { "aud", "test" },
             { "exp", new DateTimeOffset(DateTime.UtcNow.AddHours(1)).ToUnixTimeSeconds() },
             { "authorization_details", JsonSerializer.SerializeToElement(authorizationDetails) },
+        };
+
+        var token = new JwtSecurityToken(header, payload);
+        var handler = new JwtSecurityTokenHandler();
+        return handler.WriteToken(token);
+    }
+
+    private static string CreateJwtTokenWithAuthorizationDetailsAsString(string[] orgNumbers)
+    {
+        var authorizationDetails = new[]
+        {
+            new
+            {
+                type = "ansattporten:altinn:resource",
+                resource = "urn:altinn:resource:digdir-selvbetjening-klienter",
+                authorized_parties = orgNumbers.Select(orgNo => new
+                {
+                    orgno = new { authority = "iso6523-actorid-upis", ID = $"0192:{orgNo}" },
+                    resource = "digdir-selvbetjening-klienter",
+                    name = "Test org",
+                }),
+            },
+        };
+
+        var header = new JwtHeader();
+        var payload = new JwtPayload
+        {
+            { "iss", "test" },
+            { "aud", "test" },
+            { "exp", new DateTimeOffset(DateTime.UtcNow.AddHours(1)).ToUnixTimeSeconds() },
+            { "authorization_details", JsonSerializer.Serialize(authorizationDetails) },
         };
 
         var token = new JwtSecurityToken(header, payload);

--- a/src/Designer/backend/tests/Designer.Tests/Infrastructure/Authorization/OrgAccessHandlerTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Infrastructure/Authorization/OrgAccessHandlerTests.cs
@@ -13,7 +13,6 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -25,6 +24,10 @@ public class OrgAccessHandlerTests
     private const string TestOrgIdentifier = "ttd";
     private const string TestOrgNumber = "991825827";
     private const string OtherOrgNumber = "310461598";
+    private const string AccessTokenWithReportee =
+        "eyJraWQiOiJiZFhMRVduRGpMSGpwRThPZnl5TUp4UlJLbVo3MUxCOHUxeUREbVBpdVQwIiwiYWxnIjoiUlMyNTYifQ."
+        + "eyJzdWIiOiIyOTkwNjI5Njc2MiIsImNsbSI6WyIhd0FBQyJdLCJpc3MiOiJodHRwczovL3Rlc3QuYW5zYXR0cG9ydGVuLm5vIiwiY2xpZW50X2FtciI6ImNsaWVudF9zZWNyZXRfYmFzaWMiLCJwaWQiOiIyOTkwNjI5Njc2MiIsImNsaWVudF9pZCI6IjlhOTllOTZkLWI1NmMtNGY3NC1hNjg5LWY5MzZmNzFjODgxOSIsImFjciI6InN1YnN0YW50aWFsIiwic2lrIjoiZk84NmpoaHNVU0t4YWRpTXgtSmJ2czFGdkdqNFI0emtkaEx6M0JEYng4MCIsImF1dGhvcml6YXRpb25fZGV0YWlscyI6W3sicmVzb3VyY2UiOiJ1cm46YWx0aW5uOnJlc291cmNlOjI0ODA6NDAiLCJ0eXBlIjoiYW5zYXR0cG9ydGVuOmFsdGlubjpzZXJ2aWNlIiwicmVzb3VyY2VfbmFtZSI6IlByb2R1a3RlciBvZyB0amVuZXN0ZXIgZnJhIEJyw7hubsO4eXN1bmRyZWdpc3RyZW5lIiwicmVwb3J0ZWVzIjpbeyJSaWdodHMiOlsiUmVhZCIsIkFyY2hpdmVEZWxldGUiLCJBcmNoaXZlUmVhZCJdLCJBdXRob3JpdHkiOiJpc282NTIzLWFjdG9yaWQtdXBpcyIsIklEIjoiMDE5MjozMTA4ODgxNjgiLCJOYW1lIjoiREVESUtFUlQgVkVOU1RSRSBUSUdFUiBBUyJ9XX1dLCJzY29wZSI6Im9wZW5pZCBwcm9maWxlIiwiZXhwIjoxNzc3OTY3Mzc5LCJpYXQiOjE3Nzc5NjY3NzksImp0aSI6IjNuQmJ2V0hwN19vIiwiY29uc3VtZXIiOnsiYXV0aG9yaXR5IjoiaXNvNjUyMy1hY3RvcmlkLXVwaXMiLCJJRCI6IjAxOTI6OTkxODI1ODI3In19."
+        + "NkvxfzaTkQ5EdfaBBFBedM1NFJSE7d7i4QSk9RLYsCNloUn4rKMZ0Itss3vesBqr-bx44iXqVHFqWPBXak0KcTdT7ZcSyyeAvzS5hLelrlb-h4hBn8X6cyatKp6yhYJ67BH0ZiAaxFAVSnZul3xjr49wmOQoIqU2au_xGW97P1GsTEzHvmxzHnIYRDdot6ueWOPtR89tKk1rY4W4MT9Rb_T6Ia5UhKYweywp0rc3An-UbxFVFf-idomx8ukzntk9Hh7a0vU0DGt-7YhwCNzjHyaN9ZD_ZWttUSJTBBcxMkFLF9DiMouXp9jrTSXcNmiY5CsNRxkR0mLT8C58LYWRAX2PjWkk_v7hqDQOwx70V0sO16trxuU-riN6ai72q-R7Sxw0ca7OIcjbtd4cFhcr0FFI2xgZ4csd-x7b9cKGvnZzQGOaQKo1aTfc7MLzZ_VWX_muMxUUnAIzRySSxuw-DvKMAUjHdVCi4HVPjZtWHvQU2ebUzO_xdNNT9_bWMw7J";
 
     [Fact]
     public async Task HandleRequirementAsync_ShouldFail_WhenHttpContextIsNull()
@@ -38,6 +41,16 @@ public class OrgAccessHandlerTests
         await handler.HandleAsync(context);
 
         Assert.False(context.HasSucceeded);
+    }
+
+    [Fact]
+    public void ExtractReporteeOrgNumbers_ShouldReturnReportees_FromAnsattportenAccessToken()
+    {
+        var handler = CreateHandler(null);
+
+        var orgNumbers = handler.ExtractReporteeOrgNumbers(AccessTokenWithReportee);
+
+        Assert.Equal(["310888168"], orgNumbers);
     }
 
     [Fact]
@@ -414,8 +427,7 @@ public class OrgAccessHandlerTests
 
     private static OrgAccessHandler CreateHandler(
         HttpContext? httpContext,
-        Action<Mock<IEnvironmentsService>>? configureEnvironmentsService = null,
-        bool isProduction = true
+        Action<Mock<IEnvironmentsService>>? configureEnvironmentsService = null
     )
     {
         var httpContextAccessorMock = new Mock<IHttpContextAccessor>();
@@ -424,16 +436,8 @@ public class OrgAccessHandlerTests
         var environmentsServiceMock = new Mock<IEnvironmentsService>();
         configureEnvironmentsService?.Invoke(environmentsServiceMock);
 
-        var hostEnvironmentMock = new Mock<IHostEnvironment>();
-        hostEnvironmentMock.Setup(x => x.EnvironmentName).Returns(isProduction ? "Production" : "Development");
-
         var loggerMock = new Mock<ILogger<OrgAccessHandler>>();
 
-        return new OrgAccessHandler(
-            httpContextAccessorMock.Object,
-            environmentsServiceMock.Object,
-            hostEnvironmentMock.Object,
-            loggerMock.Object
-        );
+        return new OrgAccessHandler(httpContextAccessorMock.Object, environmentsServiceMock.Object, loggerMock.Object);
     }
 }

--- a/src/Designer/backend/tests/Designer.Tests/Infrastructure/Authorization/OrgAccessHandlerTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Infrastructure/Authorization/OrgAccessHandlerTests.cs
@@ -14,7 +14,6 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 
@@ -524,8 +523,6 @@ public class OrgAccessHandlerTests
         var environmentsServiceMock = new Mock<IEnvironmentsService>();
         configureEnvironmentsService?.Invoke(environmentsServiceMock);
 
-        var loggerMock = new Mock<ILogger<OrgAccessHandler>>();
-
-        return new OrgAccessHandler(httpContextAccessorMock.Object, environmentsServiceMock.Object, loggerMock.Object);
+        return new OrgAccessHandler(httpContextAccessorMock.Object, environmentsServiceMock.Object);
     }
 }

--- a/src/Designer/compose.yaml
+++ b/src/Designer/compose.yaml
@@ -142,6 +142,10 @@ services:
       - StudioOidcLoginSettings:ClientSecret=${STUDIO_OIDC_CLIENT_SECRET:-fake-secret}
       - StudioOidcLoginSettings:Authority=${STUDIO_OIDC_AUTHORITY:-http://fake-ansattporten:8443}
       - StudioOidcLoginSettings:RequireHttpsMetadata=false
+      - StudioOidcLoginSettings:AuthorizationDetails:0:Type=ansattporten:altinn:resource
+      - StudioOidcLoginSettings:AuthorizationDetails:0:Resource=urn:altinn:resource:digdir-selvbetjening-klienter
+      - StudioOidcLoginSettings:AuthorizationDetails:0:OrganizationForm=enterprise
+      - StudioOidcLoginSettings:AuthorizationDetails:0:RepresentationIsRequired=false
       - FeatureManagement:Ansattporten=${FEATUREFLAGS_ANSATTPORTEN:-false}
       - FeatureManagement:GitOpsDeploy=${FEATUREFLAGS_GITOPSDEPLOY:-true}
       - FeatureManagement:StudioOidc=${FEATUREFLAGS_STUDIOOIDC:-true}
@@ -341,5 +345,4 @@ services:
         - REDIS_HOSTS=redis
     ports:
         - "8081:8081"
-
 

--- a/src/Designer/development/fake-ansattporten/main.go
+++ b/src/Designer/development/fake-ansattporten/main.go
@@ -369,7 +369,7 @@ func handleToken(w http.ResponseWriter, r *http.Request) {
 }
 
 // buildAuthorizationDetailsClaim parses the raw authorization_details from the
-// authorize request and enriches each entry with the selected org as a reportee.
+// authorize request and enriches each entry with the selected org as an authorized party.
 func buildAuthorizationDetailsClaim(rawAuthDetails string, org *FakeOrg) []map[string]any {
 	var requested []map[string]any
 	if err := json.Unmarshal([]byte(rawAuthDetails), &requested); err != nil {
@@ -377,20 +377,21 @@ func buildAuthorizationDetailsClaim(rawAuthDetails string, org *FakeOrg) []map[s
 		return nil
 	}
 
-	reportee := map[string]any{
-		"Rights":    []string{"Read", "ArchiveDelete", "ArchiveRead"},
-		"Authority": "iso6523-actorid-upis",
-		"ID":        org.ID,
-		"Name":      org.Name,
+	authorizedParty := map[string]any{
+		"orgno": map[string]any{
+			"authority": "iso6523-actorid-upis",
+			"ID":        org.ID,
+		},
+		"resource": "digdir-selvbetjening-klienter",
+		"name":     org.Name,
 	}
 
 	var result []map[string]any
 	for _, detail := range requested {
 		enriched := map[string]any{
-			"type":          detail["type"],
-			"resource":      detail["resource"],
-			"resource_name": org.Name,
-			"reportees":     []map[string]any{reportee},
+			"type":               detail["type"],
+			"resource":           detail["resource"],
+			"authorized_parties": []map[string]any{authorizedParty},
 		}
 		result = append(result, enriched)
 	}


### PR DESCRIPTION
## Description

Switches to `digdir-selvbetjening-klienter`, drop the other `2480:40` resoure
The orgvelger lets a user choose org as usual. If a user doesnt have access to the resourcde either through the policy roles or through delegation, they dont even see the altinn-orgvelger redirect, but login still succeeds. 


orgvelger (note that my ENK is gone from the list here):

<img width="530" height="345" alt="image" src="https://github.com/user-attachments/assets/c84802b2-cc36-4414-b5db-40d906bd22ca" />

`authorization_details` from todays config: 

```json
[
  {
    "resource": "urn:altinn:resource:5613:1",
    "type": "ansattporten:altinn:service",
    "resource_name": "ukjent tjeneste",
    "reportees": []
  }
]
```

`authorization_details` that includes "Virksomhet" choice: 

```json
[
  {
    "authorized_parties": [
      {
        "orgno": {
          "authority": "iso6523-actorid-upis",
          "ID": "0192:991825827"
        },
        "resource": "digdir-selvbetjening-klienter",
        "name": "DIGITALISERINGSDIREKTORATET",
        "unit_type": "ORGL"
      }
    ],
    "resource": "urn:altinn:resource:digdir-selvbetjening-klienter",
    "type": "ansattporten:altinn:resource",
    "resource_name": "Selvbetjening av klienter i ID-porten/Maskinporten"
  }
]
```


`authorization_details` when choosing "Meg selv": 

```json
[
  {
    "type": "ansattporten:altinn:resource"
  }
]
```


The resource policy currently:

```xml
<?xml version="1.0" encoding="utf-8"?>
<xacml:Policy PolicyId="urn:altinn:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17">
  <xacml:Target />
  <xacml:Rule RuleId="urn:altinn:resource:digdir-selvbetjening-klienter:ruleid:4afbd1b2-5d5e-4b8a-a4e7-7d64b7cf1504" Effect="Permit">
    <xacml:Description>rule template for Link resource with operation: access</xacml:Description>
    <xacml:Target>
      <xacml:AnyOf>
        <xacml:AllOf>
          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">KEMN</xacml:AttributeValue>
            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
          </xacml:Match>
        </xacml:AllOf>
        <xacml:AllOf>
          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">EKTJ</xacml:AttributeValue>
            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
          </xacml:Match>
        </xacml:AllOf>
        <xacml:AllOf>
          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">best</xacml:AttributeValue>
            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
          </xacml:Match>
        </xacml:AllOf>
        <xacml:AllOf>
          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">dagl</xacml:AttributeValue>
            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
          </xacml:Match>
        </xacml:AllOf>
        <xacml:AllOf>
          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">lede</xacml:AttributeValue>
            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
          </xacml:Match>
        </xacml:AllOf>
      </xacml:AnyOf>
      <xacml:AnyOf>
        <xacml:AllOf>
          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">digdir-selvbetjening-klienter</xacml:AttributeValue>
            <xacml:AttributeDesignator AttributeId="urn:altinn:resource" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
          </xacml:Match>
        </xacml:AllOf>
      </xacml:AnyOf>
      <xacml:AnyOf>
        <xacml:AllOf>
          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">access</xacml:AttributeValue>
            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
          </xacml:Match>
        </xacml:AllOf>
      </xacml:AnyOf>
    </xacml:Target>
  </xacml:Rule>
  <xacml:ObligationExpressions>
    <xacml:ObligationExpression ObligationId="urn:altinn:obligation:authenticationLevel1" FulfillOn="Permit">
      <xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation1-assignment1" Category="urn:altinn:minimum-authenticationlevel">
        <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">4</xacml:AttributeValue>
      </xacml:AttributeAssignmentExpression>
    </xacml:ObligationExpression>
    <xacml:ObligationExpression ObligationId="urn:altinn:obligation:authenticationLevel2" FulfillOn="Permit">
      <xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation2-assignment2" Category="urn:altinn:minimum-authenticationlevel-org">
        <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">3</xacml:AttributeValue>
      </xacml:AttributeAssignmentExpression>
    </xacml:ObligationExpression>
  </xacml:ObligationExpressions>
</xacml:Policy>
```


## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated OIDC login configuration to a resource-based authorization model and unified representation setting across dev, staging and prod.
  * Made org-access checks consistent across environments so access is validated against authorized parties in tokens.
* **Tests**
  * Updated test tokens and coverage to reflect the new authorization-details format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->