### PR TITLE
feat: studioctl - app run container mode UI

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -13,6 +13,7 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 - Breaking: make `--follow` default to `false` for log commands.
 - Breaking: rename `studioctl servers` to `studioctl server`.
 - Rename `app-manager` to `studioctl-server`, including install/update migration cleanup of legacy runtime files, installed payload, and logs.
+- Show progress while `app run --mode container` pulls/builds and starts the app container.
 
 ### Fixed
 

--- a/src/cli/internal/cmd/env/localtest/env.go
+++ b/src/cli/internal/cmd/env/localtest/env.go
@@ -16,12 +16,12 @@ import (
 	"altinn.studio/devenv/pkg/resource"
 	envtypes "altinn.studio/studioctl/internal/cmd/env"
 	"altinn.studio/studioctl/internal/cmd/env/localtest/components"
-	localtestrenderer "altinn.studio/studioctl/internal/cmd/env/localtest/renderer"
 	"altinn.studio/studioctl/internal/config"
 	repocontext "altinn.studio/studioctl/internal/context"
 	"altinn.studio/studioctl/internal/envtopology"
 	"altinn.studio/studioctl/internal/osutil"
 	"altinn.studio/studioctl/internal/ui"
+	"altinn.studio/studioctl/internal/ui/resourcegraph"
 )
 
 // Sentinel errors for the localtest package.
@@ -335,13 +335,13 @@ func (e *Env) applyResources(ctx context.Context, resources []resource.Resource,
 		spinnerMsg = "Building and starting localtest environment (dev mode)..."
 	}
 
-	var renderer localtestrenderer.Renderer
+	var renderer resourcegraph.Renderer
 	if _, err := executor.Apply(ctx, graph, resource.WithApplyPlan(func(plan resource.ApplyPlan) error {
 		e.startRenderer(
 			executor,
 			&renderer,
 			applyPlannedResources(plan),
-			localtestrenderer.OperationApply,
+			resourcegraph.OperationApply,
 			plan.Snapshot.Statuses(),
 			spinnerMsg,
 		)
@@ -367,14 +367,14 @@ func (e *Env) destroyResources(ctx context.Context, resources []resource.Resourc
 		return err
 	}
 
-	var renderer localtestrenderer.Renderer
+	var renderer resourcegraph.Renderer
 	executor := resource.NewExecutor(e.client)
 	if err := executor.Destroy(ctx, graph, resource.WithDestroyPlan(func(plan resource.DestroyPlan) error {
 		e.startRenderer(
 			executor,
 			&renderer,
 			plan.Destroy,
-			localtestrenderer.OperationDestroy,
+			resourcegraph.OperationDestroy,
 			plan.Snapshot.Statuses(),
 			logStartMessage,
 		)
@@ -395,29 +395,29 @@ func (e *Env) destroyResources(ctx context.Context, resources []resource.Resourc
 
 func (e *Env) startRenderer(
 	executor *resource.Executor,
-	renderer *localtestrenderer.Renderer,
+	renderer *resourcegraph.Renderer,
 	resources []resource.PlannedResource,
-	operation localtestrenderer.Operation,
+	operation resourcegraph.Operation,
 	statuses map[resource.ResourceID]resource.Status,
 	logStartMessage string,
 ) {
-	switch localtestrenderer.DetectMode(e.out, e.cfg.Verbose) {
-	case localtestrenderer.ModeTable:
-		*renderer = localtestrenderer.NewTableWithPlan(
+	switch resourcegraph.DetectMode(e.out, e.cfg.Verbose) {
+	case resourcegraph.ModeTable:
+		*renderer = resourcegraph.NewTableWithPlan(
 			e.out,
 			resources,
 			operation,
 			statuses,
 		)
-	case localtestrenderer.ModeCompact:
-		*renderer = localtestrenderer.NewCompactWithPlan(
+	case resourcegraph.ModeCompact:
+		*renderer = resourcegraph.NewCompactWithPlan(
 			e.out,
 			resources,
 			operation,
 			statuses,
 		)
-	case localtestrenderer.ModeLog:
-		*renderer = localtestrenderer.NewLogWithPlan(
+	case resourcegraph.ModeLog:
+		*renderer = resourcegraph.NewLogWithPlan(
 			e.out,
 			resources,
 			operation,
@@ -425,7 +425,7 @@ func (e *Env) startRenderer(
 			logStartMessage,
 		)
 	default:
-		*renderer = localtestrenderer.NewLogWithPlan(e.out, resources, operation, statuses, logStartMessage)
+		*renderer = resourcegraph.NewLogWithPlan(e.out, resources, operation, statuses, logStartMessage)
 	}
 	(*renderer).Start()
 	executor.SetObserver(*renderer)

--- a/src/cli/internal/cmd/run.go
+++ b/src/cli/internal/cmd/run.go
@@ -15,7 +15,9 @@ import (
 	"time"
 
 	containerruntime "altinn.studio/devenv/pkg/container"
+	containertypes "altinn.studio/devenv/pkg/container/types"
 	"altinn.studio/devenv/pkg/processutil"
+	"altinn.studio/devenv/pkg/resource"
 	"altinn.studio/studioctl/internal/appcontainers"
 	"altinn.studio/studioctl/internal/appimage"
 	appsvc "altinn.studio/studioctl/internal/cmd/app"
@@ -26,6 +28,7 @@ import (
 	"altinn.studio/studioctl/internal/osutil"
 	"altinn.studio/studioctl/internal/studioctlserver"
 	"altinn.studio/studioctl/internal/ui"
+	"altinn.studio/studioctl/internal/ui/resourcegraph"
 )
 
 const (
@@ -126,6 +129,12 @@ type runDetachedOutput struct {
 	ProcessID   int    `json:"processId,omitempty"`
 	HostPort    int    `json:"hostPort,omitempty"`
 	JSONOutput  bool   `json:"-"`
+}
+
+type containerRunProgress struct {
+	renderer    resourcegraph.Renderer
+	imageID     resource.ResourceID
+	containerID resource.ResourceID
 }
 
 func (o runDetachedOutput) Print(out *ui.Output) error {
@@ -891,6 +900,181 @@ func (c *RunCommand) unregisterAppBestEffort(ctx context.Context, appID string) 
 	}
 }
 
+func (c *RunCommand) startContainerRunProgress(spec appsvc.DockerRunSpec, flags runFlags) *containerRunProgress {
+	progress := newContainerRunProgress(spec, flags)
+	if flags.jsonOutput {
+		return progress
+	}
+
+	verbose := false
+	if c.cfg != nil {
+		verbose = c.cfg.Verbose
+	}
+
+	resources := containerRunProgressResources(spec, flags)
+	switch resourcegraph.DetectMode(c.out, verbose) {
+	case resourcegraph.ModeTable:
+		progress.renderer = resourcegraph.NewTable(c.out, resources, resourcegraph.OperationApply)
+	case resourcegraph.ModeCompact:
+		progress.renderer = resourcegraph.NewCompact(c.out, resources, resourcegraph.OperationApply)
+	case resourcegraph.ModeLog:
+		progress.renderer = resourcegraph.NewLog(
+			c.out,
+			resources,
+			resourcegraph.OperationApply,
+			containerRunStartMessage(flags),
+		)
+	default:
+		progress.renderer = resourcegraph.NewLog(
+			c.out,
+			resources,
+			resourcegraph.OperationApply,
+			containerRunStartMessage(flags),
+		)
+	}
+	progress.renderer.Start()
+	return progress
+}
+
+func newContainerRunProgress(spec appsvc.DockerRunSpec, flags runFlags) *containerRunProgress {
+	image := containerRunProgressImage(spec.Config.Image, flags)
+	return &containerRunProgress{
+		renderer:    nil,
+		imageID:     image.ID(),
+		containerID: resource.ContainerID(spec.Config.Name),
+	}
+}
+
+func containerRunProgressResources(spec appsvc.DockerRunSpec, flags runFlags) []resource.Resource {
+	image := containerRunProgressImage(spec.Config.Image, flags)
+	container := &resource.Container{
+		HealthCheck: nil,
+		Image:       resource.Ref(image),
+		Enabled:     nil,
+		Labels:      nil,
+		Lifecycle: resource.ContainerLifecycleOptions{
+			LifecycleOptions: resource.LifecycleOptions{
+				HandleDestroyError: nil,
+				RetainOnDestroy:    false,
+			},
+			WaitForReady: false,
+		},
+		Name:           spec.Config.Name,
+		RestartPolicy:  "",
+		User:           "",
+		Networks:       nil,
+		DependsOn:      nil,
+		Ports:          nil,
+		Volumes:        nil,
+		Env:            nil,
+		Command:        nil,
+		ExtraHosts:     nil,
+		NetworkAliases: nil,
+	}
+	return []resource.Resource{image, container}
+}
+
+func containerRunProgressImage(imageTag string, flags runFlags) resource.Resource {
+	if flags.pullImage {
+		return &resource.RemoteImage{
+			Enabled:    nil,
+			Ref:        imageTag,
+			PullPolicy: resource.PullAlways,
+		}
+	}
+	return &resource.LocalImage{
+		Enabled:     nil,
+		ContextPath: ".",
+		Dockerfile:  "",
+		Tag:         imageTag,
+		Build: containertypes.BuildOptions{
+			CacheFrom: nil,
+			CacheTo:   nil,
+		},
+	}
+}
+
+func containerRunStartMessage(flags runFlags) string {
+	if flags.pullImage {
+		return "Pulling and starting app container..."
+	}
+	if flags.skipBuild {
+		return "Starting app container..."
+	}
+	return "Building and starting app container..."
+}
+
+func (p *containerRunProgress) Enabled() bool {
+	return p != nil && p.renderer != nil
+}
+
+func (p *containerRunProgress) Stop() {
+	if p.Enabled() {
+		p.renderer.Stop()
+	}
+}
+
+func (p *containerRunProgress) Fail(err error) {
+	if !p.Enabled() {
+		return
+	}
+	if err != nil {
+		p.renderer.FailAll(err.Error())
+	}
+	p.renderer.Stop()
+}
+
+func (p *containerRunProgress) DestroyStart(id resource.ResourceID) {
+	p.emit(resource.EventDestroyStart, id, nil, nil)
+}
+
+func (p *containerRunProgress) DestroyDone(id resource.ResourceID) {
+	p.emit(resource.EventDestroyDone, id, nil, nil)
+}
+
+func (p *containerRunProgress) DestroyFailed(id resource.ResourceID, err error) {
+	p.emit(resource.EventDestroyFailed, id, err, nil)
+}
+
+func (p *containerRunProgress) ApplyStart(id resource.ResourceID) {
+	p.emit(resource.EventApplyStart, id, nil, nil)
+}
+
+func (p *containerRunProgress) ApplyDone(id resource.ResourceID) {
+	p.emit(resource.EventApplyDone, id, nil, nil)
+}
+
+func (p *containerRunProgress) ApplyFailed(id resource.ResourceID, err error) {
+	p.emit(resource.EventApplyFailed, id, err, nil)
+}
+
+func (p *containerRunProgress) ApplyProgress(id resource.ResourceID, update containertypes.ProgressUpdate) {
+	progress := resource.Progress{
+		Message:       update.Message,
+		Current:       update.Current,
+		Total:         update.Total,
+		Indeterminate: update.Indeterminate,
+	}
+	p.emit(resource.EventApplyProgress, id, nil, &progress)
+}
+
+func (p *containerRunProgress) emit(
+	eventType resource.EventType,
+	id resource.ResourceID,
+	err error,
+	progress *resource.Progress,
+) {
+	if !p.Enabled() {
+		return
+	}
+	p.renderer.OnEvent(resource.Event{
+		Error:    err,
+		Progress: progress,
+		Resource: id,
+		Type:     eventType,
+	})
+}
+
 func (c *RunCommand) runDocker(
 	ctx context.Context,
 	target appsvc.RunTarget,
@@ -921,12 +1105,24 @@ func (c *RunCommand) runDocker(
 		}
 	}()
 
-	if prepareErr := c.prepareDockerRunImage(ctx, client, result, spec.Config.Image, flags); prepareErr != nil {
+	progress := c.startContainerRunProgress(spec, flags)
+	quietLifecycleOutput := flags.jsonOutput || progress.Enabled()
+
+	if prepareErr := c.prepareDockerRunImage(
+		ctx,
+		client,
+		result,
+		spec.Config.Image,
+		flags,
+		progress,
+	); prepareErr != nil {
+		progress.Fail(prepareErr)
 		return prepareErr
 	}
 
-	containerID, info, err := c.createDockerAppContainer(ctx, client, spec, flags.jsonOutput)
+	containerID, info, err := c.createDockerAppContainer(ctx, client, spec, quietLifecycleOutput, progress)
 	if err != nil {
+		progress.Fail(err)
 		return err
 	}
 
@@ -939,12 +1135,33 @@ func (c *RunCommand) runDocker(
 		target.AppID,
 		topology,
 		runInfo,
-		flags.jsonOutput,
+		quietLifecycleOutput,
 	)
 	if err != nil {
+		progress.ApplyFailed(progress.containerID, err)
+		progress.Fail(err)
 		return c.withAppContainerCleanup(ctx, client, containerID, err)
 	}
+	progress.ApplyDone(progress.containerID)
+	progress.Stop()
 
+	if !flags.jsonOutput && progress.Enabled() {
+		c.printDockerRunInfo(info)
+		c.out.Printlnf("App ready: %s", baseURL)
+	}
+
+	return c.runStartedContainerApp(ctx, client, target, containerID, info, baseURL, flags)
+}
+
+func (c *RunCommand) runStartedContainerApp(
+	ctx context.Context,
+	client containerruntime.ContainerClient,
+	target appsvc.RunTarget,
+	containerID string,
+	info containerruntime.ContainerInfo,
+	baseURL string,
+	flags runFlags,
+) error {
 	if flags.detach {
 		return c.detachedDockerOutput(target.AppID, containerID, info, baseURL, flags).Print(c.out)
 	}
@@ -967,19 +1184,27 @@ func (c *RunCommand) createDockerAppContainer(
 	client containerruntime.ContainerClient,
 	spec appsvc.DockerRunSpec,
 	jsonOutput bool,
+	progress *containerRunProgress,
 ) (string, containerruntime.ContainerInfo, error) {
+	progress.DestroyStart(progress.containerID)
 	if removeErr := client.ContainerRemove(ctx, spec.Config.Name, true); removeErr != nil &&
 		!errors.Is(removeErr, containerruntime.ErrContainerNotFound) {
+		progress.DestroyFailed(progress.containerID, removeErr)
 		return "", containerruntime.ContainerInfo{}, fmt.Errorf("remove existing app container: %w", removeErr)
+	} else if removeErr == nil {
+		progress.DestroyDone(progress.containerID)
 	}
 
+	progress.ApplyStart(progress.containerID)
 	containerID, err := client.CreateContainer(ctx, spec.Config)
 	if err != nil {
+		progress.ApplyFailed(progress.containerID, err)
 		return "", containerruntime.ContainerInfo{}, fmt.Errorf("create app container: %w", err)
 	}
 
 	info, err := client.ContainerInspect(ctx, containerID)
 	if err != nil {
+		progress.ApplyFailed(progress.containerID, err)
 		return "", containerruntime.ContainerInfo{}, c.withAppContainerCleanup(
 			ctx,
 			client,
@@ -1108,12 +1333,18 @@ func (c *RunCommand) prepareDockerRunImage(
 	result repocontext.Detection,
 	imageTag string,
 	flags runFlags,
+	progress *containerRunProgress,
 ) error {
 	if flags.pullImage {
 		c.out.Verbosef("Pulling app image %s", imageTag)
-		if pullErr := client.ImagePull(ctx, imageTag); pullErr != nil {
+		progress.ApplyStart(progress.imageID)
+		if pullErr := client.ImagePullWithProgress(ctx, imageTag, func(update containertypes.ProgressUpdate) {
+			progress.ApplyProgress(progress.imageID, update)
+		}); pullErr != nil {
+			progress.ApplyFailed(progress.imageID, pullErr)
 			return fmt.Errorf("pull app image: %w", pullErr)
 		}
+		progress.ApplyDone(progress.imageID)
 	}
 	if flags.skipBuild {
 		return nil
@@ -1130,15 +1361,21 @@ func (c *RunCommand) prepareDockerRunImage(
 	defer cleanupGeneratedDockerfile(c.out, cleanupDockerfile)
 
 	c.out.Verbosef("Building app image %s", spec.ImageTag)
-	if buildErr := client.Build(
+	progress.ApplyStart(progress.imageID)
+	if buildErr := client.BuildWithProgress(
 		ctx,
 		spec.ContextPath,
 		spec.Dockerfile,
 		spec.ImageTag,
+		func(update containertypes.ProgressUpdate) {
+			progress.ApplyProgress(progress.imageID, update)
+		},
 		spec.Build,
 	); buildErr != nil {
+		progress.ApplyFailed(progress.imageID, buildErr)
 		return fmt.Errorf("build app image: %w", buildErr)
 	}
+	progress.ApplyDone(progress.imageID)
 	return nil
 }
 

--- a/src/cli/internal/cmd/run_internal_test.go
+++ b/src/cli/internal/cmd/run_internal_test.go
@@ -15,7 +15,9 @@ import (
 
 	containermock "altinn.studio/devenv/pkg/container/mock"
 	"altinn.studio/devenv/pkg/container/types"
+	appsvc "altinn.studio/studioctl/internal/cmd/app"
 	appsupport "altinn.studio/studioctl/internal/cmd/apps"
+	repocontext "altinn.studio/studioctl/internal/context"
 	"altinn.studio/studioctl/internal/osutil"
 	"altinn.studio/studioctl/internal/ui"
 )
@@ -205,5 +207,194 @@ func TestContainerAppRunInfoIncludesContainerHandle(t *testing.T) {
 
 	if got.ContainerID != "container-id" || got.HostPort != 5006 {
 		t.Fatalf("containerAppRunInfo() = %+v, want container handle and host port", got)
+	}
+}
+
+func TestPrepareDockerRunImagePullUsesProgressRenderer(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	cmd := &RunCommand{out: ui.NewOutput(&out, io.Discard, false)}
+	flags := runFlags{imageTag: "example/app:test", pullImage: true, skipBuild: true}
+	spec := appsvc.DockerRunSpec{Config: types.ContainerConfig{
+		Name:  "localtest-app-test",
+		Image: flags.imageTag,
+	}}
+	progress := cmd.startContainerRunProgress(spec, flags)
+	defer progress.Stop()
+
+	client := containermock.New()
+	progressHandlerCalled := false
+	client.ImagePullWithProgressFunc = func(
+		_ context.Context,
+		image string,
+		onProgress types.ProgressHandler,
+	) error {
+		if image != flags.imageTag {
+			t.Fatalf("image = %q, want %q", image, flags.imageTag)
+		}
+		if onProgress == nil {
+			t.Fatal("onProgress = nil, want progress handler")
+		}
+		progressHandlerCalled = true
+		onProgress(types.ProgressUpdate{Message: "downloading", Current: 1, Total: 2})
+		return nil
+	}
+
+	err := cmd.prepareDockerRunImage(t.Context(), client, repocontext.Detection{}, flags.imageTag, flags, progress)
+	if err != nil {
+		t.Fatalf("prepareDockerRunImage() error = %v", err)
+	}
+	progress.Stop()
+
+	if !progressHandlerCalled {
+		t.Fatal("progress handler was not called")
+	}
+	assertContainerCall(t, client.Calls, "ImagePullWithProgress")
+	assertNoContainerCall(t, client.Calls, "ImagePull")
+
+	rendered := out.String()
+	for _, want := range []string{
+		"Pulling and starting app container...",
+		"localtest-app-test: pulling",
+		"downloading",
+		"localtest-app-test: image ready",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("rendered output %q missing %q", rendered, want)
+		}
+	}
+}
+
+func TestCreateDockerAppContainerRendersStartAndCanSuppressPlainInfo(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	cmd := &RunCommand{out: ui.NewOutput(&out, io.Discard, false)}
+	spec := appContainerProgressTestSpec()
+	progress := cmd.startContainerRunProgress(spec, runFlags{skipBuild: true})
+	defer progress.Stop()
+
+	client := containermock.New()
+	client.ContainerRemoveFunc = func(context.Context, string, bool) error {
+		return types.ErrContainerNotFound
+	}
+	client.ContainerInspectFunc = func(context.Context, string) (types.ContainerInfo, error) {
+		return appContainerProgressTestInfo(spec), nil
+	}
+
+	_, _, err := cmd.createDockerAppContainer(t.Context(), client, spec, true, progress)
+	if err != nil {
+		t.Fatalf("createDockerAppContainer() error = %v", err)
+	}
+	progress.Stop()
+
+	rendered := out.String()
+	if !strings.Contains(rendered, "localtest-app-test: starting") {
+		t.Fatalf("rendered output %q missing container starting state", rendered)
+	}
+	if strings.Contains(rendered, "Container:") || strings.Contains(rendered, "Port:") {
+		t.Fatalf("rendered output %q contains plain container info despite quiet output", rendered)
+	}
+}
+
+func TestCreateDockerAppContainerRendersExistingContainerRemoval(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	cmd := &RunCommand{out: ui.NewOutput(&out, io.Discard, false)}
+	spec := appContainerProgressTestSpec()
+	progress := cmd.startContainerRunProgress(spec, runFlags{skipBuild: true})
+	defer progress.Stop()
+
+	client := containermock.New()
+	client.ContainerInspectFunc = func(context.Context, string) (types.ContainerInfo, error) {
+		return appContainerProgressTestInfo(spec), nil
+	}
+
+	_, _, err := cmd.createDockerAppContainer(t.Context(), client, spec, true, progress)
+	if err != nil {
+		t.Fatalf("createDockerAppContainer() error = %v", err)
+	}
+	progress.Stop()
+
+	rendered := out.String()
+	for _, want := range []string{
+		"localtest-app-test: stopping",
+		"localtest-app-test: removed",
+		"localtest-app-test: starting",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("rendered output %q missing %q", rendered, want)
+		}
+	}
+}
+
+func TestCreateDockerAppContainerRendersRemoveFailure(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	cmd := &RunCommand{out: ui.NewOutput(&out, io.Discard, false)}
+	spec := appContainerProgressTestSpec()
+	progress := cmd.startContainerRunProgress(spec, runFlags{skipBuild: true})
+	defer progress.Stop()
+
+	client := containermock.New()
+	client.ContainerRemoveFunc = func(context.Context, string, bool) error {
+		return errRemoveFailed
+	}
+
+	_, _, err := cmd.createDockerAppContainer(t.Context(), client, spec, true, progress)
+	if err == nil {
+		t.Fatal("createDockerAppContainer() error = nil, want error")
+	}
+	progress.Fail(err)
+
+	rendered := out.String()
+	if !strings.Contains(rendered, "localtest-app-test: stopping") {
+		t.Fatalf("rendered output %q missing removal start", rendered)
+	}
+	if !strings.Contains(rendered, "localtest-app-test: failed: remove failed") {
+		t.Fatalf("rendered output %q missing removal failure", rendered)
+	}
+}
+
+func appContainerProgressTestSpec() appsvc.DockerRunSpec {
+	return appsvc.DockerRunSpec{Config: types.ContainerConfig{
+		Name:  "localtest-app-test",
+		Image: "example/app:test",
+	}}
+}
+
+func appContainerProgressTestInfo(spec appsvc.DockerRunSpec) types.ContainerInfo {
+	return types.ContainerInfo{
+		ID:    "container-id",
+		Name:  spec.Config.Name,
+		State: types.ContainerState{Running: true},
+		Ports: []types.PublishedPort{{
+			ContainerPort: "5005",
+			HostPort:      "5006",
+		}},
+	}
+}
+
+func assertContainerCall(t *testing.T, calls []containermock.Call, method string) {
+	t.Helper()
+
+	for _, call := range calls {
+		if call.Method == method {
+			return
+		}
+	}
+	t.Fatalf("container calls = %+v, want %s", calls, method)
+}
+
+func assertNoContainerCall(t *testing.T, calls []containermock.Call, method string) {
+	t.Helper()
+
+	for _, call := range calls {
+		if call.Method == method {
+			t.Fatalf("container calls = %+v, did not want %s", calls, method)
+		}
 	}
 }

--- a/src/cli/internal/ui/resourcegraph/compact.go
+++ b/src/cli/internal/ui/resourcegraph/compact.go
@@ -1,4 +1,4 @@
-package renderer
+package resourcegraph
 
 import (
 	"fmt"

--- a/src/cli/internal/ui/resourcegraph/log.go
+++ b/src/cli/internal/ui/resourcegraph/log.go
@@ -1,4 +1,4 @@
-package renderer
+package resourcegraph
 
 import (
 	"strconv"

--- a/src/cli/internal/ui/resourcegraph/model.go
+++ b/src/cli/internal/ui/resourcegraph/model.go
@@ -1,4 +1,4 @@
-package renderer
+package resourcegraph
 
 import (
 	"strings"

--- a/src/cli/internal/ui/resourcegraph/renderer_test.go
+++ b/src/cli/internal/ui/resourcegraph/renderer_test.go
@@ -1,5 +1,5 @@
-//nolint:testpackage // Same-package tests are justified here because the renderer package is internal CLI implementation detail.
-package renderer
+//nolint:testpackage // Same-package tests are justified here because the resourcegraph package is internal CLI implementation detail.
+package resourcegraph
 
 import (
 	"bytes"

--- a/src/cli/internal/ui/resourcegraph/screen.go
+++ b/src/cli/internal/ui/resourcegraph/screen.go
@@ -1,4 +1,4 @@
-package renderer
+package resourcegraph
 
 import (
 	"fmt"

--- a/src/cli/internal/ui/resourcegraph/table.go
+++ b/src/cli/internal/ui/resourcegraph/table.go
@@ -1,4 +1,4 @@
-package renderer
+package resourcegraph
 
 import (
 	"fmt"

--- a/src/cli/internal/ui/resourcegraph/types.go
+++ b/src/cli/internal/ui/resourcegraph/types.go
@@ -1,5 +1,5 @@
-// Package renderer contains the localtest resource renderers used by env up/down.
-package renderer
+// Package resourcegraph renders devenv resource graph lifecycle progress.
+package resourcegraph
 
 import (
 	"sync"
@@ -42,7 +42,7 @@ const (
 	stateCanceled   = "canceled"
 )
 
-// Mode identifies the rendering mode to use for a localtest resource operation.
+// Mode identifies the rendering mode to use for a resource graph operation.
 type Mode int
 
 const (

--- a/src/cli/internal/ui/resourcegraph/util.go
+++ b/src/cli/internal/ui/resourcegraph/util.go
@@ -1,4 +1,4 @@
-package renderer
+package resourcegraph
 
 import (
 	"fmt"


### PR DESCRIPTION
## Description

- generalizes the renderer located in the localtest package (it renders state/progress based on the devenv resource graph abstraction)
- switches `run`/`app run` to use the renderer, but still dispatches events manually for now in some places

we might consider going further in the future and actually running this through the resource graph executor in the future, it would be natural to just build the localtest graph but add the app as a container in that case (then it would start localtest if it wasnt already running). It already references the container network of localtest 

<img width="956" height="74" alt="image" src="https://github.com/user-attachments/assets/7e842084-79d5-42c6-beba-93e099cac8d9" />


## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
