### PR TITLE
chore: update otel operator to 0.151.0

### DIFF
--- a/infra/studio/otel-operator/base/helmrelease.yaml
+++ b/infra/studio/otel-operator/base/helmrelease.yaml
@@ -19,7 +19,7 @@ spec:
         kind: HelmRepository
         name: otel-oci
         namespace: otel-operator
-      version: 0.105.0
+      version: 0.113.1
   values:
     manager:
       serviceMonitor:


### PR DESCRIPTION
## Description

Updates the OpenTelemetry Operator Helm chart from `0.105.0` to `0.113.1`.

Chart `0.113.1` has app version `0.151.0`, matching the target OpenTelemetry Collector version used by the stacked collector upgrade PR.

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (manifest-only chart version bump)

Manual checks run:

- `kubectl kustomize infra/studio/otel-operator >/tmp/otel-operator.yaml`
- `helm show chart oci://ghcr.io/open-telemetry/opentelemetry-helm-charts/opentelemetry-operator --version 0.113.1 | awk '/^version:|^appVersion:/{print}'`

cc @martinothamar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenTelemetry Operator to version 0.113.1, enhancing the observability infrastructure with the latest improvements and stability updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio/pull/18823?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->