### PR TITLE
fix: refresh yarn lock for immutable install

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9542,7 +9542,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axe-core@npm:4.11.4":
+"axe-core@npm:4.11.4, axe-core@npm:^4.2.0":
   version: 4.11.4
   resolution: "axe-core@npm:4.11.4"
   checksum: 10/49095daa422d05d99a90b39301a3b5c971e234a4593403dfd6701df637a3e550bcfd7bd096709c5643564dd069208513247791f367790e0605d15386fb2a7bfe
@@ -9553,13 +9553,6 @@ __metadata:
   version: 4.11.0
   resolution: "axe-core@npm:4.11.0"
   checksum: 10/18254ee95bc328aec9a909b22e4b22e8ff14a21363fdbd1a5227267e66bf1d2fc1425c186e9001759aab5827cf4ee9dc30f7ea57e8200cbf7a1cd555ed21a908
-  languageName: node
-  linkType: hard
-
-"axe-core@npm:^4.2.0":
-  version: 4.11.4
-  resolution: "axe-core@npm:4.11.4"
-  checksum: 10/49095daa422d05d99a90b39301a3b5c971e234a4593403dfd6701df637a3e550bcfd7bd096709c5643564dd069208513247791f367790e0605d15386fb2a7bfe
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- refresh `yarn.lock` so Yarn 4.12.0 merges duplicate `axe-core` entries
- fixes the `yarn --immutable` failure currently seen on `main` Docker/frontend builds

## Why
`main` is failing in https://github.com/Altinn/altinn-studio/actions/runs/26171754766/job/76991119339 because Yarn wants to normalize the `axe-core@npm:4.11.4` and `axe-core@npm:^4.2.0` lock entries, but immutable installs reject that generated lockfile change.

## Testing
- `node .yarn/releases/yarn-4.12.0.cjs install --immutable --inline-builds`

cc @martinothamar