### PR TITLE
fix: keep Maskinporten scopes visible without org access

### DIFF
--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.module.css
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.module.css
@@ -21,6 +21,11 @@
 
 .tableWrapper {
   margin-top: var(--ds-size-6);
+  width: 100%;
+}
+
+.tableWrapper table {
+  width: 100%;
 }
 
 .dialog[open] {

--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.tsx
@@ -44,9 +44,14 @@ import {
 export type ScopeListProps = {
   maskinPortenScopes: MaskinportenScope[];
   selectedScopes: MaskinportenScope[];
+  canManageScopes?: boolean;
 };
 
-export function ScopeList({ maskinPortenScopes, selectedScopes }: ScopeListProps): ReactElement {
+export function ScopeList({
+  maskinPortenScopes,
+  selectedScopes,
+  canManageScopes = true,
+}: ScopeListProps): ReactElement {
   const { t } = useTranslation();
   const { org, app } = useStudioEnvironmentParams();
   const { data: appVersion } = useAppVersionQuery(org, app);
@@ -82,40 +87,47 @@ export function ScopeList({ maskinPortenScopes, selectedScopes }: ScopeListProps
 
   return (
     <div>
-      <LoggedInTitle />
-      <StudioParagraph className={classes.informationText}>
-        {t('app_settings.maskinporten_tab_available_scopes_description')}
-      </StudioParagraph>
-      <StudioParagraph className={classes.informationText}>
-        <Trans i18nKey='app_settings.maskinporten_tab_available_scopes_description_help'>
-          <StudioLink href={contactByEmail.url('serviceOwner')}> </StudioLink>
-        </Trans>
-      </StudioParagraph>
-      <StudioAlert data-color='info' className={classes.deploymentNotice}>
-        {t('app_settings.maskinporten_scope_changes_deployment_notice')}
-      </StudioAlert>
-      <DefaultScopesNotice
-        shouldShowDefaultScopesOptIn={shouldShowDefaultScopesOptIn}
-        initialValues={initialValues}
-        allAvailableScopes={allAvailableScopes}
-      />
+      {canManageScopes && (
+        <>
+          <LoggedInTitle />
+          <StudioParagraph className={classes.informationText}>
+            {t('app_settings.maskinporten_tab_available_scopes_description')}
+          </StudioParagraph>
+          <StudioParagraph className={classes.informationText}>
+            <Trans i18nKey='app_settings.maskinporten_tab_available_scopes_description_help'>
+              <StudioLink href={contactByEmail.url('serviceOwner')}> </StudioLink>
+            </Trans>
+          </StudioParagraph>
+          <StudioAlert data-color='info' className={classes.deploymentNotice}>
+            {t('app_settings.maskinporten_scope_changes_deployment_notice')}
+          </StudioAlert>
+          <DefaultScopesNotice
+            shouldShowDefaultScopesOptIn={shouldShowDefaultScopesOptIn}
+            initialValues={initialValues}
+            allAvailableScopes={allAvailableScopes}
+          />
 
-      <StudioButton variant='secondary' onClick={openDialog} icon={<PlusIcon />}>
-        {t('app_settings.maskinporten_add_scope')}
-      </StudioButton>
+          <StudioButton variant='secondary' onClick={openDialog} icon={<PlusIcon />}>
+            {t('app_settings.maskinporten_add_scope')}
+          </StudioButton>
+        </>
+      )}
 
       <SelectedScopesTable
         selectedScopes={sortedSelectedScopes}
         initialValues={initialValues}
         allAvailableScopes={allAvailableScopes}
+        canManageScopes={canManageScopes}
       />
-      <AddScopesDialog
-        dialogRef={dialogRef}
-        searchValue={searchValue}
-        setSearchValue={setSearchValue}
-        initialValues={initialValues}
-        allAvailableScopes={allAvailableScopes}
-      />
+      {canManageScopes && (
+        <AddScopesDialog
+          dialogRef={dialogRef}
+          searchValue={searchValue}
+          setSearchValue={setSearchValue}
+          initialValues={initialValues}
+          allAvailableScopes={allAvailableScopes}
+        />
+      )}
     </div>
   );
 }
@@ -156,12 +168,14 @@ type SelectedScopesTableProps = {
   selectedScopes: MaskinportenScope[];
   initialValues: string[];
   allAvailableScopes: MaskinportenScope[];
+  canManageScopes: boolean;
 };
 
 function SelectedScopesTable({
   selectedScopes,
   initialValues,
   allAvailableScopes,
+  canManageScopes,
 }: SelectedScopesTableProps): ReactElement {
   const { t } = useTranslation();
   const { saveScopes } = useSaveScopes(allAvailableScopes);
@@ -192,7 +206,9 @@ function SelectedScopesTable({
               {t('app_settings.maskinporten_scope_name')}
             </StudioTable.HeaderCell>
             <StudioTable.HeaderCell>{t('general.description')}</StudioTable.HeaderCell>
-            <StudioTable.HeaderCell>{t('general.delete')}</StudioTable.HeaderCell>
+            {canManageScopes && (
+              <StudioTable.HeaderCell>{t('general.delete')}</StudioTable.HeaderCell>
+            )}
           </StudioTable.Row>
         </StudioTable.Head>
         <StudioTable.Body>
@@ -203,14 +219,16 @@ function SelectedScopesTable({
               <StudioTable.Row key={scope.scope}>
                 <StudioTable.Cell>{scope.scope}</StudioTable.Cell>
                 <StudioTable.Cell>{scope.description}</StudioTable.Cell>
-                <StudioTable.Cell>
-                  <StudioDeleteButton
-                    variant='tertiary'
-                    aria-label={t('general.delete_item', { item: scope.scope })}
-                    disabled={isDefaultScope}
-                    onDelete={() => deleteScope(scope.scope)}
-                  />
-                </StudioTable.Cell>
+                {canManageScopes && (
+                  <StudioTable.Cell>
+                    <StudioDeleteButton
+                      variant='tertiary'
+                      aria-label={t('general.delete_item', { item: scope.scope })}
+                      disabled={isDefaultScope}
+                      onDelete={() => deleteScope(scope.scope)}
+                    />
+                  </StudioTable.Cell>
+                )}
               </StudioTable.Row>
             );
           })}

--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeListContainer.module.css
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeListContainer.module.css
@@ -1,0 +1,5 @@
+.noOrgAccessContent {
+  display: flex;
+  flex-direction: column;
+  max-width: 100%;
+}

--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeListContainer.test.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeListContainer.test.tsx
@@ -131,6 +131,41 @@ describe('ScopeListContainer', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('should display selected scopes without management controls if user does not have access on behalf of the organisation', async () => {
+    const getMaskinportenScopes = jest
+      .fn()
+      .mockRejectedValue(createAxiosError(ServerCodes.Forbidden));
+    const getSelectedMaskinportenScopes = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve(maskinportenScopes));
+
+    renderScopeListContainer({
+      getMaskinportenScopes,
+      getSelectedMaskinportenScopes,
+    });
+    await waitForGetScopesCheckIsDone();
+
+    expect(
+      getText(textMock('app_settings.maskinporten_no_org_access_description')),
+    ).toBeInTheDocument();
+    maskinportenScopes.scopes.forEach((scope: MaskinportenScope) => {
+      expect(getCell(scope.description)).toBeInTheDocument();
+      expect(getCell(scope.scope)).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', {
+          name: textMock('general.delete_item', { item: scope.scope }),
+        }),
+      ).not.toBeInTheDocument();
+    });
+    expect(queryButton(textMock('app_settings.maskinporten_add_scope'))).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(textMock('app_settings.maskinporten_tab_available_scopes_description')),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(textMock('app_settings.maskinporten_scope_changes_deployment_notice')),
+    ).not.toBeInTheDocument();
+  });
+
   it('should display add default scopes notice for v8.3 apps when no scopes are available', async () => {
     const getMaskinportenScopes = jest
       .fn()
@@ -178,6 +213,8 @@ const getCell = (name: string): HTMLTableCellElement => screen.getByRole('cell',
 const queryCell = (name: string): HTMLTableCellElement | null =>
   screen.queryByRole('cell', { name });
 const getButton = (name: string): HTMLButtonElement => screen.getByRole('button', { name });
+const queryButton = (name: string): HTMLButtonElement | null =>
+  screen.queryByRole('button', { name });
 
 function createAxiosError(status: ServerCodes): AxiosError {
   const error = new AxiosError();

--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeListContainer.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeListContainer.tsx
@@ -11,6 +11,7 @@ import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmen
 import { useAppVersionQuery } from 'app-shared/hooks/queries';
 import { shouldShowDefaultMaskinportenScopesOptIn } from 'app-development/utils/maskinportenScopes';
 import { ServerCodes } from 'app-shared/enums/ServerCodes';
+import classes from './ScopeListContainer.module.css';
 
 export function ScopeListContainer(): ReactElement {
   const { t } = useTranslation();
@@ -49,7 +50,7 @@ export function ScopeListContainer(): ReactElement {
 
   if (!hasOrgAccess) {
     return (
-      <>
+      <div className={classes.noOrgAccessContent}>
         <NoOrgAccessAlert />
         {selectedScopes?.scopes?.length > 0 && (
           <ScopeList
@@ -58,7 +59,7 @@ export function ScopeListContainer(): ReactElement {
             canManageScopes={false}
           />
         )}
-      </>
+      </div>
     );
   }
 

--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeListContainer.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeListContainer.tsx
@@ -36,16 +36,29 @@ export function ScopeListContainer(): ReactElement {
     return <StudioSpinner aria-hidden spinnerTitle={t('general.loading')} />;
   }
 
-  if (isForbiddenError(maskinportenScopesError)) {
-    return <NoOrgAccessAlert />;
-  }
+  const hasOrgAccess: boolean = !isForbiddenError(maskinportenScopesError);
 
-  if (hasScopes || shouldShowDefaultScopesOptIn) {
+  if (hasOrgAccess && (hasScopes || shouldShowDefaultScopesOptIn)) {
     return (
       <ScopeList
         maskinPortenScopes={maskinPortenScopes?.scopes ?? []}
         selectedScopes={selectedScopes?.scopes ?? []}
       />
+    );
+  }
+
+  if (!hasOrgAccess) {
+    return (
+      <>
+        <NoOrgAccessAlert />
+        {selectedScopes?.scopes?.length > 0 && (
+          <ScopeList
+            maskinPortenScopes={[]}
+            selectedScopes={selectedScopes.scopes}
+            canManageScopes={false}
+          />
+        )}
+      </>
     );
   }
 


### PR DESCRIPTION
## Summary
- keep already-registered app Maskinporten scopes visible when the available-scopes request returns 403
- render the selected scope table in read-only mode without add, delete, default-scope opt-in, or available-scope dialog controls
- cover the 403 + selected scopes case in `ScopeListContainer` tests

## Why
Users without access on behalf of the app owner organisation still need to see which scopes are registered on the app. The 403 only means Studio cannot list or mutate scopes through Maskinporten self-service for that user.

## Screenshot
![No access state with registered scopes visible](https://raw.githubusercontent.com/martinothamar-agent/altinn-studio/pr-assets/maskinporten-readonly-scopes/pr-assets/maskinporten-no-access-readonly-scopes.png)

## Testing
- `yarn test app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeListContainer.test.tsx`
- `yarn prettier --check app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeListContainer.tsx app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.tsx app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeListContainer.test.tsx`
- `yarn typecheck`
- Manual Playwright screenshot with `/app-scopes/maskinporten` mocked as 403 and selected scopes returned from `/app-scopes`

cc @martinothamar
