### PR TITLE
feat: support designer deploy from source ref

### DIFF
--- a/.github/actions/resolve-deploy-source/action.yaml
+++ b/.github/actions/resolve-deploy-source/action.yaml
@@ -96,8 +96,18 @@ runs:
             exit 1
           fi
 
+          if ! git check-ref-format --branch "$ref" > /dev/null; then
+            echo "The ref input must be a valid branch name." >&2
+            exit 1
+          fi
+
           if ! sha="$(git ls-remote --exit-code --heads "https://github.com/${repository}.git" "refs/heads/$ref" | awk '{ print $1 }')"; then
             echo "Branch '$ref' was not found in '$repository'." >&2
+            exit 1
+          fi
+
+          if [[ ! "$sha" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "Branch '$ref' in '$repository' did not resolve to exactly one commit SHA." >&2
             exit 1
           fi
         fi

--- a/.github/actions/resolve-deploy-source/action.yaml
+++ b/.github/actions/resolve-deploy-source/action.yaml
@@ -1,0 +1,139 @@
+name: Resolve deploy source
+description: Resolve a deploy source branch to repository, commit SHA and artifact metadata.
+
+inputs:
+  ref:
+    description: Source branch to deploy. Use branch-name, or fork-owner:branch-name for forks.
+    required: false
+    default: ''
+  default-ref:
+    description: Default branch/ref name from the workflow context.
+    required: true
+  default-repository:
+    description: Default repository from the workflow context.
+    required: true
+  default-repo-name:
+    description: Default repository name from the workflow context.
+    required: true
+  default-sha:
+    description: Default commit SHA from the workflow context.
+    required: true
+  github-ref:
+    description: Full GitHub ref from the workflow context.
+    required: true
+
+outputs:
+  repository:
+    description: Repository to checkout.
+    value: ${{ steps.resolve.outputs.repository }}
+  ref:
+    description: Branch name to checkout.
+    value: ${{ steps.resolve.outputs.ref }}
+  label:
+    description: User-facing source label.
+    value: ${{ steps.resolve.outputs.label }}
+  sha:
+    description: Resolved source commit SHA.
+    value: ${{ steps.resolve.outputs.sha }}
+  tag:
+    description: Artifact tag.
+    value: ${{ steps.resolve.outputs.tag }}
+  docker-tags:
+    description: Comma-separated Docker tags.
+    value: ${{ steps.resolve.outputs.docker-tags }}
+  tag-latest:
+    description: Whether artifacts should also be tagged as latest.
+    value: ${{ steps.resolve.outputs.tag-latest }}
+  source-url:
+    description: Source repository URL for artifact provenance.
+    value: ${{ steps.resolve.outputs.source-url }}
+  source-revision:
+    description: Source revision for artifact provenance.
+    value: ${{ steps.resolve.outputs.source-revision }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve source
+      id: resolve
+      shell: bash
+      env:
+        INPUT_REF: ${{ inputs.ref }}
+        DEFAULT_REF: ${{ inputs.default-ref }}
+        DEFAULT_REPOSITORY: ${{ inputs.default-repository }}
+        DEFAULT_REPO_NAME: ${{ inputs.default-repo-name }}
+        DEFAULT_SHA: ${{ inputs.default-sha }}
+        GITHUB_REF: ${{ inputs.github-ref }}
+      run: |
+        set -euo pipefail
+
+        repository="$DEFAULT_REPOSITORY"
+        ref="$DEFAULT_REF"
+        label="$DEFAULT_REF"
+        sha="$DEFAULT_SHA"
+        custom_source="false"
+        repository_owner=""
+
+        if [[ -n "$INPUT_REF" ]]; then
+          custom_source="true"
+          label="$INPUT_REF"
+
+          if [[ "$INPUT_REF" == *$'\n'* || "$INPUT_REF" == *$'\r'* ]]; then
+            echo "The ref input cannot contain newlines." >&2
+            exit 1
+          fi
+
+          if [[ "$INPUT_REF" == *:* ]]; then
+            repository_owner="${INPUT_REF%%:*}"
+            ref="${INPUT_REF#*:}"
+            repository="${repository_owner}/${DEFAULT_REPO_NAME}"
+          else
+            ref="$INPUT_REF"
+          fi
+
+          if [[ -z "$ref" || "$ref" == -* || "$repository" == /* || "$repository" == */*/* ]]; then
+            echo "The ref input must be a branch name or fork-owner:branch-name." >&2
+            exit 1
+          fi
+
+          if ! sha="$(git ls-remote --exit-code --heads "https://github.com/${repository}.git" "refs/heads/$ref" | awk '{ print $1 }')"; then
+            echo "Branch '$ref' was not found in '$repository'." >&2
+            exit 1
+          fi
+        fi
+
+        short_sha="${sha::10}"
+        tag_latest="true"
+
+        if [[ "$custom_source" == "false" && "$GITHUB_REF" == "refs/heads/main" ]]; then
+          tag="$short_sha"
+        else
+          sanitized_ref_name="$(echo "$label" | tr -d '()' | sed -E 's/[^A-Za-z0-9.-]+/-/g; s/^-+//; s/-+$//')"
+          if [[ -z "$sanitized_ref_name" ]]; then
+            sanitized_ref_name="source"
+          fi
+          sanitized_ref_name="${sanitized_ref_name:0:117}"
+          tag="${sanitized_ref_name}-${short_sha}"
+        fi
+
+        if [[ "$custom_source" == "true" ]]; then
+          tag_latest="false"
+        fi
+
+        if [[ "$tag_latest" == "true" ]]; then
+          docker_tags="$tag,latest"
+        else
+          docker_tags="$tag"
+        fi
+
+        {
+          echo "repository=$repository"
+          echo "ref=$ref"
+          echo "label=$label"
+          echo "sha=$sha"
+          echo "tag=$tag"
+          echo "docker-tags=$docker_tags"
+          echo "tag-latest=$tag_latest"
+          echo "source-url=https://github.com/${repository}"
+          echo "source-revision=${label}/${sha}"
+        } >> "$GITHUB_OUTPUT"

--- a/.github/actions/resolve-deploy-source/action.yaml
+++ b/.github/actions/resolve-deploy-source/action.yaml
@@ -113,9 +113,10 @@ runs:
         fi
 
         short_sha="${sha::10}"
-        tag_latest="true"
+        tag_latest="false"
 
         if [[ "$custom_source" == "false" && "$GITHUB_REF" == "refs/heads/main" ]]; then
+          tag_latest="true"
           tag="$short_sha"
         else
           sanitized_ref_name="$(echo "$label" | tr -d '()' | sed -E 's/[^A-Za-z0-9.-]+/-/g; s/^-+//; s/-+$//')"
@@ -124,10 +125,6 @@ runs:
           fi
           sanitized_ref_name="${sanitized_ref_name:0:117}"
           tag="${sanitized_ref_name}-${short_sha}"
-        fi
-
-        if [[ "$custom_source" == "true" ]]; then
-          tag_latest="false"
         fi
 
         if [[ "$tag_latest" == "true" ]]; then

--- a/.github/actions/resolve-deploy-source/action.yaml
+++ b/.github/actions/resolve-deploy-source/action.yaml
@@ -142,5 +142,5 @@ runs:
           echo "docker-tags=$docker_tags"
           echo "tag-latest=$tag_latest"
           echo "source-url=https://github.com/${repository}"
-          echo "source-revision=${label}/${sha}"
+          echo "source-revision=${ref}/${sha}"
         } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy-designer.yaml
+++ b/.github/workflows/deploy-designer.yaml
@@ -54,6 +54,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           fetch-depth: 1
           sparse-checkout: |
             .github/actions/resolve-deploy-source

--- a/.github/workflows/deploy-designer.yaml
+++ b/.github/workflows/deploy-designer.yaml
@@ -21,6 +21,10 @@ on:
         description: 'Environments to deploy to. Multiple environments can be specified by separating them with a comma.'
         required: false
         default: 'dev'
+      ref:
+        description: 'Source ref to deploy. Use branch/tag/SHA, or owner:branch for forks.'
+        required: false
+        default: ''
 
 permissions:
       id-token: write
@@ -34,82 +38,197 @@ jobs:
       inputs: ${{ toJSON(github.event.inputs) }}
       override-default-studio-environments: staging,preapproved-prod
 
-  determine-tag:
+  resolve-source:
     runs-on: ubuntu-latest
     outputs:
-      tag: ${{ steps.determine-tag.outputs.tag }}
+      repository: ${{ steps.resolve.outputs.repository }}
+      ref: ${{ steps.resolve.outputs.ref }}
+      label: ${{ steps.resolve.outputs.label }}
+      sha: ${{ steps.metadata.outputs.sha }}
+      tag: ${{ steps.metadata.outputs.tag }}
+      docker-tags: ${{ steps.metadata.outputs.docker-tags }}
+      tag-latest: ${{ steps.metadata.outputs.tag-latest }}
+      source-url: ${{ steps.metadata.outputs.source-url }}
+      source-revision: ${{ steps.metadata.outputs.source-revision }}
     steps:
-      - name: Determine tag
-        id: determine-tag
+      - name: Resolve source
+        id: resolve
+        env:
+          DEFAULT_REPOSITORY: ${{ github.repository }}
+          DEFAULT_REF: ${{ github.ref_name }}
+          DEFAULT_REPO_NAME: ${{ github.event.repository.name }}
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_REF: ${{ github.event.inputs.ref || '' }}
+          INPUT_ENVIRONMENTS: ${{ github.event.inputs.environments || 'dev' }}
         run: |
-          SHORT_SHA="${GITHUB_SHA::10}"
-          if [ "${{ github.ref }}" == "refs/heads/main" ]; then
-            echo "tag=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
-          else
-            sanitized_branch_name=$(echo "${{ github.ref_name }}" | tr -d '()' | tr '/' '-' | tr '_' '-')
-            echo "tag=${sanitized_branch_name}-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+
+          repository="$DEFAULT_REPOSITORY"
+          ref="$DEFAULT_REF"
+          label="$DEFAULT_REF"
+          custom_source="false"
+
+          if [[ "$EVENT_NAME" == "workflow_dispatch" && -n "$INPUT_REF" ]]; then
+            custom_source="true"
+            label="$INPUT_REF"
+
+            if [[ "$INPUT_REF" == *:* ]]; then
+              repository_prefix="${INPUT_REF%%:*}"
+              ref="${INPUT_REF#*:}"
+              if [[ "$repository_prefix" == */* ]]; then
+                repository="$repository_prefix"
+              else
+                repository="${repository_prefix}/${DEFAULT_REPO_NAME}"
+              fi
+            else
+              ref="$INPUT_REF"
+            fi
           fi
 
+          if [[ "$custom_source" == "true" ]]; then
+            IFS=',' read -ra environments <<< "$INPUT_ENVIRONMENTS"
+            for environment in "${environments[@]}"; do
+              environment="$(echo "$environment" | xargs)"
+              if [[ "$environment" != "dev" ]]; then
+                echo "Custom source refs can only be deployed to dev, got '$environment'." >&2
+                exit 1
+              fi
+            done
+
+            if [[ "$repository" != "$DEFAULT_REPOSITORY" && "$repository" != "martinothamar-agent/${DEFAULT_REPO_NAME}" ]]; then
+              echo "Custom source repository '$repository' is not allowed." >&2
+              exit 1
+            fi
+          fi
+
+          {
+            echo "repository=$repository"
+            echo "ref=$ref"
+            echo "label=$label"
+            echo "custom-source=$custom_source"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: ${{ steps.resolve.outputs.repository }}
+          ref: ${{ steps.resolve.outputs.ref }}
+          fetch-depth: 1
+
+      - name: Resolve source metadata
+        id: metadata
+        env:
+          SOURCE_LABEL: ${{ steps.resolve.outputs.label }}
+          SOURCE_REPOSITORY: ${{ steps.resolve.outputs.repository }}
+          CUSTOM_SOURCE: ${{ steps.resolve.outputs.custom-source }}
+          GITHUB_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+
+          SHA="$(git rev-parse HEAD)"
+          SHORT_SHA="${SHA::10}"
+          TAG_LATEST="true"
+
+          if [[ "$CUSTOM_SOURCE" == "false" && "$GITHUB_REF" == "refs/heads/main" ]]; then
+            TAG="$SHORT_SHA"
+          else
+            sanitized_ref_name="$(echo "$SOURCE_LABEL" | tr -d '()' | sed -E 's/[^A-Za-z0-9.-]+/-/g; s/^-+//; s/-+$//')"
+            if [[ -z "$sanitized_ref_name" ]]; then
+              sanitized_ref_name="source"
+            fi
+            sanitized_ref_name="${sanitized_ref_name:0:117}"
+            TAG="${sanitized_ref_name}-${SHORT_SHA}"
+          fi
+
+          if [[ "$CUSTOM_SOURCE" == "true" ]]; then
+            TAG_LATEST="false"
+          fi
+
+          if [[ "$TAG_LATEST" == "true" ]]; then
+            DOCKER_TAGS="$TAG,latest"
+          else
+            DOCKER_TAGS="$TAG"
+          fi
+
+          {
+            echo "sha=$SHA"
+            echo "tag=$TAG"
+            echo "docker-tags=$DOCKER_TAGS"
+            echo "tag-latest=$TAG_LATEST"
+            echo "source-url=https://github.com/${SOURCE_REPOSITORY}"
+            echo "source-revision=${SOURCE_LABEL}/${SHA}"
+          } >> "$GITHUB_OUTPUT"
+
   docker-build-push:
-    needs: determine-tag
+    needs: resolve-source
     uses: ./.github/workflows/template-docker-push.yaml
     with:
-      tags: ${{ needs.determine-tag.outputs.tag }},latest
+      tags: ${{ needs.resolve-source.outputs.docker-tags }}
       registry-name: altinntjenestercontainerregistry.azurecr.io
       repository-name: altinn-core
       context: .
       dockerfile: src/Designer/Dockerfile
       environment: dev # dev environment has push access and doesn't require review
+      checkout-repository: ${{ needs.resolve-source.outputs.repository }}
+      checkout-ref: ${{ needs.resolve-source.outputs.sha }}
     secrets:
       client-id: ${{ secrets.AZURE_CLIENT_ID_FC }}
       tenant-id: ${{ secrets.AZURE_TENANT_ID_FC }}
       subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID_FC }}
-      build-args: DESIGNER_VERSION=${{ needs.determine-tag.outputs.tag }}
+      build-args: DESIGNER_VERSION=${{ needs.resolve-source.outputs.tag }}
 
   db-migrations-docker-build-push:
-    needs: determine-tag
+    needs: resolve-source
     uses: ./.github/workflows/template-docker-push.yaml
     with:
-      tags: ${{ needs.determine-tag.outputs.tag }},latest
+      tags: ${{ needs.resolve-source.outputs.docker-tags }}
       registry-name: altinntjenestercontainerregistry.azurecr.io
       repository-name: altinn-designer-db-migrations
       context: src/Designer/backend
       dockerfile: src/Designer/backend/Migrations.Dockerfile
       environment: dev # dev environment has push access and doesn't require review
+      checkout-repository: ${{ needs.resolve-source.outputs.repository }}
+      checkout-ref: ${{ needs.resolve-source.outputs.sha }}
     secrets:
       client-id: ${{ secrets.AZURE_CLIENT_ID_FC }}
       tenant-id: ${{ secrets.AZURE_TENANT_ID_FC }}
       subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID_FC }}
 
   helm-push:
-    needs: determine-tag
+    needs: resolve-source
     uses: ./.github/workflows/template-helm-push.yaml
     with:
-      tag: 0.1.0+${{ needs.determine-tag.outputs.tag }} # Helm version needs to be valid sematic version
+      tag: 0.1.0+${{ needs.resolve-source.outputs.tag }} # Helm version needs to be valid sematic version
       chart-name: altinn-designer
       registry-name: altinntjenestercontainerregistry.azurecr.io
       environment: dev
+      checkout-repository: ${{ needs.resolve-source.outputs.repository }}
+      checkout-ref: ${{ needs.resolve-source.outputs.sha }}
     secrets:
       client-id: ${{ secrets.AZURE_CLIENT_ID_FC }}
       tenant-id: ${{ secrets.AZURE_TENANT_ID_FC }}
       subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID_FC }}
 
   flux-config-push:
-    needs: [construct-environments-array, determine-tag, docker-build-push, db-migrations-docker-build-push, helm-push]
+    needs: [construct-environments-array, resolve-source, docker-build-push, db-migrations-docker-build-push, helm-push]
     strategy:
       matrix:
         include: ${{ fromJSON(needs.construct-environments-array.outputs.result) }}
     uses: ./.github/workflows/template-flux-config-push.yaml
     with:
-      tag: ${{ needs.determine-tag.outputs.tag }}
+      tag: ${{ needs.resolve-source.outputs.tag }}
       registry-name: altinntjenestercontainerregistry.azurecr.io
       environment: ${{ matrix.environment }}
       artifact-environment: ${{ matrix.environment == 'preapproved-prod' && 'prod' ||  matrix.environment }}
       config-chart-name: altinn-designer-config
       artifact-name: altinn-designer
-      helm-set-arguments: environmentName=${{ matrix.environment == 'preapproved-prod' && 'prod' ||  matrix.environment }},chartVersion=0.1.0+${{ needs.determine-tag.outputs.tag }},imageTag=${{ needs.determine-tag.outputs.tag }},dbMigrationsTag=${{ needs.determine-tag.outputs.tag }},replicas=${{ matrix.environment == 'dev' && 1 || 2 }}
+      helm-set-arguments: environmentName=${{ matrix.environment == 'preapproved-prod' && 'prod' ||  matrix.environment }},chartVersion=0.1.0+${{ needs.resolve-source.outputs.tag }},imageTag=${{ needs.resolve-source.outputs.tag }},dbMigrationsTag=${{ needs.resolve-source.outputs.tag }},replicas=${{ matrix.environment == 'dev' && 1 || 2 }}
       trace-workflow: true
       trace-team-name: 'team-studio'
+      checkout-repository: ${{ needs.resolve-source.outputs.repository }}
+      checkout-ref: ${{ needs.resolve-source.outputs.sha }}
+      source-url: ${{ needs.resolve-source.outputs.source-url }}
+      source-revision: ${{ needs.resolve-source.outputs.source-revision }}
+      tag-latest: ${{ needs.resolve-source.outputs.tag-latest == 'true' }}
     secrets:
       client-id: ${{ secrets.AZURE_CLIENT_ID_FC }}
       tenant-id: ${{ secrets.AZURE_TENANT_ID_FC }}

--- a/.github/workflows/deploy-designer.yaml
+++ b/.github/workflows/deploy-designer.yaml
@@ -7,6 +7,7 @@ on:
       - '.github/workflows/template-docker-push.yaml'
       - '.github/workflows/template-flux-config-push.yaml'
       - '.github/workflows/template-helm-push.yaml'
+      - '.github/actions/resolve-deploy-source/action.yaml'
       - 'src/Designer/backend/**'
       - 'src/Designer/frontend/**'
       - 'src/Designer/Dockerfile'
@@ -41,133 +42,32 @@ jobs:
   resolve-source:
     runs-on: ubuntu-latest
     outputs:
-      repository: ${{ steps.resolve.outputs.repository }}
-      ref: ${{ steps.resolve.outputs.ref }}
-      label: ${{ steps.resolve.outputs.label }}
-      sha: ${{ steps.metadata.outputs.sha }}
-      tag: ${{ steps.metadata.outputs.tag }}
-      docker-tags: ${{ steps.metadata.outputs.docker-tags }}
-      tag-latest: ${{ steps.metadata.outputs.tag-latest }}
-      source-url: ${{ steps.metadata.outputs.source-url }}
-      source-revision: ${{ steps.metadata.outputs.source-revision }}
+      repository: ${{ steps.resolve-source.outputs.repository }}
+      ref: ${{ steps.resolve-source.outputs.ref }}
+      label: ${{ steps.resolve-source.outputs.label }}
+      sha: ${{ steps.resolve-source.outputs.sha }}
+      tag: ${{ steps.resolve-source.outputs.tag }}
+      docker-tags: ${{ steps.resolve-source.outputs.docker-tags }}
+      tag-latest: ${{ steps.resolve-source.outputs.tag-latest }}
+      source-url: ${{ steps.resolve-source.outputs.source-url }}
+      source-revision: ${{ steps.resolve-source.outputs.source-revision }}
     steps:
-      - name: Resolve source
-        id: resolve
-        env:
-          DEFAULT_REPOSITORY: ${{ github.repository }}
-          DEFAULT_REF: ${{ github.ref_name }}
-          DEFAULT_REPO_NAME: ${{ github.event.repository.name }}
-          EVENT_NAME: ${{ github.event_name }}
-          INPUT_REF: ${{ github.event.inputs.ref || '' }}
-          INPUT_ENVIRONMENTS: ${{ github.event.inputs.environments || 'dev' }}
-        run: |
-          set -euo pipefail
-
-          repository="$DEFAULT_REPOSITORY"
-          ref="$DEFAULT_REF"
-          label="$DEFAULT_REF"
-          custom_source="false"
-
-          if [[ "$EVENT_NAME" == "workflow_dispatch" && -n "$INPUT_REF" ]]; then
-            custom_source="true"
-            label="$INPUT_REF"
-
-            if [[ "$INPUT_REF" == *$'\n'* || "$INPUT_REF" == *$'\r'* ]]; then
-              echo "The ref input cannot contain newlines." >&2
-              exit 1
-            fi
-
-            if [[ "$INPUT_REF" == *:* ]]; then
-              repository_owner="${INPUT_REF%%:*}"
-              ref="${INPUT_REF#*:}"
-              repository="${repository_owner}/${DEFAULT_REPO_NAME}"
-            else
-              ref="$INPUT_REF"
-            fi
-
-            if [[ -z "$ref" || "$ref" == -* || "$repository" == */*/* ]]; then
-              echo "The ref input must be a branch name or fork-owner:branch-name." >&2
-              exit 1
-            fi
-          fi
-
-          if [[ "$custom_source" == "true" ]]; then
-            IFS=',' read -ra environments <<< "$INPUT_ENVIRONMENTS"
-            for environment in "${environments[@]}"; do
-              environment="$(echo "$environment" | xargs)"
-              if [[ "$environment" != "dev" ]]; then
-                echo "Custom source refs can only be deployed to dev, got '$environment'." >&2
-                exit 1
-              fi
-            done
-
-            if [[ "$repository" != "$DEFAULT_REPOSITORY" && "$repository" != "martinothamar-agent/${DEFAULT_REPO_NAME}" ]]; then
-              echo "Custom source repository '$repository' is not allowed." >&2
-              exit 1
-            fi
-
-            if ! git ls-remote --exit-code --heads "https://github.com/${repository}.git" "$ref" > /dev/null; then
-              echo "Branch '$ref' was not found in '$repository'." >&2
-              exit 1
-            fi
-          fi
-
-          {
-            echo "repository=$repository"
-            echo "ref=$ref"
-            echo "label=$label"
-            echo "custom-source=$custom_source"
-          } >> "$GITHUB_OUTPUT"
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          repository: ${{ steps.resolve.outputs.repository }}
-          ref: ${{ steps.resolve.outputs.ref }}
           fetch-depth: 1
+          sparse-checkout: |
+            .github/actions/resolve-deploy-source
 
-      - name: Resolve source metadata
-        id: metadata
-        env:
-          SOURCE_LABEL: ${{ steps.resolve.outputs.label }}
-          SOURCE_REPOSITORY: ${{ steps.resolve.outputs.repository }}
-          CUSTOM_SOURCE: ${{ steps.resolve.outputs.custom-source }}
-          GITHUB_REF: ${{ github.ref }}
-        run: |
-          set -euo pipefail
-
-          SHA="$(git rev-parse HEAD)"
-          SHORT_SHA="${SHA::10}"
-          TAG_LATEST="true"
-
-          if [[ "$CUSTOM_SOURCE" == "false" && "$GITHUB_REF" == "refs/heads/main" ]]; then
-            TAG="$SHORT_SHA"
-          else
-            sanitized_ref_name="$(echo "$SOURCE_LABEL" | tr -d '()' | sed -E 's/[^A-Za-z0-9.-]+/-/g; s/^-+//; s/-+$//')"
-            if [[ -z "$sanitized_ref_name" ]]; then
-              sanitized_ref_name="source"
-            fi
-            sanitized_ref_name="${sanitized_ref_name:0:117}"
-            TAG="${sanitized_ref_name}-${SHORT_SHA}"
-          fi
-
-          if [[ "$CUSTOM_SOURCE" == "true" ]]; then
-            TAG_LATEST="false"
-          fi
-
-          if [[ "$TAG_LATEST" == "true" ]]; then
-            DOCKER_TAGS="$TAG,latest"
-          else
-            DOCKER_TAGS="$TAG"
-          fi
-
-          {
-            echo "sha=$SHA"
-            echo "tag=$TAG"
-            echo "docker-tags=$DOCKER_TAGS"
-            echo "tag-latest=$TAG_LATEST"
-            echo "source-url=https://github.com/${SOURCE_REPOSITORY}"
-            echo "source-revision=${SOURCE_LABEL}/${SHA}"
-          } >> "$GITHUB_OUTPUT"
+      - name: Resolve source
+        id: resolve-source
+        uses: ./.github/actions/resolve-deploy-source
+        with:
+          ref: ${{ github.event.inputs.ref || '' }}
+          default-ref: ${{ github.ref_name }}
+          default-repository: ${{ github.repository }}
+          default-repo-name: ${{ github.event.repository.name }}
+          default-sha: ${{ github.sha }}
+          github-ref: ${{ github.ref }}
 
   docker-build-push:
     needs: resolve-source

--- a/.github/workflows/deploy-designer.yaml
+++ b/.github/workflows/deploy-designer.yaml
@@ -72,6 +72,11 @@ jobs:
             custom_source="true"
             label="$INPUT_REF"
 
+            if [[ "$INPUT_REF" == *$'\n'* || "$INPUT_REF" == *$'\r'* ]]; then
+              echo "The ref input cannot contain newlines." >&2
+              exit 1
+            fi
+
             if [[ "$INPUT_REF" == *:* ]]; then
               repository_prefix="${INPUT_REF%%:*}"
               ref="${INPUT_REF#*:}"

--- a/.github/workflows/deploy-designer.yaml
+++ b/.github/workflows/deploy-designer.yaml
@@ -22,7 +22,7 @@ on:
         required: false
         default: 'dev'
       ref:
-        description: 'Source ref to deploy. Use branch/tag/SHA, or owner:branch for forks.'
+        description: 'Source branch to deploy. Use branch-name, or fork-owner:branch-name for forks.'
         required: false
         default: ''
 
@@ -78,15 +78,16 @@ jobs:
             fi
 
             if [[ "$INPUT_REF" == *:* ]]; then
-              repository_prefix="${INPUT_REF%%:*}"
+              repository_owner="${INPUT_REF%%:*}"
               ref="${INPUT_REF#*:}"
-              if [[ "$repository_prefix" == */* ]]; then
-                repository="$repository_prefix"
-              else
-                repository="${repository_prefix}/${DEFAULT_REPO_NAME}"
-              fi
+              repository="${repository_owner}/${DEFAULT_REPO_NAME}"
             else
               ref="$INPUT_REF"
+            fi
+
+            if [[ -z "$ref" || "$ref" == -* || "$repository" == */*/* ]]; then
+              echo "The ref input must be a branch name or fork-owner:branch-name." >&2
+              exit 1
             fi
           fi
 
@@ -102,6 +103,11 @@ jobs:
 
             if [[ "$repository" != "$DEFAULT_REPOSITORY" && "$repository" != "martinothamar-agent/${DEFAULT_REPO_NAME}" ]]; then
               echo "Custom source repository '$repository' is not allowed." >&2
+              exit 1
+            fi
+
+            if ! git ls-remote --exit-code --heads "https://github.com/${repository}.git" "$ref" > /dev/null; then
+              echo "Branch '$ref' was not found in '$repository'." >&2
               exit 1
             fi
           fi

--- a/.github/workflows/template-docker-push.yaml
+++ b/.github/workflows/template-docker-push.yaml
@@ -28,6 +28,10 @@ on:
         required: false
         type: string
         default: ''
+      checkout-ref:
+        required: false
+        type: string
+        default: ''
 
     secrets:
       client-id:
@@ -47,7 +51,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          repository: ${{ inputs.checkout-repository }}
+          repository: ${{ inputs.checkout-repository || github.repository }}
+          ref: ${{ inputs.checkout-ref || github.sha }}
 
       - name: 'Azure login'
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2

--- a/.github/workflows/template-docker-push.yaml
+++ b/.github/workflows/template-docker-push.yaml
@@ -53,19 +53,39 @@ jobs:
         with:
           repository: ${{ inputs.checkout-repository || github.repository }}
           ref: ${{ inputs.checkout-ref || github.sha }}
+          persist-credentials: false
 
       - name: Docker build
+        env:
+          BUILD_ARGS: ${{ secrets.build-args }}
+          CONTEXT: ${{ inputs.context }}
+          DOCKERFILE: ${{ inputs.dockerfile }}
+          REGISTRY_NAME: ${{ inputs.registry-name }}
+          REPOSITORY_NAME: ${{ inputs.repository-name }}
+          TAGS: ${{ inputs.tags }}
         run: |
-          arguments=""
-          for tag in $(echo ${{ inputs.tags }} | tr ',' '\n'); do
-            arguments+=" -t ${{ inputs.registry-name }}/${{ inputs.repository-name }}:$tag"
+          set -euo pipefail
+
+          image="${REGISTRY_NAME}/${REPOSITORY_NAME}"
+          arguments=()
+
+          IFS=',' read -r -a tags <<< "$TAGS"
+          for tag in "${tags[@]}"; do
+            if [[ -n "$tag" ]]; then
+              arguments+=(-t "${image}:${tag}")
+            fi
           done
 
-          for buildarg in $(echo ${{ secrets.build-args }} | tr ',' '\n'); do
-            arguments+=" --build-arg $buildarg"
-          done
+          if [[ -n "$BUILD_ARGS" ]]; then
+            IFS=',' read -r -a build_args <<< "$BUILD_ARGS"
+            for build_arg in "${build_args[@]}"; do
+              if [[ -n "$build_arg" ]]; then
+                arguments+=(--build-arg "$build_arg")
+              fi
+            done
+          fi
 
-          docker build ${{ inputs.context }} -f ${{ inputs.dockerfile }} $arguments
+          docker build "$CONTEXT" -f "$DOCKERFILE" "${arguments[@]}"
 
       - name: 'Azure login'
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
@@ -85,7 +105,17 @@ jobs:
                                 --password-stdin
 
       - name: Docker push
+        env:
+          REGISTRY_NAME: ${{ inputs.registry-name }}
+          REPOSITORY_NAME: ${{ inputs.repository-name }}
+          TAGS: ${{ inputs.tags }}
         run: |
-          for tag in $(echo ${{ inputs.tags }} | tr ',' '\n'); do
-            docker push ${{ inputs.registry-name }}/${{ inputs.repository-name }}:$tag
+          set -euo pipefail
+
+          image="${REGISTRY_NAME}/${REPOSITORY_NAME}"
+          IFS=',' read -r -a tags <<< "$TAGS"
+          for tag in "${tags[@]}"; do
+            if [[ -n "$tag" ]]; then
+              docker push "${image}:${tag}"
+            fi
           done

--- a/.github/workflows/template-docker-push.yaml
+++ b/.github/workflows/template-docker-push.yaml
@@ -54,6 +54,19 @@ jobs:
           repository: ${{ inputs.checkout-repository || github.repository }}
           ref: ${{ inputs.checkout-ref || github.sha }}
 
+      - name: Docker build
+        run: |
+          arguments=""
+          for tag in $(echo ${{ inputs.tags }} | tr ',' '\n'); do
+            arguments+=" -t ${{ inputs.registry-name }}/${{ inputs.repository-name }}:$tag"
+          done
+
+          for buildarg in $(echo ${{ secrets.build-args }} | tr ',' '\n'); do
+            arguments+=" --build-arg $buildarg"
+          done
+
+          docker build ${{ inputs.context }} -f ${{ inputs.dockerfile }} $arguments
+
       - name: 'Azure login'
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
         with:
@@ -70,19 +83,6 @@ jobs:
           --only-show-errors |  docker login ${{ inputs.registry-name }} \
                                 --username 00000000-0000-0000-0000-000000000000 \
                                 --password-stdin
-
-      - name: Docker build
-        run: |
-          arguments=""
-          for tag in $(echo ${{ inputs.tags }} | tr ',' '\n'); do
-            arguments+=" -t ${{ inputs.registry-name }}/${{ inputs.repository-name }}:$tag"
-          done
-
-          for buildarg in $(echo ${{ secrets.build-args }} | tr ',' '\n'); do
-            arguments+=" --build-arg $buildarg"
-          done
-
-          docker build ${{ inputs.context }} -f ${{ inputs.dockerfile }} $arguments
 
       - name: Docker push
         run: |

--- a/.github/workflows/template-flux-config-push.yaml
+++ b/.github/workflows/template-flux-config-push.yaml
@@ -76,6 +76,7 @@ jobs:
         with:
           repository: ${{ inputs.checkout-repository || github.repository }}
           ref: ${{ inputs.checkout-ref || github.sha }}
+          persist-credentials: false
 
       - name: 'Azure login'
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
@@ -98,37 +99,60 @@ jobs:
         uses: fluxcd/flux2/action@bfa461ed2153ae5e0cca6bce08e0845268fb3088 # v2.8.2
 
       - name: Generate cofiguration file
+        env:
+          CONFIG_CHART_NAME: ${{ inputs.config-chart-name }}
+          HELM_SET_ARGUMENTS: ${{ inputs.helm-set-arguments }}
         run: |
-          mkdir ${{ inputs.config-chart-name }}-rendered
+          set -euo pipefail
 
-          arguments=""
+          mkdir "${CONFIG_CHART_NAME}-rendered"
 
-          for setarg in $(echo ${{ inputs.helm-set-arguments }} | tr ',' '\n'); do
-            arguments+=" --set $setarg"
-          done
+          arguments=()
+          if [[ -n "$HELM_SET_ARGUMENTS" ]]; then
+            IFS=',' read -r -a set_arguments <<< "$HELM_SET_ARGUMENTS"
+            for set_argument in "${set_arguments[@]}"; do
+              if [[ -n "$set_argument" ]]; then
+                arguments+=(--set "$set_argument")
+              fi
+            done
+          fi
 
-          helm template charts/${{ inputs.config-chart-name }} $arguments > ${{ inputs.config-chart-name }}-rendered/helm-release.yaml
+          helm template "charts/${CONFIG_CHART_NAME}" "${arguments[@]}" > "${CONFIG_CHART_NAME}-rendered/helm-release.yaml"
 
       - name: Push config artifact
         env:
+          ARTIFACT_ENV: ${{ inputs.artifact-environment || inputs.environment }}
+          ARTIFACT_NAME: ${{ inputs.artifact-name }}
+          CONFIG_CHART_NAME: ${{ inputs.config-chart-name }}
+          REGISTRY_NAME: ${{ inputs.registry-name }}
           SOURCE_URL: ${{ inputs.source-url }}
           SOURCE_REVISION: ${{ inputs.source-revision }}
+          TAG: ${{ inputs.tag }}
         run: |
-          artifact_env=${{ inputs.artifact-environment || inputs.environment }}
+          set -euo pipefail
+
+          artifact_env="$ARTIFACT_ENV"
           source_url="${SOURCE_URL:-$(git config --get remote.origin.url)}"
           source_sha="$(git rev-parse HEAD)"
           fallback_ref="$(git symbolic-ref --short -q HEAD || echo "${GITHUB_REF_NAME:-detached}")"
           source_revision="${SOURCE_REVISION:-${fallback_ref}/${source_sha}}"
-          flux push artifact oci://${{ inputs.registry-name }}/configs/${{ inputs.artifact-name }}-${artifact_env}:${{ inputs.tag }} \
-          --path="./${{ inputs.config-chart-name }}-rendered" \
+          flux push artifact "oci://${REGISTRY_NAME}/configs/${ARTIFACT_NAME}-${artifact_env}:${TAG}" \
+          --path="./${CONFIG_CHART_NAME}-rendered" \
           --source="$source_url" \
           --revision="$source_revision"
 
       - name: Tag artifact as latest
         if: ${{ inputs.tag-latest }}
+        env:
+          ARTIFACT_ENV: ${{ inputs.artifact-environment || inputs.environment }}
+          ARTIFACT_NAME: ${{ inputs.artifact-name }}
+          REGISTRY_NAME: ${{ inputs.registry-name }}
+          TAG: ${{ inputs.tag }}
         run: |
-          artifact_env=${{ inputs.artifact-environment || inputs.environment }}
-          flux tag artifact oci://${{ inputs.registry-name }}/configs/${{ inputs.artifact-name }}-${artifact_env}:${{ inputs.tag }} --tag latest
+          set -euo pipefail
+
+          artifact_env="$ARTIFACT_ENV"
+          flux tag artifact "oci://${REGISTRY_NAME}/configs/${ARTIFACT_NAME}-${artifact_env}:${TAG}" --tag latest
 
       - name: Send Trace to Azure Monitor
         if: ${{ inputs.trace-workflow }}

--- a/.github/workflows/template-flux-config-push.yaml
+++ b/.github/workflows/template-flux-config-push.yaml
@@ -116,7 +116,9 @@ jobs:
         run: |
           artifact_env=${{ inputs.artifact-environment || inputs.environment }}
           source_url="${SOURCE_URL:-$(git config --get remote.origin.url)}"
-          source_revision="${SOURCE_REVISION:-$(git branch --show-current)/$(git rev-parse HEAD)}"
+          source_sha="$(git rev-parse HEAD)"
+          fallback_ref="$(git symbolic-ref --short -q HEAD || echo "${GITHUB_REF_NAME:-detached}")"
+          source_revision="${SOURCE_REVISION:-${fallback_ref}/${source_sha}}"
           flux push artifact oci://${{ inputs.registry-name }}/configs/${{ inputs.artifact-name }}-${artifact_env}:${{ inputs.tag }} \
           --path="./${{ inputs.config-chart-name }}-rendered" \
           --source="$source_url" \

--- a/.github/workflows/template-flux-config-push.yaml
+++ b/.github/workflows/template-flux-config-push.yaml
@@ -32,6 +32,26 @@ on:
         required: false
         type: string
         default: ''
+      checkout-repository:
+        required: false
+        type: string
+        default: ''
+      checkout-ref:
+        required: false
+        type: string
+        default: ''
+      source-url:
+        required: false
+        type: string
+        default: ''
+      source-revision:
+        required: false
+        type: string
+        default: ''
+      tag-latest:
+        required: false
+        type: boolean
+        default: true
 
 
     secrets:
@@ -53,6 +73,9 @@ jobs:
     environment: ${{ inputs.environment }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: ${{ inputs.checkout-repository || github.repository }}
+          ref: ${{ inputs.checkout-ref || github.sha }}
 
       - name: 'Azure login'
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
@@ -87,14 +110,20 @@ jobs:
           helm template charts/${{ inputs.config-chart-name }} $arguments > ${{ inputs.config-chart-name }}-rendered/helm-release.yaml
 
       - name: Push config artifact
+        env:
+          SOURCE_URL: ${{ inputs.source-url }}
+          SOURCE_REVISION: ${{ inputs.source-revision }}
         run: |
           artifact_env=${{ inputs.artifact-environment || inputs.environment }}
+          source_url="${SOURCE_URL:-$(git config --get remote.origin.url)}"
+          source_revision="${SOURCE_REVISION:-$(git branch --show-current)/$(git rev-parse HEAD)}"
           flux push artifact oci://${{ inputs.registry-name }}/configs/${{ inputs.artifact-name }}-${artifact_env}:${{ inputs.tag }} \
           --path="./${{ inputs.config-chart-name }}-rendered" \
-          --source="$(git config --get remote.origin.url)" \
-          --revision="$(git branch --show-current)/$(git rev-parse HEAD)"
+          --source="$source_url" \
+          --revision="$source_revision"
 
       - name: Tag artifact as latest
+        if: ${{ inputs.tag-latest }}
         run: |
           artifact_env=${{ inputs.artifact-environment || inputs.environment }}
           flux tag artifact oci://${{ inputs.registry-name }}/configs/${{ inputs.artifact-name }}-${artifact_env}:${{ inputs.tag }} --tag latest

--- a/.github/workflows/template-helm-push.yaml
+++ b/.github/workflows/template-helm-push.yaml
@@ -16,6 +16,14 @@ on:
         required: false
         type: string
         default: ''
+      checkout-repository:
+        required: false
+        type: string
+        default: ''
+      checkout-ref:
+        required: false
+        type: string
+        default: ''
 
     secrets:
       client-id:
@@ -32,6 +40,9 @@ jobs:
     environment: ${{ inputs.environment }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: ${{ inputs.checkout-repository || github.repository }}
+          ref: ${{ inputs.checkout-ref || github.sha }}
 
       - name: 'Azure login'
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
@@ -63,4 +74,3 @@ jobs:
       - name: Helm push
         run: |
           helm push ${{ inputs.chart-name }}-${{ inputs.tag }}.tgz oci://${{ inputs.registry-name }}/charts
-

--- a/.github/workflows/template-helm-push.yaml
+++ b/.github/workflows/template-helm-push.yaml
@@ -43,6 +43,7 @@ jobs:
         with:
           repository: ${{ inputs.checkout-repository || github.repository }}
           ref: ${{ inputs.checkout-ref || github.sha }}
+          persist-credentials: false
 
       - name: 'Azure login'
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2


### PR DESCRIPTION
## Description

Adds a single `ref` workflow_dispatch input to the Designer deploy workflow. The input accepts either an upstream branch such as `fix/example` or a fork-style PR branch value such as `martinothamar-agent:fix/example`.

The branch parsing and deployment metadata are handled by a new reusable local composite action at `.github/actions/resolve-deploy-source`. The action resolves the branch input to a repository and immutable source SHA, then Designer passes that checkout through Docker, Helm and Flux reusable templates. Custom source branches must exist as Git branches and skip `latest` tagging so experimental deploys do not replace normal main artifacts.

## Verification

- [x] Related issues are connected (not applicable)
- [x] **Your** code builds clean without any errors or warnings (workflow YAML validated; no app build changed)
- [x] Manual testing done (simulated branch parsing for empty, upstream, fork and rejected inputs; verified `git ls-remote --heads` accepts branches and rejects SHA-only input)
- [ ] Relevant automated test added (workflow-only change)

Validation run locally:

```bash
yq . .github/workflows/deploy-designer.yaml .github/workflows/template-docker-push.yaml .github/workflows/template-helm-push.yaml .github/workflows/template-flux-config-push.yaml .github/actions/resolve-deploy-source/action.yaml >/tmp/designer-source-ref-yq.out
go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore 'SC2086' .github/workflows/deploy-designer.yaml .github/workflows/template-docker-push.yaml .github/workflows/template-helm-push.yaml .github/workflows/template-flux-config-push.yaml\nyq -r '.runs.steps[0].run' .github/actions/resolve-deploy-source/action.yaml | shellcheck -s bash -\ngit diff --check\n```\n\nNote: `SC2086` is ignored because the touched shared templates already contain existing unquoted argument expansion warnings unrelated to this change.\n\ncc @martinothamar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployments can target a specific source ref and now expose resolved source metadata (repository, ref, commit, tag, docker tags, source provenance).

* **Chores**
  * Build, push and publish steps consume resolved source metadata for consistent image/chart tagging and checkouts.
  * Docker push/login robustness improved and tag parsing hardened.
  * Flux/Helm publishing accepts explicit checkout inputs and optional "tag latest" control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio/pull/18845?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->