### PR TITLE
chore: release studioctl v0.1.0-preview.9

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -8,6 +8,8 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+## [0.1.0-preview.9] - 2026-05-22
+
 ### Added
 
 - Add `studioctl auth login --with-token` for logging in with an existing Studio/Designer API key from standard input.


### PR DESCRIPTION
## Description

Prepare release v0.1.0-preview.9

- [Added] Add `studioctl auth login --with-token` for logging in with an existing Studio/Designer API key from standard input.
- [Changed] Update localtest image.

@coderabbitai ignore

**Full Changelog**: https://github.com/Altinn/altinn-studio/compare/studioctl/v0.1.0-preview.8...studioctl/v0.1.0-preview.9