### PR TITLE
test: serialize pdf integration tests

### DIFF
--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/BasicAppTests.cs
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/BasicAppTests.cs
@@ -8,6 +8,7 @@ using Xunit.Abstractions;
 namespace Altinn.App.Integration.Tests.Basic;
 
 [Trait("Category", "Integration")]
+[Collection(IntegrationTestCollections.Pdf)]
 public class BasicAppTests(ITestOutputHelper _output, AppFixtureClassFixture _classFixture)
     : IClassFixture<AppFixtureClassFixture>
 {

--- a/src/App/backend/test/Altinn.App.Integration.Tests/InstanceLocking/InstanceLockTests.cs
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/InstanceLocking/InstanceLockTests.cs
@@ -5,6 +5,7 @@ using Xunit.Abstractions;
 namespace Altinn.App.Integration.Tests.InstanceLocking;
 
 [Trait("Category", "Integration")]
+[Collection(IntegrationTestCollections.Pdf)]
 public sealed class InstanceLockTests(ITestOutputHelper _output, AppFixtureClassFixture _classFixture)
     : IClassFixture<AppFixtureClassFixture>
 {

--- a/src/App/backend/test/Altinn.App.Integration.Tests/_fixture/IntegrationTestCollections.cs
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/_fixture/IntegrationTestCollections.cs
@@ -1,0 +1,9 @@
+namespace Altinn.App.Integration.Tests;
+
+internal static class IntegrationTestCollections
+{
+    public const string Pdf = "PDF integration tests";
+}
+
+[CollectionDefinition(IntegrationTestCollections.Pdf)]
+public sealed class PdfIntegrationTestCollection;


### PR DESCRIPTION
## What

Serializes the backend integration test classes that trigger PDF generation against shared localtest `pdf3`.

`BasicAppTests` and `InstanceLockTests` can otherwise run concurrently across xUnit classes while sharing one localtest environment and one `pdf3` browser worker. PR 18815 has repeatedly failed on Ubuntu with `process/next` returning 500 followed by PDF health-check timeouts.

## Why

This keeps unrelated integration tests parallel, but prevents the known PDF-generating classes from overlapping and overloading/wedging the shared `pdf3` service under GitHub runner load.

## Testing

- `STUDIOCTL_HOME=/data/home/code/altinn-studio-pr18815/src/cli/build/dev-home STUDIOCTL_INTERNAL_DEV=true PATH=/data/home/code/altinn-studio-pr18815/src/cli/build/dev-home/bin:$PATH SKIP_FRONTEND_BUILD=true dotnet test test/Altinn.App.Integration.Tests/Altinn.App.Integration.Tests.csproj -v m --filter "Category=Integration"`

Result: 54 passed, 1 skipped.

cc @martinothamar