### PR TITLE
fix: allow builds after Maskinporten scope changes

### DIFF
--- a/src/Designer/backend/src/Designer/Repository/Models/ReleaseEntity.cs
+++ b/src/Designer/backend/src/Designer/Repository/Models/ReleaseEntity.cs
@@ -1,4 +1,5 @@
 #nullable disable
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Altinn.Studio.Designer.Repository.Models;
@@ -33,8 +34,26 @@ public class ReleaseEntity : BaseEntity
     public string TargetCommitish { get; set; }
 
     /// <summary>
+    /// Inputs that were used to build the app release.
+    /// </summary>
+    [JsonProperty("buildInputs")]
+    public ReleaseBuildInputsEntity BuildInputs { get; set; }
+
+    /// <summary>
     /// Build
     /// </summary>
     [JsonProperty("build")]
     public BuildEntity Build { get; set; }
+}
+
+/// <summary>
+/// Build input snapshot for a release.
+/// </summary>
+public class ReleaseBuildInputsEntity
+{
+    /// <summary>
+    /// Maskinporten scopes included in the build.
+    /// </summary>
+    [JsonProperty("maskinportenScopes")]
+    public List<string> MaskinportenScopes { get; set; }
 }

--- a/src/Designer/backend/src/Designer/Services/Implementation/ReleaseService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/ReleaseService.cs
@@ -97,7 +97,8 @@ public class ReleaseService : IReleaseService
             developer,
             cancellationToken
         );
-        string appMaskinportenScopes = SerializeAppScopes(appScopes);
+        List<string> appMaskinportenScopes = GetMaskinportenScopes(appScopes);
+        release.BuildInputs = new ReleaseBuildInputsEntity { MaskinportenScopes = appMaskinportenScopes };
 
         QueueBuildParameters queueBuildParameters = new()
         {
@@ -109,7 +110,7 @@ public class ReleaseService : IReleaseService
             AppDeployToken = deployToken,
             AppAuthHeaderName = authHeaderName,
             AltinnStudioHostname = _generalSettings.HostName,
-            AppMaskinportenScopes = appMaskinportenScopes,
+            AppMaskinportenScopes = SerializeAppScopes(appMaskinportenScopes),
         };
 
         // NOTE: these codepaths are sensitive to leaving partial state/progress if the user/caller
@@ -228,16 +229,17 @@ public class ReleaseService : IReleaseService
         return appScopes;
     }
 
-    private static string SerializeAppScopes(AppScopesEntity appScopes)
+    private static List<string> GetMaskinportenScopes(AppScopesEntity appScopes)
     {
-        if (appScopes?.Scopes is null || appScopes.Scopes.Count == 0)
-        {
-            return "[]";
-        }
-
-        var scopeList = appScopes.Scopes.Select(s => s.Scope).ToArray();
-        return JsonSerializer.Serialize(scopeList);
+        return appScopes
+                ?.Scopes.Select(s => s.Scope)
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(scope => scope, StringComparer.Ordinal)
+                .ToList()
+            ?? new List<string>();
     }
+
+    private static string SerializeAppScopes(List<string> scopes) => JsonSerializer.Serialize(scopes);
 
     private async Task<bool> ShouldAddDefaultMaskinportenScopes(
         ReleaseEntity release,

--- a/src/Designer/backend/tests/Designer.Tests/Services/ReleaseServiceTest.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/ReleaseServiceTest.cs
@@ -46,6 +46,14 @@ public class ReleaseServiceTest
     private readonly GeneralSettings _generalSettings;
     private readonly string _org = "udi";
     private readonly string _app = "kjaerestebesok";
+    private const string ExpectedDefaultMaskinportenScopes =
+        "[\"altinn:serviceowner\",\"altinn:serviceowner/instances.read\",\"altinn:serviceowner/instances.write\"]";
+    private static readonly List<string> ExpectedDefaultMaskinportenScopeList =
+    [
+        DefaultMaskinportenScopes.ServiceOwner,
+        DefaultMaskinportenScopes.ServiceOwnerInstancesRead,
+        DefaultMaskinportenScopes.ServiceOwnerInstancesWrite,
+    ];
 
     public ReleaseServiceTest()
     {
@@ -385,14 +393,18 @@ public class ReleaseServiceTest
         _azureDevOpsBuildClient.Verify(
             b =>
                 b.QueueAsync(
-                    It.Is<QueueBuildParameters>(p =>
-                        p.AppMaskinportenScopes != null
-                        && p.AppMaskinportenScopes.Contains(DefaultMaskinportenScopes.ServiceOwner)
-                        && p.AppMaskinportenScopes.Contains(DefaultMaskinportenScopes.ServiceOwnerInstancesRead)
-                        && p.AppMaskinportenScopes.Contains(DefaultMaskinportenScopes.ServiceOwnerInstancesWrite)
-                    ),
+                    It.Is<QueueBuildParameters>(p => p.AppMaskinportenScopes == ExpectedDefaultMaskinportenScopes),
                     It.IsAny<int>(),
                     It.IsAny<CancellationToken>()
+                ),
+            Times.Once
+        );
+        _releaseRepository.Verify(
+            r =>
+                r.Create(
+                    It.Is<ReleaseEntity>(release =>
+                        release.BuildInputs.MaskinportenScopes.SequenceEqual(ExpectedDefaultMaskinportenScopeList)
+                    )
                 ),
             Times.Once
         );
@@ -465,6 +477,10 @@ public class ReleaseServiceTest
                 ),
             Times.Once
         );
+        _releaseRepository.Verify(
+            r => r.Create(It.Is<ReleaseEntity>(release => release.BuildInputs.MaskinportenScopes.Count == 0)),
+            Times.Once
+        );
     }
 
     [Fact]
@@ -525,6 +541,10 @@ public class ReleaseServiceTest
                     It.IsAny<int>(),
                     It.IsAny<CancellationToken>()
                 ),
+            Times.Once
+        );
+        _releaseRepository.Verify(
+            r => r.Create(It.Is<ReleaseEntity>(release => release.BuildInputs.MaskinportenScopes.Count == 0)),
             Times.Once
         );
     }

--- a/src/Designer/backend/tests/Designer.Tests/_TestData/ReleasesCollection/createdRelease.json
+++ b/src/Designer/backend/tests/Designer.Tests/_TestData/ReleasesCollection/createdRelease.json
@@ -4,6 +4,9 @@
     "name": "1",
     "body": "test-app",
     "targetCommitish": "eec136ac2d31cf984d2053df79f181b99c3b4db5",
+    "buildInputs": {
+        "maskinportenScopes": []
+    },
     "build": {
         "id": "84993",
         "status": "notStarted",

--- a/src/Designer/frontend/app-development/features/appPublish/containers/ReleaseContainer.test.tsx
+++ b/src/Designer/frontend/app-development/features/appPublish/containers/ReleaseContainer.test.tsx
@@ -191,6 +191,7 @@ describe('ReleaseContainer', () => {
       screen.queryByText(textMock('app_create_release.loading')),
     );
 
+    expect(mockGetSelectedMaskinportenScopes).toHaveBeenCalled();
     expect(screen.getByText(textMock('app_release.release_title'))).toBeInTheDocument();
     expect(
       screen.getByLabelText(textMock('app_create_release.release_version_number')),

--- a/src/Designer/frontend/app-development/features/appPublish/containers/ReleaseContainer.test.tsx
+++ b/src/Designer/frontend/app-development/features/appPublish/containers/ReleaseContainer.test.tsx
@@ -200,6 +200,93 @@ describe('ReleaseContainer', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('renders an option to build release if latest release was built before Maskinporten scopes were stored', async () => {
+    const mockLatestCommit = '123';
+    const mockGetRepoStatus = jest.fn().mockImplementation(() => Promise.resolve(repoStatus));
+    const mockGetBranchStatus = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve({ commit: { id: mockLatestCommit } }));
+    const mockGetAppReleases = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        results: [
+          {
+            targetCommitish: mockLatestCommit,
+            tagName: 'v1',
+            build: { result: BuildResult.succeeded, status: BuildStatus.completed },
+          },
+        ],
+      }),
+    );
+    const mockGetSelectedMaskinportenScopes = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        scopes: [
+          {
+            scope: 'altinn:serviceowner',
+            description: 'Brukes til å indikere at klienten er et tjenesteeiersystem.',
+          },
+        ],
+      }),
+    );
+
+    renderReleaseContainer({
+      getRepoStatus: mockGetRepoStatus,
+      getBranchStatus: mockGetBranchStatus,
+      getAppReleases: mockGetAppReleases,
+      getOrgList: jest.fn().mockImplementation(() => Promise.resolve(orgListWithTestOrg)),
+      getSelectedMaskinportenScopes: mockGetSelectedMaskinportenScopes,
+    });
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByText(textMock('app_create_release.loading')),
+    );
+
+    expect(screen.getByText(textMock('app_release.release_title'))).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(textMock('app_create_release.release_version_number')),
+    ).toBeInTheDocument();
+  });
+
+  it('does not query Maskinporten scopes for apps outside service owner organisations', async () => {
+    const mockLatestCommit = '123';
+    const mockTagName = 'v1';
+    const mockGetRepoStatus = jest.fn().mockImplementation(() => Promise.resolve(repoStatus));
+    const mockGetBranchStatus = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve({ commit: { id: mockLatestCommit } }));
+    const mockGetAppReleases = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        results: [
+          {
+            targetCommitish: mockLatestCommit,
+            tagName: mockTagName,
+            build: { result: BuildResult.succeeded, status: BuildStatus.completed },
+          },
+        ],
+      }),
+    );
+    const mockGetSelectedMaskinportenScopes = jest.fn();
+
+    renderReleaseContainer({
+      getRepoStatus: mockGetRepoStatus,
+      getBranchStatus: mockGetBranchStatus,
+      getAppReleases: mockGetAppReleases,
+      getOrgList: jest.fn().mockImplementation(() => Promise.resolve({ orgs: {} })),
+      getSelectedMaskinportenScopes: mockGetSelectedMaskinportenScopes,
+    });
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByText(textMock('app_create_release.loading')),
+    );
+
+    expect(mockGetSelectedMaskinportenScopes).not.toHaveBeenCalled();
+    expect(
+      screen.getByText(textMock('app_release.release_built_on_version', { version: mockTagName })),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(textMock('app_create_release.no_changes_on_current_release')),
+    ).toBeInTheDocument();
+  });
+
   it('renders status that there local changes that will not be included in build if not pushed', async () => {
     const user = userEvent.setup();
     const mockGetRepoStatus = jest

--- a/src/Designer/frontend/app-development/features/appPublish/containers/ReleaseContainer.test.tsx
+++ b/src/Designer/frontend/app-development/features/appPublish/containers/ReleaseContainer.test.tsx
@@ -11,6 +11,8 @@ import { repoStatus } from 'app-shared/mocks/mocks';
 import userEvent from '@testing-library/user-event';
 import { BuildResult, BuildStatus } from 'app-shared/types/Build';
 import { FeatureFlagsContextProvider } from '@studio/feature-flags';
+import type { OrgList } from 'app-shared/types/OrgList';
+import { TestAppRouter } from '@studio/testing/testRoutingUtils';
 
 const renderReleaseContainer = (queries?: Partial<ServicesContextProps>) => {
   const allQueries: ServicesContextProps = {
@@ -20,15 +22,17 @@ const renderReleaseContainer = (queries?: Partial<ServicesContextProps>) => {
 
   render(
     <FeatureFlagsContextProvider value={{ flags: [] }}>
-      <ServicesContextProvider {...allQueries} client={createQueryClientMock()}>
-        <ReleaseContainer />
-      </ServicesContextProvider>
+      <TestAppRouter>
+        <ServicesContextProvider {...allQueries} client={createQueryClientMock()}>
+          <ReleaseContainer />
+        </ServicesContextProvider>
+      </TestAppRouter>
     </FeatureFlagsContextProvider>,
   );
 };
 
 describe('ReleaseContainer', () => {
-  afterEach(() => jest.clearAllMocks);
+  afterEach(() => jest.clearAllMocks());
   it('renders the component with a spinner', () => {
     renderReleaseContainer();
     expect(screen.getByText(textMock('app_release.release_tab_versions'))).toBeInTheDocument();
@@ -62,7 +66,6 @@ describe('ReleaseContainer', () => {
     expect(screen.getByText(textMock('app_create_release.ok'))).toBeInTheDocument();
     expect(screen.getByText(textMock('app_release.release_title'))).toBeInTheDocument();
     expect(screen.getByText(textMock('app_release.release_title_link'))).toBeInTheDocument();
-    expect(mockGetBranchStatus).toHaveBeenCalledTimes(1);
     expect(mockGetBranchStatus).toHaveBeenCalledTimes(1);
   });
 
@@ -142,6 +145,61 @@ describe('ReleaseContainer', () => {
     expect(latestCommitLink).toBeInTheDocument();
   });
 
+  it('renders an option to build release if Maskinporten scopes differ from latest release', async () => {
+    const mockLatestCommit = '123';
+    const mockTagName = 'v1';
+    const mockGetRepoStatus = jest.fn().mockImplementation(() => Promise.resolve(repoStatus));
+    const mockGetBranchStatus = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve({ commit: { id: mockLatestCommit } }));
+    const mockGetAppReleases = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        results: [
+          {
+            targetCommitish: mockLatestCommit,
+            tagName: mockTagName,
+            buildInputs: { maskinportenScopes: ['altinn:serviceowner'] },
+            build: { result: BuildResult.succeeded, status: BuildStatus.completed },
+          },
+        ],
+      }),
+    );
+    const mockGetSelectedMaskinportenScopes = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        scopes: [
+          {
+            scope: 'altinn:serviceowner',
+            description: 'Brukes til å indikere at klienten er et tjenesteeiersystem.',
+          },
+          {
+            scope: 'altinn:serviceowner/instances.read',
+            description: 'Klienter kan lese data knyttet til alle appene til tjenesteeieren.',
+          },
+        ],
+      }),
+    );
+
+    renderReleaseContainer({
+      getRepoStatus: mockGetRepoStatus,
+      getBranchStatus: mockGetBranchStatus,
+      getAppReleases: mockGetAppReleases,
+      getOrgList: jest.fn().mockImplementation(() => Promise.resolve(orgListWithTestOrg)),
+      getSelectedMaskinportenScopes: mockGetSelectedMaskinportenScopes,
+    });
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByText(textMock('app_create_release.loading')),
+    );
+
+    expect(screen.getByText(textMock('app_release.release_title'))).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(textMock('app_create_release.release_version_number')),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(textMock('app_create_release.no_changes_on_current_release')),
+    ).not.toBeInTheDocument();
+  });
+
   it('renders status that there local changes that will not be included in build if not pushed', async () => {
     const user = userEvent.setup();
     const mockGetRepoStatus = jest
@@ -182,3 +240,15 @@ describe('ReleaseContainer', () => {
     ).toBeInTheDocument();
   });
 });
+
+const orgListWithTestOrg: OrgList = {
+  orgs: {
+    testOrg: {
+      name: { nb: 'Testdepartementet' },
+      logo: '',
+      orgnr: '123456789',
+      homepage: '',
+      environments: [],
+    },
+  },
+};

--- a/src/Designer/frontend/app-development/features/appPublish/containers/ReleaseContainer.tsx
+++ b/src/Designer/frontend/app-development/features/appPublish/containers/ReleaseContainer.tsx
@@ -9,6 +9,8 @@ import { UploadIcon, CheckmarkIcon } from '@studio/icons';
 import { gitCommitPath } from 'app-shared/api/paths';
 import { StudioPopover, StudioParagraph, StudioSpinner, StudioError } from '@studio/components';
 import { useBranchStatusQuery, useAppReleasesQuery } from '../../../hooks/queries';
+import { useGetSelectedScopesQuery } from '../../../hooks/queries/useGetSelectedScopesQuery';
+import { useOrgListQuery } from 'app-development/hooks/queries/useOrgListQuery';
 import { Trans, useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
 import { QueryKey } from 'app-shared/types/QueryKey';
@@ -17,6 +19,7 @@ import { useRepoStatusQuery } from 'app-shared/hooks/queries';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { Link } from '@digdir/designsystemet-react';
 import { PackagesRouter } from 'app-shared/navigation/PackagesRouter';
+import { isServiceOwnerOrg } from 'app-development/utils/serviceOwnerOrgUtils';
 
 export function ReleaseContainer() {
   const { org, app } = useStudioEnvironmentParams();
@@ -26,14 +29,27 @@ export function ReleaseContainer() {
 
   const { data: releases = [] } = useAppReleasesQuery(org, app);
   const { data: repoStatus, isPending: isRepoStatusPending } = useRepoStatusQuery(org, app);
+  const { data: orgs = {}, isPending: isOrgListPending } = useOrgListQuery();
+  const isServiceOwnerApp = isServiceOwnerOrg(orgs, org);
+  const { data: selectedMaskinportenScopes, isPending: selectedMaskinportenScopesIsPending } =
+    useGetSelectedScopesQuery(isServiceOwnerApp);
   const { data: masterBranchStatus, isPending: masterBranchStatusIsPending } = useBranchStatusQuery(
     org,
     app,
     'master',
   );
 
-  const latestRelease: AppReleaseType = releases && releases[0] ? releases[0] : null;
-
+  const latestRelease: AppReleaseType | null = releases && releases[0] ? releases[0] : null;
+  const hasMaskinportenScopeChanges = hasMaskinportenScopesChanged(
+    latestRelease,
+    selectedMaskinportenScopes?.scopes.map(({ scope }) => scope),
+    isServiceOwnerApp,
+  );
+  const isLoading =
+    isRepoStatusPending ||
+    masterBranchStatusIsPending ||
+    isOrgListPending ||
+    (isServiceOwnerApp && selectedMaskinportenScopesIsPending);
   const { t } = useTranslation();
 
   function handlePopoverKeyPress(event: KeyboardEvent) {
@@ -60,7 +76,7 @@ export function ReleaseContainer() {
   const handlePopoverClose = () => setPopoverOpenHover(false);
 
   function renderCreateRelease() {
-    if (isRepoStatusPending || masterBranchStatusIsPending) {
+    if (isLoading) {
       return (
         <>
           <div>
@@ -92,7 +108,8 @@ export function ReleaseContainer() {
       latestRelease &&
       latestRelease.targetCommitish === masterBranchStatus.commit.id &&
       latestRelease.build.status === BuildStatus.completed &&
-      latestRelease.build.result === BuildResult.succeeded
+      latestRelease.build.result === BuildResult.succeeded &&
+      !hasMaskinportenScopeChanges
     ) {
       return t('app_create_release.no_changes_on_current_release');
     }
@@ -152,6 +169,7 @@ export function ReleaseContainer() {
     if (
       !latestRelease ||
       latestRelease.targetCommitish !== masterBranchStatus.commit.id ||
+      hasMaskinportenScopeChanges ||
       !repoStatus?.contentStatus
     ) {
       return (
@@ -218,4 +236,34 @@ export function ReleaseContainer() {
       </div>
     </div>
   );
+}
+
+function hasMaskinportenScopesChanged(
+  latestRelease: AppReleaseType | null,
+  selectedScopes: string[] | undefined,
+  isServiceOwnerApp: boolean,
+): boolean {
+  if (!latestRelease || !isServiceOwnerApp || !selectedScopes) {
+    return false;
+  }
+
+  const releaseScopes = latestRelease.buildInputs?.maskinportenScopes;
+  const currentScopes = normalizeScopeNames(selectedScopes);
+
+  if (releaseScopes === undefined) {
+    return currentScopes.length > 0;
+  }
+
+  return !hasSameScopes(normalizeScopeNames(releaseScopes), currentScopes);
+}
+
+function hasSameScopes(releaseScopes: string[], currentScopes: string[]): boolean {
+  return (
+    releaseScopes.length === currentScopes.length &&
+    releaseScopes.every((scope, index) => scope === currentScopes[index])
+  );
+}
+
+function normalizeScopeNames(scopes: string[]): string[] {
+  return [...new Set(scopes)].sort((a, b) => a.localeCompare(b));
 }

--- a/src/Designer/frontend/app-development/hooks/queries/useGetSelectedScopesQuery.ts
+++ b/src/Designer/frontend/app-development/hooks/queries/useGetSelectedScopesQuery.ts
@@ -1,15 +1,17 @@
 import { useQuery } from '@tanstack/react-query';
+import type { QueryMeta } from '@tanstack/react-query';
 import { QueryKey } from 'app-shared/types/QueryKey';
 import { useServicesContext } from 'app-shared/contexts/ServicesContext';
 import { type MaskinportenScopes } from 'app-shared/types/MaskinportenScope';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 
-export const useGetSelectedScopesQuery = (enabled: boolean = true) => {
+export const useGetSelectedScopesQuery = (enabled: boolean = true, meta?: QueryMeta) => {
   const { org, app } = useStudioEnvironmentParams();
   const { getSelectedMaskinportenScopes } = useServicesContext();
   return useQuery<MaskinportenScopes>({
     queryKey: [QueryKey.SelectedAppScopes, org, app],
     queryFn: () => getSelectedMaskinportenScopes(org, app),
     enabled,
+    meta,
   });
 };

--- a/src/Designer/frontend/packages/shared/src/mocks/mocks.ts
+++ b/src/Designer/frontend/packages/shared/src/mocks/mocks.ts
@@ -51,6 +51,7 @@ export const appRelease: AppRelease = {
   app: '',
   org: '',
   targetCommitish: '',
+  buildInputs: { maskinportenScopes: [] },
   createdBy: '',
   created: '',
   build,

--- a/src/Designer/frontend/packages/shared/src/mocks/queriesMock.ts
+++ b/src/Designer/frontend/packages/shared/src/mocks/queriesMock.ts
@@ -77,7 +77,6 @@ import type { FormLayoutsResponseV3 } from 'app-shared/types/api/FormLayoutsResp
 import type { DeploymentsResponse } from 'app-shared/types/api/DeploymentsResponse';
 import type { RepoDiffResponse } from 'app-shared/types/api/RepoDiffResponse';
 import type { ExternalImageUrlValidationResponse } from 'app-shared/types/api/ExternalImageUrlValidationResponse';
-import type { MaskinportenScope } from 'app-shared/types/MaskinportenScope';
 import type { OptionList } from 'app-shared/types/OptionList';
 import type { OptionListReferences } from 'app-shared/types/OptionListReferences';
 import type { LayoutSetModel } from '../types/api/dto/LayoutSetModel';
@@ -257,12 +256,10 @@ export const queriesMock: ServicesContextProps = {
   // Queries - PrgetBpmnFile
   getBpmnFile: jest.fn().mockImplementation(() => Promise.resolve<string>('')),
   getProcessTaskType: jest.fn().mockImplementation(() => Promise.resolve<string>('')),
-  getMaskinportenScopes: jest
-    .fn()
-    .mockImplementation(() => Promise.resolve<MaskinportenScope[]>([])),
+  getMaskinportenScopes: jest.fn().mockImplementation(() => Promise.resolve({ scopes: [] })),
   getSelectedMaskinportenScopes: jest
     .fn()
-    .mockImplementation(() => Promise.resolve<MaskinportenScope[]>([])),
+    .mockImplementation(() => Promise.resolve({ scopes: [] })),
   getAppSettings: jest
     .fn()
     .mockImplementation(() => Promise.resolve<AppSettings>({ undeployOnInactivity: false })),

--- a/src/Designer/frontend/packages/shared/src/types/AppRelease.ts
+++ b/src/Designer/frontend/packages/shared/src/types/AppRelease.ts
@@ -8,7 +8,12 @@ export interface AppRelease {
   app: string;
   org: string;
   targetCommitish: string;
+  buildInputs?: AppReleaseBuildInputs;
   createdBy: string;
   created: string;
   build: Build;
+}
+
+export interface AppReleaseBuildInputs {
+  maskinportenScopes?: string[];
 }


### PR DESCRIPTION
## Summary

- Store the Maskinporten scope set used for each release build in `ReleaseEntity.BuildInputs`.
- Compare the latest release scope snapshot with the app's currently selected Maskinporten scopes on the publish page.
- Keep the build form available when the latest release commit matches master but the selected Maskinporten scopes differ.

## Why

Maskinporten scopes are now part of the build input. A new build must be possible when the app's selected scopes change, even if there has not been a new commit on `master` since the previous release.

## Manual Testing

Ran Studio locally with the rebuilt Designer container:

```bash
docker compose up -d --build studio_designer
```

Verified the publish page in Chromium against `http://studio.localhost/editor/ttd/test-app/deploy`. For the screenshots below, I used deterministic local API responses against the running built app so the release state variants could be checked directly:

- same commit and same scopes: no new build form, existing "no changes" state remains
- same commit and changed Maskinporten scopes: build form appears, entering `1.0.1` enables `Bygg versjon`, and the status icon remains the normal committed-change check state
- new master commit: build form still appears as before
- changed Maskinporten scopes with local edits: build form appears and the status popover shows the existing local-edits warning only

### Screenshots

Same commit and same scopes:

![Same commit and same scopes](https://raw.githubusercontent.com/martinothamar-agent/altinn-studio/pr-screenshots-build-on-scope-changes/pr-screenshots/build-on-scope-changes/unchanged-current-release.png)

Changed Maskinporten scopes:

![Changed Maskinporten scopes](https://raw.githubusercontent.com/martinothamar-agent/altinn-studio/pr-screenshots-build-on-scope-changes/pr-screenshots/build-on-scope-changes/maskinporten-scope-change.png)

New master commit:

![New master commit](https://raw.githubusercontent.com/martinothamar-agent/altinn-studio/pr-screenshots-build-on-scope-changes/pr-screenshots/build-on-scope-changes/new-master-commit.png)

Changed Maskinporten scopes with local edits:

![Changed Maskinporten scopes with local edits](https://raw.githubusercontent.com/martinothamar-agent/altinn-studio/pr-screenshots-build-on-scope-changes/pr-screenshots/build-on-scope-changes/scope-change-with-local-edits.png)

## Automated Testing

```bash
yarn test app-development/features/appPublish/containers/ReleaseContainer.test.tsx
yarn typecheck
yarn eslint -c src/Designer/frontend/.eslintrc.js src/Designer/frontend/app-development/features/appPublish/containers/ReleaseContainer.tsx src/Designer/frontend/app-development/features/appPublish/containers/ReleaseContainer.test.tsx src/Designer/frontend/app-development/hooks/queries/useGetSelectedScopesQuery.ts src/Designer/frontend/packages/shared/src/types/AppRelease.ts src/Designer/frontend/packages/shared/src/mocks/mocks.ts src/Designer/frontend/packages/shared/src/mocks/queriesMock.ts
dotnet test Designer.sln --filter "FullyQualifiedName~ReleaseServiceTest" --no-restore
dotnet build Designer.sln --no-restore
git diff --check
```

cc @martinothamar


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App releases now record Maskinporten scopes used during build.
  * The release UI detects when selected Maskinporten scopes differ from the latest release and surfaces an option to build a new release; service-owner scope checks are supported.
  * Loading state now accounts for organisation and scope queries.

* **Tests**
  * Updated tests and fixtures to verify scope ordering, empty-scope handling and related UI behaviours.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio/pull/18901?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->