### PR TITLE
fix: show Maskinporten org access error

### DIFF
--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/NoOrgAccessAlert/NoOrgAccessAlert.module.css
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/NoOrgAccessAlert/NoOrgAccessAlert.module.css
@@ -1,0 +1,3 @@
+.noOrgAccessAlert {
+  margin-top: var(--fds-spacing-6);
+}

--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/NoOrgAccessAlert/NoOrgAccessAlert.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/NoOrgAccessAlert/NoOrgAccessAlert.tsx
@@ -1,0 +1,23 @@
+import type { ReactElement } from 'react';
+import { useTranslation } from 'react-i18next';
+import { StudioAlert, StudioHeading, StudioParagraph } from '@studio/components';
+import { LoggedInTitle } from '../LoggedInTitle';
+import classes from './NoOrgAccessAlert.module.css';
+
+export function NoOrgAccessAlert(): ReactElement {
+  const { t } = useTranslation();
+
+  return (
+    <div>
+      <LoggedInTitle />
+      <StudioAlert data-color='warning' className={classes.noOrgAccessAlert}>
+        <StudioHeading data-size='2xs' level={4}>
+          {t('app_settings.maskinporten_no_org_access_title')}
+        </StudioHeading>
+        <StudioParagraph>
+          {t('app_settings.maskinporten_no_org_access_description')}
+        </StudioParagraph>
+      </StudioAlert>
+    </div>
+  );
+}

--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/NoOrgAccessAlert/index.ts
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/NoOrgAccessAlert/index.ts
@@ -1,0 +1,1 @@
+export { NoOrgAccessAlert } from './NoOrgAccessAlert';

--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeListContainer.test.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeListContainer.test.tsx
@@ -7,6 +7,8 @@ import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
 import { queriesMock } from 'app-shared/mocks/queriesMock';
 import { renderWithProviders } from 'app-development/test/mocks';
 import { textMock } from '@studio/testing/mocks/i18nMock';
+import { AxiosError } from 'axios';
+import { ServerCodes } from 'app-shared/enums/ServerCodes';
 
 const scopeMock1: MaskinportenScope = {
   scope: 'scope1',
@@ -107,6 +109,28 @@ describe('ScopeListContainer', () => {
     ).toBeInTheDocument();
   });
 
+  it('should display an alert if user does not have access on behalf of the organisation', async () => {
+    const getMaskinportenScopes = jest
+      .fn()
+      .mockRejectedValue(createAxiosError(ServerCodes.Forbidden));
+    const getSelectedMaskinportenScopes = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve({ scopes: [] }));
+
+    renderScopeListContainer({
+      getMaskinportenScopes,
+      getSelectedMaskinportenScopes,
+    });
+    await waitForGetScopesCheckIsDone();
+
+    expect(
+      getText(textMock('app_settings.maskinporten_no_org_access_description')),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(textMock('app_settings.maskinporten_no_scopes_available_description')),
+    ).not.toBeInTheDocument();
+  });
+
   it('should display add default scopes notice for v8.3 apps when no scopes are available', async () => {
     const getMaskinportenScopes = jest
       .fn()
@@ -154,3 +178,9 @@ const getCell = (name: string): HTMLTableCellElement => screen.getByRole('cell',
 const queryCell = (name: string): HTMLTableCellElement | null =>
   screen.queryByRole('cell', { name });
 const getButton = (name: string): HTMLButtonElement => screen.getByRole('button', { name });
+
+function createAxiosError(status: ServerCodes): AxiosError {
+  const error = new AxiosError();
+  error.response = { status } as AxiosError['response'];
+  return error;
+}

--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeListContainer.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeListContainer.tsx
@@ -1,18 +1,25 @@
 import type { ReactElement } from 'react';
 import { StudioSpinner } from '@studio/components';
+import { isAxiosError } from 'axios';
 import { useGetScopesQuery } from 'app-development/hooks/queries/useGetScopesQuery';
 import { useTranslation } from 'react-i18next';
 import { useGetSelectedScopesQuery } from 'app-development/hooks/queries/useGetSelectedScopesQuery';
 import { NoScopesAlert } from './NoScopesAlert';
+import { NoOrgAccessAlert } from './NoOrgAccessAlert';
 import { ScopeList } from './ScopeList';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useAppVersionQuery } from 'app-shared/hooks/queries';
 import { shouldShowDefaultMaskinportenScopesOptIn } from 'app-development/utils/maskinportenScopes';
+import { ServerCodes } from 'app-shared/enums/ServerCodes';
 
 export function ScopeListContainer(): ReactElement {
   const { t } = useTranslation();
   const { org, app } = useStudioEnvironmentParams();
-  const { data: maskinPortenScopes, isPending: isPendingMaskinportenScopes } = useGetScopesQuery();
+  const {
+    data: maskinPortenScopes,
+    isPending: isPendingMaskinportenScopes,
+    error: maskinportenScopesError,
+  } = useGetScopesQuery();
   const { data: selectedScopes, isPending: isPendingAppScopes } = useGetSelectedScopesQuery();
   const { data: appVersion, isPending: isPendingAppVersion } = useAppVersionQuery(org, app);
 
@@ -29,6 +36,10 @@ export function ScopeListContainer(): ReactElement {
     return <StudioSpinner aria-hidden spinnerTitle={t('general.loading')} />;
   }
 
+  if (isForbiddenError(maskinportenScopesError)) {
+    return <NoOrgAccessAlert />;
+  }
+
   if (hasScopes || shouldShowDefaultScopesOptIn) {
     return (
       <ScopeList
@@ -39,4 +50,8 @@ export function ScopeListContainer(): ReactElement {
   }
 
   return <NoScopesAlert />;
+}
+
+function isForbiddenError(error: unknown): boolean {
+  return isAxiosError(error) && error.response?.status === ServerCodes.Forbidden;
 }

--- a/src/Designer/frontend/app-development/hooks/queries/useGetScopesQuery.ts
+++ b/src/Designer/frontend/app-development/hooks/queries/useGetScopesQuery.ts
@@ -1,14 +1,19 @@
 import { useQuery } from '@tanstack/react-query';
+import type { AxiosError } from 'axios';
 import { QueryKey } from 'app-shared/types/QueryKey';
 import { useServicesContext } from 'app-shared/contexts/ServicesContext';
 import { type MaskinportenScopes } from 'app-shared/types/MaskinportenScope';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
+import { ServerCodes } from 'app-shared/enums/ServerCodes';
 
 export const useGetScopesQuery = () => {
   const { org, app } = useStudioEnvironmentParams();
   const { getMaskinportenScopes } = useServicesContext();
-  return useQuery<MaskinportenScopes>({
+  return useQuery<MaskinportenScopes, AxiosError>({
     queryKey: [QueryKey.AppScopes],
     queryFn: () => getMaskinportenScopes(org, app),
+    meta: {
+      hideDefaultError: (error: AxiosError) => error?.response?.status === ServerCodes.Forbidden,
+    },
   });
 };

--- a/src/Designer/frontend/language/src/en.json
+++ b/src/Designer/frontend/language/src/en.json
@@ -55,6 +55,8 @@
   "app_settings.left_nav_tab_run": "Run",
   "app_settings.maskinporten_add_default_scopes": "Add default scopes",
   "app_settings.maskinporten_default_scopes_opt_in_notice": "This app can use the default Maskinporten scopes for reading and writing instances as service owner.",
+  "app_settings.maskinporten_no_org_access_description": "To select Maskinporten scopes, sign in with Ansattporten on behalf of the organisation that owns the app.",
+  "app_settings.maskinporten_no_org_access_title": "You do not have access on behalf of the organisation",
   "app_settings.maskinporten_scope_changes_deployment_notice": "Scope changes take effect the next time the app is built and deployed.",
   "app_settings.run_tab_heading": "Run",
   "app_settings.run_tab_info": "This setting is used for cost reduction. The app can be undeployed automatically in test environments when it is inactive.",

--- a/src/Designer/frontend/language/src/nb.json
+++ b/src/Designer/frontend/language/src/nb.json
@@ -381,6 +381,8 @@
   "app_settings.maskinporten_add_scope_dialog_done": "Fullfør",
   "app_settings.maskinporten_add_scope_dialog_title": "Legg til nytt scope",
   "app_settings.maskinporten_default_scopes_opt_in_notice": "Denne appen kan bruke standard Maskinporten-scopes for å lese og skrive instanser som tjenesteeier.",
+  "app_settings.maskinporten_no_org_access_description": "For å velge Maskinporten-scopes må du logge inn med Ansattporten på vegne av virksomheten som eier appen.",
+  "app_settings.maskinporten_no_org_access_title": "Du har ikke tilgang på vegne av virksomheten",
   "app_settings.maskinporten_no_scopes_added": "Ingen scopes er lagt til i appen.",
   "app_settings.maskinporten_no_scopes_available_description": "Før du kan velge scopes her i Studio, må du sjekke at du har tilgang til Maskinporten.",
   "app_settings.maskinporten_no_scopes_available_link": "Ta kontakt med Altinn servicedesk for å få hjelp til å sette opp scopes.",


### PR DESCRIPTION
## Description

Shows a scoped warning in the Maskinporten tab when Studio cannot read Maskinporten scopes because the signed-in Ansattporten user is not authorised on behalf of the app owner organisation.

The Maskinporten scopes query now suppresses the default global error toast only for `403 Forbidden`, and `ScopeListContainer` renders an inline warning explaining that the user must sign in with Ansattporten on behalf of the app owner organisation.

## Screenshot

![Maskinporten org access warning](https://raw.githubusercontent.com/martinothamar-agent/altinn-studio/artifact/maskinporten-org-access-alert/maskinporten-org-access-alert.png)

## Verification

- [x] Related issues are connected (not applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

Manual/browser verification:

- Ran Studio Designer locally with `yarn start-app-development`.
- Opened the Maskinporten app settings tab with the Maskinporten scopes endpoint mocked to return `403 Forbidden`.
- Dismissed the cookie banner and verified the page shows the inline org access warning without the generic error toast.

Automated verification:

- `yarn test app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeListContainer.test.tsx`
- `yarn typecheck`
- `yarn prettier --check app-development/hooks/queries/useGetScopesQuery.ts app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeListContainer.tsx app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeListContainer.test.tsx app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/NoOrgAccessAlert/NoOrgAccessAlert.tsx language/src/nb.json language/src/en.json`

cc @martinothamar
