### PR TITLE
ci: build Designer before EF migrations checks

### DIFF
--- a/.github/workflows/designer-backend-dotnet-migrations-ensure-compatibility.yaml
+++ b/.github/workflows/designer-backend-dotnet-migrations-ensure-compatibility.yaml
@@ -34,12 +34,18 @@ jobs:
       - name: Install dotnet ef # Version should be the same as Migrations docker file and project
         run: dotnet tool install --version 9.0.0 --global dotnet-ef
 
+      - name: Build Designer backend
+        run: |
+            dotnet restore backend/src/Designer/Designer.csproj
+            dotnet build backend/src/Designer/Designer.csproj --no-restore
+        working-directory: src/Designer
+
       - name: Check if migrations script can be generated
         run: |
-            dotnet ef migrations script --project backend/src/Designer
+            dotnet ef migrations script --project backend/src/Designer --no-build
         working-directory: src/Designer
 
       - name: Check if it's possible to add a new migration
         run: |
-            dotnet ef migrations add Test --project backend/src/Designer
+            dotnet ef migrations add Test --project backend/src/Designer --no-build
         working-directory: src/Designer

--- a/src/Designer/backend/Migrations.Dockerfile
+++ b/src/Designer/backend/Migrations.Dockerfile
@@ -13,7 +13,9 @@ ENV OidcLoginSettings__ClientSecret=dummyRequired
 ENV FeatureManagement__StudioOidc=false
 ENV StudioOidcLoginSettings__FetchClientIdAndSecretFromRootEnvFile=false
 
-RUN dotnet ef migrations script --project src/Designer/Designer.csproj --idempotent -o /app/migrations.sql
+RUN dotnet restore src/Designer/Designer.csproj && \
+    dotnet build src/Designer/Designer.csproj --no-restore && \
+    dotnet ef migrations script --project src/Designer/Designer.csproj --no-build --idempotent -o /app/migrations.sql
 
 FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659 AS final
 COPY --from=build /app/migrations.sql migrations.sql


### PR DESCRIPTION
## Summary
- restore and build Designer explicitly before generating EF migration scripts in CI
- mirror the same restore/build/no-build script flow in the migration Docker image

## Why
Keeps the migration checks deterministic after the SDK/runtime setup changes by making the build step explicit instead of relying on `dotnet ef` to do it implicitly.

## Testing
- `dotnet restore backend/src/Designer/Designer.csproj`
- `dotnet build backend/src/Designer/Designer.csproj --no-restore`
- `dotnet ef migrations script --project backend/src/Designer --no-build`
- `docker compose build database_migrations`

cc @martinothamar