### PR TITLE
chore: studioctl - add user-agent header to studioctl-related HTTP requests

### DIFF
--- a/src/cli/cmd/dev/main.go
+++ b/src/cli/cmd/dev/main.go
@@ -165,6 +165,7 @@ func buildDist(opts distOptions) (distResult, error) {
 			platform.GOOS,
 			platform.GOARCH,
 			opts.OutputDir,
+			opts.Version,
 		)
 		if err != nil {
 			return distResult{}, err
@@ -303,7 +304,7 @@ func buildStudioctlFor(goos, goarch, outputDir, binaryName, buildVersion string)
 }
 
 func buildPlatformResources(
-	goos, goarch, outputDir string,
+	goos, goarch, outputDir, buildVersion string,
 ) (archivePath string, err error) {
 	serverDir := filepath.Join(outputDir, "."+config.StudioctlServerName+"-"+goos+"-"+goarch)
 	if removeErr := os.RemoveAll(serverDir); removeErr != nil {
@@ -315,7 +316,7 @@ func buildPlatformResources(
 		}
 	}()
 
-	if _, publishErr := publishStudioctlServerToDir(goos, goarch, serverDir); publishErr != nil {
+	if _, publishErr := publishStudioctlServerToDir(goos, goarch, serverDir, buildVersion); publishErr != nil {
 		return "", publishErr
 	}
 
@@ -379,7 +380,7 @@ func installWindowsHostMode() error {
 	if err != nil {
 		return err
 	}
-	resourcesArchivePath, err := buildPlatformResources(osutil.OSWindows, runtime.GOARCH, stageDirWSL)
+	resourcesArchivePath, err := buildPlatformResources(osutil.OSWindows, runtime.GOARCH, stageDirWSL, version)
 	if err != nil {
 		return err
 	}

--- a/src/cli/cmd/dev/server.go
+++ b/src/cli/cmd/dev/server.go
@@ -19,7 +19,7 @@ const (
 
 var errUnsupportedStudioctlServerRID = errors.New("unsupported " + config.StudioctlServerName + " runtime")
 
-func publishStudioctlServerToDir(goos, goarch, publishDir string) (string, error) {
+func publishStudioctlServerToDir(goos, goarch, publishDir, buildVersion string) (string, error) {
 	fmt.Printf("Publishing %s...\n", config.StudioctlServerName)
 
 	rid, err := dotnetRuntimeIdentifier(goos, goarch)
@@ -43,6 +43,7 @@ func publishStudioctlServerToDir(goos, goarch, publishDir string) (string, error
 		"--self-contained", "true",
 		"-p:DebugType=None",
 		"-p:DebugSymbols=false",
+		"-p:InformationalVersion=" + buildVersion,
 	}
 
 	cmd := processutil.CommandContext(context.Background(), "dotnet", args...)

--- a/src/cli/internal/cmd/app.go
+++ b/src/cli/internal/cmd/app.go
@@ -71,7 +71,7 @@ func (o appBuildOutput) PrintFinal(out *ui.Output) error {
 
 // NewAppCommand creates a new app command.
 func NewAppCommand(cfg *config.Config, out *ui.Output) *AppCommand {
-	service := appsvc.NewService(cfg.Home)
+	service := appsvc.NewService(cfg.Home, cfg.Version)
 	return &AppCommand{
 		out:     out,
 		logs:    newAppLogsCommand(cfg, out, service),

--- a/src/cli/internal/cmd/app/run_test.go
+++ b/src/cli/internal/cmd/app/run_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	appsvc "altinn.studio/studioctl/internal/cmd/app"
+	"altinn.studio/studioctl/internal/config"
 	repocontext "altinn.studio/studioctl/internal/context"
 	"altinn.studio/studioctl/internal/envtopology"
 )
@@ -18,7 +19,7 @@ func defaultTopology() envtopology.Local {
 func TestBuildDockerRunSpec_AddsDockerLocaltestEnv(t *testing.T) {
 	t.Parallel()
 
-	spec, err := appsvc.NewService("").BuildDockerRunSpec(repocontext.Detection{
+	spec, err := appsvc.NewService("", config.NewVersion("test-version")).BuildDockerRunSpec(repocontext.Detection{
 		AppRoot:   t.TempDir(),
 		InAppRepo: true,
 	}, nil, defaultTopology(), appsvc.DockerRunOptions{})
@@ -42,7 +43,7 @@ func TestBuildDockerRunSpec_UsesImageTagOverride(t *testing.T) {
 
 	want := "ghcr.io/altinn/altinn-studio/app:frontend-test"
 
-	spec, err := appsvc.NewService("").BuildDockerRunSpec(repocontext.Detection{
+	spec, err := appsvc.NewService("", config.NewVersion("test-version")).BuildDockerRunSpec(repocontext.Detection{
 		AppRoot:   t.TempDir(),
 		InAppRepo: true,
 	}, nil, defaultTopology(), appsvc.DockerRunOptions{ImageTag: want})
@@ -60,7 +61,7 @@ func TestBuildDotnetRunSpec_BindsNativeAppPort(t *testing.T) {
 
 	appPath := t.TempDir()
 	projectPath := writeAppProject(t, appPath)
-	spec, err := appsvc.NewService("").BuildDotnetRunSpec(
+	spec, err := appsvc.NewService("", config.NewVersion("test-version")).BuildDotnetRunSpec(
 		t.Context(),
 		appPath,
 		nil,
@@ -103,7 +104,7 @@ func TestBuildDotnetRunSpec_PreservesCurrentEnv(t *testing.T) {
 
 	appPath := t.TempDir()
 	writeAppProject(t, appPath)
-	spec, err := appsvc.NewService("").BuildDotnetRunSpec(
+	spec, err := appsvc.NewService("", config.NewVersion("test-version")).BuildDotnetRunSpec(
 		t.Context(),
 		appPath,
 		nil,
@@ -135,7 +136,7 @@ func TestBuildDotnetRunSpec_RandomHostPortAsksKestrelToSelectPort(t *testing.T) 
 
 	appPath := t.TempDir()
 	writeAppProject(t, appPath)
-	spec, err := appsvc.NewService("").BuildDotnetRunSpec(
+	spec, err := appsvc.NewService("", config.NewVersion("test-version")).BuildDotnetRunSpec(
 		t.Context(),
 		appPath,
 		[]string{"--seed", "1"},
@@ -181,7 +182,7 @@ func TestResolveRunTarget_ReadsAppID(t *testing.T) {
 	appPath := t.TempDir()
 	writeAppMetadata(t, appPath, `{"id":"ttd/test-app"}`)
 
-	target, err := appsvc.NewService("").ResolveRunTarget(t.Context(), appPath)
+	target, err := appsvc.NewService("", config.NewVersion("test-version")).ResolveRunTarget(t.Context(), appPath)
 	if err != nil {
 		t.Fatalf("ResolveRunTarget() error = %v", err)
 	}
@@ -199,7 +200,8 @@ func TestResolveRunTarget_RejectsInvalidAppID(t *testing.T) {
 	appPath := t.TempDir()
 	writeAppMetadata(t, appPath, `{"id":"invalid"}`)
 
-	if _, err := appsvc.NewService("").ResolveRunTarget(t.Context(), appPath); err == nil {
+	_, err := appsvc.NewService("", config.NewVersion("test-version")).ResolveRunTarget(t.Context(), appPath)
+	if err == nil {
 		t.Fatal("ResolveRunTarget() error = nil, want error")
 	}
 }

--- a/src/cli/internal/cmd/app/service.go
+++ b/src/cli/internal/cmd/app/service.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"altinn.studio/studioctl/internal/auth"
+	"altinn.studio/studioctl/internal/config"
 	repocontext "altinn.studio/studioctl/internal/context"
 	"altinn.studio/studioctl/internal/studio"
 )
@@ -18,11 +19,15 @@ var ErrNotLoggedIn = errors.New("not logged in")
 // Service contains app command logic.
 type Service struct {
 	credentialsHome string
+	version         config.Version
 }
 
 // NewService creates a new app command service.
-func NewService(credentialsHome string) *Service {
-	return &Service{credentialsHome: credentialsHome}
+func NewService(credentialsHome string, version config.Version) *Service {
+	return &Service{
+		credentialsHome: credentialsHome,
+		version:         version,
+	}
 }
 
 // UpdateResult contains detected app location for update flow.
@@ -98,7 +103,7 @@ func (s *Service) Clone(ctx context.Context, req CloneRequest) (CloneResult, err
 		return CloneResult{}, fmt.Errorf("get credentials for %s: %w", req.Env, err)
 	}
 
-	client := studio.NewClient(envCreds)
+	client := studio.NewClient(envCreds, s.version)
 	cloneErr := client.CloneRepo(ctx, req.Org, req.Repo, req.Destination)
 	if cloneErr != nil {
 		return CloneResult{}, fmt.Errorf("clone repo: %w", cloneErr)

--- a/src/cli/internal/cmd/auth.go
+++ b/src/cli/internal/cmd/auth.go
@@ -35,7 +35,7 @@ type AuthCommand struct {
 func NewAuthCommand(cfg *config.Config, out *ui.Output) *AuthCommand {
 	return &AuthCommand{
 		out:     out,
-		service: authsvc.NewService(cfg.Home),
+		service: authsvc.NewService(cfg.Home, cfg.Version),
 	}
 }
 

--- a/src/cli/internal/cmd/auth/service.go
+++ b/src/cli/internal/cmd/auth/service.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 
 	authstore "altinn.studio/studioctl/internal/auth"
+	"altinn.studio/studioctl/internal/config"
 	"altinn.studio/studioctl/internal/studio"
 )
 
@@ -33,11 +34,15 @@ func (e AlreadyLoggedInError) Error() string {
 // Service contains auth command logic.
 type Service struct {
 	credentialsHome string
+	version         config.Version
 }
 
 // NewService creates a new auth command service.
-func NewService(credentialsHome string) *Service {
-	return &Service{credentialsHome: credentialsHome}
+func NewService(credentialsHome string, version config.Version) *Service {
+	return &Service{
+		credentialsHome: credentialsHome,
+		version:         version,
+	}
 }
 
 // ResolveHost resolves the effective host based on env and explicit override.
@@ -84,7 +89,7 @@ func (s *Service) Login(ctx context.Context, req LoginRequest) (LoginResult, err
 		}
 	}
 
-	client := studio.NewClientWithHTTP(req.Host, req.Token, "", nil)
+	client := studio.NewClientWithHTTP(req.Host, req.Token, "", s.version, nil)
 	user, err := client.GetUser(ctx)
 	if err != nil {
 		if errors.Is(err, studio.ErrUnauthorized) {
@@ -157,7 +162,7 @@ func (s *Service) Status(ctx context.Context, req StatusRequest) (StatusResult, 
 					Env:      req.Env,
 					Host:     envCreds.Host,
 					Username: envCreds.Username,
-					Status:   validateToken(ctx, envCreds),
+					Status:   validateToken(ctx, envCreds, s.version),
 				},
 			},
 		}, nil
@@ -176,7 +181,7 @@ func (s *Service) Status(ctx context.Context, req StatusRequest) (StatusResult, 
 			Env:      envName,
 			Host:     envCreds.Host,
 			Username: envCreds.Username,
-			Status:   validateToken(ctx, envCreds),
+			Status:   validateToken(ctx, envCreds, s.version),
 		})
 	}
 
@@ -227,8 +232,8 @@ func (s *Service) Logout(req LogoutRequest) (LogoutResult, error) {
 	return LogoutResult{Removed: true}, nil
 }
 
-func validateToken(ctx context.Context, creds *authstore.EnvCredentials) string {
-	client := studio.NewClient(creds)
+func validateToken(ctx context.Context, creds *authstore.EnvCredentials, version config.Version) string {
+	client := studio.NewClient(creds, version)
 	_, err := client.GetUser(ctx)
 	if err != nil {
 		if errors.Is(err, studio.ErrUnauthorized) {

--- a/src/cli/internal/cmd/doctor/localtest_env.go
+++ b/src/cli/internal/cmd/doctor/localtest_env.go
@@ -10,12 +10,13 @@ import (
 func (s *Service) buildLocaltestEnv(ctx context.Context) *envlocaltest.DiagnosticReport {
 	topology := envtopology.NewLocal(envtopology.DefaultIngressPortString())
 	return envlocaltest.Diagnose(ctx, envlocaltest.DiagnosticOptions{
-		Debugf:          s.debugf,
-		DetectContainer: s.containerDetect,
-		ResolveHost:     nil,
-		HTTPGet:         nil,
-		DialTCP:         nil,
-		IPv6Enabled:     nil,
-		Topology:        topology,
+		Debugf:           s.debugf,
+		DetectContainer:  s.containerDetect,
+		ResolveHost:      nil,
+		HTTPGet:          nil,
+		DialTCP:          nil,
+		IPv6Enabled:      nil,
+		Topology:         topology,
+		UserAgentVersion: s.cfg.Version,
 	})
 }

--- a/src/cli/internal/cmd/doctor/service.go
+++ b/src/cli/internal/cmd/doctor/service.go
@@ -156,7 +156,7 @@ func New(cfg *config.Config, debugf func(format string, args ...any)) *Service {
 // BuildReport builds a doctor report from system state.
 func (s *Service) BuildReport(ctx context.Context) Report {
 	return Report{
-		CLI:           &CLI{Version: s.cfg.Version},
+		CLI:           &CLI{Version: s.cfg.Version.String()},
 		System:        buildSystem(ctx),
 		Prerequisites: s.collectPrerequisites(ctx),
 		Auth:          s.buildAuth(),

--- a/src/cli/internal/cmd/env/localtest/diagnostics.go
+++ b/src/cli/internal/cmd/env/localtest/diagnostics.go
@@ -14,7 +14,9 @@ import (
 	"altinn.studio/devenv/pkg/container"
 	"altinn.studio/devenv/pkg/container/types"
 	"altinn.studio/studioctl/internal/cmd/env/localtest/components"
+	"altinn.studio/studioctl/internal/config"
 	"altinn.studio/studioctl/internal/envtopology"
+	"altinn.studio/studioctl/internal/httpclient"
 	"altinn.studio/studioctl/internal/osutil"
 )
 
@@ -37,13 +39,14 @@ const (
 
 // DiagnosticOptions configures localtest diagnostics.
 type DiagnosticOptions struct {
-	DetectContainer func(ctx context.Context) (container.ContainerClient, error)
-	ResolveHost     func(ctx context.Context, host string) ([]string, error)
-	HTTPGet         func(ctx context.Context, url string) (DiagnosticHTTPResponse, error)
-	DialTCP         func(ctx context.Context, network, address string) error
-	IPv6Enabled     func() bool
-	Debugf          func(format string, args ...any)
-	Topology        envtopology.Local
+	DetectContainer  func(ctx context.Context) (container.ContainerClient, error)
+	ResolveHost      func(ctx context.Context, host string) ([]string, error)
+	HTTPGet          func(ctx context.Context, url string) (DiagnosticHTTPResponse, error)
+	DialTCP          func(ctx context.Context, network, address string) error
+	IPv6Enabled      func() bool
+	Debugf           func(format string, args ...any)
+	UserAgentVersion config.Version
+	Topology         envtopology.Local
 }
 
 // DiagnosticReport contains diagnostics for the localtest environment.
@@ -270,7 +273,10 @@ func normalizeDiagnosticOptions(opts DiagnosticOptions) DiagnosticOptions {
 		opts.ResolveHost = defaultDiagnosticResolveHost
 	}
 	if opts.HTTPGet == nil {
-		opts.HTTPGet = defaultDiagnosticHTTPGet
+		userAgentVersion := opts.UserAgentVersion
+		opts.HTTPGet = func(ctx context.Context, url string) (DiagnosticHTTPResponse, error) {
+			return defaultDiagnosticHTTPGet(ctx, url, userAgentVersion)
+		}
 	}
 	if opts.DialTCP == nil {
 		opts.DialTCP = defaultDiagnosticDialTCP
@@ -482,11 +488,16 @@ func defaultDiagnosticResolveHost(ctx context.Context, host string) ([]string, e
 	return addresses, nil
 }
 
-func defaultDiagnosticHTTPGet(ctx context.Context, url string) (DiagnosticHTTPResponse, error) {
+func defaultDiagnosticHTTPGet(
+	ctx context.Context,
+	url string,
+	userAgentVersion config.Version,
+) (DiagnosticHTTPResponse, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return DiagnosticHTTPResponse{}, fmt.Errorf("build request: %w", err)
 	}
+	httpclient.SetUserAgent(req, userAgentVersion)
 
 	client := &http.Client{Transport: diagnosticHTTPTransport()}
 	resp, err := client.Do(req)

--- a/src/cli/internal/cmd/logs_internal_test.go
+++ b/src/cli/internal/cmd/logs_internal_test.go
@@ -16,6 +16,7 @@ import (
 	containermock "altinn.studio/devenv/pkg/container/mock"
 	appsvc "altinn.studio/studioctl/internal/cmd/app"
 	appsupport "altinn.studio/studioctl/internal/cmd/apps"
+	"altinn.studio/studioctl/internal/config"
 	"altinn.studio/studioctl/internal/osutil"
 	"altinn.studio/studioctl/internal/studioctlserver"
 	"altinn.studio/studioctl/internal/ui"
@@ -268,7 +269,7 @@ func TestAppLogsStoredIDUsesCurrentAppDirectory(t *testing.T) {
 	command := &appLogsCommand{
 		out:     ui.NewOutput(&out, io.Discard, false),
 		cfg:     cfg,
-		service: appsvc.NewService(""),
+		service: appsvc.NewService("", config.NewVersion("test-version")),
 		server: studioctlServerAccess{
 			client: &fakeStudioctlServerClient{status: &studioctlserver.Status{}},
 		},

--- a/src/cli/internal/cmd/root.go
+++ b/src/cli/internal/cmd/root.go
@@ -266,7 +266,7 @@ func newEphemeralConfig(flags config.Flags, version string) *config.Config {
 		DataDir:   "",
 		BinDir:    "",
 		Images:    images,
-		Version:   version,
+		Version:   config.NewVersion(version),
 		Verbose:   flags.Verbose,
 	}
 }

--- a/src/cli/internal/cmd/run.go
+++ b/src/cli/internal/cmd/run.go
@@ -60,7 +60,7 @@ type RunCommand struct {
 
 // NewRunCommand creates a new top-level run alias command.
 func NewRunCommand(cfg *config.Config, out *ui.Output) *RunCommand {
-	return newRunCommand(cfg, out, appsvc.NewService(cfg.Home))
+	return newRunCommand(cfg, out, appsvc.NewService(cfg.Home, cfg.Version))
 }
 
 func newRunCommand(cfg *config.Config, out *ui.Output, service *appsvc.Service) *RunCommand {

--- a/src/cli/internal/cmd/self.go
+++ b/src/cli/internal/cmd/self.go
@@ -387,7 +387,7 @@ func (c *SelfCommand) runCompleteInstall(ctx context.Context, args []string) err
 		return fmt.Errorf("%w: %s", ErrInvalidFlagValue, strings.Join(args, " "))
 	}
 	bundle := installpkg.Bundle{
-		Version:              c.cfg.Version,
+		Version:              c.cfg.Version.String(),
 		BinaryPath:           "",
 		ResourcesArchivePath: os.Getenv(config.EnvResourcesArchive),
 	}

--- a/src/cli/internal/cmd/stop.go
+++ b/src/cli/internal/cmd/stop.go
@@ -57,7 +57,7 @@ type appStopOutput struct {
 
 // NewStopCommand creates a new top-level stop alias command.
 func NewStopCommand(cfg *config.Config, out *ui.Output) *StopCommand {
-	return newStopCommand(cfg, out, appsvc.NewService(cfg.Home))
+	return newStopCommand(cfg, out, appsvc.NewService(cfg.Home, cfg.Version))
 }
 
 func newStopCommand(cfg *config.Config, out *ui.Output, service *appsvc.Service) *StopCommand {

--- a/src/cli/internal/config/config.go
+++ b/src/cli/internal/config/config.go
@@ -80,7 +80,7 @@ type Config struct {
 	DataDir   string       // Directory for container volumes
 	BinDir    string       // Directory for binaries and installed payloads
 	Images    ImagesConfig // Container image configuration
-	Version   string       // Build version (embedded at build time)
+	Version   Version      // Build version (embedded at build time)
 	Verbose   bool         // Verbose output (-v)
 }
 
@@ -148,7 +148,7 @@ func newResolvedConfig(
 		DataDir:   filepath.Join(home, "data"),
 		BinDir:    filepath.Join(home, "bin"),
 		Images:    images,
-		Version:   version,
+		Version:   NewVersion(version),
 		Verbose:   flags.Verbose,
 	}
 

--- a/src/cli/internal/config/version.go
+++ b/src/cli/internal/config/version.go
@@ -1,0 +1,23 @@
+package config
+
+const userAgentProduct = "studioctl"
+
+// Version is the studioctl build version.
+type Version struct {
+	value string
+}
+
+// NewVersion creates a studioctl build version value.
+func NewVersion(value string) Version {
+	return Version{value: value}
+}
+
+// String returns the build version string.
+func (v Version) String() string {
+	return v.value
+}
+
+// UserAgent returns the studioctl User-Agent value for this version.
+func (v Version) UserAgent() string {
+	return userAgentProduct + "/" + v.value
+}

--- a/src/cli/internal/httpclient/user_agent.go
+++ b/src/cli/internal/httpclient/user_agent.go
@@ -1,0 +1,18 @@
+// Package httpclient contains shared HTTP client helpers.
+package httpclient
+
+import (
+	"net/http"
+
+	"altinn.studio/studioctl/internal/config"
+)
+
+// UserAgent returns the studioctl User-Agent value for a CLI version.
+func UserAgent(version config.Version) string {
+	return version.UserAgent()
+}
+
+// SetUserAgent sets the studioctl User-Agent header on req.
+func SetUserAgent(req *http.Request, version config.Version) {
+	req.Header.Set("User-Agent", UserAgent(version))
+}

--- a/src/cli/internal/install/bundle.go
+++ b/src/cli/internal/install/bundle.go
@@ -18,7 +18,7 @@ func (s *Service) CurrentBundle(resourcesArchivePath, targetDir string) (Bundle,
 		return Bundle{}, err
 	}
 	return Bundle{
-		Version:              s.cfg.Version,
+		Version:              s.cfg.Version.String(),
 		BinaryPath:           binaryPath,
 		ResourcesArchivePath: resourcesArchivePath,
 		installPath:          filepath.Join(targetDir, installBinaryName()),

--- a/src/cli/internal/install/resources.go
+++ b/src/cli/internal/install/resources.go
@@ -111,10 +111,10 @@ func (b Bundle) downloadResourcesArchive(ctx context.Context) (path string, clea
 	}
 
 	tmpPath := filepath.Join(tempDir, assetName)
-	if err := downloadToFile(ctx, assetBaseURL+"/"+assetName, tmpPath); err != nil {
+	if err := downloadToFile(ctx, assetBaseURL+"/"+assetName, tmpPath, config.NewVersion(b.Version)); err != nil {
 		return "", cleanup, fmt.Errorf("download resources archive: %w", err)
 	}
-	if err := verifyAssetChecksum(ctx, checksumsURL, assetName, tmpPath); err != nil {
+	if err := verifyAssetChecksum(ctx, checksumsURL, assetName, tmpPath, config.NewVersion(b.Version)); err != nil {
 		return "", cleanup, fmt.Errorf("verify resources archive checksum: %w", err)
 	}
 

--- a/src/cli/internal/install/update.go
+++ b/src/cli/internal/install/update.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"time"
 
+	"altinn.studio/studioctl/internal/config"
+	"altinn.studio/studioctl/internal/httpclient"
 	"altinn.studio/studioctl/internal/osutil"
 )
 
@@ -63,6 +65,7 @@ type resolvedUpdate struct {
 	binaryBase string
 	checksums  string
 	targetPath string
+	userAgent  config.Version
 	version    string
 	skipCheck  bool
 }
@@ -84,7 +87,7 @@ func (s *Service) ResolveUpdateBundle(
 		)
 	}
 
-	resolved, err := resolveUpdateOptions(ctx, opts, execPath)
+	resolved, err := resolveUpdateOptions(ctx, opts, execPath, s.cfg.Version)
 	if err != nil {
 		return ResolvedBundle{}, err
 	}
@@ -98,7 +101,13 @@ func (s *Service) ResolveUpdateBundle(
 	}
 
 	if !resolved.skipCheck {
-		if verifyErr := verifyAssetChecksum(ctx, resolved.checksums, resolved.asset, tmpBinaryPath); verifyErr != nil {
+		if verifyErr := verifyAssetChecksum(
+			ctx,
+			resolved.checksums,
+			resolved.asset,
+			tmpBinaryPath,
+			resolved.userAgent,
+		); verifyErr != nil {
 			if cleanup != nil {
 				verifyErr = errors.Join(verifyErr, cleanup())
 			}
@@ -117,13 +126,18 @@ func (s *Service) ResolveUpdateBundle(
 	}, nil
 }
 
-func resolveUpdateOptions(ctx context.Context, opts UpdateOptions, execPath string) (resolvedUpdate, error) {
+func resolveUpdateOptions(
+	ctx context.Context,
+	opts UpdateOptions,
+	execPath string,
+	userAgentVersion config.Version,
+) (resolvedUpdate, error) {
 	version, err := normalizeReleaseVersion(opts.Version)
 	if err != nil {
 		return resolvedUpdate{}, err
 	}
 	if version == "" {
-		version, err = resolveLatestStudioctlVersion(ctx, defaultUpdateRepo)
+		version, err = resolveLatestStudioctlVersion(ctx, defaultUpdateRepo, userAgentVersion)
 		if err != nil {
 			return resolvedUpdate{}, err
 		}
@@ -141,13 +155,14 @@ func resolveUpdateOptions(ctx context.Context, opts UpdateOptions, execPath stri
 		binaryBase: binaryBase,
 		checksums:  checksums,
 		targetPath: execPath,
+		userAgent:  userAgentVersion,
 		version:    version,
 		skipCheck:  opts.SkipChecksum,
 	}, nil
 }
 
-func resolveLatestStudioctlVersion(ctx context.Context, repo string) (string, error) {
-	return resolveLatestStudioctlVersionFromBase(ctx, repo, githubAPIReposBaseURL)
+func resolveLatestStudioctlVersion(ctx context.Context, repo string, userAgentVersion config.Version) (string, error) {
+	return resolveLatestStudioctlVersionFromBase(ctx, repo, githubAPIReposBaseURL, userAgentVersion)
 }
 
 type studioctlTagVersion struct {
@@ -271,11 +286,16 @@ func compareInt(a, b int) int {
 	return 0
 }
 
-func resolveLatestStudioctlVersionFromBase(ctx context.Context, repo, baseURL string) (string, error) {
+func resolveLatestStudioctlVersionFromBase(
+	ctx context.Context,
+	repo,
+	baseURL string,
+	userAgentVersion config.Version,
+) (string, error) {
 	var candidates releaseCandidates
 
 	for page := 1; page <= releaseMaxPages; page++ {
-		releases, err := fetchReleasesPage(ctx, repo, baseURL, page)
+		releases, err := fetchReleasesPage(ctx, repo, baseURL, page, userAgentVersion)
 		if err != nil {
 			return "", err
 		}
@@ -298,7 +318,13 @@ type githubRelease struct {
 	Prerelease bool   `json:"prerelease"`
 }
 
-func fetchReleasesPage(ctx context.Context, repo, baseURL string, page int) ([]githubRelease, error) {
+func fetchReleasesPage(
+	ctx context.Context,
+	repo,
+	baseURL string,
+	page int,
+	userAgentVersion config.Version,
+) ([]githubRelease, error) {
 	releasesURL := fmt.Sprintf(
 		"%s/%s/releases?per_page=%d&page=%d",
 		baseURL,
@@ -306,7 +332,7 @@ func fetchReleasesPage(ctx context.Context, repo, baseURL string, page int) ([]g
 		releasePageSize,
 		page,
 	)
-	data, err := downloadToMemory(ctx, releasesURL)
+	data, err := downloadToMemory(ctx, releasesURL, userAgentVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -385,7 +411,7 @@ func downloadUpdateBinary(
 		binaryPath += exeSuffix
 	}
 
-	if err := downloadToFile(ctx, plan.binaryBase+"/"+plan.asset, binaryPath); err != nil {
+	if err := downloadToFile(ctx, plan.binaryBase+"/"+plan.asset, binaryPath, plan.userAgent); err != nil {
 		return "", cleanup, err
 	}
 
@@ -581,8 +607,8 @@ func releaseURLs(repo, version string) (binaryBaseURL, checksumsURL string) {
 	return base, base + "/" + checksumAssetName
 }
 
-func downloadToFile(ctx context.Context, url, path string) (err error) {
-	resp, err := getURL(ctx, url)
+func downloadToFile(ctx context.Context, url, path string, userAgentVersion config.Version) (err error) {
+	resp, err := getURL(ctx, url, userAgentVersion)
 	if err != nil {
 		return err
 	}
@@ -606,8 +632,14 @@ func downloadToFile(ctx context.Context, url, path string) (err error) {
 	return nil
 }
 
-func verifyAssetChecksum(ctx context.Context, checksumsURL, asset, binaryPath string) error {
-	checksums, err := downloadToMemory(ctx, checksumsURL)
+func verifyAssetChecksum(
+	ctx context.Context,
+	checksumsURL,
+	asset,
+	binaryPath string,
+	userAgentVersion config.Version,
+) error {
+	checksums, err := downloadToMemory(ctx, checksumsURL, userAgentVersion)
 	if err != nil {
 		return err
 	}
@@ -633,8 +665,8 @@ func verifyAssetChecksum(ctx context.Context, checksumsURL, asset, binaryPath st
 	return nil
 }
 
-func downloadToMemory(ctx context.Context, url string) (data []byte, err error) {
-	resp, err := getURL(ctx, url)
+func downloadToMemory(ctx context.Context, url string, userAgentVersion config.Version) (data []byte, err error) {
+	resp, err := getURL(ctx, url, userAgentVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -649,11 +681,12 @@ func downloadToMemory(ctx context.Context, url string) (data []byte, err error) 
 	return data, nil
 }
 
-func getURL(ctx context.Context, url string) (*http.Response, error) {
+func getURL(ctx context.Context, url string, userAgentVersion config.Version) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}
+	httpclient.SetUserAgent(req, userAgentVersion)
 
 	client := &http.Client{Timeout: httpTimeout}
 	resp, err := client.Do(req)

--- a/src/cli/internal/install/update_internal_test.go
+++ b/src/cli/internal/install/update_internal_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"altinn.studio/studioctl/internal/config"
 )
 
 func TestResolveLatestStudioctlVersion(t *testing.T) {
@@ -69,6 +71,7 @@ func TestResolveLatestStudioctlVersion(t *testing.T) {
 				context.Background(),
 				"Altinn/altinn-studio",
 				server.URL+"/repos",
+				config.NewVersion("test-version"),
 			)
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("resolveLatestStudioctlVersion() error = %v, wantErr %v", err, tc.wantErr)
@@ -131,6 +134,7 @@ func TestResolveLatestStudioctlVersion_Paginates(t *testing.T) {
 		context.Background(),
 		"Altinn/altinn-studio",
 		server.URL+"/repos",
+		config.NewVersion("test-version"),
 	)
 	if err != nil {
 		t.Fatalf("resolveLatestStudioctlVersion() error = %v", err)

--- a/src/cli/internal/studio/client.go
+++ b/src/cli/internal/studio/client.go
@@ -17,6 +17,8 @@ import (
 
 	"altinn.studio/devenv/pkg/processutil"
 	"altinn.studio/studioctl/internal/auth"
+	"altinn.studio/studioctl/internal/config"
+	"altinn.studio/studioctl/internal/httpclient"
 )
 
 const (
@@ -77,16 +79,18 @@ type Client struct {
 	host       string
 	token      string
 	username   string
+	version    config.Version
 	httpClient *http.Client
 	scheme     string // "https" or "http" (http only for testing)
 }
 
 // NewClient creates a new Studio API client from credentials.
-func NewClient(creds *auth.EnvCredentials) *Client {
+func NewClient(creds *auth.EnvCredentials, version config.Version) *Client {
 	return &Client{
 		host:     creds.Host,
 		token:    creds.Token,
 		username: creds.Username,
+		version:  version,
 		scheme:   "https",
 		httpClient: &http.Client{
 			Timeout: httpTimeout,
@@ -95,7 +99,13 @@ func NewClient(creds *auth.EnvCredentials) *Client {
 }
 
 // NewClientWithHTTP creates a new client with a custom HTTP client (for testing).
-func NewClientWithHTTP(host, token, username string, httpClient *http.Client) *Client {
+func NewClientWithHTTP(
+	host,
+	token,
+	username string,
+	version config.Version,
+	httpClient *http.Client,
+) *Client {
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: httpTimeout}
 	}
@@ -103,6 +113,7 @@ func NewClientWithHTTP(host, token, username string, httpClient *http.Client) *C
 		host:       host,
 		token:      token,
 		username:   username,
+		version:    version,
 		scheme:     "https",
 		httpClient: httpClient,
 	}
@@ -117,7 +128,7 @@ func (c *Client) GetUser(ctx context.Context) (*User, error) {
 		return nil, fmt.Errorf("create request: %w", err)
 	}
 
-	c.setAuthHeader(req)
+	c.setRequestHeaders(req)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -153,7 +164,7 @@ func (c *Client) GetRepo(ctx context.Context, org, repo string) (*Repository, er
 		return nil, fmt.Errorf("create request: %w", err)
 	}
 
-	c.setAuthHeader(req)
+	c.setRequestHeaders(req)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -219,7 +230,15 @@ func (c *Client) execGitClone(ctx context.Context, cloneURL, destPath string) er
 		return ErrGitNotFound
 	}
 
-	cmd := processutil.CommandContext(ctx, gitPath, "clone", cloneURL, destPath)
+	cmd := processutil.CommandContext(
+		ctx,
+		gitPath,
+		"-c",
+		"http.userAgent="+httpclient.UserAgent(c.version),
+		"clone",
+		cloneURL,
+		destPath,
+	)
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -230,9 +249,10 @@ func (c *Client) execGitClone(ctx context.Context, cloneURL, destPath string) er
 	return nil
 }
 
-// setAuthHeader sets the authorization header for API requests.
-func (c *Client) setAuthHeader(req *http.Request) {
+// setRequestHeaders sets the shared headers for API requests.
+func (c *Client) setRequestHeaders(req *http.Request) {
 	req.Header.Set("Authorization", "token "+c.token)
+	httpclient.SetUserAgent(req, c.version)
 }
 
 // pathExists checks if a file or directory exists.

--- a/src/cli/internal/studio/client_test.go
+++ b/src/cli/internal/studio/client_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"altinn.studio/studioctl/internal/config"
 )
 
 func TestClient_GetUser_Success(t *testing.T) {
@@ -17,6 +19,9 @@ func TestClient_GetUser_Success(t *testing.T) {
 		authHeader := r.Header.Get("Authorization")
 		if authHeader != "token test-token" {
 			t.Errorf("expected Authorization header 'token test-token', got %q", authHeader)
+		}
+		if userAgent := r.Header.Get("User-Agent"); userAgent != "studioctl/test-version" {
+			t.Errorf("expected User-Agent 'studioctl/test-version', got %q", userAgent)
 		}
 
 		// Verify path
@@ -46,6 +51,7 @@ func TestClient_GetUser_Success(t *testing.T) {
 		host:       host,
 		token:      "test-token",
 		username:   "testuser",
+		version:    config.NewVersion("test-version"),
 		scheme:     "http",
 		httpClient: server.Client(),
 	}
@@ -67,7 +73,14 @@ func TestClient_GetUser_Unauthorized(t *testing.T) {
 	defer server.Close()
 
 	host := server.URL[7:]
-	client := &Client{host: host, token: "bad-token", username: "", scheme: "http", httpClient: server.Client()}
+	client := &Client{
+		host:       host,
+		token:      "bad-token",
+		username:   "",
+		version:    config.NewVersion("test-version"),
+		scheme:     "http",
+		httpClient: server.Client(),
+	}
 
 	_, err := client.GetUser(context.Background())
 	if !errors.Is(err, ErrUnauthorized) {
@@ -108,6 +121,7 @@ func TestClient_GetRepo_Success(t *testing.T) {
 		host:       host,
 		token:      "test-token",
 		username:   "testuser",
+		version:    config.NewVersion("test-version"),
 		scheme:     "http",
 		httpClient: server.Client(),
 	}
@@ -137,6 +151,7 @@ func TestClient_GetRepo_NotFound(t *testing.T) {
 		host:       host,
 		token:      "test-token",
 		username:   "testuser",
+		version:    config.NewVersion("test-version"),
 		scheme:     "http",
 		httpClient: server.Client(),
 	}
@@ -157,6 +172,7 @@ func TestClient_buildCloneURL_SpecialChars(t *testing.T) {
 		host:       "altinn.studio",
 		token:      "token/with+special=chars",
 		username:   "user@example.com",
+		version:    config.NewVersion("test-version"),
 		httpClient: nil,
 		scheme:     "https",
 	}

--- a/src/cli/internal/studioctlserver/client.go
+++ b/src/cli/internal/studioctlserver/client.go
@@ -21,6 +21,7 @@ import (
 
 	"altinn.studio/studioctl/internal/config"
 	"altinn.studio/studioctl/internal/envtopology"
+	"altinn.studio/studioctl/internal/httpclient"
 	"altinn.studio/studioctl/internal/osutil"
 )
 
@@ -231,6 +232,7 @@ func (c *Client) Health(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("build health request: %w", err)
 	}
+	httpclient.SetUserAgent(req, c.cfg.Version)
 
 	resp, err := c.http.Do(req)
 	if err != nil {
@@ -254,6 +256,7 @@ func (c *Client) Status(ctx context.Context) (*Status, error) {
 	if err != nil {
 		return nil, fmt.Errorf("build status request: %w", err)
 	}
+	httpclient.SetUserAgent(req, c.cfg.Version)
 
 	resp, err := c.http.Do(req)
 	if err != nil {
@@ -343,6 +346,7 @@ func (c *Client) RegisterApp(ctx context.Context, registration AppRegistration) 
 		return "", fmt.Errorf("build register app request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	httpclient.SetUserAgent(req, c.cfg.Version)
 
 	client := &http.Client{
 		Transport: transportForConfig(c.cfg),
@@ -388,6 +392,7 @@ func (c *Client) UnregisterApp(ctx context.Context, appID string) error {
 	if err != nil {
 		return fmt.Errorf("build unregister app request: %w", err)
 	}
+	httpclient.SetUserAgent(req, c.cfg.Version)
 
 	resp, err := c.http.Do(req)
 	if err != nil {
@@ -422,6 +427,7 @@ func (c *Client) UpgradeApp(ctx context.Context, upgrade AppUpgrade) (AppUpgrade
 		return AppUpgradeResult{}, fmt.Errorf("build app upgrade request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	httpclient.SetUserAgent(req, c.cfg.Version)
 
 	resp, err := c.http.Do(req)
 	if err != nil {
@@ -454,6 +460,7 @@ func (c *Client) shutdown(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("build shutdown request: %w", err)
 	}
+	httpclient.SetUserAgent(req, c.cfg.Version)
 
 	resp, err := c.http.Do(req)
 	if err != nil {

--- a/src/cli/internal/studioctlserver/client_internal_test.go
+++ b/src/cli/internal/studioctlserver/client_internal_test.go
@@ -25,6 +25,7 @@ func TestUpgradeAppUsesUpgradeTimeoutOnly(t *testing.T) {
 
 	deadlines := make(map[string]time.Duration)
 	client := &Client{
+		cfg: testConfig(t),
 		http: &http.Client{
 			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 				deadline, ok := req.Context().Deadline()
@@ -80,6 +81,7 @@ func TestUpgradeAppIncludesResponseMessageOnFailure(t *testing.T) {
 	t.Parallel()
 
 	client := &Client{
+		cfg: testConfig(t),
 		http: &http.Client{
 			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 				return &http.Response{

--- a/src/cli/studioctl-server/Discovery/ServiceCollectionExtensions.cs
+++ b/src/cli/studioctl-server/Discovery/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Altinn.Studio.StudioctlServer.Discovery.Container;
 using Altinn.Studio.StudioctlServer.Discovery.Process;
+using Altinn.Studio.StudioctlServer.Platform;
 using Altinn.Studio.StudioctlServer.Platform.PortListeners;
 
 namespace Altinn.Studio.StudioctlServer.Discovery;
@@ -16,6 +17,7 @@ internal static class ServiceCollectionExtensions
             static client =>
             {
                 client.Timeout = TimeSpan.FromSeconds(1);
+                client.DefaultRequestHeaders.UserAgent.ParseAdd(StudioctlUserAgent.Value);
             }
         );
         services.AddHttpClient(
@@ -23,6 +25,7 @@ internal static class ServiceCollectionExtensions
             static client =>
             {
                 client.Timeout = TimeSpan.FromSeconds(2);
+                client.DefaultRequestHeaders.UserAgent.ParseAdd(StudioctlUserAgent.Value);
             }
         );
         services.AddSingleton<IPortListenerSource, LinuxPortListeners>();

--- a/src/cli/studioctl-server/Platform/StudioctlUserAgent.cs
+++ b/src/cli/studioctl-server/Platform/StudioctlUserAgent.cs
@@ -1,0 +1,14 @@
+using System.Reflection;
+
+namespace Altinn.Studio.StudioctlServer.Platform;
+
+internal static class StudioctlUserAgent
+{
+    public static string Value => $"studioctl/{Version}";
+
+    public static string Version => VersionAttribute.InformationalVersion;
+
+    private static AssemblyInformationalVersionAttribute VersionAttribute =>
+        typeof(StudioctlUserAgent).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+        ?? throw new InvalidOperationException("Assembly informational version is not set");
+}

--- a/src/cli/studioctl-server/Studioctl/Endpoints.cs
+++ b/src/cli/studioctl-server/Studioctl/Endpoints.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using Altinn.Studio.EnvTopology;
 using Altinn.Studio.StudioctlServer.Discovery;
 using Altinn.Studio.StudioctlServer.Platform;
@@ -31,7 +30,7 @@ internal static class Endpoints
                 "ok",
                 Environment.ProcessId,
                 Environment.Version.ToString(),
-                Assembly.GetEntryAssembly()?.GetName().Version?.ToString() ?? "unknown",
+                StudioctlUserAgent.Version,
                 EnvironmentValues.IsTruthy(Environment.GetEnvironmentVariable("STUDIOCTL_INTERNAL_DEV")),
                 Environment.GetEnvironmentVariable("Studioctl__Path") ?? "",
                 configuration["Localtest:Url"] ?? "",

--- a/src/cli/studioctl-server/Tunnel/TunnelWorker.cs
+++ b/src/cli/studioctl-server/Tunnel/TunnelWorker.cs
@@ -6,6 +6,7 @@ using System.Net.WebSockets;
 using System.Threading.Channels;
 using Altinn.Studio.AppTunnel;
 using Altinn.Studio.EnvTopology;
+using Altinn.Studio.StudioctlServer.Platform;
 using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
 
@@ -24,7 +25,10 @@ internal sealed class TunnelWorker : BackgroundService
             PooledConnectionLifetime = TimeSpan.FromMinutes(2),
             ConnectTimeout = TimeSpan.FromSeconds(5),
         }
-    );
+    )
+    {
+        DefaultRequestHeaders = { UserAgent = { ProductInfoHeaderValue.Parse(StudioctlUserAgent.Value) } },
+    };
 
     private readonly TunnelOptions _options;
     private readonly TunnelState _state;
@@ -128,6 +132,7 @@ internal sealed class TunnelWorker : BackgroundService
 
         try
         {
+            socket.Options.SetRequestHeader(HeaderNames.UserAgent, StudioctlUserAgent.Value);
             await socket.ConnectAsync(new Uri(tunnelUrl, UriKind.Absolute), linkedCancellation.Token);
         }
         catch (OperationCanceledException)

--- a/src/cli/studioctl-server/studioctl-server.csproj
+++ b/src/cli/studioctl-server/studioctl-server.csproj
@@ -6,6 +6,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyName>studioctl-server</AssemblyName>
+    <InformationalVersion>dev</InformationalVersion>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 


### PR DESCRIPTION
## Description

Is often useful for debugging, knowing where requests came from. Also adds the version as assembly attribute to studioctl-server

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
