### PR TITLE
chore: update otel collector to 0.148.0

### DIFF
--- a/infra/observability/base/gateway.yaml
+++ b/infra/observability/base/gateway.yaml
@@ -6,7 +6,7 @@ metadata:
     altinn.studio/otel-collector: otel-gateway
 spec:
   mode: deployment
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.144.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   serviceAccount: otel-collector
   upgradeStrategy: automatic
   replicas: 1

--- a/infra/observability/base/router.yaml
+++ b/infra/observability/base/router.yaml
@@ -6,7 +6,7 @@ metadata:
     altinn.studio/otel-collector: otel-router
 spec:
   mode: deployment
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.144.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   serviceAccount: otel-collector
   upgradeStrategy: automatic
   replicas: 1
@@ -42,7 +42,7 @@ spec:
           resource_attributes:
             k8s.cluster.name:
               enabled: true
-      k8sattributes:
+      k8s_attributes:
         auth_type: 'serviceAccount'
         wait_for_metadata: true
         wait_for_metadata_timeout: 10s

--- a/infra/observability/runtime/overlay/patches/router-config.yaml
+++ b/infra/observability/runtime/overlay/patches/router-config.yaml
@@ -32,12 +32,12 @@ spec:
       pipelines:
         traces:
           receivers: [otlp]
-          processors: [resourcedetection/aks, k8sattributes, resource/environment, transform/drop, batch]
+          processors: [resourcedetection/aks, k8s_attributes, resource/environment, transform/drop, batch]
           exporters: [loadbalancing/traces]
         metrics:
           receivers: [otlp]
           exporters: [nop]
         logs:
           receivers: [otlp]
-          processors: [filter/logs, resourcedetection/aks, k8sattributes, resource/environment, transform/drop, batch]
+          processors: [filter/logs, resourcedetection/aks, k8s_attributes, resource/environment, transform/drop, batch]
           exporters: [loadbalancing/logs]

--- a/infra/observability/studio/overlay/patches/router-config.yaml
+++ b/infra/observability/studio/overlay/patches/router-config.yaml
@@ -32,12 +32,12 @@ spec:
       pipelines:
         traces:
           receivers: [otlp]
-          processors: [resourcedetection/aks, k8sattributes, resource/environment, transform/drop, batch]
+          processors: [resourcedetection/aks, k8s_attributes, resource/environment, transform/drop, batch]
           exporters: [loadbalancing/traces]
         metrics:
           receivers: [otlp]
           exporters: [nop]
         logs:
           receivers: [otlp]
-          processors: [filter/logs, resourcedetection/aks, k8sattributes, resource/environment, transform/drop, batch]
+          processors: [filter/logs, resourcedetection/aks, k8s_attributes, resource/environment, transform/drop, batch]
           exporters: [loadbalancing/logs]


### PR DESCRIPTION
## Description

Updates the OpenTelemetry Collector contrib image used by the observability gateway and router from `0.144.0` to `0.148.0`.

Also renames the router `k8sattributes` processor references to the upstream `k8s_attributes` component name introduced in newer collector releases, avoiding the deprecated alias while doing the version bump.

The target is `0.148.0` because runtime clusters currently run OpenTelemetry Operator `0.148.0`. Studio's operator has already been updated to `0.151.0` in #18823, but keeping this collector bump at `0.148.0` avoids runtime operator/collector version skew.

Release references:

- https://github.com/open-telemetry/opentelemetry-collector-releases/releases/tag/v0.148.0
- https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.148.0
- https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.148.0

Important changes to watch from `0.144.0` to `0.148.0`:

- `processor/k8sattributes` was renamed upstream to `processor/k8s_attributes` in `0.146.0`, with `k8sattributes` kept as a deprecated alias. This PR now uses `k8s_attributes`.
- `processor/k8s_attributes` has semantic-convention feature gates and behavior changes around Kubernetes labels/annotations and service-name precedence. The current config only extracts stable metadata keys and validates successfully, but deployment should watch Kubernetes resource attribution.
- `pkg/ottl`, `processor/filter`, and `processor/transform` report more type errors in newer releases instead of silently ignoring mismatches. Our transform/filter statements validate with `error_mode: ignore`, but rollout should watch collector startup logs and processor error counters.

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (manifest-only version/config rename)

Manual checks run:

- `kubectl kustomize infra/observability/runtime >/tmp/otel-runtime-148.yaml`
- `kubectl kustomize infra/observability/studio >/tmp/otel-studio-148.yaml`
- `docker pull ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0`
- `otelcol-contrib validate` via the `0.148.0` container against rendered runtime/studio gateway/router configs with dummy secret env values

cc @martinothamar