### PR TITLE
chore: ensure 3 days as minimumReleaseAge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -73,7 +73,7 @@
       ],
       "groupName": "Digdir design system",
       "schedule": ["* 0-7 * * 1-5"],
-      "minimumReleaseAge": "0"
+      "minimumReleaseAge": "3"
     },
     {
       "matchFileNames": ["src/App/**"],

--- a/renovate.json
+++ b/renovate.json
@@ -73,7 +73,7 @@
       ],
       "groupName": "Digdir design system",
       "schedule": ["* 0-7 * * 1-5"],
-      "minimumReleaseAge": "3"
+      "minimumReleaseAge": "3 days"
     },
     {
       "matchFileNames": ["src/App/**"],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Denne PR-en setter minimumReleaseAge til 3 dager også for pakkene tilhørende digdir/designsystemet.

Bakgrunnen er at designsystemet selv har avhengigheter som igjen kan introdusere indirekte risiko inn i våre applikasjoner. Ved å vente 3 dager før Renovate oppretter PR-er for nye versjoner, reduserer vi sannsynligheten for å automatisk ta inn kompromitterte eller feilaktige pakker rett etter publisering.

Dette eliminerer ikke risiko helt, men reduserer den teoretisk dersom designsystemet skulle ta inn en kompromittert pakke og publisere en ny versjon samtidig - som vi at på til oppdaterer til med engang.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- Updated the minimum release age requirement for Digdir design system package updates, now requiring releases to be at least 3 days old before application.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio/pull/18765)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->