### PR TITLE
fix: force rollout on same-version app redeploy

### DIFF
--- a/src/App/azure-pipelines/deploy-app.yaml
+++ b/src/App/azure-pipelines/deploy-app.yaml
@@ -22,6 +22,7 @@ variables:
   # GITEA_ENVIRONMENT: ''
   # HOSTNAME: ''
   # TAGNAME: ''
+  # DEPLOYMENT_ID: ''
   # APP_AUTH_HEADER_NAME: '' # Optional header name for token auth (e.g. "X-Api-Key"). When set, uses header instead of URL-embedded token.
   # TRACEPARENT: '' # Optional W3C traceparent for correlation
   # TRACESTATE: '' # Optional W3C tracestate for correlation
@@ -69,6 +70,7 @@ steps:
           [ -z "$GITEA_ENVIRONMENT" ] && ERRORS+=("GITEA_ENVIRONMENT is required when PUSH_APPS_OCI_IMAGE is not 'false'")
           [ -z "$APP_COMMIT_ID" ] && ERRORS+=("APP_COMMIT_ID is required when PUSH_APPS_OCI_IMAGE is not 'false'")
           [ -z "$TAGNAME" ] && ERRORS+=("TAGNAME is required when PUSH_APPS_OCI_IMAGE is not 'false'")
+          [ -z "$DEPLOYMENT_ID" ] && ERRORS+=("DEPLOYMENT_ID is required when PUSH_APPS_OCI_IMAGE is not 'false'")
         fi
 
         # Variables required when pushing sync-root GitOps image
@@ -650,6 +652,8 @@ steps:
               value: ${AI_INSTR_KEY}
             - name: AppSettings__AppVersion
               value: "${TAGNAME}"
+        podAnnotations:
+          altinn.studio/deployment-id: "${DEPLOYMENT_ID}"
         EOF
 
         # Add service and ingressRoute

--- a/src/Designer/backend/src/Designer/Services/Implementation/DeploymentService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/DeploymentService.cs
@@ -136,10 +136,10 @@ public class DeploymentService : IDeploymentService
             deployment.EnvName
         );
 
-        var createdEntity = await _deploymentRepository.Create(deploymentEntity);
+        deploymentEntity = await _deploymentRepository.Create(deploymentEntity);
 
         await _deployEventRepository.AddBySequenceNoAsync(
-            createdEntity.SequenceNo,
+            deploymentEntity.SequenceNo,
             new DeployEvent
             {
                 EventType = registryResult.Succeeded
@@ -189,7 +189,7 @@ public class DeploymentService : IDeploymentService
         await _deploymentRepository.Update(deploymentEntity);
 
         await _deployEventRepository.AddBySequenceNoAsync(
-            createdEntity.SequenceNo,
+            deploymentEntity.SequenceNo,
             new DeployEvent
             {
                 EventType = DeployEventType.PipelineScheduled,
@@ -210,7 +210,7 @@ public class DeploymentService : IDeploymentService
             traceContext.TraceParent,
             traceContext.TraceState
         );
-        return createdEntity;
+        return deploymentEntity;
     }
 
     private async Task<bool> AddAppToGitOpsRepoIfNotExists(
@@ -597,6 +597,7 @@ public class DeploymentService : IDeploymentService
             AppEnvironment = deploymentEntity.EnvName,
             Hostname = await _environmentsService.GetHostNameByEnvName(envName),
             TagName = deploymentEntity.TagName,
+            DeploymentId = deploymentEntity.SequenceNo.ToString(),
             GiteaEnvironment = $"{_generalSettings.HostName}/repos",
             AppDeployToken = deployToken,
             AppAuthHeaderName = authHeaderName,

--- a/src/Designer/backend/src/Designer/TypedHttpClients/AzureDevOps/Models/QueueBuildParameters.cs
+++ b/src/Designer/backend/src/Designer/TypedHttpClients/AzureDevOps/Models/QueueBuildParameters.cs
@@ -67,6 +67,12 @@ public class QueueBuildParameters
     public string TagName { get; set; }
 
     /// <summary>
+    /// The logical deployment attempt id from Designer
+    /// </summary>
+    [JsonPropertyName("DEPLOYMENT_ID")]
+    public string DeploymentId { get; set; }
+
+    /// <summary>
     /// The hostname of the altinn studio env
     /// </summary>
     [JsonPropertyName("ALTINN_STUDIO_HOSTNAME")]

--- a/src/Designer/backend/tests/Designer.Tests/Services/DeploymentServiceTest.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/DeploymentServiceTest.cs
@@ -234,6 +234,93 @@ public class DeploymentServiceTest
 
     [Theory]
     [InlineData("ttd", "apps-test-tba")]
+    public async Task CreateAsync_QueuesPipelineWithDeploymentIdFromCreatedDeployment(string org, string app)
+    {
+        // Arrange
+        const long DeploymentSequenceNo = 42;
+        DeploymentModel deploymentModel = new() { TagName = "1", EnvName = "at23" };
+
+        _releaseRepository
+            .Setup(r => r.GetSucceededReleaseFromDb(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(GetReleases("updatedRelease.json").First());
+
+        _applicationInformationService
+            .Setup(ais =>
+                ais.UpdateApplicationMetadataAndPoliciesAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Returns(Task.CompletedTask);
+
+        _applicationInformationService
+            .Setup(ais =>
+                ais.PublishToResourceRegistryAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                )
+            )
+            .ReturnsAsync(new ResourceRegistryPublishResult(true));
+
+        _azureDevOpsBuildClient
+            .Setup(b => b.QueueAsync(It.IsAny<QueueBuildParameters>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(GetBuild());
+
+        _deploymentRepository
+            .Setup(r => r.Create(It.IsAny<DeploymentEntity>()))
+            .ReturnsAsync(
+                (DeploymentEntity entity) =>
+                {
+                    entity.SequenceNo = DeploymentSequenceNo;
+                    return entity;
+                }
+            );
+
+        DeploymentService deploymentService = new(
+            GetAzureDevOpsSettings(),
+            _azureDevOpsBuildClient.Object,
+            _httpContextAccessor.Object,
+            _deploymentRepository.Object,
+            _deployEventRepository.Object,
+            _releaseRepository.Object,
+            _environementsService.Object,
+            _applicationInformationService.Object,
+            _mediatrMock.Object,
+            _generalSettings,
+            _fakeTimeProvider,
+            _gitOpsConfigurationManager.Object,
+            _featureManager.Object,
+            _runtimeGatewayClient.Object,
+            _apiKeyService.Object,
+            _notificationService.Object,
+            _hostEnvironment.Object
+        );
+
+        AltinnAuthenticatedRepoEditingContext authenticatedContext =
+            AltinnAuthenticatedRepoEditingContext.FromOrgRepoDeveloperToken(org, app, "testUser", "dummyToken");
+
+        // Act
+        await deploymentService.CreateAsync(authenticatedContext, deploymentModel);
+
+        // Assert
+        _azureDevOpsBuildClient.Verify(
+            b =>
+                b.QueueAsync(
+                    It.Is<QueueBuildParameters>(p => p.DeploymentId == DeploymentSequenceNo.ToString()),
+                    It.IsAny<int>(),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Once
+        );
+    }
+
+    [Theory]
+    [InlineData("ttd", "apps-test-tba")]
     public async Task CreateAsync_WhenResourceRegistryPublishFails_ContinuesPipelineAndRecordsFailedEvent(
         string org,
         string app


### PR DESCRIPTION
## Description

- Pass the persisted Designer deployment sequence number to the Azure DevOps deploy pipeline as `DEPLOYMENT_ID`.
- Include `DEPLOYMENT_ID` in generated Helm values as `podAnnotations.altinn.studio/deployment-id`.
- Require `DEPLOYMENT_ID` for app OCI deployments so same-version redeploys cannot silently miss the rollout marker.

Previously, retrying deployment of the same release could leave the rendered runtime Deployment unchanged: the image tag stayed the same, and the Azure DevOps build id only appeared on HelmRelease metadata. After a Helm/Flux rollback, refreshing the app config artifact was therefore not guaranteed to produce a new Kubernetes pod template. The deployment id annotation is part of `spec.values`, and the deployment chart renders `podAnnotations` into the Kubernetes Deployment pod template, so every logical Designer deployment attempt creates a rollout-relevant desired-state change even when the app version/tag is unchanged.

I also inspected the frontend deployment status logic. It keeps `PipelineSucceeded` as in-progress for normal deployments for 15 minutes unless a final Flux event arrives, but after that it can still show success based only on the pipeline event. I left that out of this PR because it is a separate UX/status semantics change from forcing the actual rollout.

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

Automated:

```text
$ dotnet test tests/Designer.Tests/Designer.Tests.csproj --filter "FullyQualifiedName~DeploymentServiceTest"
Passed!  - Failed:     0, Passed:    19, Skipped:     0, Total:    19, Duration: 322 ms - Altinn.Studio.Designer.Tests.dll (net9.0)
```

Formatting/YAML checks:

```text
$ dotnet tool restore
Restore was successful.

$ dotnet tool run csharpier check src/Designer/Services/Implementation/DeploymentService.cs src/Designer/TypedHttpClients/AzureDevOps/Models/QueueBuildParameters.cs tests/Designer.Tests/Services/DeploymentServiceTest.cs
Checked 3 files in 1117ms.

$ yq . src/App/azure-pipelines/deploy-app.yaml >/dev/null
# exit 0

$ git diff --check
# exit 0
```

Manual HelmRelease values verification:

I mirrored the pipeline merge with `mikefarah/yq:4.45.1` using normalized values containing an existing pod annotation and overrides containing `altinn.studio/deployment-id: "42"`. The resulting HelmRelease `spec.values.podAnnotations` was:

```yaml
existing.example/annotation: keep-me
altinn.studio/deployment-id: "42"
```

This verifies the generated HelmRelease values include:

```yaml
podAnnotations:
  altinn.studio/deployment-id: "<deployment sequence no>"
```

cc @martinothamar


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Introduced deployment ID tracking throughout the deployment pipeline for improved identification and traceability of deployment attempts.
- Deployment identifiers are now automatically included in pod annotations for enhanced observability and monitoring capabilities.
- Pipeline validation now ensures deployment IDs are provided when pushing application container images.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio/pull/18915?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->