### PR TITLE
fix: studioctl - add auth redirection in localtest

### DIFF
--- a/src/Runtime/localtest/src/Controllers/Authentication/AuthenticationController.cs
+++ b/src/Runtime/localtest/src/Controllers/Authentication/AuthenticationController.cs
@@ -49,6 +49,18 @@ namespace LocalTest.Controllers.Authentication
             return await Task.FromResult(Ok(token));
         }
 
+        [AllowAnonymous]
+        [HttpGet("authentication")]
+        public ActionResult Authenticate([FromQuery(Name = "goto")] string goTo)
+        {
+            if (string.IsNullOrWhiteSpace(goTo))
+            {
+                return Redirect("/");
+            }
+
+            return Redirect($"/?goto={Uri.EscapeDataString(goTo)}");
+        }
+
         [HttpGet("orgToken")]
         public async Task<ActionResult> GenerateOrgToken(
             [FromQuery] string org = "ttd",

--- a/src/Runtime/localtest/src/Controllers/HomeController.cs
+++ b/src/Runtime/localtest/src/Controllers/HomeController.cs
@@ -71,7 +71,7 @@ namespace LocalTest.Controllers
         [HttpGet("/")]
         [HttpGet("/Home")]
         [HttpGet("/Home/Index")]
-        public async Task<IActionResult> Index()
+        public async Task<IActionResult> Index([FromQuery(Name = "goto")] string goTo = null)
         {
             StartAppModel model = new StartAppModel()
             {
@@ -79,6 +79,7 @@ namespace LocalTest.Controllers
                 LocalFrontendUrl = HttpContext.Request.Cookies[
                     FrontendVersionController.FRONTEND_URL_COOKIE_NAME
                 ],
+                RedirectUrl = goTo,
             };
             model.LocalFrontendDescription = _localFrontendService.DescribeFrontendUrl(model.LocalFrontendUrl);
 
@@ -89,8 +90,11 @@ namespace LocalTest.Controllers
                 model.TestApps = await GetAppsList(cancellationToken);
                 model.TestUsers = await GetTestUsersAndPartiesSelectList(cancellationToken);
                 model.UserSelect = Request.Cookies["Localtest_User.Party_Select"];
-                var firstAppId = model.TestApps.Count() == 1 ? model.TestApps.First().Value : null;
-                var defaultAuthLevel = await GetAppAuthLevel(firstAppId, cancellationToken);
+                model.SelectRedirectApp();
+                var selectedAppId =
+                    model.AppPathSelection
+                    ?? (model.TestApps.Count() == 1 ? model.TestApps.First().Value : null);
+                var defaultAuthLevel = await GetAppAuthLevel(selectedAppId, cancellationToken);
                 model.AuthenticationLevels = GetAuthenticationLevels(defaultAuthLevel);
             }
             catch (Exception e) when (e is HttpRequestException or OperationCanceledException)
@@ -155,6 +159,13 @@ namespace LocalTest.Controllers
                 return NoContent();
             }
 
+            var prefill = Request.Form.Files.FirstOrDefault();
+
+            if (!string.IsNullOrWhiteSpace(startAppModel.RedirectUrl) && prefill == null)
+            {
+                return Redirect(startAppModel.RedirectUrl);
+            }
+
             if (startAppModel.AppPathSelection?.Equals("accessmanagement") == true)
             {
                 return Redirect($"/accessmanagement/ui/given-api-delegations/overview");
@@ -168,7 +179,6 @@ namespace LocalTest.Controllers
                 return BadRequest("App not found");
             }
 
-            var prefill = Request.Form.Files.FirstOrDefault();
             if (prefill != null)
             {
                 var instance = new Instance

--- a/src/Runtime/localtest/src/Models/StartAppModel.cs
+++ b/src/Runtime/localtest/src/Models/StartAppModel.cs
@@ -50,6 +50,11 @@ namespace LocalTest.Models
         public string AuthenticationLevel { get; set; }
 
         /// <summary>
+        /// Url to redirect to after localtest has created authentication cookies.
+        /// </summary>
+        public string RedirectUrl { get; set; }
+
+        /// <summary>
         /// Url for where to load the local frontend from
         /// (implemented as a cookie consumed by localtest proxy middleware)
         /// </summary>
@@ -74,5 +79,41 @@ namespace LocalTest.Models
         /// List of possible authentication levels
         /// </summary>
         public IEnumerable<SelectListItem> AuthenticationLevels { get; set; }
+
+        public void SelectRedirectApp()
+        {
+            var appId = GetAppIdFromRedirectUrl();
+            if (string.IsNullOrEmpty(appId))
+            {
+                return;
+            }
+
+            var selectedApp = TestApps.FirstOrDefault(
+                app => string.Equals(app.Text, appId, StringComparison.OrdinalIgnoreCase)
+            );
+            if (selectedApp == null)
+            {
+                return;
+            }
+
+            selectedApp.Selected = true;
+            AppPathSelection = selectedApp.Value;
+        }
+
+        private string GetAppIdFromRedirectUrl()
+        {
+            if (string.IsNullOrWhiteSpace(RedirectUrl) || !Uri.TryCreate(RedirectUrl, UriKind.Absolute, out var uri))
+            {
+                return null;
+            }
+
+            var segments = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            if (segments.Length < 2)
+            {
+                return null;
+            }
+
+            return $"{segments[0]}/{segments[1]}";
+        }
     }
 }

--- a/src/Runtime/localtest/src/Views/Home/Index.cshtml
+++ b/src/Runtime/localtest/src/Views/Home/Index.cshtml
@@ -60,6 +60,7 @@
       @using (Html.BeginForm("LogInTestUser", "Home", FormMethod.Post, new { Class = "form-signin", enctype = "multipart/form-data" }))
       {
         @Html.AntiForgeryToken();
+        @Html.HiddenFor(model => model.RedirectUrl);
         @if(Model.TestApps != null)
         {
           <div class="form-group">

--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -17,6 +17,7 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ### Fixed
 
+- Redirect unauthenticated app URLs opened from `studioctl app run` through the localtest login page.
 - Keep running apps visible in localtest after restarting the localtest environment.
 - Improve localtest resource reconciliation so `env up` removes managed resources that are no longer requested, such as pgAdmin or monitoring, without restarting unchanged core containers.
 

--- a/src/cli/internal/config/config.yaml
+++ b/src/cli/internal/config/config.yaml
@@ -6,7 +6,7 @@ images:
   core:
     localtest:
       image: ghcr.io/altinn/altinn-studio/runtime-localtest
-      tag: "d596e41244"
+      tag: "2342a04889"
     pdf3:
       image: ghcr.io/altinn/altinn-studio/runtime-pdf3-worker
       tag: "b885f9a75f"


### PR DESCRIPTION
## Description

App does redirect to platform authentication endpoint when the user goes directly to app without being authenticated first. This endpoint was missing. Implemented it, and it now redirects to the normal localtest home page where the user can authenticate

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Authentication flow now supports an optional redirect parameter, allowing users to be redirected to a specified location after logging in, or to the home page if no destination is provided.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio/pull/18775)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->