### PR TITLE
chore: skip designer browser downloads in docker build

### DIFF
--- a/src/Designer/Dockerfile
+++ b/src/Designer/Dockerfile
@@ -45,6 +45,11 @@ COPY src/Designer/frontend/settings/package.json ./src/Designer/frontend/setting
 COPY libs/form-component/package.json ./libs/form-component/
 COPY libs/form-engine/package.json ./libs/form-engine/
 
+ARG CYPRESS_INSTALL_BINARY=0
+ARG PUPPETEER_SKIP_DOWNLOAD=true
+ENV CYPRESS_INSTALL_BINARY=${CYPRESS_INSTALL_BINARY}
+ENV PUPPETEER_SKIP_DOWNLOAD=${PUPPETEER_SKIP_DOWNLOAD}
+
 RUN yarn --immutable
 
 COPY . .


### PR DESCRIPTION
## Summary
- Skip Cypress and Puppeteer browser binary downloads by default in the Designer frontend Docker build stage.
- Keep both settings as build args so intermediate-stage consumers can opt back in if they really need browser binaries in that stage.

## Why
The final Designer runtime image only copies built `dist/` assets from `generate-studio-frontend`; it does not copy `node_modules`, Cypress, Puppeteer, or browser binaries. The browser downloads only add work and failure surface to `yarn --immutable` during the Docker build.

Consumers that intentionally use `generate-studio-frontend` as a browser-test image can still override this with:

```bash
docker build \
  --build-arg CYPRESS_INSTALL_BINARY=1 \
  --build-arg PUPPETEER_SKIP_DOWNLOAD=false \
  --target generate-studio-frontend \
  -f src/Designer/Dockerfile .
```

## Measurements
Measured locally with a cold frontend target build:

```bash
docker build --no-cache --progress=plain --target generate-studio-frontend -f src/Designer/Dockerfile .
```

Build time:
- Before: `RUN yarn --immutable` link step completed in `57s 345ms`; Yarn total was `1m 10s`; target build/export finished at `139.9s`.
- After: `RUN yarn --immutable` link step completed in `33s 413ms`; Yarn total was `46s 28ms`; target build/export finished at `75.2s`.
- Delta: about `24s` less in the install/link step and about `65s` less for this local cold target build/export.

Image sizes reported by `docker images` after tagging before/after builds:
- `generate-studio-frontend`: `6.55GB` -> `3.65GB` (`-2.90GB`).
- Final Designer runtime image: `528MB` -> `528MB` (unchanged, as expected).

## Testing
- `docker build --no-cache --progress=plain --target generate-studio-frontend -f src/Designer/Dockerfile .`
- `docker build --target generate-studio-frontend -t altinn-studio-designer-frontend:baseline -f src/Designer/Dockerfile .`
- `docker build --target generate-studio-frontend -t altinn-studio-designer-frontend:patched -f src/Designer/Dockerfile .`
- `docker build -t altinn-studio-designer-runtime:baseline -f src/Designer/Dockerfile .`
- `docker build -t altinn-studio-designer-runtime:patched -f src/Designer/Dockerfile .`

cc @martinothamar


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker build efficiency by configuring the build stage to skip downloading unnecessary test and development tools, reducing build time and resource usage whilst preserving full functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio/pull/18851?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->