### PR TITLE
feat: Add binary update support to instance data mutator

### DIFF
--- a/src/App/backend/src/Altinn.App.Core/Features/IInstanceDataMutator.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/IInstanceDataMutator.cs
@@ -7,7 +7,7 @@ using Altinn.Platform.Storage.Interface.Models;
 namespace Altinn.App.Core.Features;
 
 /// <summary>
-/// Extension of the IInstanceDataAccessor that allows for adding and removing data elements,
+/// Extension of the IInstanceDataAccessor that allows for adding, updating and removing data elements,
 /// and also indicate that it is OK to mutate the models
 /// </summary>
 public interface IInstanceDataMutator : IInstanceDataAccessor
@@ -55,6 +55,14 @@ public interface IInstanceDataMutator : IInstanceDataAccessor
         string? filename,
         ReadOnlyMemory<byte> bytes
     ) => AddBinaryDataElement(dataType.Id, contentType, filename, bytes);
+
+    /// <summary>
+    /// Replace the binary content of an existing binary data element.
+    /// </summary>
+    /// <remarks>
+    /// Saving to storage is not done until the instance is saved, so mutations to data might or might not be sent to storage.
+    /// </remarks>
+    BinaryDataChange UpdateBinaryDataElement(DataElementIdentifier dataElementIdentifier, ReadOnlyMemory<byte> bytes);
 
     /// <summary>
     /// Remove a data element from the instance.

--- a/src/App/backend/src/Altinn.App.Core/Internal/Data/InstanceDataUnitOfWork.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/Data/InstanceDataUnitOfWork.cs
@@ -660,10 +660,11 @@ internal sealed class InstanceDataUnitOfWork : IInstanceDataMutator
             throw new InvalidOperationException("AbandonAllChanges has been called, and no changes should be saved");
         }
 
-        foreach (var change in changes.BinaryDataChanges.Where(change => change.Type == ChangeType.Updated))
-        {
-            await GetPersistedBinaryData(change.DataElementIdentifier);
-        }
+        await Task.WhenAll(
+            changes
+                .BinaryDataChanges.Where(change => change.Type == ChangeType.Updated)
+                .Select(change => GetPersistedBinaryData(change.DataElementIdentifier))
+        );
 
         var tasks = new List<Task>();
 

--- a/src/App/backend/src/Altinn.App.Core/Internal/Data/InstanceDataUnitOfWork.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/Data/InstanceDataUnitOfWork.cs
@@ -46,7 +46,7 @@ internal sealed class InstanceDataUnitOfWork : IInstanceDataMutator
     // Cache for the most up-to-date form data (can be mutated or replaced with SetFormData(dataElementId, data))
     private readonly DataElementCache<IFormDataWrapper> _formDataCache = new();
 
-    // Cache for the binary content of the file as currently in storage (updated on save)
+    // Cache for the binary content of the file as currently in storage.
     private readonly DataElementCache<ReadOnlyMemory<byte>> _binaryCache = new();
 
     // Data elements to delete (eg RemoveDataElement(dataElementId)), but not yet deleted from instance or storage
@@ -54,6 +54,9 @@ internal sealed class InstanceDataUnitOfWork : IInstanceDataMutator
 
     // Form data not yet saved to storage (thus no dataElementId)
     private readonly ConcurrentBag<DataElementChange> _changesForCreation = [];
+
+    // Existing binary data elements with updated content that is not yet saved to storage.
+    private readonly ConcurrentDictionary<DataElementIdentifier, BinaryDataChange> _changesForBinaryUpdate = [];
 
     private readonly ConcurrentDictionary<DataType, StorageAuthenticationMethod> _authenticationMethodOverrides = new(
         DataTypeComparer.Instance
@@ -207,6 +210,11 @@ internal sealed class InstanceDataUnitOfWork : IInstanceDataMutator
         // Verify that the data element exists on the instance
         GetDataElement(dataElementIdentifier);
 
+        if (_changesForBinaryUpdate.TryGetValue(dataElementIdentifier, out var updatedBinary))
+        {
+            return updatedBinary.CurrentBinaryData;
+        }
+
         return await _binaryCache.GetOrCreate(
             dataElementIdentifier,
             async () =>
@@ -286,19 +294,7 @@ internal sealed class InstanceDataUnitOfWork : IInstanceDataMutator
             );
         }
 
-        if (dataType.MaxSize.HasValue && bytes.Length > dataType.MaxSize.Value * 1024 * 1024)
-        {
-            throw new InvalidOperationException(
-                $"Data element of type {dataTypeId} exceeds the size limit of {dataType.MaxSize} MB"
-            );
-        }
-
-        if (dataType.AllowedContentTypes is { Count: > 0 } && !dataType.AllowedContentTypes.Contains(contentType))
-        {
-            throw new InvalidOperationException(
-                $"Data element of type {dataTypeId} has a Content-Type '{contentType}' which is invalid for element type '{dataTypeId}'"
-            );
-        }
+        ValidateBinaryData(dataType, contentType, bytes);
 
         BinaryDataChange change = new BinaryDataChange(
             type: ChangeType.Created,
@@ -309,6 +305,47 @@ internal sealed class InstanceDataUnitOfWork : IInstanceDataMutator
             currentBinaryData: bytes
         );
         _changesForCreation.Add(change);
+        return change;
+    }
+
+    /// <inheritdoc />
+    public BinaryDataChange UpdateBinaryDataElement(
+        DataElementIdentifier dataElementIdentifier,
+        ReadOnlyMemory<byte> bytes
+    )
+    {
+        var dataElement = GetDataElement(dataElementIdentifier);
+        var dataType = this.GetDataType(dataElementIdentifier);
+        if (dataType.AppLogic?.ClassRef is not null)
+        {
+            throw new InvalidOperationException(
+                $"Data element {dataElementIdentifier.Id} of type {dataType.Id} is not a binary data element"
+            );
+        }
+        if (_changesForDeletion.Any(c => c.DataElementIdentifier == dataElementIdentifier))
+        {
+            throw new InvalidOperationException(
+                $"Data element with id {dataElementIdentifier.Id} is marked for deletion and cannot be updated"
+            );
+        }
+        if (dataElement.ContentType is not { } contentType)
+        {
+            throw new InvalidOperationException(
+                $"Data element {dataElementIdentifier.Id} is missing Content-Type and cannot be updated"
+            );
+        }
+
+        ValidateBinaryData(dataType, contentType, bytes);
+
+        BinaryDataChange change = new BinaryDataChange(
+            type: ChangeType.Updated,
+            dataElement: dataElement,
+            dataType: dataType,
+            fileName: dataElement.Filename,
+            contentType: contentType,
+            currentBinaryData: bytes
+        );
+        _changesForBinaryUpdate[dataElementIdentifier] = change;
         return change;
     }
 
@@ -324,6 +361,7 @@ internal sealed class InstanceDataUnitOfWork : IInstanceDataMutator
                 $"Data element with id {dataElementIdentifier.Id} is already marked for deletion"
             );
         }
+        _changesForBinaryUpdate.TryRemove(dataElementIdentifier, out _);
         if (dataType.AppLogic?.ClassRef is null)
         {
             _changesForDeletion.Add(
@@ -392,9 +430,14 @@ internal sealed class InstanceDataUnitOfWork : IInstanceDataMutator
             }
             var dataType = this.GetDataType(dataElementIdentifier);
 
+            if (_changesForBinaryUpdate.TryGetValue(dataElementIdentifier, out var binaryChange))
+            {
+                changes.Add(binaryChange);
+                continue;
+            }
+
             if (!_formDataCache.TryGetCachedValue(dataElementIdentifier, out IFormDataWrapper? dataWrapper))
             {
-                // We don't support making updates to binary data elements (attachments) in IInstanceDataMutator
                 continue;
             }
 
@@ -472,6 +515,23 @@ internal sealed class InstanceDataUnitOfWork : IInstanceDataMutator
         return new DataElementChanges(changes);
     }
 
+    private static void ValidateBinaryData(DataType dataType, string contentType, ReadOnlyMemory<byte> bytes)
+    {
+        if (dataType.MaxSize.HasValue && bytes.Length > dataType.MaxSize.Value * 1024 * 1024)
+        {
+            throw new InvalidOperationException(
+                $"Data element of type {dataType.Id} exceeds the size limit of {dataType.MaxSize} MB"
+            );
+        }
+
+        if (dataType.AllowedContentTypes is { Count: > 0 } && !dataType.AllowedContentTypes.Contains(contentType))
+        {
+            throw new InvalidOperationException(
+                $"Data element of type {dataType.Id} has a Content-Type '{contentType}' which is invalid for element type '{dataType.Id}'"
+            );
+        }
+    }
+
     private async Task CreateDataElement(
         ConcurrentDictionary<DataElementChange, DataElement> createdDataElements,
         DataElementChange change
@@ -520,6 +580,21 @@ internal sealed class InstanceDataUnitOfWork : IInstanceDataMutator
             change.DataElement.Filename,
             Guid.Parse(change.DataElement.Id),
             new MemoryAsStream(bytes),
+            authenticationMethod: GetAuthenticationMethod(change.DataElementIdentifier)
+        );
+    }
+
+    private async Task UpdateDataElement(BinaryDataChange change)
+    {
+        if (change.DataElement is null)
+            throw new InvalidOperationException("ChangeType.Updated sent to SaveChanges must have a DataElement value");
+
+        await _dataClient.UpdateBinaryData(
+            new InstanceIdentifier(Instance),
+            change.ContentType,
+            change.FileName,
+            change.DataElementIdentifier.Guid,
+            new MemoryAsStream(change.CurrentBinaryData),
             authenticationMethod: GetAuthenticationMethod(change.DataElementIdentifier)
         );
     }
@@ -595,12 +670,16 @@ internal sealed class InstanceDataUnitOfWork : IInstanceDataMutator
         }
         var tasks = new List<Task>();
 
-        foreach (var change in changes.FormDataChanges)
+        foreach (var change in changes.AllChanges.Where(change => change.Type == ChangeType.Updated))
         {
-            if (change.Type != ChangeType.Updated)
-                continue; // New and deleted form data is handled separately
-
-            tasks.Add(UpdateDataElement(change));
+            tasks.Add(
+                change switch
+                {
+                    FormDataChange formDataChange => UpdateDataElement(formDataChange),
+                    BinaryDataChange binaryDataChange => UpdateDataElement(binaryDataChange),
+                    _ => throw new UnreachableException("ChangeType.Updated must be a form or binary data change"),
+                }
+            );
         }
 
         await Task.WhenAll(tasks);

--- a/src/App/backend/src/Altinn.App.Core/Internal/Data/InstanceDataUnitOfWork.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/Data/InstanceDataUnitOfWork.cs
@@ -46,7 +46,7 @@ internal sealed class InstanceDataUnitOfWork : IInstanceDataMutator
     // Cache for the most up-to-date form data (can be mutated or replaced with SetFormData(dataElementId, data))
     private readonly DataElementCache<IFormDataWrapper> _formDataCache = new();
 
-    // Cache for the binary content of the file as currently in storage.
+    // Cache for the binary content of the file as currently in storage before changes in this unit of work.
     private readonly DataElementCache<ReadOnlyMemory<byte>> _binaryCache = new();
 
     // Data elements to delete (eg RemoveDataElement(dataElementId)), but not yet deleted from instance or storage
@@ -215,16 +215,7 @@ internal sealed class InstanceDataUnitOfWork : IInstanceDataMutator
             return updatedBinary.CurrentBinaryData;
         }
 
-        return await _binaryCache.GetOrCreate(
-            dataElementIdentifier,
-            async () =>
-                await _dataClient.GetDataBytes(
-                    _instanceOwnerPartyId,
-                    _instanceGuid,
-                    dataElementIdentifier.Guid,
-                    authenticationMethod: GetAuthenticationMethod(dataElementIdentifier)
-                )
-        );
+        return await GetPersistedBinaryData(dataElementIdentifier);
     }
 
     /// <inheritdoc />
@@ -668,6 +659,12 @@ internal sealed class InstanceDataUnitOfWork : IInstanceDataMutator
         {
             throw new InvalidOperationException("AbandonAllChanges has been called, and no changes should be saved");
         }
+
+        foreach (var change in changes.BinaryDataChanges.Where(change => change.Type == ChangeType.Updated))
+        {
+            await GetPersistedBinaryData(change.DataElementIdentifier);
+        }
+
         var tasks = new List<Task>();
 
         foreach (var change in changes.AllChanges.Where(change => change.Type == ChangeType.Updated))
@@ -683,6 +680,23 @@ internal sealed class InstanceDataUnitOfWork : IInstanceDataMutator
         }
 
         await Task.WhenAll(tasks);
+    }
+
+    internal async Task<ReadOnlyMemory<byte>> GetPersistedBinaryData(DataElementIdentifier dataElementIdentifier)
+    {
+        // Verify that the data element exists on the instance
+        GetDataElement(dataElementIdentifier);
+
+        return await _binaryCache.GetOrCreate(
+            dataElementIdentifier,
+            async () =>
+                await _dataClient.GetDataBytes(
+                    _instanceOwnerPartyId,
+                    _instanceGuid,
+                    dataElementIdentifier.Guid,
+                    authenticationMethod: GetAuthenticationMethod(dataElementIdentifier)
+                )
+        );
     }
 
     /// <summary>

--- a/src/App/backend/src/Altinn.App.Core/Internal/Data/PreviousDataAccessor.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/Data/PreviousDataAccessor.cs
@@ -69,7 +69,7 @@ internal class PreviousDataAccessor : IInstanceDataAccessor
                         );
                     }
                     var dataElement = GetDataElement(id);
-                    var binaryData = await _dataAccessor.GetBinaryData(id).ConfigureAwait(false);
+                    var binaryData = await GetBinaryData(id).ConfigureAwait(false);
 
                     return FormDataWrapperFactory.Create(
                         _modelSerializationService.DeserializeFromStorage(binaryData.Span, dataType, dataElement)
@@ -107,6 +107,11 @@ internal class PreviousDataAccessor : IInstanceDataAccessor
 
     public async Task<ReadOnlyMemory<byte>> GetBinaryData(DataElementIdentifier dataElementIdentifier)
     {
+        if (_dataAccessor is InstanceDataUnitOfWork dataUnitOfWork)
+        {
+            return await dataUnitOfWork.GetPersistedBinaryData(dataElementIdentifier).ConfigureAwait(false);
+        }
+
         return await _dataAccessor.GetBinaryData(dataElementIdentifier).ConfigureAwait(false);
     }
 

--- a/src/App/backend/test/Altinn.App.Core.Tests/Internal/Data/InstanceDataUnitOfWorkTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Internal/Data/InstanceDataUnitOfWorkTests.cs
@@ -69,6 +69,44 @@ public class InstanceDataUnitOfWorkTests
     }
 
     [Fact]
+    public async Task PreviousDataAccessor_AfterUpdatingBinaryData_ReturnsOriginalBytes()
+    {
+        byte[] initialBytes = Encoding.UTF8.GetBytes("""{"status":"created"}""");
+        byte[] updatedBytes = Encoding.UTF8.GetBytes("""{"status":"paid"}""");
+
+        await using var setup = await BinaryDataUnitOfWorkSetup.Create(initialBytes);
+
+        setup.DataMutator.UpdateBinaryDataElement(setup.DataElement, updatedBytes);
+
+        ReadOnlyMemory<byte> previousBytes = await setup
+            .DataMutator.GetPreviousDataAccessor()
+            .GetBinaryData(setup.DataElement);
+
+        Assert.True(previousBytes.Span.SequenceEqual(initialBytes));
+    }
+
+    [Fact]
+    public async Task PreviousDataAccessor_AfterSavingUpdatedBinaryData_ReturnsOriginalBytes()
+    {
+        byte[] initialBytes = Encoding.UTF8.GetBytes("""{"status":"created"}""");
+        byte[] updatedBytes = Encoding.UTF8.GetBytes("""{"status":"paid"}""");
+
+        await using var setup = await BinaryDataUnitOfWorkSetup.Create(initialBytes);
+
+        setup.DataMutator.UpdateBinaryDataElement(setup.DataElement, updatedBytes);
+        DataElementChanges changes = setup.DataMutator.GetDataElementChanges(initializeAltinnRowId: false);
+
+        await setup.DataMutator.UpdateInstanceData(changes);
+        await setup.DataMutator.SaveChanges(changes);
+
+        ReadOnlyMemory<byte> previousBytes = await setup
+            .DataMutator.GetPreviousDataAccessor()
+            .GetBinaryData(setup.DataElement);
+
+        Assert.True(previousBytes.Span.SequenceEqual(initialBytes));
+    }
+
+    [Fact]
     public async Task RemoveDataElement_AfterUpdatingBinaryData_ReplacesPendingUpdateWithDeletion()
     {
         byte[] initialBytes = Encoding.UTF8.GetBytes("""{"status":"created"}""");

--- a/src/App/backend/test/Altinn.App.Core.Tests/Internal/Data/InstanceDataUnitOfWorkTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Internal/Data/InstanceDataUnitOfWorkTests.cs
@@ -1,0 +1,175 @@
+using System.Text;
+using System.Text.Json;
+using Altinn.App.Core.Internal.Data;
+using Altinn.App.Core.Models;
+using Altinn.App.Tests.Common.Fixtures;
+using Altinn.Platform.Storage.Interface.Models;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Altinn.App.Core.Tests.Internal.Data;
+
+public class InstanceDataUnitOfWorkTests
+{
+    [Fact]
+    public async Task UpdateBinaryDataElement_RegistersUpdatedBinaryChange_AndReturnsUpdatedBytes()
+    {
+        byte[] initialBytes = Encoding.UTF8.GetBytes("""{"status":"created"}""");
+        byte[] updatedBytes = Encoding.UTF8.GetBytes("""{"status":"paid"}""");
+
+        await using var setup = await BinaryDataUnitOfWorkSetup.Create(initialBytes);
+
+        BinaryDataChange updatedChange = setup.DataMutator.UpdateBinaryDataElement(setup.DataElement, updatedBytes);
+
+        ReadOnlyMemory<byte> currentBytes = await setup.DataMutator.GetBinaryData(setup.DataElement);
+        Assert.True(currentBytes.Span.SequenceEqual(updatedBytes));
+
+        DataElementChanges changes = setup.DataMutator.GetDataElementChanges(initializeAltinnRowId: false);
+        BinaryDataChange change = Assert.Single(changes.BinaryDataChanges);
+        Assert.Same(updatedChange, change);
+        Assert.Equal(ChangeType.Updated, change.Type);
+        Assert.Equal(setup.DataElement.Id, change.DataElement?.Id);
+        Assert.Equal(setup.DataElement.ContentType, change.ContentType);
+        Assert.Equal(setup.DataElement.Filename, change.FileName);
+        Assert.True(change.CurrentBinaryData.Span.SequenceEqual(updatedBytes));
+    }
+
+    [Fact]
+    public async Task SaveChanges_PersistsUpdatedBinaryDataToStorage()
+    {
+        byte[] initialBytes = Encoding.UTF8.GetBytes("""{"status":"created"}""");
+        byte[] updatedBytes = Encoding.UTF8.GetBytes("""{"status":"paid"}""");
+
+        await using var setup = await BinaryDataUnitOfWorkSetup.Create(initialBytes);
+
+        setup.DataMutator.UpdateBinaryDataElement(setup.DataElement, updatedBytes);
+        DataElementChanges changes = setup.DataMutator.GetDataElementChanges(initializeAltinnRowId: false);
+
+        await setup.DataMutator.UpdateInstanceData(changes);
+        await setup.DataMutator.SaveChanges(changes);
+
+        (_, var storedData) = setup.Services.Storage.GetInstanceAndData(setup.InstanceOwnerPartyId, setup.InstanceGuid);
+        Assert.True(storedData[setup.DataElement.Id].AsSpan().SequenceEqual(updatedBytes));
+    }
+
+    [Fact]
+    public async Task VerifyDataElementsUnchangedSincePreviousChanges_AfterSavingUpdatedBinaryData_DoesNotThrow()
+    {
+        byte[] initialBytes = Encoding.UTF8.GetBytes("""{"status":"created"}""");
+        byte[] updatedBytes = Encoding.UTF8.GetBytes("""{"status":"paid"}""");
+
+        await using var setup = await BinaryDataUnitOfWorkSetup.Create(initialBytes);
+
+        setup.DataMutator.UpdateBinaryDataElement(setup.DataElement, updatedBytes);
+        DataElementChanges changes = setup.DataMutator.GetDataElementChanges(initializeAltinnRowId: false);
+
+        await setup.DataMutator.UpdateInstanceData(changes);
+        await setup.DataMutator.SaveChanges(changes);
+
+        setup.DataMutator.VerifyDataElementsUnchangedSincePreviousChanges(changes);
+    }
+
+    [Fact]
+    public async Task RemoveDataElement_AfterUpdatingBinaryData_ReplacesPendingUpdateWithDeletion()
+    {
+        byte[] initialBytes = Encoding.UTF8.GetBytes("""{"status":"created"}""");
+        byte[] updatedBytes = Encoding.UTF8.GetBytes("""{"status":"paid"}""");
+
+        await using var setup = await BinaryDataUnitOfWorkSetup.Create(initialBytes);
+
+        setup.DataMutator.UpdateBinaryDataElement(setup.DataElement, updatedBytes);
+        setup.DataMutator.RemoveDataElement(setup.DataElement);
+
+        DataElementChanges changes = setup.DataMutator.GetDataElementChanges(initializeAltinnRowId: false);
+        BinaryDataChange change = Assert.Single(changes.BinaryDataChanges);
+        Assert.Equal(ChangeType.Deleted, change.Type);
+        Assert.Equal(setup.DataElement.Id, change.DataElement?.Id);
+        Assert.Equal(ReadOnlyMemory<byte>.Empty, change.CurrentBinaryData);
+    }
+
+    [Fact]
+    public async Task UpdateBinaryDataElement_WhenMarkedForDeletion_Throws()
+    {
+        byte[] initialBytes = Encoding.UTF8.GetBytes("""{"status":"created"}""");
+        byte[] updatedBytes = Encoding.UTF8.GetBytes("""{"status":"paid"}""");
+
+        await using var setup = await BinaryDataUnitOfWorkSetup.Create(initialBytes);
+
+        setup.DataMutator.RemoveDataElement(setup.DataElement);
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+            setup.DataMutator.UpdateBinaryDataElement(setup.DataElement, updatedBytes)
+        );
+        Assert.Contains("marked for deletion", exception.Message, StringComparison.Ordinal);
+    }
+
+    private sealed class BinaryDataUnitOfWorkSetup : IAsyncDisposable
+    {
+        public required MockedServiceCollection Services { get; init; }
+        public required WrappedServiceProvider ServiceProvider { get; init; }
+        public required InstanceDataUnitOfWork DataMutator { get; init; }
+        public required DataElement DataElement { get; init; }
+        public required int InstanceOwnerPartyId { get; init; }
+        public required Guid InstanceGuid { get; init; }
+
+        public static async Task<BinaryDataUnitOfWorkSetup> Create(byte[] initialBytes)
+        {
+            var services = new MockedServiceCollection();
+            const string taskId = "Task_1";
+            const string dataTypeId = "payment";
+            const string contentType = "application/json";
+            const string fileName = "payment.json";
+            const int instanceOwnerPartyId = 123456;
+            Guid instanceGuid = Guid.NewGuid();
+            Guid dataGuid = Guid.NewGuid();
+
+            services.AddDataType(
+                new DataType
+                {
+                    Id = dataTypeId,
+                    AllowedContentTypes = [contentType],
+                    MaxCount = 1,
+                    TaskId = taskId,
+                }
+            );
+
+            var dataElement = new DataElement
+            {
+                Id = dataGuid.ToString(),
+                InstanceGuid = instanceGuid.ToString(),
+                DataType = dataTypeId,
+                ContentType = contentType,
+                Filename = fileName,
+            };
+            var instance = new Instance
+            {
+                Id = $"{instanceOwnerPartyId}/{instanceGuid}",
+                AppId = $"{MockedServiceCollection.Org}/{MockedServiceCollection.App}",
+                InstanceOwner = new InstanceOwner { PartyId = instanceOwnerPartyId.ToString() },
+                Data = [dataElement],
+                Process = new ProcessState { CurrentTask = new ProcessElementInfo { ElementId = taskId } },
+            };
+
+            services.Storage.AddInstance(instance);
+            services.Storage.AddDataRaw(dataGuid, initialBytes);
+
+            WrappedServiceProvider serviceProvider = services.BuildServiceProvider();
+            var initializer = serviceProvider.GetRequiredService<InstanceDataUnitOfWorkInitializer>();
+            Instance instanceCopy = JsonSerializer.Deserialize<Instance>(
+                JsonSerializer.SerializeToUtf8Bytes(instance)
+            )!;
+            InstanceDataUnitOfWork dataMutator = await initializer.Init(instanceCopy, taskId, language: null);
+
+            return new BinaryDataUnitOfWorkSetup
+            {
+                Services = services,
+                ServiceProvider = serviceProvider,
+                DataMutator = dataMutator,
+                DataElement = dataElement,
+                InstanceOwnerPartyId = instanceOwnerPartyId,
+                InstanceGuid = instanceGuid,
+            };
+        }
+
+        public ValueTask DisposeAsync() => ServiceProvider.DisposeAsync();
+    }
+}

--- a/src/App/backend/test/Altinn.App.Core.Tests/Internal/Data/InstanceDataUnitOfWorkTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Internal/Data/InstanceDataUnitOfWorkTests.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Altinn.App.Core.Tests.Internal.Data;
 
-public class InstanceDataUnitOfWorkTests
+public sealed class InstanceDataUnitOfWorkTests
 {
     [Fact]
     public async Task UpdateBinaryDataElement_RegistersUpdatedBinaryChange_AndReturnsUpdatedBytes()

--- a/src/App/backend/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/src/App/backend/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -1310,6 +1310,7 @@ namespace Altinn.App.Core.Features
         Altinn.App.Core.Models.FormDataChange AddFormDataElement(Altinn.Platform.Storage.Interface.Models.DataType dataType, object model);
         Altinn.App.Core.Models.FormDataChange AddFormDataElement(string dataTypeId, object model);
         void RemoveDataElement(Altinn.App.Core.Models.DataElementIdentifier dataElementIdentifier);
+        Altinn.App.Core.Models.BinaryDataChange UpdateBinaryDataElement(Altinn.App.Core.Models.DataElementIdentifier dataElementIdentifier, System.ReadOnlyMemory<byte> bytes);
     }
     [System.Obsolete("Use ITaskValidator, IDataElementValidator or IFormDataValidator instead")]
     public interface IInstanceValidator

--- a/src/App/backend/test/Altinn.App.Integration.Tests/InstanceDataMutator/BinaryDataUpdateTests.cs
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/InstanceDataMutator/BinaryDataUpdateTests.cs
@@ -7,7 +7,7 @@ using Xunit.Abstractions;
 namespace Altinn.App.Integration.Tests.InstanceDataMutator;
 
 [Trait("Category", "Integration")]
-public class BinaryDataUpdateTests(ITestOutputHelper _output, AppFixtureClassFixture _classFixture)
+public sealed class BinaryDataUpdateTests(ITestOutputHelper _output, AppFixtureClassFixture _classFixture)
     : IClassFixture<AppFixtureClassFixture>
 {
     private static readonly byte[] _expectedBytes = Encoding.UTF8.GetBytes("updated through IInstanceDataMutator");

--- a/src/App/backend/test/Altinn.App.Integration.Tests/InstanceDataMutator/BinaryDataUpdateTests.cs
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/InstanceDataMutator/BinaryDataUpdateTests.cs
@@ -1,0 +1,95 @@
+using System.Net.Http.Json;
+using System.Text;
+using Altinn.App.Api.Models;
+using Altinn.Platform.Storage.Interface.Models;
+using Xunit.Abstractions;
+
+namespace Altinn.App.Integration.Tests.InstanceDataMutator;
+
+[Trait("Category", "Integration")]
+public class BinaryDataUpdateTests(ITestOutputHelper _output, AppFixtureClassFixture _classFixture)
+    : IClassFixture<AppFixtureClassFixture>
+{
+    private static readonly byte[] _expectedBytes = Encoding.UTF8.GetBytes("updated through IInstanceDataMutator");
+
+    [Fact]
+    public async Task UserAction_CanUpdateExistingBinaryDataThroughMutator()
+    {
+        await using var fixtureScope = await _classFixture.Get(_output, TestApps.Basic, "binary-data-update");
+        var fixture = fixtureScope.Fixture;
+
+        var token = await fixture.Auth.GetUserToken(userId: 1337);
+
+        using var instantiationResponse = await fixture.Instances.PostSimplified(
+            token,
+            new InstansiationInstance { InstanceOwner = new InstanceOwner { PartyId = "501337" } }
+        );
+        using var readInstantiationResponse = await instantiationResponse.Read<Instance>();
+        Assert.True(
+            readInstantiationResponse.Response.IsSuccessStatusCode,
+            readInstantiationResponse.Data.Body ?? readInstantiationResponse.Data.Exception?.ToString()
+        );
+
+        byte[] originalBytes = Encoding.UTF8.GetBytes("created");
+        using var uploadResponse = await fixture.Instances.PostData(
+            token,
+            readInstantiationResponse,
+            "attachment",
+            originalBytes,
+            "text/plain",
+            "attachment.txt",
+            useNewEndpoint: true
+        );
+        using var readUploadResponse = await uploadResponse.Read<DataPostResponse>();
+        Assert.True(
+            readUploadResponse.Response.IsSuccessStatusCode,
+            readUploadResponse.Data.Body ?? readUploadResponse.Data.Exception?.ToString()
+        );
+
+        var instance = Assert.IsType<Instance>(readInstantiationResponse.Data.Model);
+        int instanceOwnerPartyId = int.Parse(instance.InstanceOwner.PartyId);
+        Guid instanceGuid = Guid.Parse(instance.Id.Split('/')[1]);
+
+        using var actionResponse = await fixture.Generic.Post(
+            $"/ttd/basic/instances/{instanceOwnerPartyId}/{instanceGuid}/actions",
+            token,
+            JsonContent.Create(
+                new UserActionRequest
+                {
+                    Action = "update-binary-data",
+                    Metadata = new Dictionary<string, string>
+                    {
+                        ["dataElementId"] = readUploadResponse.Data.Model!.NewDataElementId.ToString(),
+                        ["newContent"] = Encoding.UTF8.GetString(_expectedBytes),
+                    },
+                }
+            )
+        );
+        using var readActionResponse = await actionResponse.Read<UserActionResponse>();
+        Assert.True(
+            readActionResponse.Response.IsSuccessStatusCode,
+            readActionResponse.Data.Body ?? readActionResponse.Data.Exception?.ToString()
+        );
+
+        DataElement actionResponseAttachment = Assert.Single(
+            readActionResponse.Data.Model!.Instance.Data,
+            dataElement => dataElement.DataType == "attachment"
+        );
+        Assert.Equal(readUploadResponse.Data.Model!.NewDataElementId.ToString(), actionResponseAttachment.Id);
+
+        using var updatedInstanceResponse = await fixture.Instances.Get(token, readInstantiationResponse);
+        using var readUpdatedInstanceResponse = await updatedInstanceResponse.Read<Instance>();
+        DataElement updatedAttachment = Assert.Single(
+            readUpdatedInstanceResponse.Data.Model!.Data,
+            dataElement => dataElement.DataType == "attachment"
+        );
+        Assert.Equal(readUploadResponse.Data.Model!.NewDataElementId.ToString(), updatedAttachment.Id);
+
+        using var download = await fixture.Instances.Download(token, readInstantiationResponse);
+        var downloadedAttachment = Assert.Single(download.Data.OfType<InstanceDataDownload.Binary>());
+        byte[] actualBytes = Assert.IsType<byte[]>(downloadedAttachment.Data.Data.Model);
+
+        Assert.True(actualBytes.AsSpan().SequenceEqual(_expectedBytes));
+        Assert.False(actualBytes.AsSpan().SequenceEqual(originalBytes));
+    }
+}

--- a/src/App/backend/test/Altinn.App.Integration.Tests/_testapps/basic/_scenarios/binary-data-update/config/authorization/policy.xml
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/_testapps/basic/_scenarios/binary-data-update/config/authorization/policy.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xacml:Policy PolicyId="urn:altinn:resource:app_[ORG]_[APP]:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17">
+  <xacml:Target />
+  <xacml:Rule RuleId="urn:altinn:resource:app_[ORG]_[APP]:policyid:1:ruleid:1" Effect="Permit">
+    <xacml:Description>Regel for sluttbruker: Gir rettighetene Les, Skriv, Slett, Start og oppdatering av binærdata til brukere med rollene Privatperson (PRIV) og Daglig leder (DAGL), for hele tjenesten.</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">priv</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">dagl</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">[ORG]</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">[APP]</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">read</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">write</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">delete</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">instantiate</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">update-binary-data</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+  <xacml:Rule RuleId="urn:altinn:resource:app_[ORG]_[APP]:policyid:1:ruleid:2" Effect="Permit">
+    <xacml:Description>Regel for tjenesteeier: Gir rettighetene Les, Skriv, Start, Bekreft mottatt tjenesteeier og oppdatering av binærdata til organisasjonen som eier tjenesten ([org]).</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">[org]</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">[ORG]</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">[APP]</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">read</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">write</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">instantiate</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">complete</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">update-binary-data</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+  <xacml:ObligationExpressions>
+    <xacml:ObligationExpression ObligationId="urn:altinn:obligation:authenticationLevel1" FulfillOn="Permit">
+      <xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation1-assignment1" Category="urn:altinn:minimum-authenticationlevel">
+        <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">2</xacml:AttributeValue>
+      </xacml:AttributeAssignmentExpression>
+    </xacml:ObligationExpression>
+    <xacml:ObligationExpression ObligationId="urn:altinn:obligation:authenticationLevel2" FulfillOn="Permit">
+      <xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation2-assignment2" Category="urn:altinn:minimum-authenticationlevel-org">
+        <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">3</xacml:AttributeValue>
+      </xacml:AttributeAssignmentExpression>
+    </xacml:ObligationExpression>
+  </xacml:ObligationExpressions>
+</xacml:Policy>

--- a/src/App/backend/test/Altinn.App.Integration.Tests/_testapps/basic/_scenarios/binary-data-update/config/process/process.bpmn
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/_testapps/basic/_scenarios/binary-data-update/config/process/process.bpmn
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<bpmn:definitions id="Altinn_SingleDataTask_Process_Definition" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:altinn="http://altinn.no/process" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="SingleDataTask" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1n56yn5</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_1" name="Utfylling">
+      <bpmn:incoming>SequenceFlow_1n56yn5</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1oot28q</bpmn:outgoing>
+      <bpmn:extensionElements>
+        <altinn:taskExtension>
+          <altinn:taskType>data</altinn:taskType>
+          <altinn:actions>
+            <altinn:action type="serverAction">update-binary-data</altinn:action>
+          </altinn:actions>
+        </altinn:taskExtension>
+      </bpmn:extensionElements>
+    </bpmn:task>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>SequenceFlow_1oot28q</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1n56yn5" sourceRef="StartEvent_1" targetRef="Task_1" />
+    <bpmn:sequenceFlow id="SequenceFlow_1oot28q" sourceRef="Task_1" targetRef="EndEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="SingleDataTask">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="156" y="81" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
+        <dc:Bounds x="300" y="59" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="512" y="81" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1n56yn5_di" bpmnElement="SequenceFlow_1n56yn5">
+        <di:waypoint x="192" y="99" />
+        <di:waypoint x="300" y="99" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1oot28q_di" bpmnElement="SequenceFlow_1oot28q">
+        <di:waypoint x="400" y="99" />
+        <di:waypoint x="512" y="99" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/App/backend/test/Altinn.App.Integration.Tests/_testapps/basic/_scenarios/binary-data-update/services/BinaryDataUpdateUserAction.cs
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/_testapps/basic/_scenarios/binary-data-update/services/BinaryDataUpdateUserAction.cs
@@ -27,7 +27,10 @@ internal sealed class BinaryDataUpdateUserAction : IUserAction
             );
         }
 
-        if (!context.ActionMetadata.TryGetValue("newContent", out string? newContent))
+        if (
+            !context.ActionMetadata.TryGetValue("newContent", out string? newContent)
+            || string.IsNullOrWhiteSpace(newContent)
+        )
         {
             return Task.FromResult(
                 UserActionResult.FailureResult(

--- a/src/App/backend/test/Altinn.App.Integration.Tests/_testapps/basic/_scenarios/binary-data-update/services/BinaryDataUpdateUserAction.cs
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/_testapps/basic/_scenarios/binary-data-update/services/BinaryDataUpdateUserAction.cs
@@ -1,0 +1,55 @@
+using System.Text;
+using System.Threading.Tasks;
+using Altinn.App.Core.Features;
+using Altinn.App.Core.Models;
+using Altinn.App.Core.Models.Process;
+using Altinn.App.Core.Models.UserAction;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Altinn.App.Integration.Tests.Scenarios.BinaryDataUpdate;
+
+internal sealed class BinaryDataUpdateUserAction : IUserAction
+{
+    public string Id => "update-binary-data";
+
+    public Task<UserActionResult> HandleAction(UserActionContext context)
+    {
+        if (
+            !context.ActionMetadata.TryGetValue("dataElementId", out string? dataElementId)
+            || string.IsNullOrWhiteSpace(dataElementId)
+        )
+        {
+            return Task.FromResult(
+                UserActionResult.FailureResult(
+                    new ActionError { Code = "MissingDataElementId", Message = "dataElementId metadata is required." },
+                    errorType: ProcessErrorType.BadRequest
+                )
+            );
+        }
+
+        if (!context.ActionMetadata.TryGetValue("newContent", out string? newContent))
+        {
+            return Task.FromResult(
+                UserActionResult.FailureResult(
+                    new ActionError { Code = "MissingNewContent", Message = "newContent metadata is required." },
+                    errorType: ProcessErrorType.BadRequest
+                )
+            );
+        }
+
+        context.DataMutator.UpdateBinaryDataElement(
+            new DataElementIdentifier(dataElementId),
+            Encoding.UTF8.GetBytes(newContent)
+        );
+
+        return Task.FromResult(UserActionResult.SuccessResult());
+    }
+}
+
+public static class ServiceRegistration
+{
+    public static void RegisterServices(IServiceCollection services)
+    {
+        services.AddTransient<IUserAction, BinaryDataUpdateUserAction>();
+    }
+}


### PR DESCRIPTION
Makes it possible to rewrite payment and brukerstyrt signering to use IInstanceDataMutator exclusively (no IDataClient).

## Description

<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to update existing binary attachments via a new "update-binary-data" action. Updates replace the element's content when saved, enforce payload validation (size/content-type), and are rejected for elements marked for deletion. Test app scenario and access policy for the action were added.

* **Tests**
  * Added unit and integration tests covering update, persistence, previous-data behaviour, deletion handling and error cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio/pull/18776)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->