### PR TITLE
fix: use v9 app upgrade kind in studioctl

### DIFF
--- a/src/cli/internal/cmd/app.go
+++ b/src/cli/internal/cmd/app.go
@@ -310,7 +310,7 @@ func (c *AppCommand) runUpgrade(ctx context.Context, args []string) error {
 		Kind:                     flags.kind,
 		ConvertPackageReferences: false,
 	}
-	if flags.kind == appUpgradeKindV10 && detection.InStudioRepo {
+	if flags.kind == appUpgradeKindV9 && detection.InStudioRepo {
 		upgrade.ConvertPackageReferences = true
 		upgrade.StudioRoot = detection.StudioRoot
 	}
@@ -339,7 +339,7 @@ type appUpgradeFlags struct {
 const (
 	appUpgradeKindFrontendV4 = "frontend-v4"
 	appUpgradeKindBackendV8  = "backend-v8"
-	appUpgradeKindV10        = "v10"
+	appUpgradeKindV9         = "v9"
 )
 
 func (c *AppCommand) parseAppUpgradeFlags(args []string) (appUpgradeFlags, bool, error) {
@@ -363,7 +363,7 @@ func (c *AppCommand) parseAppUpgradeFlags(args []string) (appUpgradeFlags, bool,
 
 	remaining := fs.Args()
 	if flags.kind == "" && len(remaining) == 0 {
-		flags.kind = appUpgradeKindV10
+		flags.kind = appUpgradeKindV9
 		return flags, false, nil
 	}
 	if flags.kind == "" && len(remaining) == 1 {
@@ -378,18 +378,18 @@ func (c *AppCommand) parseAppUpgradeFlags(args []string) (appUpgradeFlags, bool,
 }
 
 func isSupportedAppUpgradeKind(kind string) bool {
-	return kind == appUpgradeKindFrontendV4 || kind == appUpgradeKindBackendV8 || kind == appUpgradeKindV10
+	return kind == appUpgradeKindFrontendV4 || kind == appUpgradeKindBackendV8 || kind == appUpgradeKindV9
 }
 
 func (c *AppCommand) appUpgradeUsageLine() string {
-	return osutil.CurrentBin() + " app upgrade [frontend-v4|backend-v8|v10] [-p PATH]"
+	return osutil.CurrentBin() + " app upgrade [frontend-v4|backend-v8|v9] [-p PATH]"
 }
 
 func (c *AppCommand) appUpgradeUsage() string {
 	return joinLines(
 		"Usage: "+c.appUpgradeUsageLine(),
 		"",
-		"Upgrades an Altinn app. Defaults to v10 when no kind is specified. Package references are converted to project references only for v10 apps inside an Altinn Studio repo.",
+		"Upgrades an Altinn app. Defaults to v9 when no kind is specified. Package references are converted to project references only for v9 apps inside an Altinn Studio repo.",
 		"",
 		"Options:",
 		"  -p, --path PATH             Specify app directory (overrides auto-detect)",

--- a/src/cli/internal/cmd/app_internal_test.go
+++ b/src/cli/internal/cmd/app_internal_test.go
@@ -57,7 +57,7 @@ func TestParseAppUpgradeFlagsAcceptsSupportedKinds(t *testing.T) {
 	t.Parallel()
 
 	command := &AppCommand{}
-	for _, kind := range []string{appUpgradeKindFrontendV4, appUpgradeKindBackendV8, appUpgradeKindV10} {
+	for _, kind := range []string{appUpgradeKindFrontendV4, appUpgradeKindBackendV8, appUpgradeKindV9} {
 		t.Run(kind, func(t *testing.T) {
 			t.Parallel()
 
@@ -78,7 +78,7 @@ func TestParseAppUpgradeFlagsAcceptsSupportedKinds(t *testing.T) {
 	}
 }
 
-func TestParseAppUpgradeFlagsDefaultsToV10(t *testing.T) {
+func TestParseAppUpgradeFlagsDefaultsToV9(t *testing.T) {
 	t.Parallel()
 
 	flags, help, err := (&AppCommand{}).parseAppUpgradeFlags([]string{"-p", "/tmp/app"})
@@ -88,8 +88,8 @@ func TestParseAppUpgradeFlagsDefaultsToV10(t *testing.T) {
 	if help {
 		t.Fatal("parseAppUpgradeFlags() help = true, want false")
 	}
-	if flags.kind != appUpgradeKindV10 {
-		t.Fatalf("kind = %q, want %q", flags.kind, appUpgradeKindV10)
+	if flags.kind != appUpgradeKindV9 {
+		t.Fatalf("kind = %q, want %q", flags.kind, appUpgradeKindV9)
 	}
 }
 

--- a/src/cli/internal/studioctlserver/client_internal_test.go
+++ b/src/cli/internal/studioctlserver/client_internal_test.go
@@ -57,7 +57,7 @@ func TestUpgradeAppUsesUpgradeTimeoutOnly(t *testing.T) {
 		AppUpgrade{
 			ProjectFolder:            "/tmp/app",
 			StudioRoot:               "",
-			Kind:                     "v10",
+			Kind:                     "v9",
 			ConvertPackageReferences: false,
 		},
 	)


### PR DESCRIPTION
## Summary
- rename the studioctl app upgrade next-major kind from v10 to v9
- update help text and tests to match studioctl-server

## Verification
- make build
- make test
- make lint
- ./build/studioctl app upgrade --help

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for v9 app upgrade kind
  * v9 is now the default upgrade kind

* **Documentation**
  * Updated app upgrade command help text

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio/pull/18806?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->