### PR TITLE
chore: refactor releaser layout

### DIFF
--- a/src/tools/releaser/README.md
+++ b/src/tools/releaser/README.md
@@ -2,6 +2,19 @@
 
 Simple release flow for a component.
 
+## Supported components
+
+- `studioctl`: uses a Go builder registered by the releaser CLI.
+- `fileanalyzers`: has no releaser builder; the GitHub workflow handles package build and publish.
+
+## Builders
+
+Component-specific artifact builders live in the releaser root as `builder_<component>.go`.
+Register built-in builders in `builder_00_register.go`.
+
+Components without a builder still support `prepare` and `workflow`; `workflow` creates a changelog-only
+GitHub release and leaves artifact build/publish to the component's CI workflow.
+
 ## Branches
 
 - `main`: prereleases (`vX.Y.Z-preview.N`)

--- a/src/tools/releaser/builder_00_register.go
+++ b/src/tools/releaser/builder_00_register.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+
+	"altinn.studio/releaser/internal"
+)
+
+func registerBuilders() error {
+	if err := internal.RegisterComponentBuilder("studioctl", newStudioctlBuilder()); err != nil {
+		return fmt.Errorf("register studioctl builder: %w", err)
+	}
+	return nil
+}

--- a/src/tools/releaser/builder_studioctl.go
+++ b/src/tools/releaser/builder_studioctl.go
@@ -1,4 +1,4 @@
-package internal
+package main
 
 import (
 	"context"
@@ -9,13 +9,12 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"altinn.studio/releaser/internal"
 	"altinn.studio/releaser/internal/version"
 )
 
-// StudioctlBuilder builds studioctl release artifacts.
-// It implements ComponentBuilder and wraps the detailed build steps.
-type StudioctlBuilder struct {
-	log Logger
+type studioctlBuilder struct {
+	log internal.Logger
 }
 
 const distManifestFile = ".dist-manifest.json"
@@ -26,21 +25,22 @@ type studioctlDistManifest struct {
 	Artifacts []string `json:"artifacts"`
 }
 
-// NewStudioctlBuilder creates a builder configured for studioctl.
-func NewStudioctlBuilder() *StudioctlBuilder {
-	return &StudioctlBuilder{
-		log: NopLogger{},
+func newStudioctlBuilder() *studioctlBuilder {
+	return &studioctlBuilder{
+		log: internal.NopLogger{},
 	}
 }
 
-// Build produces all release artifacts for studioctl.
-// Returns the artifact paths reported by cmd/dev dist.
-func (b *StudioctlBuilder) Build(ctx context.Context, ver *version.Version, outputDir string) ([]string, error) {
+func (b *studioctlBuilder) Build(
+	ctx context.Context,
+	ver *version.Version,
+	outputDir string,
+) ([]string, error) {
 	if b.log == nil {
-		b.log = NopLogger{}
+		b.log = internal.NopLogger{}
 	}
 
-	git := NewGitCLI()
+	git := internal.NewGitCLI()
 	root, err := git.RepoRoot(ctx)
 	if err != nil {
 		return nil, err
@@ -48,7 +48,7 @@ func (b *StudioctlBuilder) Build(ctx context.Context, ver *version.Version, outp
 
 	buildDir := filepath.Join(root, "src/cli")
 
-	if err := EnsureDir(outputDir); err != nil {
+	if err := internal.EnsureDir(outputDir); err != nil {
 		return nil, fmt.Errorf("create output directory: %w", err)
 	}
 
@@ -61,12 +61,7 @@ func (b *StudioctlBuilder) Build(ctx context.Context, ver *version.Version, outp
 	return readStudioctlDistManifest(manifestPath)
 }
 
-// SetLogger sets the logger for build output.
-func (b *StudioctlBuilder) SetLogger(log Logger) {
-	b.log = log
-}
-
-func (b *StudioctlBuilder) buildDistribution(ctx context.Context, ver, buildDir, outputDir, manifestPath string) error {
+func (b *studioctlBuilder) buildDistribution(ctx context.Context, ver, buildDir, outputDir, manifestPath string) error {
 	absOutputDir, err := filepath.Abs(outputDir)
 	if err != nil {
 		return fmt.Errorf("resolve output directory: %w", err)
@@ -118,13 +113,4 @@ func readStudioctlDistManifest(path string) ([]string, error) {
 	}
 
 	return artifacts, nil
-}
-
-// init registers the StudioctlBuilder with the studioctl component.
-//
-//nolint:gochecknoinits // registration pattern for component builders
-func init() {
-	if c, err := GetComponent("studioctl"); err == nil {
-		c.Builder = NewStudioctlBuilder()
-	}
 }

--- a/src/tools/releaser/builder_studioctl.go
+++ b/src/tools/releaser/builder_studioctl.go
@@ -43,7 +43,7 @@ func (b *studioctlBuilder) Build(
 	git := internal.NewGitCLI()
 	root, err := git.RepoRoot(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get repo root: %w", err)
 	}
 
 	buildDir := filepath.Join(root, "src/cli")

--- a/src/tools/releaser/internal/component.go
+++ b/src/tools/releaser/internal/component.go
@@ -38,7 +38,7 @@ var components = map[string]*Component{
 		Name:          "studioctl",
 		ChangelogPath: "src/cli/CHANGELOG.md",
 		SourcePath:    "src/cli",
-		Builder:       nil, // set later to avoid import cycle, see init in builder_go.go
+		Builder:       nil, // registered by the releaser CLI
 	},
 	"fileanalyzers": {
 		Name:          "fileanalyzers",
@@ -46,6 +46,16 @@ var components = map[string]*Component{
 		SourcePath:    "src/App/fileanalyzers",
 		Builder:       nil, // YAML handles dotnet pack/push
 	},
+}
+
+// RegisterComponentBuilder registers a builder for an existing component.
+func RegisterComponentBuilder(name string, builder ComponentBuilder) error {
+	c, err := GetComponent(name)
+	if err != nil {
+		return err
+	}
+	c.Builder = builder
+	return nil
 }
 
 // GetComponent returns a component by name.

--- a/src/tools/releaser/main.go
+++ b/src/tools/releaser/main.go
@@ -117,6 +117,9 @@ Examples:
 	if err := validateWorkflowExecutionContext(*dryRun); err != nil {
 		return fmt.Errorf("validate workflow execution context: %w", err)
 	}
+	if err := registerBuilders(); err != nil {
+		return fmt.Errorf("register builders: %w", err)
+	}
 
 	req := internal.WorkflowRequest{
 		Component:             *component,

--- a/src/tools/releaser/test/e2e/workflow_test.go
+++ b/src/tools/releaser/test/e2e/workflow_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -279,17 +280,11 @@ func TestRunWorkflow_StudioctlLikeRepo_LocalRepo(t *testing.T) {
 		rel("v1.2.0-preview.1", "2025-01-01", cat("Added", "Older studioctl preview")),
 	))
 
-	t.Chdir(repo.dir)
-	err := internal.RunWorkflow(t.Context(), internal.WorkflowRequest{
-		Component:             studioctlComponent,
-		BaseBranch:            mainBranchName,
-		DryRun:                true,
-		Draft:                 true,
-		UnsafeSkipBranchCheck: false,
-	}, logger)
-	if err != nil {
-		t.Fatalf("RunWorkflow() error = %v", err)
-	}
+	runReleaser(t, logger, repo.dir, "workflow",
+		"-component", studioctlComponent,
+		"-base-branch", mainBranchName,
+		"-dry-run",
+	)
 
 	outputDir := filepath.Join(repo.dir, "build", "release")
 	notes, readErr := os.ReadFile(filepath.Join(outputDir, "release-notes.md"))
@@ -812,6 +807,41 @@ func runGit(t *testing.T, log internal.Logger, dir string, args ...string) strin
 		t.Fatalf("git %s: %v", strings.Join(args, " "), err)
 	}
 	return out
+}
+
+func runReleaser(t *testing.T, log internal.Logger, dir string, args ...string) {
+	t.Helper()
+
+	if log == nil {
+		log = internal.NopLogger{}
+	}
+
+	bin := filepath.Join(t.TempDir(), "releaser")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	buildArgs := []string{"build", "-o", bin, "."}
+	log.Command("go", buildArgs)
+	buildCmd := exec.CommandContext(t.Context(), "go", buildArgs...)
+	buildCmd.Dir = cliRootDir()
+	buildOutput, err := buildCmd.CombinedOutput()
+	if len(buildOutput) > 0 {
+		log.Info("%s", strings.TrimSpace(string(buildOutput)))
+	}
+	if err != nil {
+		t.Fatalf("go %s: %v\n%s", strings.Join(buildArgs, " "), err, string(buildOutput))
+	}
+
+	log.Command(bin, args)
+	cmd := exec.CommandContext(t.Context(), bin, args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if len(output) > 0 {
+		log.Info("%s", strings.TrimSpace(string(output)))
+	}
+	if err != nil {
+		t.Fatalf("%s %s: %v\n%s", bin, strings.Join(args, " "), err, string(output))
+	}
 }
 
 func writeFile(t *testing.T, path, content string) {


### PR DESCRIPTION
## Description

essentially move the builders/components to the main package

<img width="260" height="357" alt="image" src="https://github.com/user-attachments/assets/dadc24a5-ab81-4455-ba24-b80331f51238" />


## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified which components the releaser supports and how they integrate with build and publish workflows.

* **Improvements**
  * Reworked component builder registration so component-specific builders are discovered and used at runtime.
  * CLI now initialises component builders before running workflows.

* **Tests**
  * Enhanced end-to-end tests to invoke the built releaser binary for realistic workflow verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio/pull/18780)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->