### PR TITLE
fix: deploy spinner stuck when no pipeline events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,7 @@ AppPackages/
 
 # Others
 *.Cache
+*.lscache
 ClientBin/
 [Ss]tyle[Cc]op.*
 !stylecop.json

--- a/src/Designer/frontend/app-development/features/appPublish/components/DeploymentEnvironmentLogList.test.tsx
+++ b/src/Designer/frontend/app-development/features/appPublish/components/DeploymentEnvironmentLogList.test.tsx
@@ -326,6 +326,72 @@ describe('DeploymentEnvironmentLogList', () => {
         ),
       ).toBeInTheDocument();
     });
+
+    it('keeps deployment in progress when pipeline scheduling is still within grace period', () => {
+      render({
+        pipelineDeploymentList: [
+          {
+            ...pipelineDeployment,
+            build: undefined,
+            events: [
+              {
+                ...deployEvent,
+                eventType: WarningEventType.ResourceRegistryPublishFailed,
+                created: new Date(Date.now() - 60 * 1000).toISOString(),
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(
+        screen.getByText(textMock('app_deployment.pipeline_deployment.build_result.none')),
+      ).toBeInTheDocument();
+    });
+
+    it('renders failed status when pipeline scheduling is stale after resource registry failure', () => {
+      render({
+        pipelineDeploymentList: [
+          {
+            ...pipelineDeployment,
+            build: undefined,
+            events: [
+              {
+                ...deployEvent,
+                eventType: WarningEventType.ResourceRegistryPublishFailed,
+                created: new Date(Date.now() - 6 * 60 * 1000).toISOString(),
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(
+        screen.getByText(textMock('app_deployment.pipeline_deployment.build_result.failed')),
+      ).toBeInTheDocument();
+    });
+
+    it('renders failed status when pipeline scheduling is stale after resource registry success', () => {
+      render({
+        pipelineDeploymentList: [
+          {
+            ...pipelineDeployment,
+            build: undefined,
+            events: [
+              {
+                ...deployEvent,
+                eventType: EventType.ResourceRegistryPublishSucceeded,
+                created: new Date(Date.now() - 6 * 60 * 1000).toISOString(),
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(
+        screen.getByText(textMock('app_deployment.pipeline_deployment.build_result.failed')),
+      ).toBeInTheDocument();
+    });
   });
 
   it('does not render build log link when started date is null', () => {

--- a/src/Designer/frontend/packages/shared/src/types/api/PipelineDeployment.ts
+++ b/src/Designer/frontend/packages/shared/src/types/api/PipelineDeployment.ts
@@ -48,6 +48,11 @@ export enum WarningEventType {
 const succeededEventTypeValues = Object.values(SucceededEventType);
 const failedEventTypeValues = Object.values(FailedEventType);
 const warningEventTypeValues = Object.values(WarningEventType);
+const deploymentSchedulingGracePeriodMs = 5 * 60 * 1000;
+
+const isResourceRegistryEventType = (eventType: DeployEvent['eventType']): boolean =>
+  eventType === EventType.ResourceRegistryPublishSucceeded ||
+  eventType === WarningEventType.ResourceRegistryPublishFailed;
 
 export const getDeploymentWarnings = (
   deployment: PipelineDeployment | undefined,
@@ -68,6 +73,16 @@ export const getDeployStatus = (deployment: PipelineDeployment | undefined): Bui
   const lastEventType = lastEvent?.eventType;
   const warnings = getDeploymentWarnings(deployment);
   if (lastEventType) {
+    const lastEventAgeMs = new Date().getTime() - new Date(lastEvent.created).getTime();
+
+    if (
+      isResourceRegistryEventType(lastEventType) &&
+      !deployment?.build &&
+      lastEventAgeMs > deploymentSchedulingGracePeriodMs
+    ) {
+      return BuildResult.failed;
+    }
+
     if (succeededEventTypeValues.includes(lastEventType as SucceededEventType)) {
       if (warnings.length > 0) {
         return BuildResult.partiallySucceeded;
@@ -82,8 +97,7 @@ export const getDeployStatus = (deployment: PipelineDeployment | undefined): Bui
 
       if (
         lastEventType === EventType.PipelineSucceeded &&
-        (isDeprecatedPipeline ||
-          new Date().getTime() - new Date(lastEvent.created).getTime() > 15 * 60 * 1000)
+        (isDeprecatedPipeline || lastEventAgeMs > 15 * 60 * 1000)
       ) {
         if (warnings.length > 0) {
           return BuildResult.partiallySucceeded;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 Fix deploy spinner for deployments that never schedule a pipeline

  Treat deployments with only a Resource Registry event and no build as failed after a 5 minute grace period. This prevents the Designer deploy page from showing an
  infinite spinner if the Designer pod is killed after writing the Resource Registry event but before scheduling the Azure DevOps pipeline.

  Also ignores generated `*.lscache` files.

<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment status determination when resource registry events occur without builds. Now includes grace-period logic to ensure accurate status reporting and better handling of edge cases in deployment scheduling.

* **Tests**
  * Added test coverage for deployment status behaviour with resource registry events and missing builds.

* **Chores**
  * Updated project gitignore to exclude local storage cache files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio/pull/18926?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->