### PR TITLE
fix: fixed en crash when select first map componenent

### DIFF
--- a/src/Designer/frontend/packages/ux-editor/src/utils/dataModelUtils.test.ts
+++ b/src/Designer/frontend/packages/ux-editor/src/utils/dataModelUtils.test.ts
@@ -175,6 +175,14 @@ describe('convertDataBindingToInternalFormat', () => {
     const internalFormat = convertDataBindingToInternalFormat('', undefined);
     expect(internalFormat).toEqual({ dataType: '', field: '' });
   });
+
+  it('should convert invalid object values to safe strings', () => {
+    const internalFormat = convertDataBindingToInternalFormat('defaultModel', {
+      dataType: { model: 'invalid' } as unknown as string,
+      field: { field: 'invalid' } as unknown as string,
+    });
+    expect(internalFormat).toEqual({ dataType: 'defaultModel', field: '' });
+  });
 });
 
 describe('validateSelectedDataModel', () => {

--- a/src/Designer/frontend/packages/ux-editor/src/utils/dataModelUtils.test.ts
+++ b/src/Designer/frontend/packages/ux-editor/src/utils/dataModelUtils.test.ts
@@ -199,6 +199,19 @@ describe('convertDataBindingToInternalFormat', () => {
     });
     expect(internalFormat).toEqual({ dataType: 'validDataType', field: '' });
   });
+
+  it('should keep string binding in old format', () => {
+    const internalFormat = convertDataBindingToInternalFormat('defaultModel', 'simple.path');
+    expect(internalFormat).toEqual({ dataType: 'defaultModel', field: 'simple.path' });
+  });
+
+  it('should fallback to empty dataType when default type is undefined', () => {
+    const internalFormat = convertDataBindingToInternalFormat(undefined, {
+      field: 'validField',
+      dataType: { model: 'invalid' } as unknown as string,
+    });
+    expect(internalFormat).toEqual({ dataType: '', field: 'validField' });
+  });
 });
 
 describe('validateSelectedDataModel', () => {

--- a/src/Designer/frontend/packages/ux-editor/src/utils/dataModelUtils.test.ts
+++ b/src/Designer/frontend/packages/ux-editor/src/utils/dataModelUtils.test.ts
@@ -183,6 +183,22 @@ describe('convertDataBindingToInternalFormat', () => {
     });
     expect(internalFormat).toEqual({ dataType: 'defaultModel', field: '' });
   });
+
+  it('should keep field when string and fallback dataType when invalid', () => {
+    const internalFormat = convertDataBindingToInternalFormat('defaultModel', {
+      field: 'validField',
+      dataType: { model: 'invalid' } as unknown as string,
+    });
+    expect(internalFormat).toEqual({ dataType: 'defaultModel', field: 'validField' });
+  });
+
+  it('should keep dataType when string and fallback field when invalid', () => {
+    const internalFormat = convertDataBindingToInternalFormat('defaultModel', {
+      field: { field: 'invalid' } as unknown as string,
+      dataType: 'validDataType',
+    });
+    expect(internalFormat).toEqual({ dataType: 'validDataType', field: '' });
+  });
 });
 
 describe('validateSelectedDataModel', () => {

--- a/src/Designer/frontend/packages/ux-editor/src/utils/dataModelUtils.ts
+++ b/src/Designer/frontend/packages/ux-editor/src/utils/dataModelUtils.ts
@@ -100,18 +100,14 @@ export const getDataModelFields = ({
 const isExplicitDataModelBinding = (
   binding?: IDataModelBindings,
 ): binding is ExplicitDataModelBinding | undefined =>
-  typeof binding === 'object' &&
-  binding !== null &&
-  'dataType' in binding &&
-  'field' in binding;
+  typeof binding === 'object' && binding !== null && 'dataType' in binding && 'field' in binding;
 
 const normalizeExplicitDataModelBinding = (
   binding: ExplicitDataModelBinding,
   layoutDefaultDataType: string,
 ): ExplicitDataModelBinding => ({
   field: typeof binding.field === 'string' ? binding.field : '',
-  dataType:
-    typeof binding.dataType === 'string' ? binding.dataType : (layoutDefaultDataType ?? ''),
+  dataType: typeof binding.dataType === 'string' ? binding.dataType : (layoutDefaultDataType ?? ''),
 });
 
 export function convertDataBindingToInternalFormat(

--- a/src/Designer/frontend/packages/ux-editor/src/utils/dataModelUtils.ts
+++ b/src/Designer/frontend/packages/ux-editor/src/utils/dataModelUtils.ts
@@ -100,17 +100,31 @@ export const getDataModelFields = ({
 const isExplicitDataModelBinding = (
   binding?: IDataModelBindings,
 ): binding is ExplicitDataModelBinding | undefined =>
-  typeof binding === 'object' && 'dataType' in binding && 'field' in binding;
+  typeof binding === 'object' &&
+  binding !== null &&
+  'dataType' in binding &&
+  'field' in binding;
+
+const normalizeExplicitDataModelBinding = (
+  binding: ExplicitDataModelBinding,
+  layoutDefaultDataType: string,
+): ExplicitDataModelBinding => ({
+  field: typeof binding.field === 'string' ? binding.field : '',
+  dataType:
+    typeof binding.dataType === 'string' ? binding.dataType : (layoutDefaultDataType ?? ''),
+});
 
 export function convertDataBindingToInternalFormat(
   layoutDefaultDataTypeOrBinding: string,
   binding?: IDataModelBindings,
 ): ExplicitDataModelBinding {
   const layoutDefaultDataType = layoutDefaultDataTypeOrBinding as string | undefined;
-  if (isExplicitDataModelBinding(binding)) return binding;
+  if (isExplicitDataModelBinding(binding)) {
+    return normalizeExplicitDataModelBinding(binding, layoutDefaultDataType);
+  }
 
   return {
-    field: binding ?? '',
+    field: typeof binding === 'string' ? binding : '',
     dataType: layoutDefaultDataType,
   };
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

CLOSES: #18620 

Fixes a crash in the UX editor when selecting duplicated map components (Stedfeste i kart) after drag/drop.
Prevent UX editor crash by normalizing invalid explicit dataModelBindings (field/dataType) to safe strings before UI rendering.



https://github.com/user-attachments/assets/59ce8fc1-4be3-40e4-a8d7-f542f8f6b2ac




## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened data model binding normalisation to safely handle invalid inputs by coercing them to sensible defaults.

* **Tests**
  * Expanded test coverage for data model binding normalisation, verifying correct handling of various input formats and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->