### PR TITLE
fix: Preventing focus stealing on navigation

### DIFF
--- a/src/App/frontend/src/features/navigation/NavigationFocus.tsx
+++ b/src/App/frontend/src/features/navigation/NavigationFocus.tsx
@@ -40,7 +40,10 @@ export function NavigationFocus(): null {
       return;
     }
 
-    document.getElementById('main-content')?.focus({ preventScroll: true });
+    const existingFocus = document.activeElement;
+    if (!existingFocus || existingFocus === document.body) {
+      document.getElementById('main-content')?.focus({ preventScroll: true });
+    }
     setHandledNavigationKey(key);
   });
 


### PR DESCRIPTION
## Description

A test failed in #18652, and after some debugging @phlipsterit suggested it may have been caused by `NavigationFocus` stealing focus from the already-focused input field right after navigating to a subform. This should prevent focus stealing in case somebody got a chance to focus on something before `NavigationFocus` did.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced focus management during navigation transitions to provide more intelligent focus handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->