### PR TITLE
chore: release studioctl v0.1.0-preview.8

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -8,6 +8,8 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+## [0.1.0-preview.8] - 2026-05-13
+
 ### Changed
 
 - Breaking: make `--follow` default to `false` for log commands.


### PR DESCRIPTION
## Description

Prepare release v0.1.0-preview.8

- [Changed] Breaking: make `--follow` default to `false` for log commands.
- [Changed] Breaking: rename `studioctl servers` to `studioctl server`.
- [Changed] Breaking: simplify install scripts by removing `--repo`, `--asset`, `--skip-resources`, `STUDIOCTL_REPO`, `STUDIOCTL_ASSET`, and `STUDIOCTL_SKIP_RESOURCES`.
- [Changed] Rename `app-manager` to `studioctl-server`, including install/update migration cleanup of legacy runtime files, installed payload, and logs.
- [Changed] Show progress while `app run --mode container` pulls/builds and starts the app container.
- [Changed] `studioctl self uninstall` now asks for confirmation; use `-y` or `--yes` for non-interactive uninstall.
- [Fixed] Redirect unauthenticated app URLs opened from `studioctl app run` through the localtest login page.
- [Fixed] Keep running apps visible in localtest after restarting the localtest environment.
- [Fixed] Improve localtest resource reconciliation so `env up` removes managed resources that are no longer requested, such as pgAdmin or monitoring, without restarting unchanged core containers.

@coderabbitai ignore

**Full Changelog**: https://github.com/Altinn/altinn-studio/compare/studioctl/v0.1.0-preview.7...studioctl/v0.1.0-preview.8