### PR TITLE
chore: update the ux-editor folder to be rendered based on version

### DIFF
--- a/src/Designer/frontend/app-development/features/uiEditor/UiEditor.test.tsx
+++ b/src/Designer/frontend/app-development/features/uiEditor/UiEditor.test.tsx
@@ -35,7 +35,7 @@ describe('UiEditor', () => {
     expect(screen.queryByTestId('latest version')).not.toBeInTheDocument();
   });
 
-  type FrontendVersion = null | '3.0.0' | '4.0.0';
+  type FrontendVersion = null | '3.0.0' | '4.0.0' | '9.0.0';
   type PackageVersion = 'version 3' | 'latest version';
   type TestCase = [PackageVersion, FrontendVersion];
 

--- a/src/Designer/frontend/app-development/features/uiEditor/UiEditor.tsx
+++ b/src/Designer/frontend/app-development/features/uiEditor/UiEditor.tsx
@@ -1,4 +1,5 @@
-import { SubApp as UiEditorLatest } from '@altinn/ux-editor-v4/SubApp';
+import { SubApp as UiEditorLatest } from '@altinn/ux-editor/SubApp';
+import { SubApp as UiEditorV4 } from '@altinn/ux-editor-v4/SubApp';
 import { SubApp as UiEditorV3 } from '@altinn/ux-editor-v3/SubApp';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useAppVersionQuery } from 'app-shared/hooks/queries';
@@ -6,7 +7,7 @@ import { usePreviewContext } from '../../contexts/PreviewContext';
 import { useLayoutContext } from '../../contexts/LayoutContext';
 import { StudioPageSpinner } from '@studio/components';
 import { useTranslation } from 'react-i18next';
-import { MAXIMUM_SUPPORTED_FRONTEND_VERSION } from 'app-shared/constants';
+import { MAXIMUM_SUPPORTED_FRONTEND_VERSION, NEXT_V9_VERSION } from 'app-shared/constants';
 import { isBelowSupportedVersion } from 'app-shared/utils/compareFunctions';
 
 export default function UiEditor() {
@@ -22,24 +23,30 @@ export default function UiEditor() {
 
   if (!version) return null;
 
-  const renderUiEditorContent = () => {
-    const handleLayoutSetNameChange = (layoutSetName: string) => {
-      setSelectedLayoutSetName(layoutSetName);
-    };
-
-    return (
-      <UiEditorLatest
-        shouldReloadPreview={shouldReloadPreview}
-        previewHasLoaded={previewHasLoaded}
-        onLayoutSetNameChange={handleLayoutSetNameChange}
-      />
-    );
+  const handleLayoutSetNameChange = (layoutSetName: string) => {
+    setSelectedLayoutSetName(layoutSetName);
   };
 
-  const isLatestFrontendVersion = !isBelowSupportedVersion(
-    version?.frontendVersion,
+  const sharedProps = {
+    shouldReloadPreview,
+    previewHasLoaded,
+    onLayoutSetNameChange: handleLayoutSetNameChange,
+  };
+
+  const isV9 = !isBelowSupportedVersion(version.frontendVersion, NEXT_V9_VERSION);
+
+  if (isV9) {
+    return <UiEditorLatest {...sharedProps} />;
+  }
+
+  const isLatestSupportedVersion = !isBelowSupportedVersion(
+    version.frontendVersion,
     MAXIMUM_SUPPORTED_FRONTEND_VERSION,
   );
 
-  return isLatestFrontendVersion ? renderUiEditorContent() : <UiEditorV3 />;
+  if (isLatestSupportedVersion) {
+    return <UiEditorV4 {...sharedProps} />;
+  }
+
+  return <UiEditorV3 />;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updated `UiEditor.tsx` so that v9 apps will be render `ux-editor`, while v4 apps renders `ux-editor-v4` and so on. 


<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Extended UI editor test coverage to support additional version configurations.

* **Refactor**
  * Improved UI editor version compatibility by implementing multi-variant rendering logic that dynamically selects the appropriate editor implementation based on application version requirements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio/pull/18754)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->