### PR TITLE
fix: hide run tab for personal apps

### DIFF
--- a/src/Designer/frontend/app-development/features/appSettings/components/ContentMenu/ContentMenu.test.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/ContentMenu/ContentMenu.test.tsx
@@ -25,12 +25,15 @@ describe('ContentMenu', () => {
     }
   });
 
-  it('should hide Maskinporten for personal apps', async () => {
+  it('should hide service owner only tabs for personal apps', async () => {
     renderContentMenu({ orgs: {} });
 
     expect(
       await screen.findByRole('tab', { name: textMock('app_settings.left_nav_tab_about') }),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('tab', { name: textMock('app_settings.left_nav_tab_run') }),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByRole('tab', { name: textMock('app_settings.left_nav_tab_maskinporten') }),
     ).not.toBeInTheDocument();

--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/TabsContent.test.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/TabsContent.test.tsx
@@ -28,12 +28,15 @@ describe('TabsContent', () => {
     expect(await findHeading(tab)).toBeInTheDocument();
   });
 
-  it('should render the about tab when Maskinporten is requested for a personal app', async () => {
-    renderTabsContent('maskinporten', { orgs: {} });
+  it.each(['run', 'maskinporten'] as const)(
+    'should render the about tab when %s is requested for a personal app',
+    async (tab) => {
+      renderTabsContent(tab, { orgs: {} });
 
-    expect(await findHeading('about')).toBeInTheDocument();
-    expect(queryHeading('maskinporten')).not.toBeInTheDocument();
-  });
+      expect(await findHeading('about')).toBeInTheDocument();
+      expect(queryHeading(tab)).not.toBeInTheDocument();
+    },
+  );
 });
 
 const orgListWithTestOrg: OrgList = {

--- a/src/Designer/frontend/app-development/features/appSettings/hooks/useAppSettingsMenuTabConfig.test.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/hooks/useAppSettingsMenuTabConfig.test.tsx
@@ -59,7 +59,7 @@ describe('useAppSettingsMenuTabConfigs', () => {
     ]);
   });
 
-  it('hides the Maskinporten tab for personal apps', async () => {
+  it('hides the service owner only tabs for personal apps', async () => {
     const getOrgList = jest.fn().mockImplementation(() => Promise.resolve<OrgList>({ orgs: {} }));
     const { renderHookResult } = renderHookWithProviders({ getOrgList })(() =>
       useAppSettingsMenuTabConfigs(),
@@ -67,7 +67,10 @@ describe('useAppSettingsMenuTabConfigs', () => {
 
     await waitFor(() => expect(getOrgList).toHaveBeenCalledTimes(1));
 
-    expect(renderHookResult.result.current).toHaveLength(5);
+    expect(renderHookResult.result.current).toHaveLength(4);
+    expect(renderHookResult.result.current).not.toContainEqual(
+      expect.objectContaining({ tabId: 'run' }),
+    );
     expect(renderHookResult.result.current).not.toContainEqual(
       expect.objectContaining({ tabId: 'maskinporten' }),
     );

--- a/src/Designer/frontend/app-development/features/appSettings/hooks/useAppSettingsMenuTabConfigs.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/hooks/useAppSettingsMenuTabConfigs.tsx
@@ -19,13 +19,14 @@ const policyTabId: SettingsPageTabId = 'policy';
 const accessControlTabId: SettingsPageTabId = 'access_control';
 const maskinportenTabId: SettingsPageTabId = 'maskinporten';
 const runTabId: SettingsPageTabId = 'run';
+const serviceOwnerOnlyTabIds: SettingsPageTabId[] = [runTabId, maskinportenTabId];
 
 export const useAppSettingsMenuTabConfigs =
   (): StudioContentMenuButtonTabProps<SettingsPageTabId>[] => {
     const { t } = useTranslation();
     const { org } = useStudioEnvironmentParams();
     const { data: orgs = {} } = useOrgListQuery();
-    const shouldShowMaskinportenTab = isServiceOwnerOrg(orgs, org);
+    const isServiceOwnerApp = isServiceOwnerOrg(orgs, org);
 
     const tabs: StudioContentMenuButtonTabProps<SettingsPageTabId>[] = [
       {
@@ -60,5 +61,7 @@ export const useAppSettingsMenuTabConfigs =
       },
     ];
 
-    return shouldShowMaskinportenTab ? tabs : tabs.filter((tab) => tab.tabId !== maskinportenTabId);
+    return isServiceOwnerApp
+      ? tabs
+      : tabs.filter((tab) => !serviceOwnerOnlyTabIds.includes(tab.tabId));
   };


### PR DESCRIPTION
## Description

Hides the **Kjøring** app settings tab for repositories owned by personal users/non-serviceowner owners. The tab reads and writes `/app-settings`, which is guarded by organisation membership on the backend and does not make sense for personal apps that cannot be deployed.

This uses the existing serviceowner registry based visibility check that already hides Maskinporten for personal apps, and treats both `run` and `maskinporten` as serviceowner-only settings tabs.

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

Verification performed:

- Confirmed backend `app-settings` GET/PUT both require `MustHaveOrganizationPermission`, which checks membership in the exact `{org}` route owner through Gitea organisations.
- `yarn test --runTestsByPath app-development/features/appSettings/hooks/useAppSettingsMenuTabConfig.test.tsx app-development/features/appSettings/components/ContentMenu/ContentMenu.test.tsx app-development/features/appSettings/components/TabsContent/TabsContent.test.tsx`
- `yarn typecheck`
- `yarn strict-null-checks`
- `yarn eslint -c src/Designer/frontend/.eslintrc.js src/Designer/frontend/app-development/features/appSettings/hooks/useAppSettingsMenuTabConfigs.tsx src/Designer/frontend/app-development/features/appSettings/hooks/useAppSettingsMenuTabConfig.test.tsx src/Designer/frontend/app-development/features/appSettings/components/ContentMenu/ContentMenu.test.tsx src/Designer/frontend/app-development/features/appSettings/components/TabsContent/TabsContent.test.tsx`
- `yarn prettier --check app-development/features/appSettings/hooks/useAppSettingsMenuTabConfigs.tsx app-development/features/appSettings/hooks/useAppSettingsMenuTabConfig.test.tsx app-development/features/appSettings/components/ContentMenu/ContentMenu.test.tsx app-development/features/appSettings/components/TabsContent/TabsContent.test.tsx`
- `git diff --check`

cc @martinothamar


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Personal app users no longer see the "run" tab in app settings alongside the previously hidden "maskinporten" tab. The "about" tab remains accessible for all users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio/pull/18900?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->