### PR TITLE
feat: dynamic workflow-engine ServiceVersion

### DIFF
--- a/.github/workflows/deploy-runtime-workflow-engine-app.yaml
+++ b/.github/workflows/deploy-runtime-workflow-engine-app.yaml
@@ -116,8 +116,9 @@ jobs:
         run: |
           export IMAGE="${{ steps.vars.outputs.image-repo }}"
           export IMAGE_TAG="${{ steps.vars.outputs.short-sha }}"
-          yq -i '.metadata.annotations["altinn.studio/image"] = env(IMAGE)' deployment.yaml
-          yq -i '.metadata.annotations["altinn.studio/image-tag"] = env(IMAGE_TAG)' deployment.yaml
+          yq -i '.metadata.annotations["altinn.studio/image"] = strenv(IMAGE)' deployment.yaml
+          yq -i '.metadata.annotations["altinn.studio/image-tag"] = strenv(IMAGE_TAG)' deployment.yaml
+          yq -i '(select(.kind == "Deployment").spec.template.spec.containers[0].env[] | select(.name == "WORKFLOW_ENGINE_VERSION").value) = strenv(IMAGE_TAG)' deployment.yaml
 
       - name: push artifact
         working-directory: src/Runtime/workflow-engine-app/infra/kustomize

--- a/.github/workflows/deploy-runtime-workflow-engine-app.yaml
+++ b/.github/workflows/deploy-runtime-workflow-engine-app.yaml
@@ -99,7 +99,7 @@ jobs:
           if [ "${{ inputs.tag-latest }}" = "true" ]; then
             TAGS="$TAGS -t ghcr.io/altinn/altinn-studio/runtime-workflow-engine-app:latest"
           fi
-          docker build --platform linux/amd64,linux/arm64 $TAGS -f Runtime/workflow-engine-app/Dockerfile .
+          docker build --platform linux/amd64,linux/arm64 --build-arg VERSION=${{ steps.vars.outputs.short-sha }} $TAGS -f Runtime/workflow-engine-app/Dockerfile .
 
       - name: push image
         run: docker push ${{ steps.vars.outputs.image-repo }}
@@ -118,7 +118,6 @@ jobs:
           export IMAGE_TAG="${{ steps.vars.outputs.short-sha }}"
           yq -i '.metadata.annotations["altinn.studio/image"] = strenv(IMAGE)' deployment.yaml
           yq -i '.metadata.annotations["altinn.studio/image-tag"] = strenv(IMAGE_TAG)' deployment.yaml
-          yq -i '(select(.kind == "Deployment").spec.template.spec.containers[0].env[] | select(.name == "WORKFLOW_ENGINE_VERSION").value) = strenv(IMAGE_TAG)' deployment.yaml
 
       - name: push artifact
         working-directory: src/Runtime/workflow-engine-app/infra/kustomize

--- a/src/Runtime/workflow-engine-app/Dockerfile
+++ b/src/Runtime/workflow-engine-app/Dockerfile
@@ -6,6 +6,7 @@ EXPOSE 9090
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:8a90a473da5205a16979de99d2fc20975e922c68304f5c79d564e666dc3982fc AS build
 ARG BUILD_CONFIGURATION=Release
+ARG VERSION=dev
 WORKDIR /build
 
 COPY common/ common/
@@ -14,7 +15,7 @@ COPY Runtime/workflow-engine-app/ Runtime/workflow-engine-app/
 
 WORKDIR /build/Runtime/workflow-engine-app/src/WorkflowEngine.App
 RUN dotnet restore "WorkflowEngine.App.csproj"
-RUN dotnet publish "WorkflowEngine.App.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false /p:CSharpier_Bypass=true
+RUN dotnet publish "WorkflowEngine.App.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false /p:CSharpier_Bypass=true /p:InformationalVersion=$VERSION
 
 FROM base AS final
 WORKDIR /app

--- a/src/Runtime/workflow-engine-app/infra/kustomize/base/deployment.yaml
+++ b/src/Runtime/workflow-engine-app/infra/kustomize/base/deployment.yaml
@@ -92,8 +92,6 @@ spec:
                   key: environment
             - name: ASPNETCORE_HTTP_PORTS
               value: "9090"
-            - name: WORKFLOW_ENGINE_VERSION
-              value: ""
           volumeMounts:
             - name: secrets
               mountPath: /app/secrets

--- a/src/Runtime/workflow-engine-app/infra/kustomize/base/deployment.yaml
+++ b/src/Runtime/workflow-engine-app/infra/kustomize/base/deployment.yaml
@@ -92,6 +92,8 @@ spec:
                   key: environment
             - name: ASPNETCORE_HTTP_PORTS
               value: "9090"
+            - name: WORKFLOW_ENGINE_VERSION
+              value: ""
           volumeMounts:
             - name: secrets
               mountPath: /app/secrets

--- a/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/WorkflowEngine.App.csproj
+++ b/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/WorkflowEngine.App.csproj
@@ -4,6 +4,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <InformationalVersion>dev</InformationalVersion>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <!-- CA1515: Program must stay public for WebApplicationFactory<Program> in tests -->
     <NoWarn>$(NoWarn);CA1515</NoWarn>
   </PropertyGroup>

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Telemetry/Metrics.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Telemetry/Metrics.cs
@@ -530,7 +530,8 @@ public static class Metrics
     /// <summary>
     /// Returns the current service version from the entry assembly's
     /// <see cref="AssemblyInformationalVersionAttribute"/> (CI sets this via
-    /// <c>-p:InformationalVersion=&lt;short-sha&gt;</c> at publish time), falling back to <c>"0.0.0-dev"</c>.
+    /// <c>-p:InformationalVersion=&lt;short-sha&gt;</c> at publish time), falling back to <c>"dev"</c>
+    /// — matching the csproj default — when no entry assembly is resolvable (e.g. some test hosts).
     /// </summary>
     private static string ResolveServiceVersion()
     {
@@ -541,6 +542,6 @@ public static class Metrics
         if (!string.IsNullOrWhiteSpace(fromAssembly))
             return fromAssembly;
 
-        return "0.0.0-dev";
+        return "dev";
     }
 }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Telemetry/Metrics.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Telemetry/Metrics.cs
@@ -528,17 +528,15 @@ public static class Metrics
         contexts.OfType<ActivityContext>().Select(x => new ActivityLink(x));
 
     /// <summary>
-    /// Returns the current service version by resolving the <c>WORKFLOW_ENGINE_VERSION</c> environment variable (from CI),
-    /// falling back to the assembly's <see cref="AssemblyInformationalVersionAttribute"/>, then lastly to <c>"0.0.0-dev"</c>.
+    /// Returns the current service version from the entry assembly's
+    /// <see cref="AssemblyInformationalVersionAttribute"/> (CI sets this via
+    /// <c>-p:InformationalVersion=&lt;short-sha&gt;</c> at publish time), falling back to <c>"0.0.0-dev"</c>.
     /// </summary>
     private static string ResolveServiceVersion()
     {
-        var fromEnv = Environment.GetEnvironmentVariable("WORKFLOW_ENGINE_VERSION");
-        if (!string.IsNullOrWhiteSpace(fromEnv))
-            return fromEnv;
-
-        var fromAssembly = typeof(Metrics)
-            .Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+        var fromAssembly = Assembly
+            .GetEntryAssembly()
+            ?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion;
         if (!string.IsNullOrWhiteSpace(fromAssembly))
             return fromAssembly;

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Telemetry/Metrics.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Telemetry/Metrics.cs
@@ -36,7 +36,7 @@ public static class Metrics
 
     /// <summary>
     /// Counter of generic engine-side errors that don't have a more specific instrument.
-    /// </summary>okay,
+    /// </summary>
     public static readonly Counter<long> Errors = Meter.CreateCounter<long>("engine.errors");
 
     /// <summary>

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Telemetry/Metrics.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Telemetry/Metrics.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using System.Reflection;
 
 // CA1724: Type names should not match namespaces
 #pragma warning disable CA1724
@@ -21,7 +22,7 @@ public static class Metrics
     /// <summary>
     /// Service version reported on the engine's resource attributes.
     /// </summary>
-    public const string ServiceVersion = "1.0.0";
+    public static readonly string ServiceVersion = ResolveServiceVersion();
 
     /// <summary>
     /// Activity source for engine-emitted spans (workflow lifecycle, step lifecycle, DB IO).
@@ -35,7 +36,7 @@ public static class Metrics
 
     /// <summary>
     /// Counter of generic engine-side errors that don't have a more specific instrument.
-    /// </summary>
+    /// </summary>okay,
     public static readonly Counter<long> Errors = Meter.CreateCounter<long>("engine.errors");
 
     /// <summary>
@@ -525,4 +526,23 @@ public static class Metrics
     /// </summary>
     public static IEnumerable<ActivityLink> ToActivityLinks(this IEnumerable<ActivityContext?> contexts) =>
         contexts.OfType<ActivityContext>().Select(x => new ActivityLink(x));
+
+    /// <summary>
+    /// Returns the current service version by resolving the <c>WORKFLOW_ENGINE_VERSION</c> environment variable (from CI),
+    /// falling back to the assembly's <see cref="AssemblyInformationalVersionAttribute"/>, then lastly to <c>"0.0.0-dev"</c>.
+    /// </summary>
+    private static string ResolveServiceVersion()
+    {
+        var fromEnv = Environment.GetEnvironmentVariable("WORKFLOW_ENGINE_VERSION");
+        if (!string.IsNullOrWhiteSpace(fromEnv))
+            return fromEnv;
+
+        var fromAssembly = typeof(Metrics)
+            .Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion;
+        if (!string.IsNullOrWhiteSpace(fromAssembly))
+            return fromAssembly;
+
+        return "0.0.0-dev";
+    }
 }


### PR DESCRIPTION
## Summary
- Replace hardcoded `Metrics.ServiceVersion = "1.0.0"` with the entry assembly's `AssemblyInformationalVersionAttribute`, falling back to `"0.0.0-dev"`.
- `WorkflowEngine.App.csproj` declares `<InformationalVersion>dev</InformationalVersion>` (with `<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>` to suppress the auto-appended `+sha`).
- Docker build accepts `VERSION` as a build-arg and passes it as `-p:InformationalVersion=$VERSION` to `dotnet publish`; the deploy workflow sets it to the same short SHA already used for the image tag.
- Aligns with the pattern used by `studioctl-server`.

## Test plan
- [x] CI build green
- [ ] After deploy: confirm `service.version` resource attribute on traces/metrics matches the image short SHA in Grafana

Closes #18557