### PR TITLE
fix: studioctl - run renders colors only when interactive/color enabled

### DIFF
--- a/src/cli/internal/cmd/run.go
+++ b/src/cli/internal/cmd/run.go
@@ -443,7 +443,7 @@ func (c *RunCommand) configureDotnetRunCommand(
 	flags runFlags,
 ) (string, func(), error) {
 	cmd.Dir = spec.Dir
-	cmd.Env = dotnetRunCommandEnv(spec.Env, flags, ui.Colors())
+	cmd.Env = dotnetRunCommandEnv(spec.Env, flags, ui.Colors() && c.out.IsTerminal())
 	logFile, logPath, err := c.openAppLog(target.AppID)
 	if err != nil {
 		return "", nil, err

--- a/src/cli/internal/cmd/run_internal_test.go
+++ b/src/cli/internal/cmd/run_internal_test.go
@@ -282,6 +282,15 @@ func TestDotnetRunCommandEnvDoesNotEnableAnsiColorForDetached(t *testing.T) {
 	}
 }
 
+func TestDotnetRunCommandEnvDoesNotEnableAnsiColorWhenOutputIsNotTerminal(t *testing.T) {
+	t.Parallel()
+
+	got := dotnetRunCommandEnv([]string{"PATH=/bin"}, runFlags{}, false)
+	if envContainsPrefix(got, dotnetAnsiColorRedirectionEnv+"=") {
+		t.Fatalf("env = %v, did not want %s", got, dotnetAnsiColorRedirectionEnv)
+	}
+}
+
 func TestNextAppLogPathUsesNextRunIDForDate(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Description

Includes IsTerminal check to align with the rest of the studioctl code

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
