### PR TITLE
fix: app backend integration test snapshots

### DIFF
--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldServiceOwner_testCase=MultipartNoPrefill_7_Logs.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldServiceOwner_testCase=MultipartNoPrefill_7_Logs.verified.txt
@@ -26,7 +26,6 @@
 [basic/default] [INFO] IFormDataValidator.ValidateFormData
 [basic/default] [INFO] IProcessTaskEnd.End
 [basic/default] [INFO] IDataProcessor.ProcessDataRead
-[basic/default] [INFO] IExternalApiClient.GetExternalApiDataAsync
 [basic/default] [INFO] IProcessEnd.End
 [basic/default] [INFO] ### Response: Process.NextElement - OkObjectResult, StatusCode: 200
 [basic/default] [INFO] ### Request: Instances.Get - User: ServiceOwner/405003309, AuthLevel: 3, AuthMethod: localtest

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldServiceOwner_testCase=MultipartXmlPrefill_7_Logs.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldServiceOwner_testCase=MultipartXmlPrefill_7_Logs.verified.txt
@@ -26,7 +26,6 @@
 [basic/default] [INFO] IFormDataValidator.ValidateFormData
 [basic/default] [INFO] IProcessTaskEnd.End
 [basic/default] [INFO] IDataProcessor.ProcessDataRead
-[basic/default] [INFO] IExternalApiClient.GetExternalApiDataAsync
 [basic/default] [INFO] IProcessEnd.End
 [basic/default] [INFO] ### Response: Process.NextElement - OkObjectResult, StatusCode: 200
 [basic/default] [INFO] ### Request: Instances.Get - User: ServiceOwner/405003309, AuthLevel: 3, AuthMethod: localtest

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldServiceOwner_testCase=SimplifiedNoPrefill_7_Logs.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldServiceOwner_testCase=SimplifiedNoPrefill_7_Logs.verified.txt
@@ -25,7 +25,6 @@
 [basic/default] [INFO] IFormDataValidator.ValidateFormData
 [basic/default] [INFO] IProcessTaskEnd.End
 [basic/default] [INFO] IDataProcessor.ProcessDataRead
-[basic/default] [INFO] IExternalApiClient.GetExternalApiDataAsync
 [basic/default] [INFO] IProcessEnd.End
 [basic/default] [INFO] ### Response: Process.NextElement - OkObjectResult, StatusCode: 200
 [basic/default] [INFO] ### Request: Instances.Get - User: ServiceOwner/405003309, AuthLevel: 3, AuthMethod: localtest

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldServiceOwner_testCase=SimplifiedWithPrefill_7_Logs.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldServiceOwner_testCase=SimplifiedWithPrefill_7_Logs.verified.txt
@@ -25,7 +25,6 @@
 [basic/default] [INFO] IFormDataValidator.ValidateFormData
 [basic/default] [INFO] IProcessTaskEnd.End
 [basic/default] [INFO] IDataProcessor.ProcessDataRead
-[basic/default] [INFO] IExternalApiClient.GetExternalApiDataAsync
 [basic/default] [INFO] IProcessEnd.End
 [basic/default] [INFO] ### Response: Process.NextElement - OkObjectResult, StatusCode: 200
 [basic/default] [INFO] ### Request: Instances.Get - User: ServiceOwner/405003309, AuthLevel: 3, AuthMethod: localtest

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldUser_testCase=MultipartNoPrefill_7_Logs.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldUser_testCase=MultipartNoPrefill_7_Logs.verified.txt
@@ -26,7 +26,6 @@
 [basic/default] [INFO] IFormDataValidator.ValidateFormData
 [basic/default] [INFO] IProcessTaskEnd.End
 [basic/default] [INFO] IDataProcessor.ProcessDataRead
-[basic/default] [INFO] IExternalApiClient.GetExternalApiDataAsync
 [basic/default] [INFO] IProcessEnd.End
 [basic/default] [INFO] ### Response: Process.NextElement - OkObjectResult, StatusCode: 200
 [basic/default] [INFO] ### Request: Instances.Get - User: User/1337/501337/SophieDDG, AuthLevel: 2, AuthMethod: localtest

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldUser_testCase=MultipartXmlPrefill_7_Logs.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldUser_testCase=MultipartXmlPrefill_7_Logs.verified.txt
@@ -26,7 +26,6 @@
 [basic/default] [INFO] IFormDataValidator.ValidateFormData
 [basic/default] [INFO] IProcessTaskEnd.End
 [basic/default] [INFO] IDataProcessor.ProcessDataRead
-[basic/default] [INFO] IExternalApiClient.GetExternalApiDataAsync
 [basic/default] [INFO] IProcessEnd.End
 [basic/default] [INFO] ### Response: Process.NextElement - OkObjectResult, StatusCode: 200
 [basic/default] [INFO] ### Request: Instances.Get - User: User/1337/501337/SophieDDG, AuthLevel: 2, AuthMethod: localtest

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldUser_testCase=SimplifiedNoPrefill_7_Logs.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldUser_testCase=SimplifiedNoPrefill_7_Logs.verified.txt
@@ -25,7 +25,6 @@
 [basic/default] [INFO] IFormDataValidator.ValidateFormData
 [basic/default] [INFO] IProcessTaskEnd.End
 [basic/default] [INFO] IDataProcessor.ProcessDataRead
-[basic/default] [INFO] IExternalApiClient.GetExternalApiDataAsync
 [basic/default] [INFO] IProcessEnd.End
 [basic/default] [INFO] ### Response: Process.NextElement - OkObjectResult, StatusCode: 200
 [basic/default] [INFO] ### Request: Instances.Get - User: User/1337/501337/SophieDDG, AuthLevel: 2, AuthMethod: localtest

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldUser_testCase=SimplifiedWithPrefill_7_Logs.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldUser_testCase=SimplifiedWithPrefill_7_Logs.verified.txt
@@ -25,7 +25,6 @@
 [basic/default] [INFO] IFormDataValidator.ValidateFormData
 [basic/default] [INFO] IProcessTaskEnd.End
 [basic/default] [INFO] IDataProcessor.ProcessDataRead
-[basic/default] [INFO] IExternalApiClient.GetExternalApiDataAsync
 [basic/default] [INFO] IProcessEnd.End
 [basic/default] [INFO] ### Response: Process.NextElement - OkObjectResult, StatusCode: 200
 [basic/default] [INFO] ### Request: Instances.Get - User: User/1337/501337/SophieDDG, AuthLevel: 2, AuthMethod: localtest

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartNoPrefill_7_Logs.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartNoPrefill_7_Logs.verified.txt
@@ -26,7 +26,6 @@
 [basic/default] [INFO] IFormDataValidator.ValidateFormData
 [basic/default] [INFO] IProcessTaskEnd.End
 [basic/default] [INFO] IDataProcessor.ProcessDataRead
-[basic/default] [INFO] IExternalApiClient.GetExternalApiDataAsync
 [basic/default] [INFO] IProcessEnd.End
 [basic/default] [INFO] ### Response: Process.NextElement - OkObjectResult, StatusCode: 200
 [basic/default] [INFO] ### Request: Instances.Get - User: ServiceOwner/405003309, AuthLevel: 3, AuthMethod: maskinporten

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartXmlPrefill_7_Logs.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartXmlPrefill_7_Logs.verified.txt
@@ -26,7 +26,6 @@
 [basic/default] [INFO] IFormDataValidator.ValidateFormData
 [basic/default] [INFO] IProcessTaskEnd.End
 [basic/default] [INFO] IDataProcessor.ProcessDataRead
-[basic/default] [INFO] IExternalApiClient.GetExternalApiDataAsync
 [basic/default] [INFO] IProcessEnd.End
 [basic/default] [INFO] ### Response: Process.NextElement - OkObjectResult, StatusCode: 200
 [basic/default] [INFO] ### Request: Instances.Get - User: ServiceOwner/405003309, AuthLevel: 3, AuthMethod: maskinporten

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedNoPrefill_7_Logs.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedNoPrefill_7_Logs.verified.txt
@@ -25,7 +25,6 @@
 [basic/default] [INFO] IFormDataValidator.ValidateFormData
 [basic/default] [INFO] IProcessTaskEnd.End
 [basic/default] [INFO] IDataProcessor.ProcessDataRead
-[basic/default] [INFO] IExternalApiClient.GetExternalApiDataAsync
 [basic/default] [INFO] IProcessEnd.End
 [basic/default] [INFO] ### Response: Process.NextElement - OkObjectResult, StatusCode: 200
 [basic/default] [INFO] ### Request: Instances.Get - User: ServiceOwner/405003309, AuthLevel: 3, AuthMethod: maskinporten

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedWithPrefill_7_Logs.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedWithPrefill_7_Logs.verified.txt
@@ -25,7 +25,6 @@
 [basic/default] [INFO] IFormDataValidator.ValidateFormData
 [basic/default] [INFO] IProcessTaskEnd.End
 [basic/default] [INFO] IDataProcessor.ProcessDataRead
-[basic/default] [INFO] IExternalApiClient.GetExternalApiDataAsync
 [basic/default] [INFO] IProcessEnd.End
 [basic/default] [INFO] ### Response: Process.NextElement - OkObjectResult, StatusCode: 200
 [basic/default] [INFO] ### Request: Instances.Get - User: ServiceOwner/405003309, AuthLevel: 3, AuthMethod: maskinporten

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartNoPrefill_7_Logs.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartNoPrefill_7_Logs.verified.txt
@@ -26,7 +26,6 @@
 [basic/default] [INFO] IFormDataValidator.ValidateFormData
 [basic/default] [INFO] IProcessTaskEnd.End
 [basic/default] [INFO] IDataProcessor.ProcessDataRead
-[basic/default] [INFO] IExternalApiClient.GetExternalApiDataAsync
 [basic/default] [INFO] IProcessEnd.End
 [basic/default] [INFO] ### Response: Process.NextElement - OkObjectResult, StatusCode: 200
 [basic/default] [INFO] ### Request: Instances.Get - User: User/1337/501337, AuthLevel: 2, AuthMethod: BankID

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartXmlPrefill_7_Logs.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartXmlPrefill_7_Logs.verified.txt
@@ -26,7 +26,6 @@
 [basic/default] [INFO] IFormDataValidator.ValidateFormData
 [basic/default] [INFO] IProcessTaskEnd.End
 [basic/default] [INFO] IDataProcessor.ProcessDataRead
-[basic/default] [INFO] IExternalApiClient.GetExternalApiDataAsync
 [basic/default] [INFO] IProcessEnd.End
 [basic/default] [INFO] ### Response: Process.NextElement - OkObjectResult, StatusCode: 200
 [basic/default] [INFO] ### Request: Instances.Get - User: User/1337/501337, AuthLevel: 2, AuthMethod: BankID

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedNoPrefill_7_Logs.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedNoPrefill_7_Logs.verified.txt
@@ -25,7 +25,6 @@
 [basic/default] [INFO] IFormDataValidator.ValidateFormData
 [basic/default] [INFO] IProcessTaskEnd.End
 [basic/default] [INFO] IDataProcessor.ProcessDataRead
-[basic/default] [INFO] IExternalApiClient.GetExternalApiDataAsync
 [basic/default] [INFO] IProcessEnd.End
 [basic/default] [INFO] ### Response: Process.NextElement - OkObjectResult, StatusCode: 200
 [basic/default] [INFO] ### Request: Instances.Get - User: User/1337/501337, AuthLevel: 2, AuthMethod: BankID

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedWithPrefill_7_Logs.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedWithPrefill_7_Logs.verified.txt
@@ -25,7 +25,6 @@
 [basic/default] [INFO] IFormDataValidator.ValidateFormData
 [basic/default] [INFO] IProcessTaskEnd.End
 [basic/default] [INFO] IDataProcessor.ProcessDataRead
-[basic/default] [INFO] IExternalApiClient.GetExternalApiDataAsync
 [basic/default] [INFO] IProcessEnd.End
 [basic/default] [INFO] ### Response: Process.NextElement - OkObjectResult, StatusCode: 200
 [basic/default] [INFO] ### Request: Instances.Get - User: User/1337/501337, AuthLevel: 2, AuthMethod: BankID


### PR DESCRIPTION
## Description

This PR: https://github.com/Altinn/altinn-studio/pull/18638
seems to, according to codex,

> Current code only calls useExternalApis if expression analysis says the layout actually needs externalApis: src/App/frontend/src/utils/layout/useExpressionDataSources.ts:68 and src/App/frontend/src/utils/layout/useExpressionDataSources.ts:127

which lead to app backend integration test snapshot changes, but those tests didnt run as part of that PR due to the diff,
cc @olemartinorg 

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated integration test verification snapshots across multiple scenarios covering different authentication methods, data handling patterns, and prefill configurations. Snapshot updates ensure test expectations accurately reflect the application's current operational behaviour throughout the integration testing process and maintain consistency across all test variations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio/pull/18762)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->