### PR TITLE
fix(resource-adm): fix resource list parameters for getting Altinn 2 delegationcount

### DIFF
--- a/src/Designer/backend/src/Designer/Controllers/ResourceAdminController.cs
+++ b/src/Designer/backend/src/Designer/Controllers/ResourceAdminController.cs
@@ -566,8 +566,8 @@ public class ResourceAdminController : ControllerBase
     {
         List<ServiceResource> allResources = await _resourceRegistry.GetServiceResourceList(
             env.ToLower(),
-            includeAltinn2: false,
-            includeApps: true,
+            includeAltinn2: true,
+            includeApps: false,
             includeMigratedApps: false
         );
         bool serviceExists = allResources.Any(x => x.Identifier!.Equals($"se_{serviceCode}_{serviceEdition}"));


### PR DESCRIPTION
## Description
- set `includeAltinn2: true` when getting resource list to check if Altinn 2 link service to get delegation count for exists

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the service resource retrieval parameters used when calculating delegation counts, improving the accuracy of delegation information display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio/pull/18798)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->