### PR TITLE
fix: rename workflow-engine-app Docker build-arg to BUILD_VERSION

### DIFF
--- a/.github/workflows/deploy-runtime-workflow-engine-app.yaml
+++ b/.github/workflows/deploy-runtime-workflow-engine-app.yaml
@@ -99,7 +99,7 @@ jobs:
           if [ "${{ inputs.tag-latest }}" = "true" ]; then
             TAGS="$TAGS -t ghcr.io/altinn/altinn-studio/runtime-workflow-engine-app:latest"
           fi
-          docker build --platform linux/amd64,linux/arm64 --build-arg VERSION=${{ steps.vars.outputs.short-sha }} $TAGS -f Runtime/workflow-engine-app/Dockerfile .
+          docker build --platform linux/amd64,linux/arm64 --build-arg BUILD_VERSION=${{ steps.vars.outputs.short-sha }} $TAGS -f Runtime/workflow-engine-app/Dockerfile .
 
       - name: push image
         run: docker push ${{ steps.vars.outputs.image-repo }}

--- a/src/Runtime/workflow-engine-app/Dockerfile
+++ b/src/Runtime/workflow-engine-app/Dockerfile
@@ -6,7 +6,7 @@ EXPOSE 9090
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:8a90a473da5205a16979de99d2fc20975e922c68304f5c79d564e666dc3982fc AS build
 ARG BUILD_CONFIGURATION=Release
-ARG VERSION=dev
+ARG BUILD_VERSION=dev
 WORKDIR /build
 
 COPY common/ common/
@@ -15,7 +15,7 @@ COPY Runtime/workflow-engine-app/ Runtime/workflow-engine-app/
 
 WORKDIR /build/Runtime/workflow-engine-app/src/WorkflowEngine.App
 RUN dotnet restore "WorkflowEngine.App.csproj"
-RUN dotnet publish "WorkflowEngine.App.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false /p:CSharpier_Bypass=true /p:InformationalVersion=$VERSION
+RUN dotnet publish "WorkflowEngine.App.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false /p:CSharpier_Bypass=true /p:InformationalVersion=$BUILD_VERSION
 
 FROM base AS final
 WORKDIR /app


### PR DESCRIPTION
## Summary
- Follow-up to #18764 (CD failed on main: [run 25723361441](https://github.com/Altinn/altinn-studio/actions/runs/25723361441/job/75529789687)).
- `ARG VERSION` exposed `VERSION` as an env var to every `RUN` in the build stage. MSBuild reads `VERSION` env → `$(Version)` property during `dotnet restore`, and NuGet rejects the short SHA as an invalid semver.
- Renaming to `BUILD_VERSION` avoids the MSBuild property-name collision.

## Test plan
- [x] Local `docker build --build-arg BUILD_VERSION=dc0a6d24af` succeeds and the published DLL reports `InformationalVersion=dc0a6d24af`
- [ ] CI deploy job green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated internal build and deployment configuration processes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio/pull/18769)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->