### PR TITLE
fix: harden studioctl install on Windows

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -13,6 +13,8 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 - Fix Windows PowerShell installer architecture detection.
 - Make Windows installs fall back to the default location when no usable interactive prompt is available.
 - Support `studioctl self update` and `studioctl self uninstall` on Windows by completing binary replacement/removal after the running process exits.
+- Render plain output in Windows PowerShell ISE to avoid unreadable ANSI codes and spinner/status glyphs.
+- Clean up stale `studioctl` update artifacts from the Windows install directory during uninstall.
 
 ## [0.1.0-preview.9] - 2026-05-22
 

--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -8,6 +8,12 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Windows PowerShell installer architecture detection.
+- Make Windows installs fall back to the default location when no usable interactive prompt is available.
+- Support `studioctl self update` and `studioctl self uninstall` on Windows by completing binary replacement/removal after the running process exits.
+
 ## [0.1.0-preview.9] - 2026-05-22
 
 ### Added

--- a/src/cli/cmd/studioctl/install.ps1
+++ b/src/cli/cmd/studioctl/install.ps1
@@ -33,12 +33,23 @@ if ($Version -ne "latest") {
     $Version = "studioctl/$Version"
 }
 
-$arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant()
-switch ($arch) {
-    "x64" { $arch = "amd64" }
-    "arm64" { $arch = "arm64" }
-    default { throw "Unsupported architecture: $arch" }
+function Resolve-StudioctlArchitecture {
+    $rawArch = $env:PROCESSOR_ARCHITEW6432
+    if (-not $rawArch) { $rawArch = $env:PROCESSOR_ARCHITECTURE }
+
+    if (-not $rawArch) {
+        throw "Unsupported architecture: unable to determine processor architecture"
+    }
+
+    switch ($rawArch.ToLowerInvariant()) {
+        "amd64" { return "amd64" }
+        "x86_64" { return "amd64" }
+        "arm64" { return "arm64" }
+        default { throw "Unsupported architecture: $rawArch" }
+    }
 }
+
+$arch = Resolve-StudioctlArchitecture
 
 $asset = "studioctl-windows-$arch.exe"
 $repo = "Altinn/altinn-studio"

--- a/src/cli/cmd/studioctl/install.ps1
+++ b/src/cli/cmd/studioctl/install.ps1
@@ -43,7 +43,6 @@ function Resolve-StudioctlArchitecture {
 
     switch ($rawArch.ToLowerInvariant()) {
         "amd64" { return "amd64" }
-        "x86_64" { return "amd64" }
         "arm64" { return "arm64" }
         default { throw "Unsupported architecture: $rawArch" }
     }

--- a/src/cli/internal/cmd/doctor/system.go
+++ b/src/cli/internal/cmd/doctor/system.go
@@ -18,7 +18,7 @@ func buildSystem(ctx context.Context) *System {
 		OSName:       "",
 		OSVersion:    "",
 		Terminal:     os.Getenv("TERM"),
-		ColorEnabled: os.Getenv("NO_COLOR") == "",
+		ColorEnabled: ui.Colors(),
 		TTY:          ui.StdoutIsTerminal(),
 	}
 

--- a/src/cli/internal/cmd/self.go
+++ b/src/cli/internal/cmd/self.go
@@ -23,6 +23,7 @@ import (
 const (
 	selfCompleteInstallSubcmd = "__complete-install"
 	selfMigrateSubcmd         = "__migrate"
+	selfWindowsHelperSubcmd   = "__windows-helper"
 )
 
 // SelfCommand implements the 'self' subcommand.
@@ -119,6 +120,8 @@ func (c *SelfCommand) Run(ctx context.Context, args []string) error {
 	case selfCompleteInstallSubcmd, selfMigrateSubcmd:
 		// __migrate is a preview.7 compatibility alias used by old updaters after replacing the binary.
 		return c.runCompleteInstall(ctx, subArgs)
+	case selfWindowsHelperSubcmd:
+		return c.runWindowsSelfHelper(ctx, subArgs)
 	case "-h", flagHelp, helpSubcmd:
 		c.out.Print(c.Usage())
 		return nil
@@ -334,6 +337,16 @@ func (c *SelfCommand) runUpdate(ctx context.Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("resolve update bundle: %w", err)
 	}
+	if runtime.GOOS == osutil.OSWindows {
+		if err := c.startWindowsUpdateHelper(resolved); err != nil {
+			if resolved.Cleanup != nil {
+				err = errors.Join(err, resolved.Cleanup())
+			}
+			return err
+		}
+		c.out.Successf("%s update started. The replacement will finish after this process exits.", osutil.CurrentBin())
+		return nil
+	}
 	if resolved.Cleanup != nil {
 		defer func() {
 			if cleanupErr := resolved.Cleanup(); cleanupErr != nil {
@@ -443,16 +456,17 @@ func (c *SelfCommand) runUninstall(ctx context.Context, args []string) error {
 		return fmt.Errorf("parsing flags: %w", err)
 	}
 
-	if runtime.GOOS == osutil.OSWindows {
-		c.out.Error("Self-uninstall while running is not supported on Windows.")
-		c.out.Println("Run this after studioctl has exited:")
-		c.out.Println(`  Remove-Item "<path-to-studioctl.exe>"`)
-		return nil
-	}
-
 	if proceed, err := c.confirmUninstallIfNeeded(ctx, flags); err != nil {
 		return err
 	} else if !proceed {
+		return nil
+	}
+
+	if runtime.GOOS == osutil.OSWindows {
+		if err := c.startWindowsUninstallHelper(); err != nil {
+			return err
+		}
+		c.out.Successf("%s uninstall started. The binary will be removed after this process exits.", osutil.CurrentBin())
 		return nil
 	}
 

--- a/src/cli/internal/cmd/self.go
+++ b/src/cli/internal/cmd/self.go
@@ -24,6 +24,8 @@ const (
 	selfCompleteInstallSubcmd = "__complete-install"
 	selfMigrateSubcmd         = "__migrate"
 	selfWindowsHelperSubcmd   = "__windows-helper"
+	selfUpdateSubcmd          = "update"
+	selfUninstallSubcmd       = "uninstall"
 )
 
 // SelfCommand implements the 'self' subcommand.
@@ -113,9 +115,9 @@ func (c *SelfCommand) Run(ctx context.Context, args []string) error {
 	switch subCmd {
 	case "install":
 		return c.runInstall(ctx, subArgs)
-	case "update":
+	case selfUpdateSubcmd:
 		return c.runUpdate(ctx, subArgs)
-	case "uninstall":
+	case selfUninstallSubcmd:
 		return c.runUninstall(ctx, subArgs)
 	case selfCompleteInstallSubcmd, selfMigrateSubcmd:
 		// __migrate is a preview.7 compatibility alias used by old updaters after replacing the binary.
@@ -338,7 +340,7 @@ func (c *SelfCommand) runUpdate(ctx context.Context, args []string) error {
 		return fmt.Errorf("resolve update bundle: %w", err)
 	}
 	if runtime.GOOS == osutil.OSWindows {
-		if err := c.startWindowsUpdateHelper(resolved); err != nil {
+		if err := c.startWindowsUpdateHelper(ctx, resolved); err != nil {
 			if resolved.Cleanup != nil {
 				err = errors.Join(err, resolved.Cleanup())
 			}
@@ -463,7 +465,7 @@ func (c *SelfCommand) runUninstall(ctx context.Context, args []string) error {
 	}
 
 	if runtime.GOOS == osutil.OSWindows {
-		if err := c.startWindowsUninstallHelper(); err != nil {
+		if err := c.startWindowsUninstallHelper(ctx); err != nil {
 			return err
 		}
 		c.out.Successf(

--- a/src/cli/internal/cmd/self.go
+++ b/src/cli/internal/cmd/self.go
@@ -500,6 +500,9 @@ func (c *SelfCommand) runUninstall(ctx context.Context, args []string) error {
 	removed = true
 
 	c.out.Successf("Removed %s", result.RemovedPath)
+	if result.RemovedDir != "" {
+		c.out.Successf("Removed %s", result.RemovedDir)
+	}
 	c.out.Successf("Removed %s", removedHome)
 	return nil
 }

--- a/src/cli/internal/cmd/self.go
+++ b/src/cli/internal/cmd/self.go
@@ -466,7 +466,10 @@ func (c *SelfCommand) runUninstall(ctx context.Context, args []string) error {
 		if err := c.startWindowsUninstallHelper(); err != nil {
 			return err
 		}
-		c.out.Successf("%s uninstall started. The binary will be removed after this process exits.", osutil.CurrentBin())
+		c.out.Successf(
+			"%s uninstall started. The binary will be removed after this process exits.",
+			osutil.CurrentBin(),
+		)
 		return nil
 	}
 

--- a/src/cli/internal/cmd/self.go
+++ b/src/cli/internal/cmd/self.go
@@ -43,6 +43,8 @@ type applyBundleOptions struct {
 	WarnPath   bool
 }
 
+type uninstallBinaryFunc func() (installpkg.UninstallResult, error)
+
 // NewSelfCommand creates a new self command.
 func NewSelfCommand(cfg *config.Config, out *ui.Output) *SelfCommand {
 	return &SelfCommand{
@@ -475,6 +477,10 @@ func (c *SelfCommand) runUninstall(ctx context.Context, args []string) error {
 		return nil
 	}
 
+	return c.runConfirmedUninstall(ctx, c.service.UninstallBinary)
+}
+
+func (c *SelfCommand) runConfirmedUninstall(ctx context.Context, uninstallBinary uninstallBinaryFunc) error {
 	state, err := c.transition.Prepare(ctx)
 	if err != nil {
 		return fmt.Errorf("prepare uninstall: %w", err)
@@ -498,7 +504,7 @@ func (c *SelfCommand) runUninstall(ctx context.Context, args []string) error {
 		return fmt.Errorf("remove home directory: %w", err)
 	}
 
-	result, err := c.service.UninstallBinary()
+	result, err := uninstallBinary()
 	if err != nil {
 		return fmt.Errorf("self uninstall: %w", err)
 	}

--- a/src/cli/internal/cmd/self_internal_test.go
+++ b/src/cli/internal/cmd/self_internal_test.go
@@ -50,6 +50,9 @@ func TestSelfUsageHidesInternalSubcommands(t *testing.T) {
 	if strings.Contains(usage, selfMigrateSubcmd) {
 		t.Fatalf("Usage() includes %s:\n%s", selfMigrateSubcmd, usage)
 	}
+	if strings.Contains(usage, selfWindowsHelperSubcmd) {
+		t.Fatalf("Usage() includes %s:\n%s", selfWindowsHelperSubcmd, usage)
+	}
 }
 
 func TestInstalledSelfCommandArgsIncludesConfigFlags(t *testing.T) {

--- a/src/cli/internal/cmd/self_other.go
+++ b/src/cli/internal/cmd/self_other.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	installpkg "altinn.studio/studioctl/internal/install"
+)
+
+func (c *SelfCommand) startWindowsUpdateHelper(installpkg.ResolvedBundle) error {
+	return fmt.Errorf("%w: Windows self helper is only available on Windows", ErrInvalidFlagValue)
+}
+
+func (c *SelfCommand) startWindowsUninstallHelper() error {
+	return fmt.Errorf("%w: Windows self helper is only available on Windows", ErrInvalidFlagValue)
+}
+
+func (c *SelfCommand) runWindowsSelfHelper(context.Context, []string) error {
+	return fmt.Errorf("%w: Windows self helper is only available on Windows", ErrInvalidFlagValue)
+}

--- a/src/cli/internal/cmd/self_other.go
+++ b/src/cli/internal/cmd/self_other.go
@@ -9,11 +9,11 @@ import (
 	installpkg "altinn.studio/studioctl/internal/install"
 )
 
-func (c *SelfCommand) startWindowsUpdateHelper(installpkg.ResolvedBundle) error {
+func (c *SelfCommand) startWindowsUpdateHelper(context.Context, installpkg.ResolvedBundle) error {
 	return fmt.Errorf("%w: Windows self helper is only available on Windows", ErrInvalidFlagValue)
 }
 
-func (c *SelfCommand) startWindowsUninstallHelper() error {
+func (c *SelfCommand) startWindowsUninstallHelper(context.Context) error {
 	return fmt.Errorf("%w: Windows self helper is only available on Windows", ErrInvalidFlagValue)
 }
 

--- a/src/cli/internal/cmd/self_windows.go
+++ b/src/cli/internal/cmd/self_windows.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -21,20 +22,26 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-const windowsHelperExe = "studioctl-self-helper.exe"
+const (
+	windowsHelperExe      = "studioctl-self-helper.exe"
+	windowsHelperFilePerm = 0o755
+)
 
+var errUnexpectedWindowsWaitStatus = errors.New("unexpected Windows wait status")
+
+//nolint:gochecknoglobals // Test seam for system PowerShell path resolution.
 var windowsPowerShellPathFunc = windowsPowerShellPath
 
 type windowsSelfHelperFlags struct {
 	operation    string
-	parentHandle windows.Handle
 	target       string
 	source       string
 	version      string
 	tempDir      string
+	parentHandle windows.Handle
 }
 
-func (c *SelfCommand) startWindowsUpdateHelper(resolved installpkg.ResolvedBundle) error {
+func (c *SelfCommand) startWindowsUpdateHelper(ctx context.Context, resolved installpkg.ResolvedBundle) error {
 	source := resolved.Bundle.BinaryPath
 	target := resolved.Bundle.InstallPath()
 	if source == "" || target == "" {
@@ -47,17 +54,18 @@ func (c *SelfCommand) startWindowsUpdateHelper(resolved installpkg.ResolvedBundl
 	}
 
 	args := c.windowsSelfHelperArgs(windowsSelfHelperFlags{
-		operation: "update",
-		source:    source,
-		target:    target,
-		version:   resolved.Bundle.Version,
-		tempDir:   tempDir,
+		operation:    selfUpdateSubcmd,
+		target:       target,
+		source:       source,
+		version:      resolved.Bundle.Version,
+		tempDir:      tempDir,
+		parentHandle: 0,
 	})
 
-	return startWindowsHelperProcess(helperPath, args)
+	return startWindowsHelperProcess(ctx, helperPath, args)
 }
 
-func (c *SelfCommand) startWindowsUninstallHelper() error {
+func (c *SelfCommand) startWindowsUninstallHelper(ctx context.Context) error {
 	tempDir, err := os.MkdirTemp("", "studioctl-self-uninstall-*")
 	if err != nil {
 		return fmt.Errorf("create uninstall helper directory: %w", err)
@@ -68,11 +76,14 @@ func (c *SelfCommand) startWindowsUninstallHelper() error {
 	}
 
 	args := c.windowsSelfHelperArgs(windowsSelfHelperFlags{
-		operation: "uninstall",
-		target:    current,
-		tempDir:   tempDir,
+		operation:    selfUninstallSubcmd,
+		target:       current,
+		source:       "",
+		version:      "",
+		tempDir:      tempDir,
+		parentHandle: 0,
 	})
-	if err := startWindowsHelperProcess(helperPath, args); err != nil {
+	if err := startWindowsHelperProcess(ctx, helperPath, args); err != nil {
 		return errors.Join(err, os.RemoveAll(tempDir))
 	}
 	return nil
@@ -96,19 +107,25 @@ func (c *SelfCommand) windowsSelfHelperArgs(flags windowsSelfHelperFlags) []stri
 	return args
 }
 
-func startWindowsHelperProcess(path string, args []string) error {
-	parentHandle, err := windows.OpenProcess(windows.SYNCHRONIZE, true, uint32(os.Getpid()))
+func startWindowsHelperProcess(ctx context.Context, path string, args []string) (err error) {
+	processID, err := currentWindowsProcessID()
+	if err != nil {
+		return err
+	}
+	parentHandle, err := windows.OpenProcess(windows.SYNCHRONIZE, true, processID)
 	if err != nil {
 		return fmt.Errorf("open current process for Windows self helper: %w", err)
 	}
 	defer func() {
-		_ = windows.CloseHandle(parentHandle)
+		if closeErr := windows.CloseHandle(parentHandle); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("close Windows self helper parent handle: %w", closeErr))
+		}
 	}()
 
 	args = append(args, "--parent-handle", strconv.FormatUint(uint64(parentHandle), 10))
 
 	//nolint:gosec // G204: helper path is a temp copy of the current studioctl binary.
-	cmd := exec.Command(path, args...)
+	cmd := exec.CommandContext(context.WithoutCancel(ctx), path, args...)
 	osutil.ApplyDetachedAttrs(cmd)
 	cmd.SysProcAttr.AdditionalInheritedHandles = append(
 		cmd.SysProcAttr.AdditionalInheritedHandles,
@@ -135,12 +152,12 @@ func (c *SelfCommand) runWindowsSelfHelper(ctx context.Context, args []string) e
 		return err
 	}
 
-	defer scheduleWindowsTempCleanup(c, flags.tempDir)
+	defer scheduleWindowsTempCleanup(ctx, c, flags.tempDir)
 
 	switch flags.operation {
-	case "update":
+	case selfUpdateSubcmd:
 		return c.runWindowsUpdateHelper(ctx, flags)
-	case "uninstall":
+	case selfUninstallSubcmd:
 		return c.runWindowsUninstallHelper(ctx, flags)
 	default:
 		return fmt.Errorf("%w: unsupported Windows self helper operation %q", ErrInvalidFlagValue, flags.operation)
@@ -233,27 +250,43 @@ func (c *SelfCommand) runWindowsUninstallHelper(ctx context.Context, flags windo
 	return nil
 }
 
-func waitForWindowsProcessExit(handle windows.Handle) error {
-	defer windows.CloseHandle(handle) //nolint:errcheck // Nothing useful can be done during helper shutdown.
+func waitForWindowsProcessExit(handle windows.Handle) (err error) {
+	defer func() {
+		if closeErr := windows.CloseHandle(handle); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("close Windows parent process handle: %w", closeErr))
+		}
+	}()
 
 	status, err := windows.WaitForSingleObject(handle, windows.INFINITE)
 	if err != nil {
 		return fmt.Errorf("wait for parent process: %w", err)
 	}
 	if status != windows.WAIT_OBJECT_0 {
-		return fmt.Errorf("wait for parent process: unexpected status %d", status)
+		return fmt.Errorf("wait for parent process: %w %d", errUnexpectedWindowsWaitStatus, status)
 	}
 	return nil
+}
+
+func currentWindowsProcessID() (uint32, error) {
+	pid := os.Getpid()
+	if pid < 0 || uint64(pid) > math.MaxUint32 {
+		return 0, fmt.Errorf("%w: %d", ErrInvalidFlagValue, pid)
+	}
+	return uint32(pid), nil
 }
 
 func currentExecutablePath() (string, error) {
 	path, err := os.Executable()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("resolve current executable: %w", err)
 	}
 	resolved, err := filepath.EvalSymlinks(path)
 	if err != nil {
-		return filepath.Abs(path)
+		absolute, absErr := filepath.Abs(path)
+		if absErr != nil {
+			return "", fmt.Errorf("resolve absolute executable path: %w", absErr)
+		}
+		return absolute, nil
 	}
 	return resolved, nil
 }
@@ -271,8 +304,8 @@ func copyCurrentExecutableToWindowsHelper(tempDir string) (currentPath, helperPa
 }
 
 func copyFileForWindowsHelper(src, dst string) (err error) {
-	if err := os.MkdirAll(filepath.Dir(dst), osutil.DirPermDefault); err != nil {
-		return fmt.Errorf("create helper directory: %w", err)
+	if mkdirErr := os.MkdirAll(filepath.Dir(dst), osutil.DirPermDefault); mkdirErr != nil {
+		return fmt.Errorf("create helper directory: %w", mkdirErr)
 	}
 
 	//nolint:gosec // G304: source is the resolved current studioctl executable.
@@ -287,7 +320,7 @@ func copyFileForWindowsHelper(src, dst string) (err error) {
 	}()
 
 	//nolint:gosec // G304: destination is a freshly-created temp helper path.
-	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, windowsHelperFilePerm)
 	if err != nil {
 		return fmt.Errorf("create helper copy: %w", err)
 	}
@@ -303,7 +336,7 @@ func copyFileForWindowsHelper(src, dst string) (err error) {
 	return nil
 }
 
-func scheduleWindowsTempCleanup(c *SelfCommand, tempDir string) {
+func scheduleWindowsTempCleanup(ctx context.Context, c *SelfCommand, tempDir string) {
 	if tempDir == "" {
 		return
 	}
@@ -313,7 +346,9 @@ func scheduleWindowsTempCleanup(c *SelfCommand, tempDir string) {
 		"Start-Sleep -Seconds 2; Remove-Item -LiteralPath '%s' -Recurse -Force -ErrorAction SilentlyContinue",
 		quoted,
 	)
-	cmd := exec.Command(
+	//nolint:gosec // G204: executable is the system PowerShell path; command only targets the helper temp directory.
+	cmd := exec.CommandContext(
+		context.WithoutCancel(ctx),
 		windowsPowerShellPathFunc(),
 		"-NoProfile",
 		"-ExecutionPolicy",

--- a/src/cli/internal/cmd/self_windows.go
+++ b/src/cli/internal/cmd/self_windows.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	installpkg "altinn.studio/studioctl/internal/install"
 	"altinn.studio/studioctl/internal/osutil"
@@ -23,11 +24,16 @@ import (
 )
 
 const (
-	windowsHelperExe      = "studioctl-self-helper.exe"
-	windowsHelperFilePerm = 0o755
+	windowsHelperExe               = "studioctl-self-helper.exe"
+	windowsHelperFilePerm          = 0o755
+	windowsParentExitWaitTimeout   = 30 * time.Second
+	windowsPowerShellSystemSubpath = `WindowsPowerShell\v1.0\powershell.exe`
 )
 
-var errUnexpectedWindowsWaitStatus = errors.New("unexpected Windows wait status")
+var (
+	errUnexpectedWindowsWaitStatus = errors.New("unexpected Windows wait status")
+	errWindowsParentWaitTimeout    = errors.New("timed out waiting for parent process")
+)
 
 //nolint:gochecknoglobals // Test seam for system PowerShell path resolution.
 var windowsPowerShellPathFunc = windowsPowerShellPath
@@ -213,41 +219,9 @@ func (c *SelfCommand) runWindowsUpdateHelper(ctx context.Context, flags windowsS
 }
 
 func (c *SelfCommand) runWindowsUninstallHelper(ctx context.Context, flags windowsSelfHelperFlags) error {
-	state, err := c.transition.Prepare(ctx)
-	if err != nil {
-		return fmt.Errorf("prepare uninstall: %w", err)
-	}
-	removed := false
-	defer func() {
-		if !removed {
-			c.transition.Restore(ctx, state, "")
-		}
-	}()
-
-	if validateErr := c.service.ValidateHomeRemoval(); validateErr != nil {
-		return fmt.Errorf("validate home directory removal: %w", validateErr)
-	}
-
-	result, err := c.service.UninstallBinaryAt(flags.target)
-	if err != nil {
-		return fmt.Errorf("self uninstall: %w", err)
-	}
-	removed = true
-
-	if resetErr := c.transition.ResetEnvs(ctx); resetErr != nil {
-		return fmt.Errorf("reset environments before uninstall: %w", resetErr)
-	}
-	removedHome, err := c.service.RemoveHome()
-	if err != nil {
-		return fmt.Errorf("remove home directory: %w", err)
-	}
-
-	c.out.Successf("Removed %s", result.RemovedPath)
-	if result.RemovedDir != "" {
-		c.out.Successf("Removed %s", result.RemovedDir)
-	}
-	c.out.Successf("Removed %s", removedHome)
-	return nil
+	return c.runConfirmedUninstall(ctx, func() (installpkg.UninstallResult, error) {
+		return c.service.UninstallBinaryAt(flags.target)
+	})
 }
 
 func waitForWindowsProcessExit(handle windows.Handle) (err error) {
@@ -257,14 +231,21 @@ func waitForWindowsProcessExit(handle windows.Handle) (err error) {
 		}
 	}()
 
-	status, err := windows.WaitForSingleObject(handle, windows.INFINITE)
+	status, err := windows.WaitForSingleObject(handle, windowsParentExitWaitMilliseconds())
 	if err != nil {
 		return fmt.Errorf("wait for parent process: %w", err)
+	}
+	if status == uint32(windows.WAIT_TIMEOUT) {
+		return fmt.Errorf("wait for parent process: %w", errWindowsParentWaitTimeout)
 	}
 	if status != windows.WAIT_OBJECT_0 {
 		return fmt.Errorf("wait for parent process: %w %d", errUnexpectedWindowsWaitStatus, status)
 	}
 	return nil
+}
+
+func windowsParentExitWaitMilliseconds() uint32 {
+	return uint32(windowsParentExitWaitTimeout / time.Millisecond)
 }
 
 func currentWindowsProcessID() (uint32, error) {
@@ -367,5 +348,7 @@ func windowsPowerShellPath() string {
 	if err != nil || systemDir == "" {
 		systemDir = `C:\Windows\System32`
 	}
-	return filepath.Join(systemDir, "WindowsPowerShell", "v1.0", "powershell.exe")
+	// Windows PowerShell 5.1 is included with supported Windows versions and is
+	// a better fallback for this cleanup task than pwsh, which may not be installed.
+	return filepath.Join(systemDir, windowsPowerShellSystemSubpath)
 }

--- a/src/cli/internal/cmd/self_windows.go
+++ b/src/cli/internal/cmd/self_windows.go
@@ -1,0 +1,330 @@
+//go:build windows
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+
+	installpkg "altinn.studio/studioctl/internal/install"
+	"altinn.studio/studioctl/internal/osutil"
+
+	"golang.org/x/sys/windows"
+)
+
+const windowsHelperExe = "studioctl-self-helper.exe"
+
+var windowsPowerShellPathFunc = windowsPowerShellPath
+
+type windowsSelfHelperFlags struct {
+	operation    string
+	parentHandle windows.Handle
+	target       string
+	source       string
+	version      string
+	tempDir      string
+}
+
+func (c *SelfCommand) startWindowsUpdateHelper(resolved installpkg.ResolvedBundle) error {
+	source := resolved.Bundle.BinaryPath
+	target := resolved.Bundle.InstallPath()
+	if source == "" || target == "" {
+		return fmt.Errorf("%w: update helper source and target are required", ErrInvalidFlagValue)
+	}
+	tempDir := filepath.Dir(source)
+	_, helperPath, err := copyCurrentExecutableToWindowsHelper(tempDir)
+	if err != nil {
+		return err
+	}
+
+	args := c.windowsSelfHelperArgs(windowsSelfHelperFlags{
+		operation: "update",
+		source:    source,
+		target:    target,
+		version:   resolved.Bundle.Version,
+		tempDir:   tempDir,
+	})
+
+	return startWindowsHelperProcess(helperPath, args)
+}
+
+func (c *SelfCommand) startWindowsUninstallHelper() error {
+	tempDir, err := os.MkdirTemp("", "studioctl-self-uninstall-*")
+	if err != nil {
+		return fmt.Errorf("create uninstall helper directory: %w", err)
+	}
+	current, helperPath, err := copyCurrentExecutableToWindowsHelper(tempDir)
+	if err != nil {
+		return errors.Join(err, os.RemoveAll(tempDir))
+	}
+
+	args := c.windowsSelfHelperArgs(windowsSelfHelperFlags{
+		operation: "uninstall",
+		target:    current,
+		tempDir:   tempDir,
+	})
+	if err := startWindowsHelperProcess(helperPath, args); err != nil {
+		return errors.Join(err, os.RemoveAll(tempDir))
+	}
+	return nil
+}
+
+func (c *SelfCommand) windowsSelfHelperArgs(flags windowsSelfHelperFlags) []string {
+	args := c.installedSelfCommandArgs(selfWindowsHelperSubcmd)
+	args = append(args,
+		"--operation", flags.operation,
+		"--target", flags.target,
+	)
+	if flags.source != "" {
+		args = append(args, "--source", flags.source)
+	}
+	if flags.version != "" {
+		args = append(args, "--version", flags.version)
+	}
+	if flags.tempDir != "" {
+		args = append(args, "--temp-dir", flags.tempDir)
+	}
+	return args
+}
+
+func startWindowsHelperProcess(path string, args []string) error {
+	parentHandle, err := windows.OpenProcess(windows.SYNCHRONIZE, true, uint32(os.Getpid()))
+	if err != nil {
+		return fmt.Errorf("open current process for Windows self helper: %w", err)
+	}
+	defer func() {
+		_ = windows.CloseHandle(parentHandle)
+	}()
+
+	args = append(args, "--parent-handle", strconv.FormatUint(uint64(parentHandle), 10))
+
+	//nolint:gosec // G204: helper path is a temp copy of the current studioctl binary.
+	cmd := exec.Command(path, args...)
+	osutil.ApplyDetachedAttrs(cmd)
+	cmd.SysProcAttr.AdditionalInheritedHandles = append(
+		cmd.SysProcAttr.AdditionalInheritedHandles,
+		syscall.Handle(parentHandle),
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start Windows self helper: %w", err)
+	}
+	return nil
+}
+
+func (c *SelfCommand) runWindowsSelfHelper(ctx context.Context, args []string) error {
+	flags, err := parseWindowsSelfHelperFlags(args)
+	if err != nil {
+		return err
+	}
+
+	if err := waitForWindowsProcessExit(flags.parentHandle); err != nil {
+		return err
+	}
+
+	defer scheduleWindowsTempCleanup(c, flags.tempDir)
+
+	switch flags.operation {
+	case "update":
+		return c.runWindowsUpdateHelper(ctx, flags)
+	case "uninstall":
+		return c.runWindowsUninstallHelper(ctx, flags)
+	default:
+		return fmt.Errorf("%w: unsupported Windows self helper operation %q", ErrInvalidFlagValue, flags.operation)
+	}
+}
+
+func parseWindowsSelfHelperFlags(args []string) (windowsSelfHelperFlags, error) {
+	fs := flag.NewFlagSet("self "+selfWindowsHelperSubcmd, flag.ContinueOnError)
+	var flags windowsSelfHelperFlags
+	var parentHandle string
+	fs.StringVar(&flags.operation, "operation", "", "operation")
+	fs.StringVar(&parentHandle, "parent-handle", "", "parent process handle")
+	fs.StringVar(&flags.target, "target", "", "target executable path")
+	fs.StringVar(&flags.source, "source", "", "source executable path")
+	fs.StringVar(&flags.version, "version", "", "bundle version")
+	fs.StringVar(&flags.tempDir, "temp-dir", "", "temporary directory")
+
+	if err := fs.Parse(args); err != nil {
+		return windowsSelfHelperFlags{}, fmt.Errorf("parsing flags: %w", err)
+	}
+	if parentHandle == "" {
+		return windowsSelfHelperFlags{}, fmt.Errorf("%w: parent-handle is required", ErrInvalidFlagValue)
+	}
+	handle, err := strconv.ParseUint(parentHandle, 10, 0)
+	if err != nil || handle == 0 {
+		return windowsSelfHelperFlags{}, fmt.Errorf("%w: invalid parent-handle", ErrInvalidFlagValue)
+	}
+	flags.parentHandle = windows.Handle(handle)
+	if flags.target == "" {
+		return windowsSelfHelperFlags{}, fmt.Errorf("%w: target is required", ErrInvalidFlagValue)
+	}
+	return flags, nil
+}
+
+func (c *SelfCommand) runWindowsUpdateHelper(ctx context.Context, flags windowsSelfHelperFlags) error {
+	if flags.source == "" {
+		return fmt.Errorf("%w: source is required for update", ErrInvalidFlagValue)
+	}
+	version := flags.version
+	if version == "" {
+		version = c.cfg.Version.String()
+	}
+	bundle := installpkg.NewBundle(version, flags.source, "", flags.target)
+	if err := c.applyBundle(ctx, bundle, applyBundleOptions{
+		TargetDir:  filepath.Dir(flags.target),
+		Candidates: nil,
+		WarnPath:   false,
+	}); err != nil {
+		return fmt.Errorf("apply Windows self update: %w", err)
+	}
+	c.out.Successf("%s updated successfully.", osutil.CurrentBin())
+	return nil
+}
+
+func (c *SelfCommand) runWindowsUninstallHelper(ctx context.Context, flags windowsSelfHelperFlags) error {
+	state, err := c.transition.Prepare(ctx)
+	if err != nil {
+		return fmt.Errorf("prepare uninstall: %w", err)
+	}
+	removed := false
+	defer func() {
+		if !removed {
+			c.transition.Restore(ctx, state, "")
+		}
+	}()
+
+	if validateErr := c.service.ValidateHomeRemoval(); validateErr != nil {
+		return fmt.Errorf("validate home directory removal: %w", validateErr)
+	}
+
+	result, err := c.service.UninstallBinaryAt(flags.target)
+	if err != nil {
+		return fmt.Errorf("self uninstall: %w", err)
+	}
+	removed = true
+
+	if resetErr := c.transition.ResetEnvs(ctx); resetErr != nil {
+		return fmt.Errorf("reset environments before uninstall: %w", resetErr)
+	}
+	removedHome, err := c.service.RemoveHome()
+	if err != nil {
+		return fmt.Errorf("remove home directory: %w", err)
+	}
+
+	c.out.Successf("Removed %s", result.RemovedPath)
+	c.out.Successf("Removed %s", removedHome)
+	return nil
+}
+
+func waitForWindowsProcessExit(handle windows.Handle) error {
+	defer windows.CloseHandle(handle) //nolint:errcheck // Nothing useful can be done during helper shutdown.
+
+	status, err := windows.WaitForSingleObject(handle, windows.INFINITE)
+	if err != nil {
+		return fmt.Errorf("wait for parent process: %w", err)
+	}
+	if status != windows.WAIT_OBJECT_0 {
+		return fmt.Errorf("wait for parent process: unexpected status %d", status)
+	}
+	return nil
+}
+
+func currentExecutablePath() (string, error) {
+	path, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return filepath.Abs(path)
+	}
+	return resolved, nil
+}
+
+func copyCurrentExecutableToWindowsHelper(tempDir string) (currentPath, helperPath string, err error) {
+	currentPath, err = currentExecutablePath()
+	if err != nil {
+		return "", "", fmt.Errorf("resolve current executable path: %w", err)
+	}
+	helperPath = filepath.Join(tempDir, windowsHelperExe)
+	if err := copyFileForWindowsHelper(currentPath, helperPath); err != nil {
+		return "", "", err
+	}
+	return currentPath, helperPath, nil
+}
+
+func copyFileForWindowsHelper(src, dst string) (err error) {
+	if err := os.MkdirAll(filepath.Dir(dst), osutil.DirPermDefault); err != nil {
+		return fmt.Errorf("create helper directory: %w", err)
+	}
+
+	//nolint:gosec // G304: source is the resolved current studioctl executable.
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open helper source: %w", err)
+	}
+	defer func() {
+		if closeErr := in.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("close helper source: %w", closeErr)
+		}
+	}()
+
+	//nolint:gosec // G304: destination is a freshly-created temp helper path.
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		return fmt.Errorf("create helper copy: %w", err)
+	}
+	defer func() {
+		if closeErr := out.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("close helper copy: %w", closeErr)
+		}
+	}()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return fmt.Errorf("copy helper executable: %w", err)
+	}
+	return nil
+}
+
+func scheduleWindowsTempCleanup(c *SelfCommand, tempDir string) {
+	if tempDir == "" {
+		return
+	}
+
+	quoted := strings.ReplaceAll(tempDir, "'", "''")
+	command := fmt.Sprintf(
+		"Start-Sleep -Seconds 2; Remove-Item -LiteralPath '%s' -Recurse -Force -ErrorAction SilentlyContinue",
+		quoted,
+	)
+	cmd := exec.Command(
+		windowsPowerShellPathFunc(),
+		"-NoProfile",
+		"-ExecutionPolicy",
+		"Bypass",
+		"-Command",
+		command,
+	)
+	osutil.ApplyDetachedAttrs(cmd)
+	if err := cmd.Start(); err != nil {
+		c.out.Verbosef("failed to schedule helper cleanup for %s: %v", tempDir, err)
+	}
+}
+
+func windowsPowerShellPath() string {
+	systemDir, err := windows.GetSystemDirectory()
+	if err != nil || systemDir == "" {
+		systemDir = `C:\Windows\System32`
+	}
+	return filepath.Join(systemDir, "WindowsPowerShell", "v1.0", "powershell.exe")
+}

--- a/src/cli/internal/cmd/self_windows.go
+++ b/src/cli/internal/cmd/self_windows.go
@@ -223,6 +223,9 @@ func (c *SelfCommand) runWindowsUninstallHelper(ctx context.Context, flags windo
 	}
 
 	c.out.Successf("Removed %s", result.RemovedPath)
+	if result.RemovedDir != "" {
+		c.out.Successf("Removed %s", result.RemovedDir)
+	}
 	c.out.Successf("Removed %s", removedHome)
 	return nil
 }

--- a/src/cli/internal/cmd/self_windows.go
+++ b/src/cli/internal/cmd/self_windows.go
@@ -116,6 +116,9 @@ func startWindowsHelperProcess(path string, args []string) error {
 	)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	if osutil.IsPowerShellISEHost() {
+		cmd.Env = append(os.Environ(), osutil.DisableTerminalDecorationsEnv+"=1")
+	}
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("start Windows self helper: %w", err)
 	}

--- a/src/cli/internal/cmd/self_windows.go
+++ b/src/cli/internal/cmd/self_windows.go
@@ -35,9 +35,6 @@ var (
 	errWindowsParentWaitTimeout    = errors.New("timed out waiting for parent process")
 )
 
-//nolint:gochecknoglobals // Test seam for system PowerShell path resolution.
-var windowsPowerShellPathFunc = windowsPowerShellPath
-
 type windowsSelfHelperFlags struct {
 	operation    string
 	target       string
@@ -113,7 +110,7 @@ func (c *SelfCommand) windowsSelfHelperArgs(flags windowsSelfHelperFlags) []stri
 	return args
 }
 
-func startWindowsHelperProcess(ctx context.Context, path string, args []string) (err error) {
+func startWindowsHelperProcess(ctx context.Context, path string, args []string) error {
 	processID, err := currentWindowsProcessID()
 	if err != nil {
 		return err
@@ -122,11 +119,7 @@ func startWindowsHelperProcess(ctx context.Context, path string, args []string) 
 	if err != nil {
 		return fmt.Errorf("open current process for Windows self helper: %w", err)
 	}
-	defer func() {
-		if closeErr := windows.CloseHandle(parentHandle); closeErr != nil {
-			err = errors.Join(err, fmt.Errorf("close Windows self helper parent handle: %w", closeErr))
-		}
-	}()
+	defer closeWindowsHandle(parentHandle)
 
 	args = append(args, "--parent-handle", strconv.FormatUint(uint64(parentHandle), 10))
 
@@ -224,12 +217,8 @@ func (c *SelfCommand) runWindowsUninstallHelper(ctx context.Context, flags windo
 	})
 }
 
-func waitForWindowsProcessExit(handle windows.Handle) (err error) {
-	defer func() {
-		if closeErr := windows.CloseHandle(handle); closeErr != nil {
-			err = errors.Join(err, fmt.Errorf("close Windows parent process handle: %w", closeErr))
-		}
-	}()
+func waitForWindowsProcessExit(handle windows.Handle) error {
+	defer closeWindowsHandle(handle)
 
 	status, err := windows.WaitForSingleObject(handle, windowsParentExitWaitMilliseconds())
 	if err != nil {
@@ -242,6 +231,14 @@ func waitForWindowsProcessExit(handle windows.Handle) (err error) {
 		return fmt.Errorf("wait for parent process: %w %d", errUnexpectedWindowsWaitStatus, status)
 	}
 	return nil
+}
+
+func closeWindowsHandle(handle windows.Handle) {
+	// Handle closure is cleanup only; a failure must not turn a successful
+	// helper start or parent wait into a failed self update/uninstall.
+	if err := windows.CloseHandle(handle); err != nil {
+		return
+	}
 }
 
 func windowsParentExitWaitMilliseconds() uint32 {
@@ -330,7 +327,7 @@ func scheduleWindowsTempCleanup(ctx context.Context, c *SelfCommand, tempDir str
 	//nolint:gosec // G204: executable is the system PowerShell path; command only targets the helper temp directory.
 	cmd := exec.CommandContext(
 		context.WithoutCancel(ctx),
-		windowsPowerShellPathFunc(),
+		windowsPowerShellPath(),
 		"-NoProfile",
 		"-ExecutionPolicy",
 		"Bypass",

--- a/src/cli/internal/cmd/self_windows_test.go
+++ b/src/cli/internal/cmd/self_windows_test.go
@@ -68,7 +68,7 @@ func TestParseWindowsSelfHelperFlagsParsesUpdate(t *testing.T) {
 func TestWindowsPowerShellPathUsesSystemDirectory(t *testing.T) {
 	got := windowsPowerShellPath()
 	wantSuffix := `\System32\WindowsPowerShell\v1.0\powershell.exe`
-	if !strings.HasSuffix(got, wantSuffix) {
+	if !strings.HasSuffix(strings.ToLower(got), strings.ToLower(wantSuffix)) {
 		t.Fatalf("windowsPowerShellPath() = %q, want suffix %q", got, wantSuffix)
 	}
 }

--- a/src/cli/internal/cmd/self_windows_test.go
+++ b/src/cli/internal/cmd/self_windows_test.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-package cmd
+package cmd //nolint:testpackage // Tests cover unexported Windows helper parsing and path helpers.
 
 import (
 	"strings"

--- a/src/cli/internal/cmd/self_windows_test.go
+++ b/src/cli/internal/cmd/self_windows_test.go
@@ -1,0 +1,74 @@
+//go:build windows
+
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseWindowsSelfHelperFlagsRequiresParentHandle(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseWindowsSelfHelperFlags([]string{
+		"--operation", "update",
+		"--target", `C:\Users\me\.local\bin\studioctl.exe`,
+	})
+	if err == nil {
+		t.Fatal("parseWindowsSelfHelperFlags() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "parent-handle is required") {
+		t.Fatalf("parseWindowsSelfHelperFlags() error = %v, want parent-handle message", err)
+	}
+}
+
+func TestParseWindowsSelfHelperFlagsRequiresTarget(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseWindowsSelfHelperFlags([]string{
+		"--operation", "uninstall",
+		"--parent-handle", "1234",
+	})
+	if err == nil {
+		t.Fatal("parseWindowsSelfHelperFlags() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "target is required") {
+		t.Fatalf("parseWindowsSelfHelperFlags() error = %v, want target message", err)
+	}
+}
+
+func TestParseWindowsSelfHelperFlagsParsesUpdate(t *testing.T) {
+	t.Parallel()
+
+	got, err := parseWindowsSelfHelperFlags([]string{
+		"--operation", "update",
+		"--parent-handle", "1234",
+		"--target", `C:\Users\me\.local\bin\studioctl.exe`,
+		"--source", `C:\Temp\studioctl-download.exe`,
+		"--version", "v0.1.0-preview.9",
+		"--temp-dir", `C:\Temp\studioctl-self-update`,
+	})
+	if err != nil {
+		t.Fatalf("parseWindowsSelfHelperFlags() error = %v", err)
+	}
+	if got.operation != "update" {
+		t.Fatalf("operation = %q, want update", got.operation)
+	}
+	if got.parentHandle != 1234 {
+		t.Fatalf("parentHandle = %d, want 1234", got.parentHandle)
+	}
+	if got.source != `C:\Temp\studioctl-download.exe` {
+		t.Fatalf("source = %q", got.source)
+	}
+	if got.version != "v0.1.0-preview.9" {
+		t.Fatalf("version = %q", got.version)
+	}
+}
+
+func TestWindowsPowerShellPathUsesSystemDirectory(t *testing.T) {
+	got := windowsPowerShellPath()
+	wantSuffix := `\System32\WindowsPowerShell\v1.0\powershell.exe`
+	if !strings.HasSuffix(got, wantSuffix) {
+		t.Fatalf("windowsPowerShellPath() = %q, want suffix %q", got, wantSuffix)
+	}
+}

--- a/src/cli/internal/install/bundle.go
+++ b/src/cli/internal/install/bundle.go
@@ -11,6 +11,21 @@ type Bundle struct {
 	installPath string
 }
 
+// NewBundle returns an installable bundle for an explicit target path.
+func NewBundle(version, binaryPath, resourcesArchivePath, installPath string) Bundle {
+	return Bundle{
+		Version:              version,
+		BinaryPath:           binaryPath,
+		ResourcesArchivePath: resourcesArchivePath,
+		installPath:          installPath,
+	}
+}
+
+// InstallPath returns the binary installation target.
+func (b Bundle) InstallPath() string {
+	return b.installPath
+}
+
 // CurrentBundle returns an installable bundle containing the currently running studioctl binary.
 func (s *Service) CurrentBundle(resourcesArchivePath, targetDir string) (Bundle, error) {
 	binaryPath, err := currentExecutablePath()

--- a/src/cli/internal/install/files_other.go
+++ b/src/cli/internal/install/files_other.go
@@ -5,3 +5,7 @@ package install
 func isRetryableWindowsReplaceError(error) bool {
 	return false
 }
+
+func uninstallBinaryAtWindows(string) (UninstallResult, error) {
+	return UninstallResult{}, errUninstallUnsupported
+}

--- a/src/cli/internal/install/files_windows.go
+++ b/src/cli/internal/install/files_windows.go
@@ -4,6 +4,7 @@ package install
 
 import (
 	"errors"
+	"fmt"
 	"os"
 
 	"golang.org/x/sys/windows"
@@ -14,4 +15,19 @@ func isRetryableWindowsReplaceError(err error) bool {
 		errors.Is(err, windows.ERROR_ACCESS_DENIED) ||
 		errors.Is(err, windows.ERROR_SHARING_VIOLATION) ||
 		errors.Is(err, windows.ERROR_LOCK_VIOLATION)
+}
+
+func uninstallBinaryAtWindows(execPath string) (UninstallResult, error) {
+	if err := os.Remove(execPath); err != nil {
+		if isRetryableWindowsReplaceError(err) {
+			return UninstallResult{}, fmt.Errorf(
+				"%w: %s is still running or locked",
+				errUninstallUnsupported,
+				execPath,
+			)
+		}
+		return UninstallResult{}, fmt.Errorf("remove binary %q: %w", execPath, err)
+	}
+
+	return UninstallResult{RemovedPath: execPath}, nil
 }

--- a/src/cli/internal/install/files_windows.go
+++ b/src/cli/internal/install/files_windows.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"golang.org/x/sys/windows"
 )
@@ -29,5 +31,44 @@ func uninstallBinaryAtWindows(execPath string) (UninstallResult, error) {
 		return UninstallResult{}, fmt.Errorf("remove binary %q: %w", execPath, err)
 	}
 
-	return UninstallResult{RemovedPath: execPath}, nil
+	removedDir, err := cleanupWindowsInstallDir(execPath)
+	if err != nil {
+		return UninstallResult{}, err
+	}
+
+	return UninstallResult{
+		RemovedPath: execPath,
+		RemovedDir:  removedDir,
+	}, nil
+}
+
+func cleanupWindowsInstallDir(execPath string) (string, error) {
+	dir := filepath.Dir(execPath)
+	for _, path := range windowsInstallDirArtifacts(execPath) {
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("remove managed install artifact %q: %w", path, err)
+		}
+	}
+
+	if err := os.Remove(dir); err != nil {
+		if errors.Is(err, os.ErrNotExist) || errors.Is(err, windows.ERROR_DIR_NOT_EMPTY) {
+			return "", nil
+		}
+		return "", fmt.Errorf("remove empty install directory %q: %w", dir, err)
+	}
+	return dir, nil
+}
+
+func windowsInstallDirArtifacts(execPath string) []string {
+	dir := filepath.Dir(execPath)
+	base := filepath.Base(execPath)
+	ext := filepath.Ext(base)
+	name := strings.TrimSuffix(base, ext)
+
+	artifacts := []string{filepath.Join(dir, name+".new"+ext)}
+	matches, err := filepath.Glob(filepath.Join(dir, "."+base+".old-*"))
+	if err == nil {
+		artifacts = append(artifacts, matches...)
+	}
+	return artifacts
 }

--- a/src/cli/internal/install/files_windows.go
+++ b/src/cli/internal/install/files_windows.go
@@ -44,7 +44,11 @@ func uninstallBinaryAtWindows(execPath string) (UninstallResult, error) {
 
 func cleanupWindowsInstallDir(execPath string) (string, error) {
 	dir := filepath.Dir(execPath)
-	for _, path := range windowsInstallDirArtifacts(execPath) {
+	artifacts, err := windowsInstallDirArtifacts(execPath)
+	if err != nil {
+		return "", err
+	}
+	for _, path := range artifacts {
 		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return "", fmt.Errorf("remove managed install artifact %q: %w", path, err)
 		}
@@ -59,16 +63,18 @@ func cleanupWindowsInstallDir(execPath string) (string, error) {
 	return dir, nil
 }
 
-func windowsInstallDirArtifacts(execPath string) []string {
+func windowsInstallDirArtifacts(execPath string) ([]string, error) {
 	dir := filepath.Dir(execPath)
 	base := filepath.Base(execPath)
 	ext := filepath.Ext(base)
 	name := strings.TrimSuffix(base, ext)
 
-	artifacts := []string{filepath.Join(dir, name+".new"+ext)}
 	matches, err := filepath.Glob(filepath.Join(dir, "."+base+".old-*"))
-	if err == nil {
-		artifacts = append(artifacts, matches...)
+	if err != nil {
+		return nil, fmt.Errorf("glob old install artifacts: %w", err)
 	}
-	return artifacts
+	artifacts := make([]string, 0, 1+len(matches))
+	artifacts = append(artifacts, filepath.Join(dir, name+".new"+ext))
+	artifacts = append(artifacts, matches...)
+	return artifacts, nil
 }

--- a/src/cli/internal/install/files_windows_test.go
+++ b/src/cli/internal/install/files_windows_test.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-package install
+package install //nolint:testpackage // Tests cover unexported Windows install cleanup helpers.
 
 import (
 	"os"
@@ -63,7 +63,10 @@ func TestUninstallBinaryAtWindowsKeepsInstallDirWithUnmanagedFile(t *testing.T) 
 }
 
 func TestWindowsInstallDirArtifacts(t *testing.T) {
-	got := windowsInstallDirArtifacts(`C:\Users\me\AppData\Local\Programs\studioctl\studioctl.exe`)
+	got, err := windowsInstallDirArtifacts(`C:\Users\me\AppData\Local\Programs\studioctl\studioctl.exe`)
+	if err != nil {
+		t.Fatalf("windowsInstallDirArtifacts() error = %v", err)
+	}
 	wantNew := `C:\Users\me\AppData\Local\Programs\studioctl\studioctl.new.exe`
 	if len(got) == 0 || got[0] != wantNew {
 		t.Fatalf("windowsInstallDirArtifacts()[0] = %q, want %q", got, wantNew)

--- a/src/cli/internal/install/files_windows_test.go
+++ b/src/cli/internal/install/files_windows_test.go
@@ -1,0 +1,79 @@
+//go:build windows
+
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func TestUninstallBinaryAtWindowsRemovesManagedArtifactsAndEmptyInstallDir(t *testing.T) {
+	dir := t.TempDir()
+	execPath := filepath.Join(dir, "studioctl.exe")
+	writeWindowsInstallTestFile(t, execPath)
+	writeWindowsInstallTestFile(t, filepath.Join(dir, "studioctl.new.exe"))
+	writeWindowsInstallTestFile(t, filepath.Join(dir, ".studioctl.exe.old-123"))
+	writeWindowsInstallTestFile(t, filepath.Join(dir, ".studioctl.exe.old-456"))
+
+	result, err := uninstallBinaryAtWindows(execPath)
+	if err != nil {
+		t.Fatalf("uninstallBinaryAtWindows() error = %v", err)
+	}
+	if result.RemovedPath != execPath {
+		t.Fatalf("RemovedPath = %q, want %q", result.RemovedPath, execPath)
+	}
+	if result.RemovedDir != dir {
+		t.Fatalf("RemovedDir = %q, want %q", result.RemovedDir, dir)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("install dir still exists after cleanup: %v", err)
+	}
+}
+
+func TestUninstallBinaryAtWindowsKeepsInstallDirWithUnmanagedFile(t *testing.T) {
+	dir := t.TempDir()
+	execPath := filepath.Join(dir, "studioctl.exe")
+	unmanagedPath := filepath.Join(dir, "notes.txt")
+	writeWindowsInstallTestFile(t, execPath)
+	writeWindowsInstallTestFile(t, filepath.Join(dir, "studioctl.new.exe"))
+	writeWindowsInstallTestFile(t, filepath.Join(dir, ".studioctl.exe.old-123"))
+	writeWindowsInstallTestFile(t, unmanagedPath)
+
+	result, err := uninstallBinaryAtWindows(execPath)
+	if err != nil {
+		t.Fatalf("uninstallBinaryAtWindows() error = %v", err)
+	}
+	if result.RemovedDir != "" {
+		t.Fatalf("RemovedDir = %q, want empty when install dir has unmanaged files", result.RemovedDir)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read install dir: %v", err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	if !slices.Equal(names, []string{"notes.txt"}) {
+		t.Fatalf("install dir entries = %v, want only unmanaged file", names)
+	}
+}
+
+func TestWindowsInstallDirArtifacts(t *testing.T) {
+	got := windowsInstallDirArtifacts(`C:\Users\me\AppData\Local\Programs\studioctl\studioctl.exe`)
+	wantNew := `C:\Users\me\AppData\Local\Programs\studioctl\studioctl.new.exe`
+	if len(got) == 0 || got[0] != wantNew {
+		t.Fatalf("windowsInstallDirArtifacts()[0] = %q, want %q", got, wantNew)
+	}
+}
+
+func writeWindowsInstallTestFile(t *testing.T, path string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte("test"), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/src/cli/internal/install/update.go
+++ b/src/cli/internal/install/update.go
@@ -91,13 +91,6 @@ func (s *Service) ResolveUpdateBundle(
 		return ResolvedBundle{}, fmt.Errorf("resolve current executable path: %w", err)
 	}
 
-	if runtime.GOOS == osutil.OSWindows {
-		return ResolvedBundle{}, fmt.Errorf(
-			"%w: windows executable is locked while running",
-			ErrUpdateUnsupported,
-		)
-	}
-
 	downloads := newHTTPDownloader(s.cfg.Version)
 	resolved, err := downloads.resolveUpdateOptions(ctx, opts, execPath)
 	if err != nil {
@@ -438,11 +431,13 @@ func (s *Service) UninstallBinary() (UninstallResult, error) {
 		return UninstallResult{}, fmt.Errorf("resolve current executable path: %w", err)
 	}
 
+	return s.UninstallBinaryAt(execPath)
+}
+
+// UninstallBinaryAt removes a studioctl executable from disk.
+func (s *Service) UninstallBinaryAt(execPath string) (UninstallResult, error) {
 	if runtime.GOOS == osutil.OSWindows {
-		return UninstallResult{}, fmt.Errorf(
-			"%w: remove manually after process exits",
-			errUninstallUnsupported,
-		)
+		return uninstallBinaryAtWindows(execPath)
 	}
 
 	if err := os.Remove(execPath); err != nil {

--- a/src/cli/internal/install/update.go
+++ b/src/cli/internal/install/update.go
@@ -52,6 +52,7 @@ type UpdateOptions struct {
 // UninstallResult describes a completed self uninstall.
 type UninstallResult struct {
 	RemovedPath string
+	RemovedDir  string
 }
 
 // ResolvedBundle describes a downloaded update bundle and its install target.

--- a/src/cli/internal/install/update.go
+++ b/src/cli/internal/install/update.go
@@ -445,7 +445,7 @@ func (s *Service) UninstallBinaryAt(execPath string) (UninstallResult, error) {
 		return UninstallResult{}, fmt.Errorf("remove binary %q: %w", execPath, err)
 	}
 
-	return UninstallResult{RemovedPath: execPath}, nil
+	return UninstallResult{RemovedPath: execPath, RemovedDir: ""}, nil
 }
 
 // RemoveHome removes the studioctl home directory.

--- a/src/cli/internal/install/update.go
+++ b/src/cli/internal/install/update.go
@@ -438,6 +438,10 @@ func (s *Service) UninstallBinary() (UninstallResult, error) {
 // UninstallBinaryAt removes a studioctl executable from disk.
 func (s *Service) UninstallBinaryAt(execPath string) (UninstallResult, error) {
 	if runtime.GOOS == osutil.OSWindows {
+		// Windows user installs live in a dedicated studioctl directory, so the
+		// platform cleanup also removes managed update artifacts and the directory
+		// itself when no unmanaged files remain. Other platforms install into
+		// shared PATH directories and only remove the studioctl binary.
 		return uninstallBinaryAtWindows(execPath)
 	}
 

--- a/src/cli/internal/osutil/osutil.go
+++ b/src/cli/internal/osutil/osutil.go
@@ -10,6 +10,8 @@ import (
 const fallbackCommandName = "studioctl"
 
 const (
+	// DisableTerminalDecorationsEnv disables ANSI colors, animated spinners, and Unicode status markers.
+	DisableTerminalDecorationsEnv = "STUDIOCTL_DISABLE_TERMINAL_DECORATIONS"
 	// OSLinux is the runtime.GOOS value for Linux.
 	OSLinux = "linux"
 	// OSDarwin is the runtime.GOOS value for macOS.

--- a/src/cli/internal/osutil/powershell_ise.go
+++ b/src/cli/internal/osutil/powershell_ise.go
@@ -1,0 +1,44 @@
+package osutil
+
+import "strings"
+
+const (
+	powerShellISEProcessName = "powershell_ise.exe"
+	maxProcessTreeDepth      = 32
+)
+
+type processSnapshotEntry struct {
+	parentPID uint32
+	exe       string
+}
+
+func isPowerShellISEProcessTree(currentPID uint32, processes map[uint32]processSnapshotEntry) bool {
+	seen := map[uint32]struct{}{}
+	for range maxProcessTreeDepth {
+		if currentPID == 0 {
+			return false
+		}
+		if _, ok := seen[currentPID]; ok {
+			return false
+		}
+		seen[currentPID] = struct{}{}
+
+		entry, ok := processes[currentPID]
+		if !ok {
+			return false
+		}
+		if isPowerShellISEProcessName(entry.exe) {
+			return true
+		}
+		currentPID = entry.parentPID
+	}
+	return false
+}
+
+func isPowerShellISEProcessName(name string) bool {
+	name = strings.TrimSpace(name)
+	if idx := strings.LastIndexAny(name, `\/`); idx >= 0 {
+		name = name[idx+1:]
+	}
+	return strings.EqualFold(name, powerShellISEProcessName)
+}

--- a/src/cli/internal/osutil/powershell_ise.go
+++ b/src/cli/internal/osutil/powershell_ise.go
@@ -8,8 +8,8 @@ const (
 )
 
 type processSnapshotEntry struct {
-	parentPID uint32
 	exe       string
+	parentPID uint32
 }
 
 func isPowerShellISEProcessTree(currentPID uint32, processes map[uint32]processSnapshotEntry) bool {

--- a/src/cli/internal/osutil/powershell_ise_internal_test.go
+++ b/src/cli/internal/osutil/powershell_ise_internal_test.go
@@ -1,0 +1,39 @@
+package osutil
+
+import "testing"
+
+func TestIsPowerShellISEProcessTreeDetectsAncestor(t *testing.T) {
+	processes := map[uint32]processSnapshotEntry{
+		10: {parentPID: 9, exe: "studioctl.exe"},
+		9:  {parentPID: 8, exe: "dev.exe"},
+		8:  {parentPID: 7, exe: `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`},
+		7:  {parentPID: 6, exe: `C:\Windows\System32\WindowsPowerShell\v1.0\powershell_ise.exe`},
+	}
+
+	if !isPowerShellISEProcessTree(10, processes) {
+		t.Fatal("isPowerShellISEProcessTree() = false, want true")
+	}
+}
+
+func TestIsPowerShellISEProcessTreeRejectsPowerShellConsole(t *testing.T) {
+	processes := map[uint32]processSnapshotEntry{
+		10: {parentPID: 9, exe: "studioctl.exe"},
+		9:  {parentPID: 8, exe: "dev.exe"},
+		8:  {parentPID: 0, exe: `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`},
+	}
+
+	if isPowerShellISEProcessTree(10, processes) {
+		t.Fatal("isPowerShellISEProcessTree() = true, want false")
+	}
+}
+
+func TestIsPowerShellISEProcessTreeStopsOnCycle(t *testing.T) {
+	processes := map[uint32]processSnapshotEntry{
+		10: {parentPID: 9, exe: "studioctl.exe"},
+		9:  {parentPID: 10, exe: "go.exe"},
+	}
+
+	if isPowerShellISEProcessTree(10, processes) {
+		t.Fatal("isPowerShellISEProcessTree() = true, want false")
+	}
+}

--- a/src/cli/internal/osutil/powershell_ise_other.go
+++ b/src/cli/internal/osutil/powershell_ise_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package osutil
+
+// IsPowerShellISEHost reports whether studioctl is running under Windows PowerShell ISE.
+func IsPowerShellISEHost() bool {
+	return false
+}

--- a/src/cli/internal/osutil/powershell_ise_windows.go
+++ b/src/cli/internal/osutil/powershell_ise_windows.go
@@ -1,0 +1,51 @@
+//go:build windows
+
+package osutil
+
+import (
+	"errors"
+	"os"
+	"sync"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var (
+	powerShellISEOnce sync.Once
+	powerShellISEHost bool
+)
+
+// IsPowerShellISEHost reports whether studioctl is running under Windows PowerShell ISE.
+func IsPowerShellISEHost() bool {
+	powerShellISEOnce.Do(func() {
+		processes, err := windowsProcessSnapshot()
+		if err != nil {
+			return
+		}
+		powerShellISEHost = isPowerShellISEProcessTree(uint32(os.Getpid()), processes)
+	})
+	return powerShellISEHost
+}
+
+func windowsProcessSnapshot() (map[uint32]processSnapshotEntry, error) {
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer windows.CloseHandle(snapshot) //nolint:errcheck // Best-effort cleanup after snapshot read.
+
+	processes := map[uint32]processSnapshotEntry{}
+	var entry windows.ProcessEntry32
+	entry.Size = uint32(unsafe.Sizeof(entry))
+	for err := windows.Process32First(snapshot, &entry); err == nil; err = windows.Process32Next(snapshot, &entry) {
+		processes[entry.ProcessID] = processSnapshotEntry{
+			parentPID: entry.ParentProcessID,
+			exe:       windows.UTF16ToString(entry.ExeFile[:]),
+		}
+	}
+	if len(processes) == 0 {
+		return nil, errors.New("process snapshot is empty")
+	}
+	return processes, nil
+}

--- a/src/cli/internal/osutil/powershell_ise_windows.go
+++ b/src/cli/internal/osutil/powershell_ise_windows.go
@@ -4,6 +4,7 @@ package osutil
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"sync"
 	"unsafe"
@@ -11,6 +12,9 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+var errProcessSnapshotEmpty = errors.New("process snapshot is empty")
+
+//nolint:gochecknoglobals // Cached host detection avoids repeated Windows process snapshots on every output write.
 var (
 	powerShellISEOnce sync.Once
 	powerShellISEHost bool
@@ -19,23 +23,31 @@ var (
 // IsPowerShellISEHost reports whether studioctl is running under Windows PowerShell ISE.
 func IsPowerShellISEHost() bool {
 	powerShellISEOnce.Do(func() {
+		processID, err := windowsProcessID(os.Getpid())
+		if err != nil {
+			return
+		}
 		processes, err := windowsProcessSnapshot()
 		if err != nil {
 			return
 		}
-		powerShellISEHost = isPowerShellISEProcessTree(uint32(os.Getpid()), processes)
+		powerShellISEHost = isPowerShellISEProcessTree(processID, processes)
 	})
 	return powerShellISEHost
 }
 
-func windowsProcessSnapshot() (map[uint32]processSnapshotEntry, error) {
+func windowsProcessSnapshot() (processes map[uint32]processSnapshotEntry, err error) {
 	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("create process snapshot: %w", err)
 	}
-	defer windows.CloseHandle(snapshot) //nolint:errcheck // Best-effort cleanup after snapshot read.
+	defer func() {
+		if closeErr := windows.CloseHandle(snapshot); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("close process snapshot handle: %w", closeErr))
+		}
+	}()
 
-	processes := map[uint32]processSnapshotEntry{}
+	processes = map[uint32]processSnapshotEntry{}
 	var entry windows.ProcessEntry32
 	entry.Size = uint32(unsafe.Sizeof(entry))
 	for err := windows.Process32First(snapshot, &entry); err == nil; err = windows.Process32Next(snapshot, &entry) {
@@ -45,7 +57,7 @@ func windowsProcessSnapshot() (map[uint32]processSnapshotEntry, error) {
 		}
 	}
 	if len(processes) == 0 {
-		return nil, errors.New("process snapshot is empty")
+		return nil, errProcessSnapshotEmpty
 	}
 	return processes, nil
 }

--- a/src/cli/internal/ui/input.go
+++ b/src/cli/internal/ui/input.go
@@ -19,6 +19,7 @@ import (
 var ErrInterrupted = errors.New("interrupted")
 
 var errFDOverflow = errors.New("file descriptor overflow")
+var errInteractiveOutputUnavailable = errors.New("interactive output is unavailable")
 
 // Control characters for terminal input.
 const (
@@ -56,6 +57,9 @@ func ReadPassword(ctx context.Context, out *Output) ([]byte, error) {
 
 // InteractiveInput returns input suitable for interactive prompts.
 func InteractiveInput() (io.Reader, func() error, error) {
+	if !StdoutIsTerminal() {
+		return nil, nil, errInteractiveOutputUnavailable
+	}
 	if stdinIsTerminal() {
 		return os.Stdin, func() error { return nil }, nil
 	}

--- a/src/cli/internal/ui/output.go
+++ b/src/cli/internal/ui/output.go
@@ -20,7 +20,7 @@ func Colors() bool {
 var terminalDecorations = defaultTerminalDecorations
 
 func defaultTerminalDecorations() bool {
-	return !osutil.IsPowerShellISEHost()
+	return os.Getenv(osutil.DisableTerminalDecorationsEnv) == "" && !osutil.IsPowerShellISEHost()
 }
 
 // Style functions return ANSI styles for terminal output.

--- a/src/cli/internal/ui/output.go
+++ b/src/cli/internal/ui/output.go
@@ -13,7 +13,14 @@ import (
 // Colors checks if color output is enabled.
 func Colors() bool {
 	_, noColor := os.LookupEnv("NO_COLOR")
-	return !noColor
+	return !noColor && terminalDecorations()
+}
+
+//nolint:gochecknoglobals // Package-internal hook keeps ISE output mode unit-testable.
+var terminalDecorations = defaultTerminalDecorations
+
+func defaultTerminalDecorations() bool {
+	return !osutil.IsPowerShellISEHost()
 }
 
 // Style functions return ANSI styles for terminal output.

--- a/src/cli/internal/ui/output.go
+++ b/src/cli/internal/ui/output.go
@@ -16,10 +16,7 @@ func Colors() bool {
 	return !noColor && terminalDecorations()
 }
 
-//nolint:gochecknoglobals // Package-internal hook keeps ISE output mode unit-testable.
-var terminalDecorations = defaultTerminalDecorations
-
-func defaultTerminalDecorations() bool {
+func terminalDecorations() bool {
 	return os.Getenv(osutil.DisableTerminalDecorationsEnv) == "" && !osutil.IsPowerShellISEHost()
 }
 

--- a/src/cli/internal/ui/output_internal_test.go
+++ b/src/cli/internal/ui/output_internal_test.go
@@ -38,7 +38,9 @@ func TestColors_DisabledWhenNoColorIsSet(t *testing.T) {
 func TestColors_DisabledWhenTerminalDecorationsDisabled(t *testing.T) {
 	setTerminalDecorationsForTest(t, false)
 	t.Setenv("NO_COLOR", "")
-	os.Unsetenv("NO_COLOR")
+	if err := os.Unsetenv("NO_COLOR"); err != nil {
+		t.Fatalf("unset NO_COLOR: %v", err)
+	}
 
 	if Colors() {
 		t.Fatal("Colors() = true, want false when terminal decorations are disabled")
@@ -48,7 +50,9 @@ func TestColors_DisabledWhenTerminalDecorationsDisabled(t *testing.T) {
 func TestColors_DisabledWhenTerminalDecorationsEnvSet(t *testing.T) {
 	t.Setenv(osutil.DisableTerminalDecorationsEnv, "1")
 	t.Setenv("NO_COLOR", "")
-	os.Unsetenv("NO_COLOR")
+	if err := os.Unsetenv("NO_COLOR"); err != nil {
+		t.Fatalf("unset NO_COLOR: %v", err)
+	}
 
 	if Colors() {
 		t.Fatal("Colors() = true, want false when terminal decorations env is set")

--- a/src/cli/internal/ui/output_internal_test.go
+++ b/src/cli/internal/ui/output_internal_test.go
@@ -45,6 +45,27 @@ func TestColors_DisabledWhenTerminalDecorationsDisabled(t *testing.T) {
 	}
 }
 
+func TestColors_DisabledWhenTerminalDecorationsEnvSet(t *testing.T) {
+	t.Setenv(osutil.DisableTerminalDecorationsEnv, "1")
+	t.Setenv("NO_COLOR", "")
+	os.Unsetenv("NO_COLOR")
+
+	if Colors() {
+		t.Fatal("Colors() = true, want false when terminal decorations env is set")
+	}
+}
+
+func TestStatusUsesPlainTextWhenTerminalDecorationsDisabled(t *testing.T) {
+	setTerminalDecorationsForTest(t, false)
+
+	if got := Status(true).Text; got != "[ok]" {
+		t.Fatalf("Status(true).Text = %q, want [ok]", got)
+	}
+	if got := Status(false).Text; got != "[error]" {
+		t.Fatalf("Status(false).Text = %q, want [error]", got)
+	}
+}
+
 func TestOutputPrintlnUsesPlatformLineBreak(t *testing.T) {
 	var out bytes.Buffer
 	output := NewOutput(&out, &out, false)

--- a/src/cli/internal/ui/output_internal_test.go
+++ b/src/cli/internal/ui/output_internal_test.go
@@ -36,7 +36,7 @@ func TestColors_DisabledWhenNoColorIsSet(t *testing.T) {
 }
 
 func TestColors_DisabledWhenTerminalDecorationsDisabled(t *testing.T) {
-	setTerminalDecorationsForTest(t, false)
+	t.Setenv(osutil.DisableTerminalDecorationsEnv, "1")
 	t.Setenv("NO_COLOR", "")
 	if err := os.Unsetenv("NO_COLOR"); err != nil {
 		t.Fatalf("unset NO_COLOR: %v", err)
@@ -60,7 +60,7 @@ func TestColors_DisabledWhenTerminalDecorationsEnvSet(t *testing.T) {
 }
 
 func TestStatusUsesPlainTextWhenTerminalDecorationsDisabled(t *testing.T) {
-	setTerminalDecorationsForTest(t, false)
+	t.Setenv(osutil.DisableTerminalDecorationsEnv, "1")
 
 	if got := Status(true).Text; got != "[ok]" {
 		t.Fatalf("Status(true).Text = %q, want [ok]", got)
@@ -109,16 +109,4 @@ func TestOutputErrorlnfUsesPlatformLineBreak(t *testing.T) {
 	if got != want {
 		t.Fatalf("Errorlnf() wrote %q, want %q", got, want)
 	}
-}
-
-func setTerminalDecorationsForTest(t *testing.T, enabled bool) {
-	t.Helper()
-
-	original := terminalDecorations
-	terminalDecorations = func() bool {
-		return enabled
-	}
-	t.Cleanup(func() {
-		terminalDecorations = original
-	})
 }

--- a/src/cli/internal/ui/output_internal_test.go
+++ b/src/cli/internal/ui/output_internal_test.go
@@ -35,6 +35,16 @@ func TestColors_DisabledWhenNoColorIsSet(t *testing.T) {
 	}
 }
 
+func TestColors_DisabledWhenTerminalDecorationsDisabled(t *testing.T) {
+	setTerminalDecorationsForTest(t, false)
+	t.Setenv("NO_COLOR", "")
+	os.Unsetenv("NO_COLOR")
+
+	if Colors() {
+		t.Fatal("Colors() = true, want false when terminal decorations are disabled")
+	}
+}
+
 func TestOutputPrintlnUsesPlatformLineBreak(t *testing.T) {
 	var out bytes.Buffer
 	output := NewOutput(&out, &out, false)
@@ -74,4 +84,16 @@ func TestOutputErrorlnfUsesPlatformLineBreak(t *testing.T) {
 	if got != want {
 		t.Fatalf("Errorlnf() wrote %q, want %q", got, want)
 	}
+}
+
+func setTerminalDecorationsForTest(t *testing.T, enabled bool) {
+	t.Helper()
+
+	original := terminalDecorations
+	terminalDecorations = func() bool {
+		return enabled
+	}
+	t.Cleanup(func() {
+		terminalDecorations = original
+	})
 }

--- a/src/cli/internal/ui/spinner.go
+++ b/src/cli/internal/ui/spinner.go
@@ -21,6 +21,7 @@ type Spinner struct {
 	style   Style
 	done    chan struct{}
 	message string
+	animate bool
 	mu      sync.Mutex
 	running bool
 }
@@ -31,6 +32,7 @@ func NewSpinner(out *Output, message string) *Spinner {
 		out:     out,
 		message: message,
 		style:   ColorStyle(ColorBlue),
+		animate: terminalDecorations(),
 		done:    nil, // initialized on Start()
 		mu:      sync.Mutex{},
 		running: false,
@@ -46,7 +48,13 @@ func (s *Spinner) Start() {
 	}
 	s.running = true
 	s.done = make(chan struct{})
+	animate := s.animate
 	s.mu.Unlock()
+
+	if !animate {
+		s.out.Println(s.message)
+		return
+	}
 
 	go s.run()
 }
@@ -60,9 +68,12 @@ func (s *Spinner) Stop() {
 	}
 	s.running = false
 	close(s.done)
+	animate := s.animate
 	s.mu.Unlock()
 
-	s.clearLine()
+	if animate {
+		s.clearLine()
+	}
 }
 
 // StopWithSuccess stops the spinner and shows a success message.

--- a/src/cli/internal/ui/spinner_internal_test.go
+++ b/src/cli/internal/ui/spinner_internal_test.go
@@ -23,7 +23,7 @@ func TestSpinner_UsesPlainOutputWhenTerminalDecorationsDisabled(t *testing.T) {
 	if !strings.Contains(output, "[ok] Installation completed") {
 		t.Fatalf("spinner output = %q, want plain success message", output)
 	}
-	for _, forbidden := range []string{"\x1b", "\r", "⠋", "✓"} {
+	for _, forbidden := range []string{"\x1b", "\r\033[K", "⠋", "✓"} {
 		if strings.Contains(output, forbidden) {
 			t.Fatalf("spinner output = %q, did not want %q", output, forbidden)
 		}

--- a/src/cli/internal/ui/spinner_internal_test.go
+++ b/src/cli/internal/ui/spinner_internal_test.go
@@ -1,0 +1,31 @@
+package ui
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestSpinner_UsesPlainOutputWhenTerminalDecorationsDisabled(t *testing.T) {
+	setTerminalDecorationsForTest(t, false)
+
+	var buf bytes.Buffer
+	out := NewOutput(&buf, &buf, false)
+	spinner := NewSpinner(out, "Completing installation...")
+
+	spinner.Start()
+	spinner.StopWithSuccess("Installation completed")
+
+	output := buf.String()
+	if !strings.Contains(output, "Completing installation...") {
+		t.Fatalf("spinner output = %q, want start message", output)
+	}
+	if !strings.Contains(output, "[ok] Installation completed") {
+		t.Fatalf("spinner output = %q, want plain success message", output)
+	}
+	for _, forbidden := range []string{"\x1b", "\r", "⠋", "✓"} {
+		if strings.Contains(output, forbidden) {
+			t.Fatalf("spinner output = %q, did not want %q", output, forbidden)
+		}
+	}
+}

--- a/src/cli/internal/ui/spinner_internal_test.go
+++ b/src/cli/internal/ui/spinner_internal_test.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"altinn.studio/studioctl/internal/osutil"
 )
 
 func TestSpinner_UsesPlainOutputWhenTerminalDecorationsDisabled(t *testing.T) {
-	setTerminalDecorationsForTest(t, false)
+	t.Setenv(osutil.DisableTerminalDecorationsEnv, "1")
 
 	var buf bytes.Buffer
 	out := NewOutput(&buf, &buf, false)

--- a/src/cli/internal/ui/table.go
+++ b/src/cli/internal/ui/table.go
@@ -155,6 +155,12 @@ func ErrorText(text string) Cell {
 
 // Status creates a success or error status icon cell.
 func Status(ok bool) Cell {
+	if !terminalDecorations() {
+		if ok {
+			return SuccessText("[ok]")
+		}
+		return ErrorText("[error]")
+	}
 	if ok {
 		return SuccessText("✓")
 	}


### PR DESCRIPTION
## Description

Hardens the Windows studioctl install/update/uninstall path:

- Fixes PowerShell installer architecture detection without relying on RuntimeInformation.OSArchitecture.
- Falls back to the default install location when no usable interactive prompt is available.
- Supports Windows self update and self uninstall by running a detached helper after the current executable exits.
- Cleans up known studioctl update artifacts during uninstall, then removes the install directory only if it is empty.
- Renders plain output in PowerShell ISE by disabling ANSI colors, animated spinner redraws, and Unicode status markers for that host.

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

Automated checks run from src/cli:

```
go test ./...
GOOS=windows GOARCH=amd64 go test -c ./internal/cmd
GOOS=windows GOARCH=arm64 go test -c ./internal/cmd
GOOS=windows GOARCH=amd64 go test -c ./internal/install
GOOS=windows GOARCH=arm64 go test -c ./internal/install
GOOS=windows GOARCH=amd64 go test -c ./internal/osutil
GOOS=windows GOARCH=amd64 go test -c ./internal/ui
GOOS=windows GOARCH=amd64 go test -c ./internal/cmd/doctor
```

Manual Windows smoke testing during branch iteration:

```powershell
go run ./cmd/dev install -user
studioctl doctor
studioctl self uninstall --yes
Test-Path ":LOCALAPPDATA\Programs\studioctl\studioctl.exe"
Test-Path ":LOCALAPPDATA\Programs\studioctl"
```

Covered Windows Terminal Windows PowerShell and PowerShell ISE behavior while iterating on the branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows: self update and self uninstall now run via a helper process so the commands can complete while the original process exits.
  * New env var STUDIOCTL_DISABLE_TERMINAL_DECORATIONS to disable colours, spinners and Unicode markers.

* **Bug Fixes**
  * Improved PowerShell installer architecture detection and fallbacks for non-interactive installs.
  * Render plain output when running under PowerShell ISE and clean up stale install artefacts on Windows.

* **Documentation**
  * Updated changelog with Windows fixes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio/pull/18937?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->