### PR TITLE
fix: hide Maskinporten for personal apps

### DIFF
--- a/src/Designer/backend/src/Designer/Constants/AppScopesErrorMessages.cs
+++ b/src/Designer/backend/src/Designer/Constants/AppScopesErrorMessages.cs
@@ -1,0 +1,9 @@
+namespace Altinn.Studio.Designer.Constants;
+
+public static class AppScopesErrorMessages
+{
+    public const string NotSupportedTitle = "Maskinporten scopes are not supported for this app";
+
+    public static string NotSupportedDetail(string org) =>
+        $"Maskinporten scopes are only supported for service-owner organisations. '{org}' is not a service-owner organisation.";
+}

--- a/src/Designer/backend/src/Designer/Controllers/AppScopesController.cs
+++ b/src/Designer/backend/src/Designer/Controllers/AppScopesController.cs
@@ -102,9 +102,8 @@ public class AppScopesController(
     private static ProblemDetails CreateAppScopesNotSupportedProblemDetails(string org) =>
         new()
         {
-            Title = "Maskinporten scopes are not supported for this app",
-            Detail =
-                $"Maskinporten scopes are only supported for service-owner organisations. '{org}' is not a service-owner organisation.",
+            Title = AppScopesErrorMessages.NotSupportedTitle,
+            Detail = AppScopesErrorMessages.NotSupportedDetail(org),
             Status = StatusCodes.Status400BadRequest,
         };
 }

--- a/src/Designer/backend/src/Designer/Controllers/AppScopesController.cs
+++ b/src/Designer/backend/src/Designer/Controllers/AppScopesController.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Constants;
+using Altinn.Studio.Designer.Exceptions.AppScopes;
 using Altinn.Studio.Designer.Helpers;
 using Altinn.Studio.Designer.Infrastructure.StudioOidc;
 using Altinn.Studio.Designer.Models;
@@ -43,7 +44,7 @@ public class AppScopesController(IMaskinPortenHttpClient maskinPortenHttpClient,
 
     [Authorize]
     [HttpPut]
-    public async Task UpsertAppScopes(
+    public async Task<IActionResult> UpsertAppScopes(
         string org,
         string app,
         [FromBody] AppScopesUpsertRequest appScopesUpsertRequest,
@@ -55,21 +56,38 @@ public class AppScopesController(IMaskinPortenHttpClient maskinPortenHttpClient,
             .ToHashSet();
 
         string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
-        await appScopesService.UpsertScopesAsync(
-            AltinnRepoEditingContext.FromOrgRepoDeveloper(org, app, developer),
-            scopes,
-            cancellationToken
-        );
+        try
+        {
+            await appScopesService.UpsertScopesAsync(
+                AltinnRepoEditingContext.FromOrgRepoDeveloper(org, app, developer),
+                scopes,
+                cancellationToken
+            );
+        }
+        catch (AppScopesNotSupportedException exception)
+        {
+            return BadRequest(exception.Message);
+        }
+
+        return Ok();
     }
 
     [Authorize]
     [HttpGet]
     public async Task<IActionResult> GetAppScopes(string org, string app, CancellationToken cancellationToken)
     {
-        var appScopes = await appScopesService.GetAppScopesAsync(
-            AltinnRepoContext.FromOrgRepo(org, app),
-            cancellationToken
-        );
+        AppScopesEntity? appScopes;
+        try
+        {
+            appScopes = await appScopesService.GetAppScopesAsync(
+                AltinnRepoContext.FromOrgRepo(org, app),
+                cancellationToken
+            );
+        }
+        catch (AppScopesNotSupportedException exception)
+        {
+            return BadRequest(exception.Message);
+        }
 
         var reponse = new AppScopesResponse()
         {

--- a/src/Designer/backend/src/Designer/Controllers/AppScopesController.cs
+++ b/src/Designer/backend/src/Designer/Controllers/AppScopesController.cs
@@ -19,8 +19,11 @@ namespace Altinn.Studio.Designer.Controllers;
 [ApiController]
 [FeatureGate(StudioFeatureFlags.StudioOidc)]
 [Route("designer/api/{org}/{app:regex(^(?!datamodels$)[[a-z]][[a-z0-9-]]{{1,28}}[[a-z0-9]]$)}/app-scopes")]
-public class AppScopesController(IMaskinPortenHttpClient maskinPortenHttpClient, IAppScopesService appScopesService)
-    : ControllerBase
+public class AppScopesController(
+    IMaskinPortenHttpClient maskinPortenHttpClient,
+    IAppScopesService appScopesService,
+    IEnvironmentsService environmentsService
+) : ControllerBase
 {
     [Authorize(StudioOidcConstants.OrgAccessAuthorizationPolicy)]
     [HttpGet("maskinporten")]
@@ -51,23 +54,21 @@ public class AppScopesController(IMaskinPortenHttpClient maskinPortenHttpClient,
         CancellationToken cancellationToken
     )
     {
+        if (!await environmentsService.IsAltinnOrg(org, cancellationToken))
+        {
+            return BadRequest(AppScopesNotSupportedException.CreateMessage(org));
+        }
+
         var scopes = appScopesUpsertRequest
             .Scopes.Select(x => new MaskinPortenScopeEntity() { Scope = x.Scope, Description = x.Description })
             .ToHashSet();
 
         string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
-        try
-        {
-            await appScopesService.UpsertScopesAsync(
-                AltinnRepoEditingContext.FromOrgRepoDeveloper(org, app, developer),
-                scopes,
-                cancellationToken
-            );
-        }
-        catch (AppScopesNotSupportedException exception)
-        {
-            return BadRequest(exception.Message);
-        }
+        await appScopesService.UpsertScopesAsync(
+            AltinnRepoEditingContext.FromOrgRepoDeveloper(org, app, developer),
+            scopes,
+            cancellationToken
+        );
 
         return Ok();
     }
@@ -76,18 +77,15 @@ public class AppScopesController(IMaskinPortenHttpClient maskinPortenHttpClient,
     [HttpGet]
     public async Task<IActionResult> GetAppScopes(string org, string app, CancellationToken cancellationToken)
     {
-        AppScopesEntity? appScopes;
-        try
+        if (!await environmentsService.IsAltinnOrg(org, cancellationToken))
         {
-            appScopes = await appScopesService.GetAppScopesAsync(
-                AltinnRepoContext.FromOrgRepo(org, app),
-                cancellationToken
-            );
+            return BadRequest(AppScopesNotSupportedException.CreateMessage(org));
         }
-        catch (AppScopesNotSupportedException exception)
-        {
-            return BadRequest(exception.Message);
-        }
+
+        var appScopes = await appScopesService.GetAppScopesAsync(
+            AltinnRepoContext.FromOrgRepo(org, app),
+            cancellationToken
+        );
 
         var reponse = new AppScopesResponse()
         {

--- a/src/Designer/backend/src/Designer/Controllers/AppScopesController.cs
+++ b/src/Designer/backend/src/Designer/Controllers/AppScopesController.cs
@@ -2,7 +2,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Constants;
-using Altinn.Studio.Designer.Exceptions.AppScopes;
 using Altinn.Studio.Designer.Helpers;
 using Altinn.Studio.Designer.Infrastructure.StudioOidc;
 using Altinn.Studio.Designer.Models;
@@ -11,6 +10,7 @@ using Altinn.Studio.Designer.Repository.Models.AppScope;
 using Altinn.Studio.Designer.Services.Interfaces;
 using Altinn.Studio.Designer.TypedHttpClients.MaskinPorten;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.FeatureManagement.Mvc;
 
@@ -56,7 +56,7 @@ public class AppScopesController(
     {
         if (!await environmentsService.IsAltinnOrg(org, cancellationToken))
         {
-            return BadRequest(AppScopesNotSupportedException.CreateMessage(org));
+            return BadRequest(CreateAppScopesNotSupportedProblemDetails(org));
         }
 
         var scopes = appScopesUpsertRequest
@@ -79,7 +79,7 @@ public class AppScopesController(
     {
         if (!await environmentsService.IsAltinnOrg(org, cancellationToken))
         {
-            return BadRequest(AppScopesNotSupportedException.CreateMessage(org));
+            return BadRequest(CreateAppScopesNotSupportedProblemDetails(org));
         }
 
         var appScopes = await appScopesService.GetAppScopesAsync(
@@ -98,4 +98,13 @@ public class AppScopesController(
 
         return Ok(reponse);
     }
+
+    private static ProblemDetails CreateAppScopesNotSupportedProblemDetails(string org) =>
+        new()
+        {
+            Title = "Maskinporten scopes are not supported for this app",
+            Detail =
+                $"Maskinporten scopes are only supported for service-owner organisations. '{org}' is not a service-owner organisation.",
+            Status = StatusCodes.Status400BadRequest,
+        };
 }

--- a/src/Designer/backend/src/Designer/Exceptions/AppScopes/AppScopesNotSupportedException.cs
+++ b/src/Designer/backend/src/Designer/Exceptions/AppScopes/AppScopesNotSupportedException.cs
@@ -2,7 +2,8 @@ using System;
 
 namespace Altinn.Studio.Designer.Exceptions.AppScopes;
 
-public sealed class AppScopesNotSupportedException(string org)
-    : Exception(
-        $"Maskinporten scopes are only supported for service-owner organisations. '{org}' is not a service-owner organisation."
-    );
+public sealed class AppScopesNotSupportedException(string org) : Exception(CreateMessage(org))
+{
+    public static string CreateMessage(string org) =>
+        $"Maskinporten scopes are only supported for service-owner organisations. '{org}' is not a service-owner organisation.";
+}

--- a/src/Designer/backend/src/Designer/Exceptions/AppScopes/AppScopesNotSupportedException.cs
+++ b/src/Designer/backend/src/Designer/Exceptions/AppScopes/AppScopesNotSupportedException.cs
@@ -1,9 +1,0 @@
-using System;
-
-namespace Altinn.Studio.Designer.Exceptions.AppScopes;
-
-public sealed class AppScopesNotSupportedException(string org) : Exception(CreateMessage(org))
-{
-    public static string CreateMessage(string org) =>
-        $"Maskinporten scopes are only supported for service-owner organisations. '{org}' is not a service-owner organisation.";
-}

--- a/src/Designer/backend/src/Designer/Exceptions/AppScopes/AppScopesNotSupportedException.cs
+++ b/src/Designer/backend/src/Designer/Exceptions/AppScopes/AppScopesNotSupportedException.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace Altinn.Studio.Designer.Exceptions.AppScopes;
+
+public sealed class AppScopesNotSupportedException(string org)
+    : Exception(
+        $"Maskinporten scopes are only supported for service-owner organisations. '{org}' is not a service-owner organisation."
+    );

--- a/src/Designer/backend/src/Designer/Services/Implementation/AppScopesService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/AppScopesService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using Altinn.Studio.Designer.Constants;
 using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Repository;
 using Altinn.Studio.Designer.Repository.Models.AppScope;
@@ -85,9 +86,7 @@ public class AppScopesService : IAppScopesService
     {
         if (!await IsServiceOwnerOrg(org, cancellationToken))
         {
-            throw new InvalidOperationException(
-                $"Maskinporten scopes are only supported for service-owner organisations. '{org}' is not a service-owner organisation."
-            );
+            throw new InvalidOperationException(AppScopesErrorMessages.NotSupportedDetail(org));
         }
     }
 

--- a/src/Designer/backend/src/Designer/Services/Implementation/AppScopesService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/AppScopesService.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
-using Altinn.Studio.Designer.Exceptions.AppScopes;
 using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Repository;
 using Altinn.Studio.Designer.Repository.Models.AppScope;
@@ -86,7 +85,9 @@ public class AppScopesService : IAppScopesService
     {
         if (!await IsServiceOwnerOrg(org, cancellationToken))
         {
-            throw new AppScopesNotSupportedException(org);
+            throw new InvalidOperationException(
+                $"Maskinporten scopes are only supported for service-owner organisations. '{org}' is not a service-owner organisation."
+            );
         }
     }
 

--- a/src/Designer/backend/src/Designer/Services/Implementation/AppScopesService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/AppScopesService.cs
@@ -7,27 +7,42 @@ using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Repository;
 using Altinn.Studio.Designer.Repository.Models.AppScope;
 using Altinn.Studio.Designer.Services.Interfaces;
+using Microsoft.Extensions.Logging;
 
 namespace Altinn.Studio.Designer.Services.Implementation;
 
 public class AppScopesService : IAppScopesService
 {
     private readonly IAppScopesRepository _appRepository;
+    private readonly IEnvironmentsService _environmentsService;
+    private readonly ILogger<AppScopesService> _logger;
     private readonly TimeProvider _timeProvider;
 
-    public AppScopesService(IAppScopesRepository appRepository, TimeProvider timeProvider)
+    public AppScopesService(
+        IAppScopesRepository appRepository,
+        IEnvironmentsService environmentsService,
+        ILogger<AppScopesService> logger,
+        TimeProvider timeProvider
+    )
     {
         _appRepository = appRepository;
+        _environmentsService = environmentsService;
+        _logger = logger;
         _timeProvider = timeProvider;
     }
 
-    public Task<AppScopesEntity> GetAppScopesAsync(
+    public async Task<AppScopesEntity> GetAppScopesAsync(
         AltinnRepoContext context,
         CancellationToken cancellationToken = default
     )
     {
         cancellationToken.ThrowIfCancellationRequested();
-        return _appRepository.GetAppScopesAsync(context, cancellationToken);
+        if (!await IsServiceOwnerOrg(context.Org, cancellationToken))
+        {
+            return null;
+        }
+
+        return await _appRepository.GetAppScopesAsync(context, cancellationToken);
     }
 
     public async Task<AppScopesEntity> UpsertScopesAsync(
@@ -37,6 +52,11 @@ public class AppScopesService : IAppScopesService
     )
     {
         cancellationToken.ThrowIfCancellationRequested();
+        if (!await IsServiceOwnerOrg(editingContext.Org, cancellationToken))
+        {
+            return null;
+        }
+
         var appScopes =
             await _appRepository.GetAppScopesAsync(editingContext, cancellationToken)
             ?? GenerateNewAppScopesEntity(editingContext);
@@ -52,6 +72,11 @@ public class AppScopesService : IAppScopesService
     )
     {
         cancellationToken.ThrowIfCancellationRequested();
+        if (!await IsServiceOwnerOrg(editingContext.Org, cancellationToken))
+        {
+            return null;
+        }
+
         var appScopes =
             await _appRepository.GetAppScopesAsync(editingContext, cancellationToken)
             ?? GenerateNewAppScopesEntity(editingContext);
@@ -64,6 +89,23 @@ public class AppScopesService : IAppScopesService
         appScopes.Scopes = DefaultMaskinportenScopes.MergeWith(appScopes.Scopes);
         appScopes.LastModifiedBy = editingContext.Developer;
         return await _appRepository.UpsertAppScopesAsync(appScopes, cancellationToken);
+    }
+
+    private async Task<bool> IsServiceOwnerOrg(string org, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await _environmentsService.IsAltinnOrg(org, cancellationToken);
+        }
+        catch (Exception exception)
+        {
+            _logger.LogWarning(
+                exception,
+                "Unable to determine whether {Org} is a registered service owner organization. Skipping app scopes.",
+                org
+            );
+            return false;
+        }
     }
 
     private AppScopesEntity GenerateNewAppScopesEntity(AltinnRepoEditingContext context)

--- a/src/Designer/backend/src/Designer/Services/Implementation/AppScopesService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/AppScopesService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -96,17 +95,10 @@ public class AppScopesService : IAppScopesService
         }
         catch (Exception exception)
         {
-            Activity.Current?.AddEvent(
-                new ActivityEvent(
-                    "app_scopes.service_owner_lookup_failed",
-                    tags: new ActivityTagsCollection
-                    {
-                        ["org"] = org,
-                        ["exception.type"] = exception.GetType().FullName,
-                        ["exception.message"] = exception.Message,
-                    }
-                )
-            );
+            var activity = Activity.Current;
+            activity?.SetTag("org", org);
+            activity?.AddException(exception);
+            activity?.SetStatus(ActivityStatusCode.Error, exception.GetType().Name);
             return false;
         }
     }

--- a/src/Designer/backend/src/Designer/Services/Implementation/AppScopesService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/AppScopesService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using Altinn.Studio.Designer.Exceptions.AppScopes;
 using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Repository;
 using Altinn.Studio.Designer.Repository.Models.AppScope;
@@ -33,10 +34,7 @@ public class AppScopesService : IAppScopesService
     )
     {
         cancellationToken.ThrowIfCancellationRequested();
-        if (!await IsServiceOwnerOrg(context.Org, cancellationToken))
-        {
-            return null;
-        }
+        await EnsureServiceOwnerOrg(context.Org, cancellationToken);
 
         return await _appRepository.GetAppScopesAsync(context, cancellationToken);
     }
@@ -48,10 +46,7 @@ public class AppScopesService : IAppScopesService
     )
     {
         cancellationToken.ThrowIfCancellationRequested();
-        if (!await IsServiceOwnerOrg(editingContext.Org, cancellationToken))
-        {
-            return null;
-        }
+        await EnsureServiceOwnerOrg(editingContext.Org, cancellationToken);
 
         var appScopes =
             await _appRepository.GetAppScopesAsync(editingContext, cancellationToken)
@@ -85,6 +80,14 @@ public class AppScopesService : IAppScopesService
         appScopes.Scopes = DefaultMaskinportenScopes.MergeWith(appScopes.Scopes);
         appScopes.LastModifiedBy = editingContext.Developer;
         return await _appRepository.UpsertAppScopesAsync(appScopes, cancellationToken);
+    }
+
+    private async Task EnsureServiceOwnerOrg(string org, CancellationToken cancellationToken)
+    {
+        if (!await IsServiceOwnerOrg(org, cancellationToken))
+        {
+            throw new AppScopesNotSupportedException(org);
+        }
     }
 
     private async Task<bool> IsServiceOwnerOrg(string org, CancellationToken cancellationToken)

--- a/src/Designer/backend/src/Designer/Services/Implementation/AppScopesService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/AppScopesService.cs
@@ -93,6 +93,10 @@ public class AppScopesService : IAppScopesService
         {
             return await _environmentsService.IsAltinnOrg(org, cancellationToken);
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception exception)
         {
             var activity = Activity.Current;

--- a/src/Designer/backend/src/Designer/Services/Implementation/AppScopesService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/AppScopesService.cs
@@ -1,13 +1,13 @@
-#nullable disable
+#nullable enable
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Repository;
 using Altinn.Studio.Designer.Repository.Models.AppScope;
 using Altinn.Studio.Designer.Services.Interfaces;
-using Microsoft.Extensions.Logging;
 
 namespace Altinn.Studio.Designer.Services.Implementation;
 
@@ -15,23 +15,20 @@ public class AppScopesService : IAppScopesService
 {
     private readonly IAppScopesRepository _appRepository;
     private readonly IEnvironmentsService _environmentsService;
-    private readonly ILogger<AppScopesService> _logger;
     private readonly TimeProvider _timeProvider;
 
     public AppScopesService(
         IAppScopesRepository appRepository,
         IEnvironmentsService environmentsService,
-        ILogger<AppScopesService> logger,
         TimeProvider timeProvider
     )
     {
         _appRepository = appRepository;
         _environmentsService = environmentsService;
-        _logger = logger;
         _timeProvider = timeProvider;
     }
 
-    public async Task<AppScopesEntity> GetAppScopesAsync(
+    public async Task<AppScopesEntity?> GetAppScopesAsync(
         AltinnRepoContext context,
         CancellationToken cancellationToken = default
     )
@@ -45,7 +42,7 @@ public class AppScopesService : IAppScopesService
         return await _appRepository.GetAppScopesAsync(context, cancellationToken);
     }
 
-    public async Task<AppScopesEntity> UpsertScopesAsync(
+    public async Task<AppScopesEntity?> UpsertScopesAsync(
         AltinnRepoEditingContext editingContext,
         ISet<MaskinPortenScopeEntity> scopes,
         CancellationToken cancellationToken = default
@@ -66,7 +63,7 @@ public class AppScopesService : IAppScopesService
         return await _appRepository.UpsertAppScopesAsync(appScopes, cancellationToken);
     }
 
-    public async Task<AppScopesEntity> AddDefaultMaskinportenScopesAsync(
+    public async Task<AppScopesEntity?> AddDefaultMaskinportenScopesAsync(
         AltinnRepoEditingContext editingContext,
         CancellationToken cancellationToken = default
     )
@@ -99,10 +96,16 @@ public class AppScopesService : IAppScopesService
         }
         catch (Exception exception)
         {
-            _logger.LogWarning(
-                exception,
-                "Unable to determine whether {Org} is a registered service owner organization. Skipping app scopes.",
-                org
+            Activity.Current?.AddEvent(
+                new ActivityEvent(
+                    "app_scopes.service_owner_lookup_failed",
+                    tags: new ActivityTagsCollection
+                    {
+                        ["org"] = org,
+                        ["exception.type"] = exception.GetType().FullName,
+                        ["exception.message"] = exception.Message,
+                    }
+                )
             );
             return false;
         }

--- a/src/Designer/backend/src/Designer/Services/Implementation/EnvironmentsService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/EnvironmentsService.cs
@@ -169,6 +169,12 @@ public class EnvironmentsService : IEnvironmentsService
         return orgModel.OrgNr;
     }
 
+    public async Task<bool> IsAltinnOrg(string org, CancellationToken cancellationToken = default)
+    {
+        var orgs = await GetAltinnOrgs(cancellationToken);
+        return orgs.ContainsKey(org);
+    }
+
     private Task<Dictionary<string, AltinnOrgModel>> GetAltinnOrgs(CancellationToken cancellationToken = default)
     {
         return _cache.GetOrCreateAsync(

--- a/src/Designer/backend/src/Designer/Services/Interfaces/IAppScopesService.cs
+++ b/src/Designer/backend/src/Designer/Services/Interfaces/IAppScopesService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Designer/backend/src/Designer/Services/Interfaces/IAppScopesService.cs
+++ b/src/Designer/backend/src/Designer/Services/Interfaces/IAppScopesService.cs
@@ -1,4 +1,4 @@
-#nullable disable
+#nullable enable
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,13 +9,13 @@ namespace Altinn.Studio.Designer.Services.Interfaces;
 
 public interface IAppScopesService
 {
-    Task<AppScopesEntity> GetAppScopesAsync(AltinnRepoContext context, CancellationToken cancellationToken = default);
-    Task<AppScopesEntity> UpsertScopesAsync(
+    Task<AppScopesEntity?> GetAppScopesAsync(AltinnRepoContext context, CancellationToken cancellationToken = default);
+    Task<AppScopesEntity?> UpsertScopesAsync(
         AltinnRepoEditingContext editingContext,
         ISet<MaskinPortenScopeEntity> scopes,
         CancellationToken cancellationToken = default
     );
-    Task<AppScopesEntity> AddDefaultMaskinportenScopesAsync(
+    Task<AppScopesEntity?> AddDefaultMaskinportenScopesAsync(
         AltinnRepoEditingContext editingContext,
         CancellationToken cancellationToken = default
     );

--- a/src/Designer/backend/src/Designer/Services/Interfaces/IEnvironmentsService.cs
+++ b/src/Designer/backend/src/Designer/Services/Interfaces/IEnvironmentsService.cs
@@ -32,4 +32,12 @@ public interface IEnvironmentsService
     /// <param name="org">Organization identifier</param>
     /// <returns>Organization number</returns>
     Task<string> GetAltinnOrgNumber(string org);
+
+    /// <summary>
+    /// Checks whether the organization identifier is registered in altinn-orgs.json
+    /// </summary>
+    /// <param name="org">Organization identifier</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>True when the organization identifier is registered in altinn-orgs.json</returns>
+    Task<bool> IsAltinnOrg(string org, CancellationToken cancellationToken = default);
 }

--- a/src/Designer/backend/tests/Designer.Tests/Controllers/AppScopesController/Base/AppScopesControllerTestsBase.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Controllers/AppScopesController/Base/AppScopesControllerTestsBase.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Altinn.Studio.Designer.Constants;
 using Altinn.Studio.Designer.Services.Interfaces;
 using Altinn.Studio.Designer.Services.Models;
@@ -48,6 +49,9 @@ public class AppScopesControllerTestsBase<TControllerTest> : DbDesignerEndpoints
         environmentsServiceMock
             .Setup(x => x.GetAltinnOrgNumber(It.IsAny<string>()))
             .ReturnsAsync((string org) => "991825827");
+        environmentsServiceMock
+            .Setup(x => x.IsAltinnOrg(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string org, CancellationToken _) => org == "ttd");
 
         services.AddSingleton(environmentsServiceMock.Object);
     }

--- a/src/Designer/backend/tests/Designer.Tests/Controllers/AppScopesController/GetAppScopesTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Controllers/AppScopesController/GetAppScopesTests.cs
@@ -33,6 +33,19 @@ public class GetAppScopesTests
         Assert.Empty(repsponseContent.Scopes);
     }
 
+    [Fact]
+    public async Task GetAppScopes_Should_ReturnBadRequest_WhenRepoOwnerIsNotServiceOwner()
+    {
+        using var httpRequestMessage = new HttpRequestMessage(
+            HttpMethod.Get,
+            VersionPrefix("developer", "personal-app")
+        );
+
+        using var response = await HttpClient.SendAsync(httpRequestMessage);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
     [Theory]
     [InlineData("ttd", "empty-app")]
     public async Task GetAppScopes_Should_ReturnOk_WithScopes_IfRecordExists(string org, string app)

--- a/src/Designer/backend/tests/Designer.Tests/Controllers/AppScopesController/UpsertAppScopesTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Controllers/AppScopesController/UpsertAppScopesTests.cs
@@ -52,6 +52,32 @@ public class UpsertAppScopesTests
         await CallUpsertEndpointAndAssertFromDb(org, app, payload);
     }
 
+    [Fact]
+    public async Task UpsertAppScopes_Should_ReturnBadRequest_WhenRepoOwnerIsNotServiceOwner()
+    {
+        AppScopesUpsertRequest payload = new()
+        {
+            Scopes = new HashSet<MaskinPortenScopeDto>()
+            {
+                new() { Scope = "test", Description = "test" },
+            },
+        };
+
+        using var httpRequestMessage = new HttpRequestMessage(
+            HttpMethod.Put,
+            VersionPrefix("developer", "personal-app")
+        );
+        httpRequestMessage.Content = new StringContent(
+            JsonSerializer.Serialize(payload),
+            Encoding.UTF8,
+            MediaTypeNames.Application.Json
+        );
+
+        using var response = await HttpClient.SendAsync(httpRequestMessage);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
     private async Task CallUpsertEndpointAndAssertFromDb(string org, string app, AppScopesUpsertRequest payload)
     {
         using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Put, VersionPrefix(org, app));

--- a/src/Designer/backend/tests/Designer.Tests/Services/AppScopesServiceTest.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/AppScopesServiceTest.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Altinn.Studio.Designer.Exceptions.AppScopes;
 using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Repository;
 using Altinn.Studio.Designer.Repository.Models.AppScope;
@@ -107,7 +106,7 @@ public class AppScopesServiceTest
         Mock<IAppScopesRepository> appScopesRepository = new(MockBehavior.Strict);
         AppScopesService service = CreateAppScopesService(appScopesRepository.Object, isAltinnOrg: false);
 
-        await Assert.ThrowsAsync<AppScopesNotSupportedException>(() => service.GetAppScopesAsync(context));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.GetAppScopesAsync(context));
     }
 
     [Fact]
@@ -121,7 +120,7 @@ public class AppScopesServiceTest
         Mock<IAppScopesRepository> appScopesRepository = new(MockBehavior.Strict);
         AppScopesService service = CreateAppScopesService(appScopesRepository.Object, isAltinnOrg: false);
 
-        await Assert.ThrowsAsync<AppScopesNotSupportedException>(() =>
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
             service.UpsertScopesAsync(
                 context,
                 new HashSet<MaskinPortenScopeEntity> { new() { Scope = "custom:scope" } }

--- a/src/Designer/backend/tests/Designer.Tests/Services/AppScopesServiceTest.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/AppScopesServiceTest.cs
@@ -8,7 +8,6 @@ using Altinn.Studio.Designer.Repository;
 using Altinn.Studio.Designer.Repository.Models.AppScope;
 using Altinn.Studio.Designer.Services.Implementation;
 using Altinn.Studio.Designer.Services.Interfaces;
-using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
@@ -157,11 +156,6 @@ public class AppScopesServiceTest
             .Setup(s => s.IsAltinnOrg(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(isAltinnOrg);
 
-        return new AppScopesService(
-            appScopesRepository,
-            environmentsService.Object,
-            NullLogger<AppScopesService>.Instance,
-            TimeProvider.System
-        );
+        return new AppScopesService(appScopesRepository, environmentsService.Object, TimeProvider.System);
     }
 }

--- a/src/Designer/backend/tests/Designer.Tests/Services/AppScopesServiceTest.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/AppScopesServiceTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Altinn.Studio.Designer.Exceptions.AppScopes;
 using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Repository;
 using Altinn.Studio.Designer.Repository.Models.AppScope;
@@ -100,19 +101,17 @@ public class AppScopesServiceTest
     }
 
     [Fact]
-    public async Task GetAppScopesAsync_WhenOrgIsNotAltinnOrg_ReturnsNullAndDoesNotReadRepository()
+    public async Task GetAppScopesAsync_WhenOrgIsNotAltinnOrg_ThrowsAndDoesNotReadRepository()
     {
         AltinnRepoContext context = AltinnRepoContext.FromOrgRepo("developer", "app");
         Mock<IAppScopesRepository> appScopesRepository = new(MockBehavior.Strict);
         AppScopesService service = CreateAppScopesService(appScopesRepository.Object, isAltinnOrg: false);
 
-        AppScopesEntity result = await service.GetAppScopesAsync(context);
-
-        Assert.Null(result);
+        await Assert.ThrowsAsync<AppScopesNotSupportedException>(() => service.GetAppScopesAsync(context));
     }
 
     [Fact]
-    public async Task UpsertScopesAsync_WhenOrgIsNotAltinnOrg_ReturnsNullAndDoesNotPersist()
+    public async Task UpsertScopesAsync_WhenOrgIsNotAltinnOrg_ThrowsAndDoesNotPersist()
     {
         AltinnRepoEditingContext context = AltinnRepoEditingContext.FromOrgRepoDeveloper(
             "developer",
@@ -122,12 +121,12 @@ public class AppScopesServiceTest
         Mock<IAppScopesRepository> appScopesRepository = new(MockBehavior.Strict);
         AppScopesService service = CreateAppScopesService(appScopesRepository.Object, isAltinnOrg: false);
 
-        AppScopesEntity result = await service.UpsertScopesAsync(
-            context,
-            new HashSet<MaskinPortenScopeEntity> { new() { Scope = "custom:scope" } }
+        await Assert.ThrowsAsync<AppScopesNotSupportedException>(() =>
+            service.UpsertScopesAsync(
+                context,
+                new HashSet<MaskinPortenScopeEntity> { new() { Scope = "custom:scope" } }
+            )
         );
-
-        Assert.Null(result);
     }
 
     [Fact]

--- a/src/Designer/backend/tests/Designer.Tests/Services/AppScopesServiceTest.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/AppScopesServiceTest.cs
@@ -7,6 +7,8 @@ using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Repository;
 using Altinn.Studio.Designer.Repository.Models.AppScope;
 using Altinn.Studio.Designer.Services.Implementation;
+using Altinn.Studio.Designer.Services.Interfaces;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
@@ -27,7 +29,7 @@ public class AppScopesServiceTest
             .Setup(r => r.UpsertAppScopesAsync(It.IsAny<AppScopesEntity>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((AppScopesEntity entity, CancellationToken _) => entity);
 
-        AppScopesService service = new(appScopesRepository.Object, TimeProvider.System);
+        AppScopesService service = CreateAppScopesService(appScopesRepository.Object);
 
         // Act
         AppScopesEntity result = await service.AddDefaultMaskinportenScopesAsync(context);
@@ -68,7 +70,7 @@ public class AppScopesServiceTest
             .Setup(r => r.GetAppScopesAsync(context, It.IsAny<CancellationToken>()))
             .ReturnsAsync(appScopes);
 
-        AppScopesService service = new(appScopesRepository.Object, TimeProvider.System);
+        AppScopesService service = CreateAppScopesService(appScopesRepository.Object);
 
         // Act
         AppScopesEntity result = await service.AddDefaultMaskinportenScopesAsync(context);
@@ -96,5 +98,70 @@ public class AppScopesServiceTest
         Assert.Contains(result, s => s.Scope == DefaultMaskinportenScopes.ServiceOwner);
         Assert.Contains(result, s => s.Scope == DefaultMaskinportenScopes.ServiceOwnerInstancesRead);
         Assert.Contains(result, s => s.Scope == DefaultMaskinportenScopes.ServiceOwnerInstancesWrite);
+    }
+
+    [Fact]
+    public async Task GetAppScopesAsync_WhenOrgIsNotAltinnOrg_ReturnsNullAndDoesNotReadRepository()
+    {
+        AltinnRepoContext context = AltinnRepoContext.FromOrgRepo("developer", "app");
+        Mock<IAppScopesRepository> appScopesRepository = new(MockBehavior.Strict);
+        AppScopesService service = CreateAppScopesService(appScopesRepository.Object, isAltinnOrg: false);
+
+        AppScopesEntity result = await service.GetAppScopesAsync(context);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task UpsertScopesAsync_WhenOrgIsNotAltinnOrg_ReturnsNullAndDoesNotPersist()
+    {
+        AltinnRepoEditingContext context = AltinnRepoEditingContext.FromOrgRepoDeveloper(
+            "developer",
+            "app",
+            "developer"
+        );
+        Mock<IAppScopesRepository> appScopesRepository = new(MockBehavior.Strict);
+        AppScopesService service = CreateAppScopesService(appScopesRepository.Object, isAltinnOrg: false);
+
+        AppScopesEntity result = await service.UpsertScopesAsync(
+            context,
+            new HashSet<MaskinPortenScopeEntity> { new() { Scope = "custom:scope" } }
+        );
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task AddDefaultMaskinportenScopesAsync_WhenOrgIsNotAltinnOrg_ReturnsNullAndDoesNotPersist()
+    {
+        AltinnRepoEditingContext context = AltinnRepoEditingContext.FromOrgRepoDeveloper(
+            "developer",
+            "app",
+            "developer"
+        );
+        Mock<IAppScopesRepository> appScopesRepository = new(MockBehavior.Strict);
+        AppScopesService service = CreateAppScopesService(appScopesRepository.Object, isAltinnOrg: false);
+
+        AppScopesEntity result = await service.AddDefaultMaskinportenScopesAsync(context);
+
+        Assert.Null(result);
+    }
+
+    private static AppScopesService CreateAppScopesService(
+        IAppScopesRepository appScopesRepository,
+        bool isAltinnOrg = true
+    )
+    {
+        Mock<IEnvironmentsService> environmentsService = new();
+        environmentsService
+            .Setup(s => s.IsAltinnOrg(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(isAltinnOrg);
+
+        return new AppScopesService(
+            appScopesRepository,
+            environmentsService.Object,
+            NullLogger<AppScopesService>.Instance,
+            TimeProvider.System
+        );
     }
 }

--- a/src/Designer/backend/tests/Designer.Tests/Services/AppScopesServiceTest.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/AppScopesServiceTest.cs
@@ -146,6 +146,20 @@ public class AppScopesServiceTest
         Assert.Null(result);
     }
 
+    [Fact]
+    public async Task GetAppScopesAsync_WhenServiceOwnerLookupIsCanceled_ThrowsOperationCanceledException()
+    {
+        AltinnRepoContext context = AltinnRepoContext.FromOrgRepo("ttd", "app");
+        Mock<IAppScopesRepository> appScopesRepository = new(MockBehavior.Strict);
+        Mock<IEnvironmentsService> environmentsService = new();
+        environmentsService
+            .Setup(s => s.IsAltinnOrg(context.Org, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+        AppScopesService service = new(appScopesRepository.Object, environmentsService.Object, TimeProvider.System);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => service.GetAppScopesAsync(context));
+    }
+
     private static AppScopesService CreateAppScopesService(
         IAppScopesRepository appScopesRepository,
         bool isAltinnOrg = true

--- a/src/Designer/frontend/app-development/features/appPublish/components/CreateRelease.test.tsx
+++ b/src/Designer/frontend/app-development/features/appPublish/components/CreateRelease.test.tsx
@@ -12,6 +12,19 @@ import { app, org } from '@studio/testing/testids';
 import { BuildResult } from 'app-shared/types/Build';
 import { TestAppRouter } from '@studio/testing/testRoutingUtils';
 import { FeatureFlagsContextProvider } from '@studio/feature-flags';
+import type { OrgList } from 'app-shared/types/OrgList';
+
+const orgListWithTestOrg: OrgList = {
+  orgs: {
+    [org]: {
+      name: { nb: org },
+      logo: '',
+      orgnr: '123456789',
+      homepage: '',
+      environments: [],
+    },
+  },
+};
 
 const renderCreateRelease = (queries?: Partial<ServicesContextProps>) => {
   const allQueries: ServicesContextProps = {
@@ -48,6 +61,7 @@ describe('CreateRelease', () => {
     renderCreateRelease({
       getAppVersion: () =>
         Promise.resolve({ frontendVersion: '4.0.0', backendVersion: '9.0.0-preview.1' }),
+      getOrgList: () => Promise.resolve(orgListWithTestOrg),
       getSelectedMaskinportenScopes: () => Promise.resolve({ scopes: [] }),
     });
 
@@ -63,6 +77,7 @@ describe('CreateRelease', () => {
 
     renderCreateRelease({
       getAppVersion: () => Promise.resolve({ frontendVersion: '4.0.0', backendVersion: '8.3.0' }),
+      getOrgList: () => Promise.resolve(orgListWithTestOrg),
       getSelectedMaskinportenScopes,
     });
 
@@ -94,10 +109,32 @@ describe('CreateRelease', () => {
 
     renderCreateRelease({
       getAppVersion: () => Promise.resolve({ frontendVersion: '4.0.0', backendVersion: '9.0.0' }),
+      getOrgList: () => Promise.resolve(orgListWithTestOrg),
       getSelectedMaskinportenScopes,
     });
 
     await waitFor(() => expect(getSelectedMaskinportenScopes).toHaveBeenCalled());
+    expect(
+      screen.queryByText(textMock('app_create_release.maskinporten_scopes_auto_add')),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not fetch selected Maskinporten scopes or show the notice for personal apps', async () => {
+    const getSelectedMaskinportenScopes = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve({ scopes: [] }));
+
+    renderCreateRelease({
+      getAppVersion: () => Promise.resolve({ frontendVersion: '4.0.0', backendVersion: '9.0.0' }),
+      getOrgList: () => Promise.resolve({ orgs: {} }),
+      getSelectedMaskinportenScopes,
+    });
+
+    expect(
+      await screen.findByLabelText(textMock('app_create_release.release_version_number')),
+    ).toBeInTheDocument();
+
+    expect(getSelectedMaskinportenScopes).not.toHaveBeenCalled();
     expect(
       screen.queryByText(textMock('app_create_release.maskinporten_scopes_auto_add')),
     ).not.toBeInTheDocument();

--- a/src/Designer/frontend/app-development/features/appPublish/components/CreateRelease.tsx
+++ b/src/Designer/frontend/app-development/features/appPublish/components/CreateRelease.tsx
@@ -32,8 +32,7 @@ export function CreateRelease() {
   const { data: appVersion } = useAppVersionQuery(org, app);
   const { data: orgs = {} } = useOrgListQuery();
   const repoOwnerIsServiceOwner = !!org && Object.prototype.hasOwnProperty.call(orgs, org);
-  const { data: selectedMaskinportenScopes } =
-    useGetSelectedScopesQuery(repoOwnerIsServiceOwner);
+  const { data: selectedMaskinportenScopes } = useGetSelectedScopesQuery(repoOwnerIsServiceOwner);
   const { refetch: getMasterBranchStatus } = useBranchStatusQuery(org, app, 'master');
   const { data: appValidationResult } = useAppValidationQuery(org, app);
   const { t } = useTranslation();

--- a/src/Designer/frontend/app-development/features/appPublish/components/CreateRelease.tsx
+++ b/src/Designer/frontend/app-development/features/appPublish/components/CreateRelease.tsx
@@ -23,6 +23,7 @@ import { appHasCriticalValidationErrors } from 'app-shared/utils/appValidationUt
 import { useAppVersionQuery } from 'app-shared/hooks/queries';
 import { hasDefaultMaskinportenScopes } from 'app-development/utils/maskinportenScopes';
 import { isVersionAtLeast } from 'app-development/utils/versionUtils';
+import { isServiceOwnerOrg } from 'app-development/utils/serviceOwnerOrgUtils';
 
 export function CreateRelease() {
   const { org, app } = useStudioEnvironmentParams();
@@ -31,7 +32,7 @@ export function CreateRelease() {
   const { data: releases = [] } = useAppReleasesQuery(org, app);
   const { data: appVersion } = useAppVersionQuery(org, app);
   const { data: orgs = {} } = useOrgListQuery();
-  const repoOwnerIsServiceOwner = !!org && Object.prototype.hasOwnProperty.call(orgs, org);
+  const repoOwnerIsServiceOwner = isServiceOwnerOrg(orgs, org);
   const { data: selectedMaskinportenScopes } = useGetSelectedScopesQuery(repoOwnerIsServiceOwner);
   const { refetch: getMasterBranchStatus } = useBranchStatusQuery(org, app, 'master');
   const { data: appValidationResult } = useAppValidationQuery(org, app);

--- a/src/Designer/frontend/app-development/features/appPublish/components/CreateRelease.tsx
+++ b/src/Designer/frontend/app-development/features/appPublish/components/CreateRelease.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import classes from './CreateRelease.module.css';
 import type { ChangeEvent } from 'react';
 import { versionNameValid } from './utils';
-import { useBranchStatusQuery, useAppReleasesQuery } from '../../../hooks/queries';
+import { useBranchStatusQuery, useAppReleasesQuery, useOrgListQuery } from '../../../hooks/queries';
 import { useCreateReleaseMutation } from '../../../hooks/mutations';
 import { useGetSelectedScopesQuery } from '../../../hooks/queries/useGetSelectedScopesQuery';
 import { Trans, useTranslation } from 'react-i18next';
@@ -30,7 +30,10 @@ export function CreateRelease() {
   const [body, setBody] = useState<string>('');
   const { data: releases = [] } = useAppReleasesQuery(org, app);
   const { data: appVersion } = useAppVersionQuery(org, app);
-  const { data: selectedMaskinportenScopes } = useGetSelectedScopesQuery();
+  const { data: orgs = {} } = useOrgListQuery();
+  const repoOwnerIsServiceOwner = !!org && Object.prototype.hasOwnProperty.call(orgs, org);
+  const { data: selectedMaskinportenScopes } =
+    useGetSelectedScopesQuery(repoOwnerIsServiceOwner);
   const { refetch: getMasterBranchStatus } = useBranchStatusQuery(org, app, 'master');
   const { data: appValidationResult } = useAppValidationQuery(org, app);
   const { t } = useTranslation();
@@ -62,6 +65,7 @@ export function CreateRelease() {
   const canBuild = validVersionName;
   const shouldShowMaskinportenScopesNotice =
     appVersion !== undefined &&
+    repoOwnerIsServiceOwner &&
     selectedMaskinportenScopes !== undefined &&
     isVersionAtLeast(appVersion.backendVersion, 9, 0, 0) &&
     !hasDefaultMaskinportenScopes(selectedMaskinportenScopes);

--- a/src/Designer/frontend/app-development/features/appSettings/components/ContentMenu/ContentMenu.test.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/ContentMenu/ContentMenu.test.tsx
@@ -1,24 +1,39 @@
 import { render, screen } from '@testing-library/react';
 import { ContentMenu } from './ContentMenu';
-import { useAppSettingsMenuTabConfigs } from '../../hooks/useAppSettingsMenuTabConfigs';
-import type { StudioContentMenuButtonTabProps } from '@studio/components';
-import type { SettingsPageTabId } from 'app-development/types/SettingsPageTabId';
 import { textMock } from '@studio/testing/mocks/i18nMock';
-import { MemoryRouter } from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
+import { TestAppRouter } from '@studio/testing/testRoutingUtils';
+import { ServicesContextProvider } from 'app-shared/contexts/ServicesContext';
+import { queriesMock } from 'app-shared/mocks/queriesMock';
+import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
+import type { OrgList } from 'app-shared/types/OrgList';
+
+const allTabNames = ['about', 'setup', 'policy', 'access_control', 'run', 'maskinporten'].map(
+  (tabId) => textMock(`app_settings.left_nav_tab_${tabId}`),
+);
 
 describe('ContentMenu', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should render all menu tabs', () => {
-    const menuTabConfigs = useAppSettingsMenuTabConfigs();
+  it('should render all menu tabs for service owner apps', async () => {
     renderContentMenu();
 
-    menuTabConfigs.forEach((tab: StudioContentMenuButtonTabProps<SettingsPageTabId>) => {
-      expect(screen.getByRole('tab', { name: tab.tabName })).toBeInTheDocument();
-    });
+    for (const tabName of allTabNames) {
+      expect(await screen.findByRole('tab', { name: tabName })).toBeInTheDocument();
+    }
+  });
+
+  it('should hide Maskinporten for personal apps', async () => {
+    renderContentMenu({ orgs: {} });
+
+    expect(
+      await screen.findByRole('tab', { name: textMock('app_settings.left_nav_tab_about') }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('tab', { name: textMock('app_settings.left_nav_tab_maskinporten') }),
+    ).not.toBeInTheDocument();
   });
 
   it('should call setTabToDisplay when a tab is clicked', async () => {
@@ -41,10 +56,29 @@ describe('ContentMenu', () => {
   });
 });
 
-const renderContentMenu = () => {
+const orgListWithTestOrg: OrgList = {
+  orgs: {
+    testOrg: {
+      name: { nb: 'Testdepartementet' },
+      logo: '',
+      orgnr: '123456789',
+      homepage: '',
+      environments: [],
+    },
+  },
+};
+
+const renderContentMenu = (orgList: OrgList = orgListWithTestOrg) => {
+  const queryClient = createQueryClientMock();
   return render(
-    <MemoryRouter initialEntries={[`?currentTab=about`]}>
-      <ContentMenu />
-    </MemoryRouter>,
+    <TestAppRouter initialPath='/testOrg/testApp?currentTab=about'>
+      <ServicesContextProvider
+        {...queriesMock}
+        client={queryClient}
+        getOrgList={jest.fn().mockImplementation(() => Promise.resolve(orgList))}
+      >
+        <ContentMenu />
+      </ServicesContextProvider>
+    </TestAppRouter>,
   );
 };

--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/TabsContent.test.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/TabsContent.test.tsx
@@ -5,8 +5,9 @@ import { queriesMock } from 'app-shared/mocks/queriesMock';
 import { textMock } from '@studio/testing/mocks/i18nMock';
 import type { SettingsTabId } from '../../types/SettingsTabId';
 import type { SettingsPageTabId } from 'app-development/types/SettingsPageTabId';
-import { MemoryRouter } from 'react-router-dom';
 import { ServicesContextProvider } from 'app-shared/contexts/ServicesContext';
+import { TestAppRouter } from '@studio/testing/testRoutingUtils';
+import type { OrgList } from 'app-shared/types/OrgList';
 
 const tabs: SettingsPageTabId[] = [
   'about',
@@ -22,25 +23,54 @@ describe('TabsContent', () => {
     jest.clearAllMocks();
   });
 
-  it.each(tabs)('should render %s tab content when tabToDisplay is "%s"', (tab) => {
+  it.each(tabs)('should render %s tab content when tabToDisplay is "%s"', async (tab) => {
     renderTabsContent(tab);
-    expect(getHeading(tab)).toBeInTheDocument();
+    expect(await findHeading(tab)).toBeInTheDocument();
+  });
+
+  it('should render the about tab when Maskinporten is requested for a personal app', async () => {
+    renderTabsContent('maskinporten', { orgs: {} });
+
+    expect(await findHeading('about')).toBeInTheDocument();
+    expect(queryHeading('maskinporten')).not.toBeInTheDocument();
   });
 });
 
-const renderTabsContent = (initialEntries: string = '') => {
+const orgListWithTestOrg: OrgList = {
+  orgs: {
+    testOrg: {
+      name: { nb: 'Testdepartementet' },
+      logo: '',
+      orgnr: '123456789',
+      homepage: '',
+      environments: [],
+    },
+  },
+};
+
+const renderTabsContent = (initialEntries: string = '', orgList: OrgList = orgListWithTestOrg) => {
   const queryClient = createQueryClientMock();
   return render(
-    <MemoryRouter initialEntries={[`?currentTab=${initialEntries}`]}>
-      <ServicesContextProvider {...queriesMock} client={queryClient}>
+    <TestAppRouter initialPath={`/testOrg/testApp?currentTab=${initialEntries}`}>
+      <ServicesContextProvider
+        {...queriesMock}
+        client={queryClient}
+        getOrgList={jest.fn().mockImplementation(() => Promise.resolve(orgList))}
+      >
         <TabsContent />
       </ServicesContextProvider>
-    </MemoryRouter>,
+    </TestAppRouter>,
   );
 };
 
-const getHeading = (tabId: SettingsTabId): HTMLHeadingElement =>
-  screen.getByRole('heading', {
+const findHeading = (tabId: SettingsTabId): Promise<HTMLHeadingElement> =>
+  screen.findByRole('heading', {
+    name: textMock(`app_settings.${tabId}_tab_heading`),
+    level: 3,
+  });
+
+const queryHeading = (tabId: SettingsTabId): HTMLHeadingElement | null =>
+  screen.queryByRole('heading', {
     name: textMock(`app_settings.${tabId}_tab_heading`),
     level: 3,
   });

--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/TabsContent.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/TabsContent.tsx
@@ -6,9 +6,12 @@ import { MaskinportenTab } from './Tabs/MaskinportenTab';
 import { AccessControlTab } from './Tabs/AccessControlTab';
 import { RunTab } from './Tabs/RunTab';
 import { useCurrentSettingsTab } from '../../hooks/useCurrentSettingsTab';
+import { useAppSettingsMenuTabConfigs } from '../../hooks/useAppSettingsMenuTabConfigs';
 
 export function TabsContent(): ReactElement {
-  const { tabToDisplay } = useCurrentSettingsTab();
+  const menuTabConfigs = useAppSettingsMenuTabConfigs();
+  const tabIds = menuTabConfigs.map((tabConfig) => tabConfig.tabId);
+  const { tabToDisplay } = useCurrentSettingsTab(tabIds);
 
   switch (tabToDisplay) {
     case 'about': {

--- a/src/Designer/frontend/app-development/features/appSettings/hooks/useAppSettingsMenuTabConfig.test.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/hooks/useAppSettingsMenuTabConfig.test.tsx
@@ -1,14 +1,31 @@
-import { renderHook } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
 import { useAppSettingsMenuTabConfigs } from './useAppSettingsMenuTabConfigs';
 import { textMock } from '@studio/testing/mocks/i18nMock';
+import { renderHookWithProviders } from 'app-development/test/mocks';
+import type { OrgList } from 'app-shared/types/OrgList';
+
+const orgListWithTestOrg: OrgList = {
+  orgs: {
+    testOrg: {
+      name: { nb: 'Testdepartementet' },
+      logo: '',
+      orgnr: '123456789',
+      homepage: '',
+      environments: [],
+    },
+  },
+};
 
 describe('useAppSettingsMenuTabConfigs', () => {
-  it('returns correct tab configurations with translated names and icons', () => {
-    const { result } = renderHook(() => useAppSettingsMenuTabConfigs());
+  it('returns correct tab configurations with translated names and icons for service owner apps', async () => {
+    const getOrgList = jest.fn().mockImplementation(() => Promise.resolve(orgListWithTestOrg));
+    const { renderHookResult } = renderHookWithProviders({ getOrgList })(() =>
+      useAppSettingsMenuTabConfigs(),
+    );
 
-    expect(result.current).toHaveLength(6);
+    await waitFor(() => expect(renderHookResult.result.current).toHaveLength(6));
 
-    expect(result.current).toEqual([
+    expect(renderHookResult.result.current).toEqual([
       {
         tabId: 'about',
         tabName: textMock('app_settings.left_nav_tab_about'),
@@ -40,5 +57,19 @@ describe('useAppSettingsMenuTabConfigs', () => {
         icon: expect.any(Object),
       },
     ]);
+  });
+
+  it('hides the Maskinporten tab for personal apps', async () => {
+    const getOrgList = jest.fn().mockImplementation(() => Promise.resolve<OrgList>({ orgs: {} }));
+    const { renderHookResult } = renderHookWithProviders({ getOrgList })(() =>
+      useAppSettingsMenuTabConfigs(),
+    );
+
+    await waitFor(() => expect(getOrgList).toHaveBeenCalledTimes(1));
+
+    expect(renderHookResult.result.current).toHaveLength(5);
+    expect(renderHookResult.result.current).not.toContainEqual(
+      expect.objectContaining({ tabId: 'maskinporten' }),
+    );
   });
 });

--- a/src/Designer/frontend/app-development/features/appSettings/hooks/useAppSettingsMenuTabConfigs.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/hooks/useAppSettingsMenuTabConfigs.tsx
@@ -10,6 +10,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import type { StudioContentMenuButtonTabProps } from '@studio/components';
 import { useOrgListQuery } from 'app-development/hooks/queries/useOrgListQuery';
+import { isServiceOwnerOrg } from 'app-development/utils/serviceOwnerOrgUtils';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 
 const aboutTabId: SettingsPageTabId = 'about';
@@ -24,7 +25,7 @@ export const useAppSettingsMenuTabConfigs =
     const { t } = useTranslation();
     const { org } = useStudioEnvironmentParams();
     const { data: orgs = {} } = useOrgListQuery();
-    const shouldShowMaskinportenTab = !!org && Object.prototype.hasOwnProperty.call(orgs, org);
+    const shouldShowMaskinportenTab = isServiceOwnerOrg(orgs, org);
 
     const tabs: StudioContentMenuButtonTabProps<SettingsPageTabId>[] = [
       {

--- a/src/Designer/frontend/app-development/features/appSettings/hooks/useAppSettingsMenuTabConfigs.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/hooks/useAppSettingsMenuTabConfigs.tsx
@@ -9,6 +9,8 @@ import {
 } from '@studio/icons';
 import { useTranslation } from 'react-i18next';
 import type { StudioContentMenuButtonTabProps } from '@studio/components';
+import { useOrgListQuery } from 'app-development/hooks/queries/useOrgListQuery';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 
 const aboutTabId: SettingsPageTabId = 'about';
 const setupTabId: SettingsPageTabId = 'setup';
@@ -20,8 +22,11 @@ const runTabId: SettingsPageTabId = 'run';
 export const useAppSettingsMenuTabConfigs =
   (): StudioContentMenuButtonTabProps<SettingsPageTabId>[] => {
     const { t } = useTranslation();
+    const { org } = useStudioEnvironmentParams();
+    const { data: orgs = {} } = useOrgListQuery();
+    const shouldShowMaskinportenTab = !!org && Object.prototype.hasOwnProperty.call(orgs, org);
 
-    return [
+    const tabs: StudioContentMenuButtonTabProps<SettingsPageTabId>[] = [
       {
         tabId: aboutTabId,
         tabName: t(`app_settings.left_nav_tab_${aboutTabId}`),
@@ -53,4 +58,6 @@ export const useAppSettingsMenuTabConfigs =
         icon: <MaskinportenIcon />,
       },
     ];
+
+    return shouldShowMaskinportenTab ? tabs : tabs.filter((tab) => tab.tabId !== maskinportenTabId);
   };

--- a/src/Designer/frontend/app-development/hooks/queries/useGetSelectedScopesQuery.ts
+++ b/src/Designer/frontend/app-development/hooks/queries/useGetSelectedScopesQuery.ts
@@ -4,11 +4,12 @@ import { useServicesContext } from 'app-shared/contexts/ServicesContext';
 import { type MaskinportenScopes } from 'app-shared/types/MaskinportenScope';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 
-export const useGetSelectedScopesQuery = () => {
+export const useGetSelectedScopesQuery = (enabled: boolean = true) => {
   const { org, app } = useStudioEnvironmentParams();
   const { getSelectedMaskinportenScopes } = useServicesContext();
   return useQuery<MaskinportenScopes>({
     queryKey: [QueryKey.SelectedAppScopes, org, app],
     queryFn: () => getSelectedMaskinportenScopes(org, app),
+    enabled,
   });
 };

--- a/src/Designer/frontend/app-development/utils/serviceOwnerOrgUtils.ts
+++ b/src/Designer/frontend/app-development/utils/serviceOwnerOrgUtils.ts
@@ -1,0 +1,4 @@
+import type { OrgList } from 'app-shared/types/OrgList';
+
+export const isServiceOwnerOrg = (orgs: OrgList['orgs'], org?: string): boolean =>
+  !!org && Object.hasOwn(orgs, org);


### PR DESCRIPTION
## Summary
- hide the Maskinporten settings tab unless the app owner is a registered service owner in `altinn-orgs.json`
- make app scope reads, updates and default-scope creation no-op for non-serviceowner owners
- fall back from a direct `currentTab=maskinporten` URL to the default settings tab when the app owner is personal

## Screenshot
Personal app owned by `martinothamar`, with Maskinporten hidden from app settings:

<img width="1440" alt="Personal app settings without Maskinporten tab" src="https://raw.githubusercontent.com/martinothamar-agent/altinn-studio/assets/maskinporten-serviceowner-only/screenshots/maskinporten-personal-app-hidden.png" />

## Testing
- `dotnet test src/Designer/backend/tests/Designer.Tests/Designer.Tests.csproj --filter FullyQualifiedName~AppScopesServiceTest`
- `yarn test --runTestsByPath app-development/features/appSettings/hooks/useAppSettingsMenuTabConfig.test.tsx app-development/features/appSettings/components/ContentMenu/ContentMenu.test.tsx app-development/features/appSettings/components/TabsContent/TabsContent.test.tsx`
- `yarn typecheck`
- `./node_modules/.bin/eslint src/Designer/frontend/app-development/features/appSettings/hooks/useAppSettingsMenuTabConfigs.tsx src/Designer/frontend/app-development/features/appSettings/hooks/useAppSettingsMenuTabConfig.test.tsx src/Designer/frontend/app-development/features/appSettings/components/TabsContent/TabsContent.tsx src/Designer/frontend/app-development/features/appSettings/components/TabsContent/TabsContent.test.tsx src/Designer/frontend/app-development/features/appSettings/components/ContentMenu/ContentMenu.test.tsx`
- `git diff --check`
- Playwright smoke screenshot with mocked personal app owner and mocked org list

One-off cleanup script is kept outside the repo at `/data/home/code/run.sh` and `/data/home/code/script.sql`. It was tested against a temporary PostgreSQL database by deleting a `martinothamar/personal-app` row while preserving `ttd/org-app`.

cc @martinothamar


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Maskinporten scopes functionality is now restricted to service owner organisations only
  * Personal app developers will no longer see the Maskinporten configuration tab in app settings
  * Requests to scopes endpoints from personal app organisations now return a clear error response

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio/pull/18898?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->