### PR TITLE
chore: update studioctl localtest image

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -8,6 +8,14 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+### Added
+
+- Add `studioctl auth login --with-token` for logging in with an existing Studio/Designer API key from standard input.
+
+### Changed
+
+- Update localtest image.
+
 ## [0.1.0-preview.8] - 2026-05-13
 
 ### Changed

--- a/src/cli/internal/config/config.yaml
+++ b/src/cli/internal/config/config.yaml
@@ -6,7 +6,7 @@ images:
   core:
     localtest:
       image: ghcr.io/altinn/altinn-studio/runtime-localtest
-      tag: "6487f5d034"
+      tag: "4b44bcf7f2"
     pdf3:
       image: ghcr.io/altinn/altinn-studio/runtime-pdf3-worker
       tag: "b885f9a75f"


### PR DESCRIPTION
## Description

Updates `studioctl`'s bundled Localtest image tag to `ghcr.io/altinn/altinn-studio/runtime-localtest:4b44bcf7f2`, produced by https://github.com/Altinn/altinn-studio/actions/runs/26272579320 from upstream `main`.

Adds a `studioctl` changelog entry for the bundled Localtest image update with ProcessDataCleanupService support.

## Verification

- [x] Related issues are connected (not applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (config/changelog-only change)

Validation run locally:

```bash
yq . src/cli/internal/config/config.yaml >/tmp/studioctl-config-yq.out
go test ./internal/config/... # from src/cli
docker manifest inspect ghcr.io/altinn/altinn-studio/runtime-localtest:4b44bcf7f2 >/tmp/runtime-localtest-4b44bcf7f2-manifest.json
jq -r ' .manifests[]?.platform | "\\(.os)/\\(.architecture)" ' /tmp/runtime-localtest-4b44bcf7f2-manifest.json\ngit diff --check\ngo run . validate-changelog -component studioctl -base upstream/main -head HEAD # from src/tools/releaser\n```\n\nRelevant outputs:\n\n```text\nok  altinn.studio/studioctl/internal/config  (cached)\nlinux/amd64\nlinux/arm64\nchangelog validated\n```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added `--with-token` flag to `studioctl auth login`, enabling authentication using an existing API key via standard input.

* **Chores**
  * Updated the default localtest container image version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio/pull/18930?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->