### PR TITLE
fix: app-frontend - throw clear error when Settings.json is missing defaultDataType

### DIFF
--- a/src/App/frontend/src/features/form/FormContext.tsx
+++ b/src/App/frontend/src/features/form/FormContext.tsx
@@ -5,7 +5,6 @@ import { createZustandHooks } from 'src/core/contexts/zustandContext';
 import { processLayouts } from 'src/features/form/layout/LayoutsContext';
 import { makeLayoutLookups } from 'src/features/form/layout/makeLayoutLookups';
 import { pageNavigationHooks } from 'src/features/form/layout/PageNavigationContext';
-import { getUiFolderSettings } from 'src/features/form/ui';
 import { formBootstrapHooks } from 'src/features/formBootstrap/FormBootstrap';
 import { formDataHooks } from 'src/features/formData/FormDataWrite';
 import { validationHooks } from 'src/features/validation/validationContext';
@@ -88,12 +87,7 @@ interface FormBootstrapSliceState extends FormBootstrapContextValue {
 }
 
 export function processBootstrap(bootstrap: FormBootstrapBase): FormBootstrapContextValue {
-  const defaultDataType = getUiFolderSettings(bootstrap.uiFolder)?.defaultDataType;
-  if (!defaultDataType) {
-    throw new Error(`Expected defaultDataType to be defined for uiFolder: ${bootstrap.uiFolder}`);
-  }
-
-  const processedLayouts = processLayouts(bootstrap.layouts, defaultDataType);
+  const processedLayouts = processLayouts(bootstrap.layouts, bootstrap.defaultDataType);
   const layoutLookups = makeLayoutLookups(processedLayouts.processedLayouts);
 
   return {

--- a/src/App/frontend/src/features/form/FormProvider.tsx
+++ b/src/App/frontend/src/features/form/FormProvider.tsx
@@ -164,20 +164,25 @@ function useBoostrapQuery({ uiFolderOverride, dataElementIdOverride }: FormProvi
     }
   }, [data, prefill]);
 
-  const bootstrap = useMemo<FormBootstrapBase | null>(
-    () =>
-      data && uiFolder
-        ? {
-            uiFolder,
-            layouts: data.layouts,
-            dataModels: data.dataModels,
-            staticOptions: data.staticOptions,
-            validationIssues: data.validationIssues,
-            allInitialValidations: data.allInitialValidations,
-          }
-        : null,
-    [data, uiFolder],
-  );
+  const bootstrap = useMemo<FormBootstrapBase | null>(() => {
+    const defaultDataType = folderSettings?.defaultDataType;
+    if (!data || !uiFolder || !defaultDataType) {
+      return null;
+    }
+    return {
+      uiFolder,
+      defaultDataType,
+      layouts: data.layouts,
+      dataModels: data.dataModels,
+      staticOptions: data.staticOptions,
+      validationIssues: data.validationIssues,
+      allInitialValidations: data.allInitialValidations,
+    };
+  }, [data, uiFolder, folderSettings]);
+
+  if (uiFolder && folderSettings && !folderSettings.defaultDataType) {
+    throw new Error(`Expected defaultDataType to be defined for uiFolder: ${uiFolder}`);
+  }
 
   return { error, bootstrap, enabled };
 }

--- a/src/App/frontend/src/features/formBootstrap/types.ts
+++ b/src/App/frontend/src/features/formBootstrap/types.ts
@@ -39,6 +39,7 @@ export interface ProcessedDataModelInfo extends Omit<RawDataModelInfo, 'expressi
 
 export interface FormBootstrapBase extends Omit<FormBootstrapQueryResponse, 'staticOptions'> {
   uiFolder: string;
+  defaultDataType: string;
   staticOptions: Record<string, StaticOptionSet>;
 }
 


### PR DESCRIPTION
Throw clear error when Settings.json is missing defaultDataType. The old check drowned and gave me:

`Error: Generator is missing
    useCtx context.tsx:77
    useRegistry GeneratorContext.tsx:310
    useWaitUntilReady NodesContext.tsx:349
    useWaitForValidation validationContext.tsx:156
    useOnFormSubmitValidation onFormSubmitValidation.ts:24
    FormPage Form.tsx:79
    React 18
    node_modules altinn-app-frontend.js:387940
    notifyFn notifyManager.js:8
    node_modules altinn-app-frontend.js:387914
    node_modules altinn-app-frontend.js:387913
    batchNotifyFn notifyManager.js:11
    node_modules altinn-app-frontend.js:387912
    setTimeout handler*systemSetTimeoutZero timeoutManager.js:63
    flush notifyManager.js:27
    batch notifyManager.js:45
    #dispatch query.js:392
    setData query.js:62
    fetch query.js:289
    #executeFetch queryObserver.js:179
    onSubscribe queryObserver.js:52
    subscribe subscribable.js:9
    node_modules altinn-app-frontend.js:394110
    React 26`

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced form bootstrap and data type handling architecture.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio/pull/18841?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->