### PR TITLE
fix: allow studioctl release workflow retries

### DIFF
--- a/.github/workflows/release-studioctl.yaml
+++ b/.github/workflows/release-studioctl.yaml
@@ -11,6 +11,7 @@ on:
       - 'release/studioctl/v*'
     paths:
       - 'src/cli/CHANGELOG.md'
+  workflow_dispatch: {}
 
 permissions:
   contents: write
@@ -19,10 +20,19 @@ jobs:
   release:
     name: Build and release
     runs-on: ubuntu-latest
-    # Only run if PR was merged AND has the release label
+    # Automatically release same-repo release PRs. Fork PRs can be retried manually
+    # from main after merge because their pull_request token cannot publish releases.
     if: >
-      github.event.pull_request.merged == true &&
-      contains(github.event.pull_request.labels.*.name, 'release/studioctl')
+      (
+        github.event_name == 'workflow_dispatch' &&
+        github.ref == 'refs/heads/main'
+      ) ||
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.merged == true &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        contains(github.event.pull_request.labels.*.name, 'release/studioctl')
+      )
 
     steps:
       - name: Checkout repository
@@ -30,14 +40,25 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.merge_commit_sha || github.sha }}
 
       - name: Checkout base branch
+        env:
+          BASE_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || 'main' }}
+          MERGE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.merge_commit_sha || github.sha }}
         run: |
-          BASE="${{ github.event.pull_request.base.ref }}"
-          MERGE_SHA="${{ github.event.pull_request.merge_commit_sha }}"
-          git fetch origin "$BASE"
-          git checkout -B "$BASE" "$MERGE_SHA"
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && "${GITHUB_REF}" != "refs/heads/main" ]]; then
+            echo "Manual studioctl releases must be dispatched from main"
+            exit 1
+          fi
+
+          if [[ "${BASE_BRANCH}" != "main" && ! "${BASE_BRANCH}" =~ ^release/studioctl/v[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid base branch: ${BASE_BRANCH}"
+            exit 1
+          fi
+
+          git fetch origin "$BASE_BRANCH"
+          git checkout -B "$BASE_BRANCH" "$MERGE_SHA"
 
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
@@ -58,23 +79,33 @@ jobs:
       - name: Run release workflow
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || 'main' }}
         run: |
-          go run . workflow --component studioctl --base-branch "${{ github.event.pull_request.base.ref }}"
+          go run . workflow --component studioctl --base-branch "$BASE_BRANCH"
         working-directory: src/tools/releaser
 
       - name: Summary
         if: always()
         run: |
-          echo "## Release Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **PR**: #${{ github.event.pull_request.number }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Base branch**: ${{ github.event.pull_request.base.ref }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Version source**: latest released section in src/cli/CHANGELOG.md" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Release Summary"
+            echo ""
+            if [[ -n "${PR_NUMBER}" ]]; then
+              echo "- **PR**: #${PR_NUMBER}"
+            fi
+            echo "- **Base branch**: ${BASE_BRANCH}"
+            echo "- **Version source**: latest released section in src/cli/CHANGELOG.md"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
 
           if [[ -d "build/release" ]]; then
-            echo "### Assets" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            ls -la build/release/ >> $GITHUB_STEP_SUMMARY 2>/dev/null || echo "No assets found"
-            echo '```' >> $GITHUB_STEP_SUMMARY
+            {
+              echo "### Assets"
+              echo '```'
+              ls -la build/release/ 2>/dev/null || echo "No assets found"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
+        env:
+          BASE_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || 'main' }}
+          PR_NUMBER: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}


### PR DESCRIPTION
## Description

Fixes the `Release - studioctl` workflow after the `v0.1.0-preview.9` release run failed at `gh release create` with `HTTP 403: Resource not accessible by integration`. The failed run was triggered from a merged fork PR through `pull_request`, so the token could build artifacts but could not create the GitHub release.

Changes:

- Keep the existing `pull_request` trigger and avoid `pull_request_target`.
- Only auto-release merged release-prep PRs when the PR branch belongs to the upstream repository. Fork release-prep PR merges are intentionally skipped because their `pull_request` token cannot publish releases.
- Add a `workflow_dispatch` retry path, but only when dispatched from `main`.
- Remove manual branch input handling so dispatch cannot inject shell content or release a different selected branch.
- Pass the derived base branch through `env`, validate it as `main` or `release/studioctl/vX.Y`, and run the releaser with that value.

After this merges, trigger `Release - studioctl` manually from `main` to publish `studioctl/v0.1.0-preview.9`.

## Verification

- [x] Related issues are connected (not applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (workflow validation)
- [ ] Relevant automated test added (workflow-only fix)

Validation run locally:

```bash
yq . .github/workflows/release-studioctl.yaml >/tmp/release-studioctl-yq.out
go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release-studioctl.yaml
git diff --check
cd src/tools/releaser && go test ./...
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow to support both automatic and manual release processes with enhanced validation and logging.

**Note:** This release contains no user-facing changes. Updates are limited to internal release infrastructure enhancements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio/pull/18932?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->