### PR TITLE
fix: warn about unsupported app scopes versions

### DIFF
--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.module.css
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.module.css
@@ -8,6 +8,11 @@
   margin-bottom: var(--ds-size-4);
 }
 
+.unsupportedVersionNotice {
+  margin-top: var(--ds-size-4);
+  margin-bottom: var(--ds-size-4);
+}
+
 .defaultScopesNotice {
   display: flex;
   flex-direction: column;

--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.test.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.test.tsx
@@ -39,7 +39,7 @@ const selectedScopesMock: MaskinportenScope[] = [scopeMock3, scopeMock4];
 describe('ScopeList', () => {
   afterEach(jest.clearAllMocks);
 
-  it('should render description and help text', () => {
+  it('should render description and help text', async () => {
     renderScopeList();
 
     expect(
@@ -49,7 +49,9 @@ describe('ScopeList', () => {
       getText(textMock('app_settings.maskinporten_tab_available_scopes_description_help')),
     ).toBeInTheDocument();
     expect(
-      getText(textMock('app_settings.maskinporten_scope_changes_deployment_notice')),
+      await screen.findByText(
+        textMock('app_settings.maskinporten_scope_changes_deployment_notice'),
+      ),
     ).toBeInTheDocument();
   });
 
@@ -78,6 +80,24 @@ describe('ScopeList', () => {
     renderScopeList({ componentProps: { selectedScopes: [] } });
 
     expect(getText(textMock('app_settings.maskinporten_no_scopes_added'))).toBeInTheDocument();
+  });
+
+  it('should warn that Maskinporten scopes cannot be used for apps older than v8.3', async () => {
+    renderScopeList({
+      queries: {
+        getAppVersion: () => Promise.resolve({ frontendVersion: '4.0.0', backendVersion: '8.2.9' }),
+      },
+    });
+
+    expect(
+      await screen.findByText(textMock('app_settings.maskinporten_unsupported_app_version_title')),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(textMock('app_settings.maskinporten_unsupported_app_version_description')),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(textMock('app_settings.maskinporten_scope_changes_deployment_notice')),
+    ).not.toBeInTheDocument();
   });
 
   it('should offer adding default scopes for v8.3 apps when default scopes are missing', async () => {

--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.test.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.test.tsx
@@ -48,8 +48,9 @@ describe('ScopeList', () => {
     expect(
       getText(textMock('app_settings.maskinporten_tab_available_scopes_description_help')),
     ).toBeInTheDocument();
+    const deploymentNotice = await screen.findByRole('note');
     expect(
-      await screen.findByText(
+      within(deploymentNotice).getByText(
         textMock('app_settings.maskinporten_scope_changes_deployment_notice'),
       ),
     ).toBeInTheDocument();
@@ -89,11 +90,16 @@ describe('ScopeList', () => {
       },
     });
 
+    const unsupportedVersionAlert = await screen.findByRole('alert');
     expect(
-      await screen.findByText(textMock('app_settings.maskinporten_unsupported_app_version_title')),
+      within(unsupportedVersionAlert).getByRole('heading', {
+        name: textMock('app_settings.maskinporten_unsupported_app_version_title'),
+      }),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(textMock('app_settings.maskinporten_unsupported_app_version_description')),
+      within(unsupportedVersionAlert).getByText(
+        textMock('app_settings.maskinporten_unsupported_app_version_description'),
+      ),
     ).toBeInTheDocument();
     expect(
       screen.queryByText(textMock('app_settings.maskinporten_scope_changes_deployment_notice')),

--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.tsx
@@ -105,7 +105,7 @@ export function ScopeList({
           </StudioParagraph>
           {isUnsupportedAppVersion && <UnsupportedAppVersionAlert />}
           {shouldShowDeploymentNotice && (
-            <StudioAlert data-color='info' className={classes.deploymentNotice}>
+            <StudioAlert data-color='info' className={classes.deploymentNotice} role='note'>
               {t('app_settings.maskinporten_scope_changes_deployment_notice')}
             </StudioAlert>
           )}
@@ -144,7 +144,7 @@ function UnsupportedAppVersionAlert(): ReactElement {
   const { t } = useTranslation();
 
   return (
-    <StudioAlert data-color='danger' className={classes.unsupportedVersionNotice}>
+    <StudioAlert data-color='danger' className={classes.unsupportedVersionNotice} role='alert'>
       <StudioHeading data-size='2xs' level={4}>
         {t('app_settings.maskinporten_unsupported_app_version_title')}
       </StudioHeading>

--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.tsx
@@ -33,6 +33,7 @@ import {
   defaultMaskinportenScopeNames,
   shouldShowDefaultMaskinportenScopesOptIn,
 } from 'app-development/utils/maskinportenScopes';
+import { isMaskinportenScopesSupportedVersion } from 'app-development/utils/versionUtils';
 import {
   combineSelectedAndMaskinportenScopes,
   isDefaultMaskinportenScope,
@@ -54,11 +55,15 @@ export function ScopeList({
 }: ScopeListProps): ReactElement {
   const { t } = useTranslation();
   const { org, app } = useStudioEnvironmentParams();
-  const { data: appVersion } = useAppVersionQuery(org, app);
+  const { data: appVersion, isPending: isPendingAppVersion } = useAppVersionQuery(org, app);
   const dialogRef = useRef<HTMLDialogElement | null>(null);
   const [searchValue, setSearchValue] = useState<string>('');
+  const backendVersion = appVersion?.backendVersion;
+  const isUnsupportedAppVersion: boolean =
+    !!backendVersion && !isMaskinportenScopesSupportedVersion(backendVersion);
+  const shouldShowDeploymentNotice: boolean = !isPendingAppVersion && !isUnsupportedAppVersion;
   const shouldShowDefaultScopesOptIn: boolean = shouldShowDefaultMaskinportenScopesOptIn(
-    appVersion?.backendVersion,
+    backendVersion,
     selectedScopes,
   );
 
@@ -98,9 +103,12 @@ export function ScopeList({
               <StudioLink href={contactByEmail.url('serviceOwner')}> </StudioLink>
             </Trans>
           </StudioParagraph>
-          <StudioAlert data-color='info' className={classes.deploymentNotice}>
-            {t('app_settings.maskinporten_scope_changes_deployment_notice')}
-          </StudioAlert>
+          {isUnsupportedAppVersion && <UnsupportedAppVersionAlert />}
+          {shouldShowDeploymentNotice && (
+            <StudioAlert data-color='info' className={classes.deploymentNotice}>
+              {t('app_settings.maskinporten_scope_changes_deployment_notice')}
+            </StudioAlert>
+          )}
           <DefaultScopesNotice
             shouldShowDefaultScopesOptIn={shouldShowDefaultScopesOptIn}
             initialValues={initialValues}
@@ -129,6 +137,21 @@ export function ScopeList({
         />
       )}
     </div>
+  );
+}
+
+function UnsupportedAppVersionAlert(): ReactElement {
+  const { t } = useTranslation();
+
+  return (
+    <StudioAlert data-color='danger' className={classes.unsupportedVersionNotice}>
+      <StudioHeading data-size='2xs' level={4}>
+        {t('app_settings.maskinporten_unsupported_app_version_title')}
+      </StudioHeading>
+      <StudioParagraph>
+        {t('app_settings.maskinporten_unsupported_app_version_description')}
+      </StudioParagraph>
+    </StudioAlert>
   );
 }
 

--- a/src/Designer/frontend/app-development/utils/versionUtils.test.ts
+++ b/src/Designer/frontend/app-development/utils/versionUtils.test.ts
@@ -1,4 +1,8 @@
-import { isMaskinportenDefaultScopesOptInVersion, isVersionAtLeast } from './versionUtils';
+import {
+  isMaskinportenDefaultScopesOptInVersion,
+  isMaskinportenScopesSupportedVersion,
+  isVersionAtLeast,
+} from './versionUtils';
 
 describe('versionUtils', () => {
   describe('isVersionAtLeast', () => {
@@ -33,6 +37,17 @@ describe('versionUtils', () => {
       [undefined, false],
     ])('returns %s for %s', (version, expected) => {
       expect(isMaskinportenDefaultScopesOptInVersion(version)).toBe(expected);
+    });
+  });
+
+  describe('isMaskinportenScopesSupportedVersion', () => {
+    it.each([
+      ['8.2.9', false],
+      ['8.3.0', true],
+      ['9.0.0', true],
+      [undefined, false],
+    ])('returns %s for %s', (version, expected) => {
+      expect(isMaskinportenScopesSupportedVersion(version)).toBe(expected);
     });
   });
 });

--- a/src/Designer/frontend/app-development/utils/versionUtils.ts
+++ b/src/Designer/frontend/app-development/utils/versionUtils.ts
@@ -17,8 +17,12 @@ export const isVersionAtLeast = (
   return actualPatch >= patch;
 };
 
+const maskinportenScopesSupportedVersion = [8, 3, 0] as const;
+const maskinportenDefaultScopesOptInCutoffVersion = [9, 0, 0] as const;
+
 export const isMaskinportenScopesSupportedVersion = (version: string | undefined): boolean =>
-  isVersionAtLeast(version, 8, 3, 0);
+  isVersionAtLeast(version, ...maskinportenScopesSupportedVersion);
 
 export const isMaskinportenDefaultScopesOptInVersion = (version: string | undefined): boolean =>
-  isMaskinportenScopesSupportedVersion(version) && !isVersionAtLeast(version, 9, 0, 0);
+  isMaskinportenScopesSupportedVersion(version) &&
+  !isVersionAtLeast(version, ...maskinportenDefaultScopesOptInCutoffVersion);

--- a/src/Designer/frontend/app-development/utils/versionUtils.ts
+++ b/src/Designer/frontend/app-development/utils/versionUtils.ts
@@ -17,5 +17,8 @@ export const isVersionAtLeast = (
   return actualPatch >= patch;
 };
 
+export const isMaskinportenScopesSupportedVersion = (version: string | undefined): boolean =>
+  isVersionAtLeast(version, 8, 3, 0);
+
 export const isMaskinportenDefaultScopesOptInVersion = (version: string | undefined): boolean =>
-  isVersionAtLeast(version, 8, 3, 0) && !isVersionAtLeast(version, 9, 0, 0);
+  isMaskinportenScopesSupportedVersion(version) && !isVersionAtLeast(version, 9, 0, 0);

--- a/src/Designer/frontend/language/src/en.json
+++ b/src/Designer/frontend/language/src/en.json
@@ -58,6 +58,8 @@
   "app_settings.maskinporten_no_org_access_description": "To select Maskinporten scopes, sign in with Ansattporten on behalf of the organisation that owns the app.",
   "app_settings.maskinporten_no_org_access_title": "You do not have access on behalf of the organisation",
   "app_settings.maskinporten_scope_changes_deployment_notice": "Scope changes take effect the next time the app is built and deployed.",
+  "app_settings.maskinporten_unsupported_app_version_description": "This app uses an Altinn App version older than 8.3.0. Maskinporten scopes selected here are saved in Studio, but the app cannot use them when it is built and deployed until it is upgraded to Altinn App v8.3.0 or newer.",
+  "app_settings.maskinporten_unsupported_app_version_title": "The app must be upgraded before scopes can be used",
   "app_settings.run_tab_heading": "Run",
   "app_settings.run_tab_info": "This setting is used for cost reduction. The app can be undeployed automatically in test environments when it is inactive.",
   "app_settings.run_tab_switch_undeploy_on_inactivity": "Undeploy on inactivity in test environments",

--- a/src/Designer/frontend/language/src/nb.json
+++ b/src/Designer/frontend/language/src/nb.json
@@ -405,6 +405,8 @@
   "app_settings.maskinporten_tab_save_scopes": "Lagre",
   "app_settings.maskinporten_tab_save_scopes_error_message": "Det oppsto en feil under lagring av innstillingene. Prøv igjen senere.",
   "app_settings.maskinporten_tab_save_scopes_success_message": "Innstillingene ble lagret.",
+  "app_settings.maskinporten_unsupported_app_version_description": "Denne appen bruker en Altinn App-versjon eldre enn 8.3.0. Maskinporten-scopes du velger her blir lagret i Studio, men appen kan ikke bruke dem når den bygges og publiseres før den er oppgradert til Altinn App v8.3.0 eller nyere.",
+  "app_settings.maskinporten_unsupported_app_version_title": "Appen må oppgraderes før scopes kan brukes",
   "app_settings.navigation_warning_dialog_delete_changes_button": "Slett endringene mine",
   "app_settings.navigation_warning_dialog_go_back_button": "Gå tilbake",
   "app_settings.navigation_warning_dialog_header": "Du har ikke lagret endringene dine",


### PR DESCRIPTION
## Description

Warn users on the Maskinporten scopes settings page when the app backend version is older than v8.3.0. Scopes can still be saved in Studio, but apps below v8.3.0 do not read the operator-managed runtime secret, so the deployed app cannot use those scopes.

The normal deployment notice is hidden in this unsupported state to avoid implying that rebuilding and publishing alone is enough.

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

Automated checks run locally:

```bash
yarn test app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeListContainer.test.tsx app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.test.tsx app-development/utils/versionUtils.test.ts
yarn test app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.test.tsx app-development/utils/versionUtils.test.ts
yarn typecheck
yarn eslint src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.tsx src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.test.tsx src/Designer/frontend/app-development/utils/versionUtils.ts src/Designer/frontend/app-development/utils/versionUtils.test.ts
git diff --check
```

Manual browser verification with local app-development server:

- Mocked `app-development/app-version` as `8.2.9`: verified the danger alert is visible and the deployment notice is absent.
- Mocked `app-development/app-version` as `8.3.0`: verified the deployment notice is visible and the unsupported-version alert is absent.

Screenshot from the unsupported `8.2.9` state:

![Maskinporten scopes unsupported app version warning](https://raw.githubusercontent.com/martinothamar-agent/altinn-studio/pr-assets-18925-maskinporten/pr-assets/18925/maskinporten-unsupported-app-version-clean.png)

Browser screenshots were captured locally from both tested states.

cc @martinothamar


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a warning alert that notifies users when their app version does not support Maskinporten scope configuration (requires version 8.3.0 or later).
  * The system now prevents scope deployment notifications from appearing on unsupported app versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio/pull/18925?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

