### PR TITLE
chore(settings): replace api keys icon and replace `--fds` spacing/color tokens with `--ds` equivalents

### DIFF
--- a/src/Designer/frontend/settings/features/orgs/pages/BotAccounts/BotAccounts.module.css
+++ b/src/Designer/frontend/settings/features/orgs/pages/BotAccounts/BotAccounts.module.css
@@ -10,7 +10,7 @@
 }
 
 .heading {
-  gap: var(--fds-spacing-6);
+  gap: var(--ds-size-7);
 }
 
 .content {

--- a/src/Designer/frontend/settings/features/orgs/pages/BotAccounts/components/BotAccountApiKeys/BotAccountApiKeys.module.css
+++ b/src/Designer/frontend/settings/features/orgs/pages/BotAccounts/components/BotAccountApiKeys/BotAccountApiKeys.module.css
@@ -13,21 +13,3 @@
   flex-direction: column;
   gap: var(--ds-size-4);
 }
-
-.heading {
-  margin-bottom: var(--fds-spacing-2);
-}
-
-.table {
-  margin-bottom: var(--fds-spacing-2);
-}
-
-.expiredTag {
-  margin-left: var(--fds-spacing-2);
-}
-
-.actionsCell {
-  display: flex;
-  justify-content: flex-end;
-  gap: var(--ds-size-3);
-}

--- a/src/Designer/frontend/settings/features/orgs/pages/BotAccounts/components/BotAccountDialog/BotAccountDialog.module.css
+++ b/src/Designer/frontend/settings/features/orgs/pages/BotAccounts/components/BotAccountDialog/BotAccountDialog.module.css
@@ -1,14 +1,14 @@
 .dialogBlock {
   display: flex;
   flex-direction: column;
-  gap: var(--fds-spacing-4);
+  gap: var(--ds-size-5);
   min-width: 400px;
 }
 
 .fields {
   display: flex;
   flex-direction: column;
-  gap: var(--fds-spacing-4);
+  gap: var(--ds-size-5);
 }
 
 .environments {
@@ -19,9 +19,9 @@
 .environmentOptions {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--fds-spacing-2);
+  gap: var(--ds-size-3);
 }
 
 .actionsWrapper {
-  margin-top: var(--fds-spacing-2);
+  margin-top: var(--ds-size-3);
 }

--- a/src/Designer/frontend/settings/features/orgs/pages/BotAccounts/components/BotAccountsList/BotAccountsList.module.css
+++ b/src/Designer/frontend/settings/features/orgs/pages/BotAccounts/components/BotAccountsList/BotAccountsList.module.css
@@ -29,26 +29,7 @@
   word-break: break-all;
 }
 
-.apiKeysCell {
-  display: flex;
-  align-items: center;
-  gap: var(--ds-size-2);
-}
-
-.apiKeysPreview {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: var(--ds-size-2);
-  min-height: var(--ds-size-8);
-}
-
-.apiKeysPlaceholder {
-  color: var(--fds-semantic-text-neutral-subtle);
-  white-space: nowrap;
-}
-
 .detailsCell {
-  background-color: var(--fds-semantic-surface-neutral-subtle);
-  padding: var(--fds-spacing-4);
+  background-color: var(--ds-color-neutral-background-tinted);
+  padding: var(--ds-size-5);
 }

--- a/src/Designer/frontend/settings/features/user/components/Menu/Menu.tsx
+++ b/src/Designer/frontend/settings/features/user/components/Menu/Menu.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 import { StudioContentMenu } from '@studio/components';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { ShieldLockIcon } from '@studio/icons';
+import { KeyHorizontalIcon } from '@studio/icons';
 import { useTranslation } from 'react-i18next';
 import { RoutePaths } from '../../routes/RoutePaths';
 
@@ -14,7 +14,7 @@ export function Menu(): ReactElement {
     {
       tabId: RoutePaths.ApiKeys,
       tabName: t('settings.user.api_keys.api_keys'),
-      icon: <ShieldLockIcon />,
+      icon: <KeyHorizontalIcon />,
     },
   ];
   return (

--- a/src/Designer/frontend/settings/features/user/pages/ApiKeys/ApiKeys.module.css
+++ b/src/Designer/frontend/settings/features/user/pages/ApiKeys/ApiKeys.module.css
@@ -10,7 +10,7 @@
 }
 
 .heading {
-  gap: var(--fds-spacing-6);
+  gap: var(--ds-size-7);
 }
 
 .content {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Replace api keys icon and replace `--fds` spacing/color tokens with `--ds` equivalents

| BEFORE | AFTER |
|--------|--------|
| <img width="517" height="142" alt="Screenshot from 2026-05-08 15-07-48" src="https://github.com/user-attachments/assets/976c1abc-ac9a-43b6-b5eb-054ec1400033" /> | <img width="517" height="142" alt="Screenshot from 2026-05-08 15-07-54" src="https://github.com/user-attachments/assets/9529ea2d-0761-4a47-9a90-ddeb6a69820d" /> | 

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated spacing and styling across API key management interfaces for improved visual consistency.
  * Refreshed design system tokens for consistent spacing throughout the application.
  * Changed the icon for the API Keys menu item for better visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->