### PR TITLE
fix: use canonical Maskinporten scope descriptions

### DIFF
--- a/src/Designer/backend/src/Designer/Services/Implementation/DefaultMaskinportenScopes.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/DefaultMaskinportenScopes.cs
@@ -17,8 +17,12 @@ public static class DefaultMaskinportenScopes
 
     private static readonly IReadOnlyList<MaskinPortenScopeEntity> s_scopes =
     [
-        new() { Scope = ServiceOwnerInstancesRead, Description = "Read instances" },
-        new() { Scope = ServiceOwnerInstancesWrite, Description = "Write instances" },
+        new()
+        {
+            Scope = ServiceOwnerInstancesRead,
+            Description = "Klienter kan lese data knyttet til alle appene til tjenesteeieren.",
+        },
+        new() { Scope = ServiceOwnerInstancesWrite, Description = "Klienter kan skrive data for alle deres apper." },
     ];
 
     public static bool ContainsAll(ISet<MaskinPortenScopeEntity>? scopes)

--- a/src/Designer/backend/tests/Designer.Tests/Services/ReleaseServiceTest.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/ReleaseServiceTest.cs
@@ -327,8 +327,16 @@ public class ReleaseServiceTest
             App = _app,
             Scopes = new HashSet<MaskinPortenScopeEntity>
             {
-                new() { Scope = "altinn:serviceowner/instances.read", Description = "Read instances" },
-                new() { Scope = "altinn:serviceowner/instances.write", Description = "Write instances" },
+                new()
+                {
+                    Scope = "altinn:serviceowner/instances.read",
+                    Description = "Klienter kan lese data knyttet til alle appene til tjenesteeieren.",
+                },
+                new()
+                {
+                    Scope = "altinn:serviceowner/instances.write",
+                    Description = "Klienter kan skrive data for alle deres apper.",
+                },
             },
         };
 

--- a/src/Designer/frontend/app-development/features/appPublish/components/CreateRelease.test.tsx
+++ b/src/Designer/frontend/app-development/features/appPublish/components/CreateRelease.test.tsx
@@ -76,8 +76,14 @@ describe('CreateRelease', () => {
     const getSelectedMaskinportenScopes = jest.fn().mockImplementation(() =>
       Promise.resolve({
         scopes: [
-          { scope: 'altinn:serviceowner/instances.read', description: 'Read instances' },
-          { scope: 'altinn:serviceowner/instances.write', description: 'Write instances' },
+          {
+            scope: 'altinn:serviceowner/instances.read',
+            description: 'Klienter kan lese data knyttet til alle appene til tjenesteeieren.',
+          },
+          {
+            scope: 'altinn:serviceowner/instances.write',
+            description: 'Klienter kan skrive data for alle deres apper.',
+          },
         ],
       }),
     );

--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.test.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.test.tsx
@@ -91,7 +91,7 @@ describe('ScopeList', () => {
     await user.click(getButton(textMock('app_settings.maskinporten_add_default_scopes')));
 
     const updatedScopes: MaskinportenScopes = {
-      scopes: [scopeMock4, scopeMock2, scopeMock3],
+      scopes: [...defaultMaskinportenScopes, scopeMock3],
     };
 
     expect(queriesMock.updateSelectedMaskinportenScopes).toHaveBeenCalledTimes(1);

--- a/src/Designer/frontend/app-development/utils/maskinportenScopes.test.ts
+++ b/src/Designer/frontend/app-development/utils/maskinportenScopes.test.ts
@@ -10,11 +10,11 @@ import {
 
 const readScope: MaskinportenScope = {
   scope: 'altinn:serviceowner/instances.read',
-  description: 'Read instances',
+  description: 'Klienter kan lese data knyttet til alle appene til tjenesteeieren.',
 };
 const writeScope: MaskinportenScope = {
   scope: 'altinn:serviceowner/instances.write',
-  description: 'Write instances',
+  description: 'Klienter kan skrive data for alle deres apper.',
 };
 const customScope: MaskinportenScope = {
   scope: 'custom:scope',
@@ -38,14 +38,14 @@ describe('maskinportenScopes', () => {
     ]);
   });
 
-  it('keeps existing default scope data when adding missing default scopes', () => {
+  it('uses canonical default scope data when adding default scopes', () => {
     const readScopeWithApiDescription: MaskinportenScope = {
       ...readScope,
       description: 'Description from API',
     };
 
     expect(addDefaultMaskinportenScopes([readScopeWithApiDescription, customScope])).toEqual([
-      readScopeWithApiDescription,
+      readScope,
       customScope,
       writeScope,
     ]);

--- a/src/Designer/frontend/app-development/utils/maskinportenScopes.ts
+++ b/src/Designer/frontend/app-development/utils/maskinportenScopes.ts
@@ -4,11 +4,11 @@ import { isMaskinportenDefaultScopesOptInVersion } from './versionUtils';
 export const defaultMaskinportenScopes: MaskinportenScope[] = [
   {
     scope: 'altinn:serviceowner/instances.read',
-    description: 'Read instances',
+    description: 'Klienter kan lese data knyttet til alle appene til tjenesteeieren.',
   },
   {
     scope: 'altinn:serviceowner/instances.write',
-    description: 'Write instances',
+    description: 'Klienter kan skrive data for alle deres apper.',
   },
 ];
 
@@ -24,9 +24,7 @@ export const addDefaultMaskinportenScopes = (
     maskinportenScopes.map((scope: MaskinportenScope) => [scope.scope, scope]),
   );
   defaultMaskinportenScopes.forEach((scope: MaskinportenScope) => {
-    if (!scopeMap.has(scope.scope)) {
-      scopeMap.set(scope.scope, scope);
-    }
+    scopeMap.set(scope.scope, scope);
   });
 
   return Array.from(scopeMap.values());


### PR DESCRIPTION
## Summary
- use the production self-service portal descriptions for the default service owner Maskinporten scopes
- make default scope merging overwrite existing default-scope descriptions so v8 opt-in, new apps and v9 release automation stay consistent
- update frontend and backend tests for the canonical descriptions

## Testing
- `yarn test app-development/utils/maskinportenScopes.test.ts app-development/features/appPublish/components/CreateRelease.test.tsx`
- `dotnet test src/Designer/backend/tests/Designer.Tests/Designer.Tests.csproj --filter 'FullyQualifiedName~ReleaseServiceTest' --no-restore`\n\ncc @martinothamar