### PR TITLE
fix(policy-editor): case-insensitive comparison of subject urns

### DIFF
--- a/src/Designer/frontend/packages/policy-editor/src/components/PolicyCardRules/PolicyRule/PolicySubjects/SubjectListItem/SubjectListItem.module.css
+++ b/src/Designer/frontend/packages/policy-editor/src/components/PolicyCardRules/PolicyRule/PolicySubjects/SubjectListItem/SubjectListItem.module.css
@@ -30,7 +30,7 @@
 
 .subjectSubTitle {
   color: var(--ds-color-text-subtle);
-  font-size: var(--ds-font-size-1);
+  font-size: var(--ds-font-size-2);
   font-weight: var(--ds-font-weight-regular);
   line-height: normal;
 }

--- a/src/Designer/frontend/packages/policy-editor/src/utils/PolicyRuleUtils/index.ts
+++ b/src/Designer/frontend/packages/policy-editor/src/utils/PolicyRuleUtils/index.ts
@@ -54,20 +54,22 @@ export const getPolicyRuleIdString = (policyRule: PolicyRuleCard) => {
   return policyRule.ruleId.toString();
 };
 
+const PRIV_SUBJECT = 'urn:altinn:rolecode:priv';
+const SELN_SUBJECT = 'urn:altinn:rolecode:seln';
 const isPersonSubject = (subjectUrn: string) => {
-  return (
-    subjectUrn?.toLocaleLowerCase() === 'urn:altinn:rolecode:priv' ||
-    subjectUrn?.toLowerCase() === 'urn:altinn:rolecode:seln'
-  );
+  return subjectUrn?.toLowerCase() === PRIV_SUBJECT || subjectUrn?.toLowerCase() === SELN_SUBJECT;
 };
 export const getCcrSubjects = (subjects: PolicySubject[]) => {
   return subjects.filter((s) => s.provider?.code?.toLowerCase() === 'sys-ccr');
 };
+
+const ALTINN2_PROVIDER = 'sys-altinn2';
+const ALTINN3_PROVIDER = 'sys-altinn3';
 export const getAltinnSubjects = (subjects: PolicySubject[]) => {
   return subjects.filter((s) => {
     const isAltinn =
-      s.provider?.code?.toLowerCase() === 'sys-altinn2' ||
-      s.provider?.code?.toLowerCase() === 'sys-altinn3';
+      s.provider?.code?.toLowerCase() === ALTINN2_PROVIDER ||
+      s.provider?.code?.toLowerCase() === ALTINN3_PROVIDER;
     const isPersonRole = isPersonSubject(s.legacyUrn);
     return isAltinn && !isPersonRole;
   });

--- a/src/Designer/frontend/packages/policy-editor/src/utils/PolicyRuleUtils/index.ts
+++ b/src/Designer/frontend/packages/policy-editor/src/utils/PolicyRuleUtils/index.ts
@@ -55,14 +55,19 @@ export const getPolicyRuleIdString = (policyRule: PolicyRuleCard) => {
 };
 
 const isPersonSubject = (subjectUrn: string) => {
-  return subjectUrn === 'urn:altinn:rolecode:PRIV' || subjectUrn === 'urn:altinn:rolecode:SELN';
+  return (
+    subjectUrn?.toLocaleLowerCase() === 'urn:altinn:rolecode:priv' ||
+    subjectUrn?.toLowerCase() === 'urn:altinn:rolecode:seln'
+  );
 };
 export const getCcrSubjects = (subjects: PolicySubject[]) => {
-  return subjects.filter((s) => s.provider?.code === 'sys-ccr');
+  return subjects.filter((s) => s.provider?.code?.toLowerCase() === 'sys-ccr');
 };
 export const getAltinnSubjects = (subjects: PolicySubject[]) => {
   return subjects.filter((s) => {
-    const isAltinn = s.provider?.code === 'sys-altinn2' || s.provider?.code === 'sys-altinn3';
+    const isAltinn =
+      s.provider?.code?.toLowerCase() === 'sys-altinn2' ||
+      s.provider?.code?.toLowerCase() === 'sys-altinn3';
     const isPersonRole = isPersonSubject(s.legacyUrn);
     return isAltinn && !isPersonRole;
   });


### PR DESCRIPTION
## Description
- Subject metadata API has changed; urns are now sent as `urn:altinn:rolecode:priv` instead of `urn:altinn:rolecode:PRIV`. Change comparison check to be case insensitive

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted subtitle font size for subject list items to improve visual consistency and readability in the policy editor interface

* **Bug Fixes**
  * Enhanced subject-URN matching logic to correctly handle case variations in identifiers
  * Improved provider code filtering with case-insensitive comparison for more reliable and consistent subject identification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->