### PR TITLE
feat: add app v9 release packaging

### DIFF
--- a/.github/workflows/release-app.yaml
+++ b/.github/workflows/release-app.yaml
@@ -1,0 +1,186 @@
+name: Release - app
+
+# Automatically triggers release when an app changelog promotion PR is merged.
+# PRs must have the 'release/app' label.
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+      - 'release/app/v*'
+    paths:
+      - 'src/App/backend/CHANGELOG.md'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  resolve-release-context:
+    name: Resolve release context
+    runs-on: ubuntu-latest
+    # Automatically release same-repo release PRs. Fork PRs can be retried manually
+    # from main after merge because their pull_request token cannot publish releases.
+    if: >
+      (
+        github.event_name == 'workflow_dispatch' &&
+        github.ref == 'refs/heads/main'
+      ) ||
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.merged == true &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        contains(github.event.pull_request.labels.*.name, 'release/app')
+      )
+    outputs:
+      environment: ${{ steps.context.outputs.environment }}
+      version: ${{ steps.context.outputs.version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.merge_commit_sha || github.sha }}
+
+      - name: Resolve environment
+        id: context
+        run: |
+          version="$(
+            awk '
+              /^## \[/ {
+                section = $0
+                gsub(/^## \[/, "", section)
+                gsub(/\].*$/, "", section)
+                if (section != "Unreleased") {
+                  print section
+                  exit
+                }
+              }
+            ' src/App/backend/CHANGELOG.md
+          )"
+
+          if [[ -z "$version" ]]; then
+            echo "Could not resolve release version from src/App/backend/CHANGELOG.md" >&2
+            exit 1
+          fi
+
+          environment="prod"
+          if [[ "$version" == *"-preview."* ]]; then
+            environment="test"
+          elif [[ "$version" == *"-rc."* ]]; then
+            environment="staging"
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "environment=$environment" >> "$GITHUB_OUTPUT"
+
+  release:
+    name: Build, release and publish
+    runs-on: ubuntu-latest
+    needs: resolve-release-context
+    environment: ${{ needs.resolve-release-context.outputs.environment }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.merge_commit_sha || github.sha }}
+
+      - name: Checkout base branch
+        env:
+          BASE_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || 'main' }}
+          MERGE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.merge_commit_sha || github.sha }}
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && "${GITHUB_REF}" != "refs/heads/main" ]]; then
+            echo "Manual app releases must be dispatched from main"
+            exit 1
+          fi
+
+          if [[ "${BASE_BRANCH}" != "main" && ! "${BASE_BRANCH}" =~ ^release/app/v[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid base branch: ${BASE_BRANCH}"
+            exit 1
+          fi
+
+          git fetch origin "$BASE_BRANCH"
+          git checkout -B "$BASE_BRANCH" "$MERGE_SHA"
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
+        with:
+          global-json-file: src/App/backend/global.json
+
+      - name: Setup Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: '22'
+          cache: yarn
+          cache-dependency-path: yarn.lock
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: 'src/tools/releaser/go.mod'
+          cache-dependency-path: src/tools/releaser/go.sum
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Run release workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || 'main' }}
+        run: |
+          go run . workflow --component app --base-branch "$BASE_BRANCH"
+        working-directory: src/tools/releaser
+
+      - name: Publish packages to NuGet
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: |
+          shopt -s nullglob
+          packages=(build/release/*.nupkg build/release/*.snupkg)
+
+          if (( ${#packages[@]} == 0 )); then
+            echo "No NuGet packages found in build/release" >&2
+            exit 1
+          fi
+
+          for package in "${packages[@]}"; do
+            dotnet nuget push "$package" \
+              --api-key "$NUGET_API_KEY" \
+              --source https://api.nuget.org/v3/index.json \
+              --skip-duplicate
+          done
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## Release Summary"
+            echo ""
+            if [[ -n "${PR_NUMBER}" ]]; then
+              echo "- **PR**: #${PR_NUMBER}"
+            fi
+            echo "- **Base branch**: ${BASE_BRANCH}"
+            echo "- **Version**: ${RELEASE_VERSION}"
+            echo "- **Environment**: ${{ needs.resolve-release-context.outputs.environment }}"
+            echo "- **Version source**: latest released section in src/App/backend/CHANGELOG.md"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [[ -d "build/release" ]]; then
+            {
+              echo "### Assets"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            ls -la build/release/ >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || echo "No assets found"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          fi
+        env:
+          BASE_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || 'main' }}
+          PR_NUMBER: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
+          RELEASE_VERSION: ${{ needs.resolve-release-context.outputs.version }}

--- a/.github/workflows/release-app.yaml
+++ b/.github/workflows/release-app.yaml
@@ -41,6 +41,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.merge_commit_sha || github.sha }}
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -81,6 +82,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.merge_commit_sha || github.sha }}
+          persist-credentials: false
 
       - name: Checkout base branch
         env:

--- a/.github/workflows/release-app.yaml
+++ b/.github/workflows/release-app.yaml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   resolve-release-context:
@@ -70,6 +70,8 @@ jobs:
     name: Build, release and publish
     runs-on: ubuntu-latest
     needs: resolve-release-context
+    permissions:
+      contents: write
     environment: ${{ needs.resolve-release-context.outputs.environment }}
 
     steps:

--- a/.github/workflows/release-app.yaml
+++ b/.github/workflows/release-app.yaml
@@ -42,27 +42,18 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.merge_commit_sha || github.sha }}
 
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: 'src/tools/releaser/go.mod'
+          cache-dependency-path: src/tools/releaser/go.sum
+
       - name: Resolve environment
         id: context
+        env:
+          BASE_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || 'main' }}
         run: |
-          version="$(
-            awk '
-              /^## \[/ {
-                section = $0
-                gsub(/^## \[/, "", section)
-                gsub(/\].*$/, "", section)
-                if (section != "Unreleased") {
-                  print section
-                  exit
-                }
-              }
-            ' src/App/backend/CHANGELOG.md
-          )"
-
-          if [[ -z "$version" ]]; then
-            echo "Could not resolve release version from src/App/backend/CHANGELOG.md" >&2
-            exit 1
-          fi
+          version="$(go run . resolve-version --component app --base-branch "$BASE_BRANCH")"
 
           environment="prod"
           if [[ "$version" == *"-preview."* ]]; then
@@ -73,6 +64,7 @@ jobs:
 
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "environment=$environment" >> "$GITHUB_OUTPUT"
+        working-directory: src/tools/releaser
 
   release:
     name: Build, release and publish

--- a/.github/workflows/release-app.yaml
+++ b/.github/workflows/release-app.yaml
@@ -58,7 +58,7 @@ jobs:
 
           environment="prod"
           if [[ "$version" == *"-preview."* ]]; then
-            environment="test"
+            environment="dev"
           elif [[ "$version" == *"-rc."* ]]; then
             environment="staging"
           fi

--- a/.github/workflows/release-app.yaml
+++ b/.github/workflows/release-app.yaml
@@ -73,6 +73,7 @@ jobs:
     needs: resolve-release-context
     permissions:
       contents: write
+      id-token: write
     environment: ${{ needs.resolve-release-context.outputs.environment }}
 
     steps:
@@ -133,9 +134,15 @@ jobs:
           go run . workflow --component app --base-branch "$BASE_BRANCH"
         working-directory: src/tools/releaser
 
+      - name: NuGet login
+        id: nuget-login
+        uses: NuGet/login@ebc737b6fc418a6ca0073cf116ec8dc156d8b81e # v1
+        with:
+          user: altinn
+
       - name: Publish packages to NuGet
         env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
         run: |
           shopt -s nullglob
           packages=(build/release/*.nupkg build/release/*.snupkg)

--- a/src/App/backend/AGENTS.md
+++ b/src/App/backend/AGENTS.md
@@ -110,7 +110,7 @@ We have Architecture Decision Records in the `/doc/adr/` folder.
 
 ### Versioning
 
-- Uses **semantic versioning** with MinVer
+- Uses **semantic versioning** for packages
 - Avoid breaking changes (we plan to release major versions yearly. Some breaking changes can be done inbetween but must be manually verified)
 - PR titles become release notes
 - Normal interfaces in Altinn.App.Core must be binary compatible within a major version so that users can have local packages that still work (never remove a method)

--- a/src/App/backend/CHANGELOG.md
+++ b/src/App/backend/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to Altinn app backend packages will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
+
+## [Unreleased]
+
+### Added
+
+- Bundle the built app frontend in `Altinn.App.Api`.
+- Add app package release tooling.

--- a/src/App/backend/Directory.Packages.props
+++ b/src/App/backend/Directory.Packages.props
@@ -38,7 +38,6 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="Microsoft.OpenApi" Version="1.6.29" />
     <PackageVersion Include="Microsoft.OpenApi.Readers" Version="1.6.29" />
-    <PackageVersion Include="MinVer" Version="6.1.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="NetEscapades.EnumGenerators" Version="1.0.0-beta21" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />

--- a/src/App/backend/src/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/App/backend/src/Altinn.App.Api/Altinn.App.Api.csproj
@@ -45,18 +45,18 @@
     <!-- We will probably use System.Text.Json while analyzing in the future, this setup has been tested -->
     <!-- <None Include="../Altinn.App.Analyzers/bin/$(Configuration)/netstandard2.0/System.Text.Json.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="true" /> -->
     <!-- These MSBuild props are applied to the app when they reference the Altinn.App.Api package. Used for <AdditionalFile /> inclusions etc. -->
-    <None Include="packaging/Altinn.App.Api.props" Pack="true" PackagePath="build/" Visible="true" Condition="'$(MinVerVersionOverride)'==''" />
-    <None Include="packaging/Altinn.App.Api.targets" Pack="true" PackagePath="build/" Visible="true" Condition="'$(MinVerVersionOverride)'==''" />
+    <None Include="packaging/Altinn.App.Api.props" Pack="true" PackagePath="build/" Visible="true" Condition="'$(UseExperimentalPackageId)'!='true'" />
+    <None Include="packaging/Altinn.App.Api.targets" Pack="true" PackagePath="build/" Visible="true" Condition="'$(UseExperimentalPackageId)'!='true'" />
     <!--
       When we do PR builds/experimental releases we set the MinVerVersionOverride from CI, and we also append '.Experimental' to package IDs.
       The props file name must match the package ID for the package it is included in.
      -->
-    <None Include="packaging/Altinn.App.Api.Experimental.props" Pack="true" PackagePath="build/" Visible="true" Condition="'$(MinVerVersionOverride)'!=''" />
-    <None Include="packaging/Altinn.App.Api.Experimental.targets" Pack="true" PackagePath="build/" Visible="true" Condition="'$(MinVerVersionOverride)'!=''" />
+    <None Include="packaging/Altinn.App.Api.Experimental.props" Pack="true" PackagePath="build/" Visible="true" Condition="'$(UseExperimentalPackageId)'=='true'" />
+    <None Include="packaging/Altinn.App.Api.Experimental.targets" Pack="true" PackagePath="build/" Visible="true" Condition="'$(UseExperimentalPackageId)'=='true'" />
     <None Include="$(AppFrontendDistPath)/**/*" Pack="true" PackagePath="build/Altinn.App.Api/altinn-app-frontend/%(RecursiveDir)%(Filename)%(Extension)" Visible="false" />
   </ItemGroup>
 
-  <Target Name="CreateExperimentalBuildAssetFiles" AfterTargets="Build" Condition="'$(MinVerVersionOverride)'!=''">
+  <Target Name="CreateExperimentalBuildAssetFiles" AfterTargets="Build" Condition="'$(UseExperimentalPackageId)'=='true'">
     <!-- For PR/experimental builds the build asset file names must match the experimental package ID. -->
     <Copy SourceFiles="packaging/Altinn.App.Api.props;packaging/Altinn.App.Api.targets" DestinationFiles="packaging/Altinn.App.Api.Experimental.props;packaging/Altinn.App.Api.Experimental.targets" />
   </Target>

--- a/src/App/backend/src/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/App/backend/src/Altinn.App.Api/Altinn.App.Api.csproj
@@ -48,7 +48,7 @@
     <None Include="packaging/Altinn.App.Api.props" Pack="true" PackagePath="build/" Visible="true" Condition="'$(UseExperimentalPackageId)'!='true'" />
     <None Include="packaging/Altinn.App.Api.targets" Pack="true" PackagePath="build/" Visible="true" Condition="'$(UseExperimentalPackageId)'!='true'" />
     <!--
-      When we do PR builds/experimental releases we set AppPackageVersion from CI, and we also append '.Experimental' to package IDs.
+      When we do PR builds/experimental releases we set UseExperimentalPackageId, and we also append '.Experimental' to package IDs.
       The props file name must match the package ID for the package it is included in.
      -->
     <None Include="packaging/Altinn.App.Api.Experimental.props" Pack="true" PackagePath="build/" Visible="true" Condition="'$(UseExperimentalPackageId)'=='true'" />

--- a/src/App/backend/src/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/App/backend/src/Altinn.App.Api/Altinn.App.Api.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <OutputType>Library</OutputType>
+    <AppFrontendDistPath>../../../frontend/dist</AppFrontendDistPath>
     <PackageTags>Altinn;Studio;App;Api;Controllers</PackageTags>
     <Description>
       This class library holds all the API controllers used by a standard Altinn 3 App.
@@ -45,16 +46,23 @@
     <!-- <None Include="../Altinn.App.Analyzers/bin/$(Configuration)/netstandard2.0/System.Text.Json.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="true" /> -->
     <!-- These MSBuild props are applied to the app when they reference the Altinn.App.Api package. Used for <AdditionalFile /> inclusions etc. -->
     <None Include="packaging/Altinn.App.Api.props" Pack="true" PackagePath="build/" Visible="true" Condition="'$(MinVerVersionOverride)'==''" />
+    <None Include="packaging/Altinn.App.Api.targets" Pack="true" PackagePath="build/" Visible="true" Condition="'$(MinVerVersionOverride)'==''" />
     <!--
-      When we do PR builds/experimental releases we set tne MinVerVersionOverride from CI, and we also append '.Experimental' to package IDs.
+      When we do PR builds/experimental releases we set the MinVerVersionOverride from CI, and we also append '.Experimental' to package IDs.
       The props file name must match the package ID for the package it is included in.
      -->
     <None Include="packaging/Altinn.App.Api.Experimental.props" Pack="true" PackagePath="build/" Visible="true" Condition="'$(MinVerVersionOverride)'!=''" />
+    <None Include="packaging/Altinn.App.Api.Experimental.targets" Pack="true" PackagePath="build/" Visible="true" Condition="'$(MinVerVersionOverride)'!=''" />
+    <None Include="$(AppFrontendDistPath)/**/*" Pack="true" PackagePath="build/Altinn.App.Api/altinn-app-frontend/%(RecursiveDir)%(Filename)%(Extension)" Visible="false" />
   </ItemGroup>
 
-  <Target Name="CreateExperimentalPropsFile" AfterTargets="Build" Condition="'$(MinVerVersionOverride)'!=''">
-    <!-- For PR/experimental builds we need to rename the props file (only happens in CI) -->
-    <Move SourceFiles="packaging/Altinn.App.Api.props" DestinationFiles="packaging/Altinn.App.Api.Experimental.props"/>
+  <Target Name="CreateExperimentalBuildAssetFiles" AfterTargets="Build" Condition="'$(MinVerVersionOverride)'!=''">
+    <!-- For PR/experimental builds the build asset file names must match the experimental package ID. -->
+    <Copy SourceFiles="packaging/Altinn.App.Api.props;packaging/Altinn.App.Api.targets" DestinationFiles="packaging/Altinn.App.Api.Experimental.props;packaging/Altinn.App.Api.Experimental.targets" />
+  </Target>
+
+  <Target Name="ValidateAppFrontendDistForPack" BeforeTargets="Pack">
+    <Error Condition="!Exists('$(AppFrontendDistPath)/altinn-app-frontend.js') OR !Exists('$(AppFrontendDistPath)/altinn-app-frontend.css')" Text="App frontend assets are missing. Run 'cd src/App/frontend &amp;&amp; yarn build' before packing Altinn.App.Api." />
   </Target>
 
   <ItemGroup>

--- a/src/App/backend/src/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/App/backend/src/Altinn.App.Api/Altinn.App.Api.csproj
@@ -48,7 +48,7 @@
     <None Include="packaging/Altinn.App.Api.props" Pack="true" PackagePath="build/" Visible="true" Condition="'$(UseExperimentalPackageId)'!='true'" />
     <None Include="packaging/Altinn.App.Api.targets" Pack="true" PackagePath="build/" Visible="true" Condition="'$(UseExperimentalPackageId)'!='true'" />
     <!--
-      When we do PR builds/experimental releases we set the MinVerVersionOverride from CI, and we also append '.Experimental' to package IDs.
+      When we do PR builds/experimental releases we set AppPackageVersion from CI, and we also append '.Experimental' to package IDs.
       The props file name must match the package ID for the package it is included in.
      -->
     <None Include="packaging/Altinn.App.Api.Experimental.props" Pack="true" PackagePath="build/" Visible="true" Condition="'$(UseExperimentalPackageId)'=='true'" />

--- a/src/App/backend/src/Altinn.App.Api/packaging/Altinn.App.Api.targets
+++ b/src/App/backend/src/Altinn.App.Api/packaging/Altinn.App.Api.targets
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <!--
+    This targets file is included in the Altinn.App.Api NuGet package and
+    exposes the bundled app frontend as static files in consuming apps.
+   -->
+  <ItemGroup Condition="'$(IsAltinnApp)' == 'true'">
+    <AltinnAppFrontendAsset Include="$(MSBuildThisFileDirectory)Altinn.App.Api/altinn-app-frontend/**/*" />
+    <Content Include="@(AltinnAppFrontendAsset)">
+      <Link>wwwroot/altinn-app-frontend/%(RecursiveDir)%(Filename)%(Extension)</Link>
+      <TargetPath>wwwroot/altinn-app-frontend/%(RecursiveDir)%(Filename)%(Extension)</TargetPath>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/src/App/backend/src/Altinn.App.Api/packaging/Altinn.App.Api.targets
+++ b/src/App/backend/src/Altinn.App.Api/packaging/Altinn.App.Api.targets
@@ -6,11 +6,18 @@
    -->
   <ItemGroup Condition="'$(IsAltinnApp)' == 'true'">
     <AltinnAppFrontendAsset Include="$(MSBuildThisFileDirectory)Altinn.App.Api/altinn-app-frontend/**/*" />
-    <Content Include="@(AltinnAppFrontendAsset)">
-      <Link>wwwroot/altinn-app-frontend/%(RecursiveDir)%(Filename)%(Extension)</Link>
-      <TargetPath>wwwroot/altinn-app-frontend/%(RecursiveDir)%(Filename)%(Extension)</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    <StaticWebAsset Include="@(AltinnAppFrontendAsset)">
+      <SourceType>Package</SourceType>
+      <SourceId>Altinn.App.Api</SourceId>
+      <ContentRoot>$(MSBuildThisFileDirectory)Altinn.App.Api/</ContentRoot>
+      <BasePath>/</BasePath>
+      <RelativePath>altinn-app-frontend/%(RecursiveDir)%(Filename)%(Extension)</RelativePath>
+      <AssetKind>All</AssetKind>
+      <AssetMode>All</AssetMode>
+      <AssetRole>Primary</AssetRole>
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </Content>
+      <OriginalItemSpec>%(FullPath)</OriginalItemSpec>
+    </StaticWebAsset>
   </ItemGroup>
 </Project>

--- a/src/App/backend/src/Altinn.App.Core/Internal/App/IndexPageGenerator.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/App/IndexPageGenerator.cs
@@ -42,32 +42,7 @@ internal sealed class IndexPageGenerator : IIndexPageGenerator
         string? appFrontendAssetBaseUrl = null
     )
     {
-        if (appFrontendAssetBaseUrl is null)
-        {
-            var htmlContentError = $$"""
-                <!DOCTYPE html>
-                <html lang="no">
-                <head>
-                 <meta charset="utf-8">
-                 <meta http-equiv="X-UA-Compatible" content="IE=edge">
-                 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-                 <title>{{org}} - {{app}}</title>
-                 <link rel="icon" href="https://altinncdn.no/favicon.ico">
-                </head>
-                <body>
-                <h1>Not implemented yet</h1>
-                  <p>Sorry, loading our built-in frontend is not yet supported. Please build and host frontend from the monorepo code yourself.</p>
-                  <p>To serve a production-level/faster build with no hot-reloads:</p>
-                  <pre>cd src/App/frontend; yarn build; yarn serve 8080</pre>
-                  <p>To serve a slightly slower build with hot-reloads tailored for development:</p>
-                  <pre>cd src/App/frontend; yarn start</pre>
-                  <p>Then make sure to restart this app with:</p>
-                  <pre>studioctl run --dev-frontend</pre>
-                </body>
-                </html>
-                """;
-            return htmlContentError;
-        }
+        appFrontendAssetBaseUrl ??= $"/{org}/{app}/altinn-app-frontend";
 
         var featureToggles = await _frontendFeatures.GetFrontendFeatures();
         var featureTogglesJson = JsonSerializer.Serialize(featureToggles, _jsonSerializerOptions);

--- a/src/App/backend/src/Altinn.App.Core/Models/ApplicationMetadata.cs
+++ b/src/App/backend/src/Altinn.App.Core/Models/ApplicationMetadata.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Altinn.Platform.Storage.Interface.Models;
 using Newtonsoft.Json;
 
@@ -68,7 +69,14 @@ public class ApplicationMetadata : Application
 
     static ApplicationMetadata()
     {
-        LibVersion = "9.0.0.0";
+        LibVersion = ResolveLibVersion();
+    }
+
+    private static string? ResolveLibVersion()
+    {
+        Assembly assembly = typeof(ApplicationMetadata).Assembly;
+        string? fileVersion = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version;
+        return string.IsNullOrWhiteSpace(fileVersion) ? assembly.GetName().Version?.ToString() : fileVersion;
     }
 
     /// <summary>

--- a/src/App/backend/src/Directory.Build.props
+++ b/src/App/backend/src/Directory.Build.props
@@ -44,8 +44,8 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(UseExperimentalPackageId)' == '' AND '$(AppPackageVersion)'!=''">
-    <UseExperimentalPackageId>true</UseExperimentalPackageId>
+  <PropertyGroup Condition="'$(UseExperimentalPackageId)' == ''">
+    <UseExperimentalPackageId>false</UseExperimentalPackageId>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(UseExperimentalPackageId)' == 'true'">

--- a/src/App/backend/src/Directory.Build.props
+++ b/src/App/backend/src/Directory.Build.props
@@ -59,7 +59,7 @@
       IgnoreExitCode="true"
       StandardOutputImportance="Low"
       StandardErrorImportance="Low"
-      Condition="'$(AppPackageVersion)' == '' OR '$(AppCompatVersion)' == '' OR '$(AppInformationalVersion)' == ''"
+      Condition="'$(AppPackageVersion)' == '' OR '$(AppAssemblyVersion)' == '' OR '$(AppInformationalVersion)' == ''"
     >
       <Output TaskParameter="ConsoleOutput" ItemName="_AppLatestTagOutput" />
       <Output TaskParameter="ExitCode" PropertyName="_AppLatestTagExitCode" />
@@ -75,7 +75,7 @@
       IgnoreExitCode="true"
       StandardOutputImportance="Low"
       StandardErrorImportance="Low"
-      Condition="'$(_AppLatestTag)' != '' AND ('$(AppPackageVersion)' == '' OR '$(AppCompatVersion)' == '')"
+      Condition="'$(_AppLatestTag)' != '' AND ('$(AppPackageVersion)' == '' OR '$(AppAssemblyVersion)' == '')"
     >
       <Output TaskParameter="ConsoleOutput" ItemName="_AppVersionHeightOutput" />
       <Output TaskParameter="ExitCode" PropertyName="_AppVersionHeightExitCode" />
@@ -106,13 +106,13 @@
       <_AppVersionMajor>$([System.Text.RegularExpressions.Regex]::Match('$(AppPackageVersion)', '^([0-9]+)\.([0-9]+)\.([0-9]+)').Groups[1].Value)</_AppVersionMajor>
       <_AppVersionMinor>$([System.Text.RegularExpressions.Regex]::Match('$(AppPackageVersion)', '^([0-9]+)\.([0-9]+)\.([0-9]+)').Groups[2].Value)</_AppVersionMinor>
       <_AppVersionPatch>$([System.Text.RegularExpressions.Regex]::Match('$(AppPackageVersion)', '^([0-9]+)\.([0-9]+)\.([0-9]+)').Groups[3].Value)</_AppVersionPatch>
-      <AppCompatVersion Condition="'$(AppCompatVersion)' == ''">$(_AppVersionMajor).$(_AppVersionMinor).$(_AppVersionPatch).$(_AppVersionHeight)</AppCompatVersion>
+      <AppAssemblyVersion Condition="'$(AppAssemblyVersion)' == ''">$(_AppVersionMajor).$(_AppVersionMinor).$(_AppVersionPatch).$(_AppVersionHeight)</AppAssemblyVersion>
       <AppInformationalVersion Condition="'$(AppInformationalVersion)' == '' AND '$(_AppCommit)' != ''">$(AppPackageVersion)+$(_AppCommit)</AppInformationalVersion>
       <AppInformationalVersion Condition="'$(AppInformationalVersion)' == ''">$(AppPackageVersion)</AppInformationalVersion>
       <Version>$(AppPackageVersion)</Version>
       <PackageVersion>$(AppPackageVersion)</PackageVersion>
-      <FileVersion>$(AppCompatVersion)</FileVersion>
-      <AssemblyVersion>$(AppCompatVersion)</AssemblyVersion>
+      <FileVersion>$(AppAssemblyVersion)</FileVersion>
+      <AssemblyVersion>$(AppAssemblyVersion)</AssemblyVersion>
       <InformationalVersion>$(AppInformationalVersion)</InformationalVersion>
     </PropertyGroup>
   </Target>

--- a/src/App/backend/src/Directory.Build.props
+++ b/src/App/backend/src/Directory.Build.props
@@ -3,7 +3,6 @@
   <Import Project="../Directory.Build.props" />
 
   <ItemGroup>
-    <PackageReference Include="MinVer" PrivateAssets="All" />
     <PackageReference Include="Nullable.Extended.Analyzer">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
@@ -26,10 +25,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <MinVerDefaultPreReleaseIdentifiers>preview.0</MinVerDefaultPreReleaseIdentifiers>
-    <MinVerTagPrefix>v</MinVerTagPrefix>
 
     <RepoRoot>$([System.IO.Directory]::GetParent($(MSBuildThisFileDirectory)).Parent.FullName)</RepoRoot>
+    <AppVersionTagPattern>app/v[0-9]*</AppVersionTagPattern>
+    <AppDefaultBaseVersion>9.0.0-preview.0</AppDefaultBaseVersion>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
+    <GetPackageVersionDependsOn>ResolveAppVersionFromGit;$(GetPackageVersionDependsOn)</GetPackageVersionDependsOn>
 
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Altinn Platform Contributors</Authors>
@@ -43,7 +44,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(UseExperimentalPackageId)' == '' AND '$(MinVerVersionOverride)'!=''">
+  <PropertyGroup Condition="'$(UseExperimentalPackageId)' == '' AND '$(AppPackageVersion)'!=''">
     <UseExperimentalPackageId>true</UseExperimentalPackageId>
   </PropertyGroup>
 
@@ -51,11 +52,68 @@
     <PackageId>$(MSBuildProjectName).Experimental</PackageId>
   </PropertyGroup>
 
-  <Target Name="AssemblyVersionTarget" AfterTargets="MinVer" Condition="'$(MinVerVersion)'!='' AND '$(BuildNumber)' != ''">
+  <Target Name="ResolveAppVersionFromGit" BeforeTargets="GetAssemblyVersion;GenerateNuspec">
+    <Exec
+      Command="git -C &quot;$(RepoRoot)&quot; describe --tags --match &quot;$(AppVersionTagPattern)&quot; --abbrev=0"
+      ConsoleToMSBuild="true"
+      IgnoreExitCode="true"
+      StandardOutputImportance="Low"
+      StandardErrorImportance="Low"
+      Condition="'$(AppPackageVersion)' == '' OR '$(AppCompatVersion)' == '' OR '$(AppInformationalVersion)' == ''"
+    >
+      <Output TaskParameter="ConsoleOutput" ItemName="_AppLatestTagOutput" />
+      <Output TaskParameter="ExitCode" PropertyName="_AppLatestTagExitCode" />
+    </Exec>
+
+    <PropertyGroup Condition="'$(_AppLatestTagExitCode)' == '0' AND '@(_AppLatestTagOutput)' != ''">
+      <_AppLatestTag>@(_AppLatestTagOutput->'%(Identity)')</_AppLatestTag>
+    </PropertyGroup>
+
+    <Exec
+      Command="git -C &quot;$(RepoRoot)&quot; rev-list --count $(_AppLatestTag)..HEAD"
+      ConsoleToMSBuild="true"
+      IgnoreExitCode="true"
+      StandardOutputImportance="Low"
+      StandardErrorImportance="Low"
+      Condition="'$(_AppLatestTag)' != '' AND ('$(AppPackageVersion)' == '' OR '$(AppCompatVersion)' == '')"
+    >
+      <Output TaskParameter="ConsoleOutput" ItemName="_AppVersionHeightOutput" />
+      <Output TaskParameter="ExitCode" PropertyName="_AppVersionHeightExitCode" />
+    </Exec>
+
+    <Exec
+      Command="git -C &quot;$(RepoRoot)&quot; rev-parse --short=12 HEAD"
+      ConsoleToMSBuild="true"
+      IgnoreExitCode="true"
+      StandardOutputImportance="Low"
+      StandardErrorImportance="Low"
+      Condition="'$(AppInformationalVersion)' == ''"
+    >
+      <Output TaskParameter="ConsoleOutput" ItemName="_AppCommitOutput" />
+      <Output TaskParameter="ExitCode" PropertyName="_AppCommitExitCode" />
+    </Exec>
+
     <PropertyGroup>
-      <FileVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(BuildNumber)</FileVersion>
-      <Version>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(BuildNumber)</Version>
-      <AssemblyVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(BuildNumber)</AssemblyVersion>
+      <_AppBaseVersion Condition="'$(_AppLatestTag)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$(_AppLatestTag)', '^app/v', ''))</_AppBaseVersion>
+      <_AppBaseVersion Condition="'$(_AppBaseVersion)' == ''">$(AppDefaultBaseVersion)</_AppBaseVersion>
+      <_AppVersionHeight Condition="'$(_AppVersionHeightExitCode)' == '0' AND '@(_AppVersionHeightOutput)' != ''">@(_AppVersionHeightOutput->'%(Identity)')</_AppVersionHeight>
+      <_AppVersionHeight Condition="'$(_AppVersionHeight)' == ''">0</_AppVersionHeight>
+      <_AppCommit Condition="'$(_AppCommitExitCode)' == '0' AND '@(_AppCommitOutput)' != ''">@(_AppCommitOutput->'%(Identity)')</_AppCommit>
+      <_AppPackageVersionSuffix Condition="'$(_AppLatestTag)' == '' AND '$(_AppVersionHeight)' == '0'">.dev.0</_AppPackageVersionSuffix>
+      <_AppPackageVersionSuffix Condition="'$(_AppVersionHeight)' != '0' AND $([System.Text.RegularExpressions.Regex]::IsMatch('$(_AppBaseVersion)', '-'))">.dev.$(_AppVersionHeight)</_AppPackageVersionSuffix>
+      <_AppPackageVersionSuffix Condition="'$(_AppVersionHeight)' != '0' AND !$([System.Text.RegularExpressions.Regex]::IsMatch('$(_AppBaseVersion)', '-'))">-dev.$(_AppVersionHeight)</_AppPackageVersionSuffix>
+      <AppPackageVersion Condition="'$(AppPackageVersion)' == ''">$(_AppBaseVersion)$(_AppPackageVersionSuffix)</AppPackageVersion>
+      <_AppVersionMajor>$([System.Text.RegularExpressions.Regex]::Match('$(AppPackageVersion)', '^([0-9]+)\.([0-9]+)\.([0-9]+)').Groups[1].Value)</_AppVersionMajor>
+      <_AppVersionMinor>$([System.Text.RegularExpressions.Regex]::Match('$(AppPackageVersion)', '^([0-9]+)\.([0-9]+)\.([0-9]+)').Groups[2].Value)</_AppVersionMinor>
+      <_AppVersionPatch>$([System.Text.RegularExpressions.Regex]::Match('$(AppPackageVersion)', '^([0-9]+)\.([0-9]+)\.([0-9]+)').Groups[3].Value)</_AppVersionPatch>
+      <AppCompatVersion Condition="'$(AppCompatVersion)' == ''">$(_AppVersionMajor).$(_AppVersionMinor).$(_AppVersionPatch).$(_AppVersionHeight)</AppCompatVersion>
+      <AppInformationalVersion Condition="'$(AppInformationalVersion)' == '' AND '$(_AppCommit)' != ''">$(AppPackageVersion)+$(_AppCommit)</AppInformationalVersion>
+      <AppInformationalVersion Condition="'$(AppInformationalVersion)' == ''">$(AppPackageVersion)</AppInformationalVersion>
+      <Version>$(AppPackageVersion)</Version>
+      <PackageVersion>$(AppPackageVersion)</PackageVersion>
+      <FileVersion>$(AppCompatVersion)</FileVersion>
+      <AssemblyVersion>$(AppCompatVersion)</AssemblyVersion>
+      <InformationalVersion>$(AppInformationalVersion)</InformationalVersion>
     </PropertyGroup>
   </Target>
 

--- a/src/App/backend/src/Directory.Build.props
+++ b/src/App/backend/src/Directory.Build.props
@@ -43,7 +43,11 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(MinVerVersionOverride)'!=''">
+  <PropertyGroup Condition="'$(UseExperimentalPackageId)' == '' AND '$(MinVerVersionOverride)'!=''">
+    <UseExperimentalPackageId>true</UseExperimentalPackageId>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(UseExperimentalPackageId)' == 'true'">
     <PackageId>$(MSBuildProjectName).Experimental</PackageId>
   </PropertyGroup>
 

--- a/src/App/backend/test/Altinn.App.Api.Tests/Controllers/HomeControllerTest_AppFrontendAssetBaseUrl.cs
+++ b/src/App/backend/test/Altinn.App.Api.Tests/Controllers/HomeControllerTest_AppFrontendAssetBaseUrl.cs
@@ -17,6 +17,8 @@ public class HomeControllerTest_AppFrontendAssetBaseUrl : ApiTestBase, IClassFix
 {
     private const string Org = "tdd";
     private const string App = "contributer-restriction";
+    private const string GeneratedOrg = "xunit";
+    private const string GeneratedApp = "test-app";
 
     public HomeControllerTest_AppFrontendAssetBaseUrl(
         WebApplicationFactory<Program> factory,
@@ -46,14 +48,16 @@ public class HomeControllerTest_AppFrontendAssetBaseUrl : ApiTestBase, IClassFix
     }
 
     [Fact]
-    public async Task Index_FailsByDefault()
+    public async Task Index_UsesBundledAppFrontendByDefault()
     {
         using var client = GetRootedClient(Org, App, configureServices: ConfigureStatelessAnonymousApp);
         using var response = await client.GetAsync($"{Org}/{App}/");
         var html = await response.Content.ReadAsStringAsync();
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        Assert.Contains("loading our built-in frontend is not yet supported", html);
+        Assert.Contains($"href=\"/{GeneratedOrg}/{GeneratedApp}/altinn-app-frontend/altinn-app-frontend.css\"", html);
+        Assert.Contains($"src=\"/{GeneratedOrg}/{GeneratedApp}/altinn-app-frontend/altinn-app-frontend.js\"", html);
+        Assert.DoesNotContain("loading our built-in frontend is not yet supported", html);
     }
 
     private static void ConfigureStatelessAnonymousApp(IServiceCollection services)

--- a/src/App/backend/test/Altinn.App.Core.Tests/Models/ApplicationMetdataTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Models/ApplicationMetdataTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Altinn.App.Core.Models;
 using FluentAssertions;
 
@@ -36,5 +37,17 @@ public class ApplicationMetdataTests
         metadata.AppIdentifier.Should().BeEquivalentTo(expected);
         Assert.Throws<ArgumentOutOfRangeException>(() => metadata.Id = "invalid");
         metadata.AppIdentifier.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void AltinnNugetVersionUsesAssemblyFileVersion()
+    {
+        string? fileVersion = typeof(ApplicationMetadata)
+            .Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()
+            ?.Version;
+
+        ApplicationMetadata.LibVersion.Should().Be(fileVersion);
+        Version.TryParse(ApplicationMetadata.LibVersion, out _).Should().BeTrue();
+        new ApplicationMetadata("ttd/test").AltinnNugetVersion.Should().Be(fileVersion);
     }
 }

--- a/src/App/backend/test/Altinn.App.Core.Tests/Models/ApplicationMetdataTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Models/ApplicationMetdataTests.cs
@@ -46,8 +46,8 @@ public class ApplicationMetdataTests
             .Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()
             ?.Version;
 
-        ApplicationMetadata.LibVersion.Should().Be(fileVersion);
-        Version.TryParse(ApplicationMetadata.LibVersion, out _).Should().BeTrue();
-        new ApplicationMetadata("ttd/test").AltinnNugetVersion.Should().Be(fileVersion);
+        Assert.Equal(fileVersion, ApplicationMetadata.LibVersion);
+        Assert.True(Version.TryParse(ApplicationMetadata.LibVersion, out _));
+        Assert.Equal(fileVersion, new ApplicationMetadata("ttd/test").AltinnNugetVersion);
     }
 }

--- a/src/App/backend/test/Altinn.App.Integration.Tests/_fixture/AppFixture.ApiResponse.cs
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/_fixture/AppFixture.ApiResponse.cs
@@ -37,10 +37,20 @@ public sealed partial class AppFixture
         }
     }
 
-    internal class ApiResponse(AppFixture fixture, HttpResponseMessage response) : IDisposable
+    internal class ApiResponse : IDisposable
     {
-        public AppFixture Fixture = fixture;
-        private HttpResponseMessage? _response = response;
+        public AppFixture Fixture { get; }
+        private HttpResponseMessage? _response;
+
+        public ApiResponse(AppFixture fixture, HttpResponseMessage response)
+        {
+            Fixture = fixture;
+            _response = response;
+
+            if ((int)response.StatusCode >= 500)
+                fixture.TestErrored = true;
+        }
+
         public HttpResponseMessage Response
         {
             get

--- a/src/App/backend/test/Altinn.App.Integration.Tests/_fixture/AppFixture.cs
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/_fixture/AppFixture.cs
@@ -426,7 +426,7 @@ public sealed partial class AppFixture : IAsyncDisposable
 
         await SyncPackages(generatedDirectory, cancellationToken);
         await SyncShared(generatedDirectory, cancellationToken);
-        await SyncFrontend(generatedDirectory, logger, cancellationToken);
+        Directory.CreateDirectory(Path.Join(generatedDirectory, "App", "wwwroot"));
         CopyScenarioOverrides(name, scenario, generatedDirectory);
 
         foreach (
@@ -789,41 +789,6 @@ public sealed partial class AppFixture : IAsyncDisposable
             var fileName = Path.GetFileName(file);
             var destFile = Path.Join(appSharedDirectory, fileName);
             await using var source = File.OpenRead(file);
-            await using var destination = File.Create(destFile);
-            await source.CopyToAsync(destination, cancellationToken);
-        }
-    }
-
-    private static async Task SyncFrontend(
-        string generatedDirectory,
-        ILogger logger,
-        CancellationToken cancellationToken
-    )
-    {
-        var frontendBuildDirectory = Path.Join(_repoSourceDirectory, "App", "frontend", "dist");
-
-        const string missingFilesErrorMessage =
-            "The frontend should have been built during test setup. Install yarn and run "
-            + "'cd src/App/frontend && yarn build', or set SKIP_FRONTEND_BUILD=true to use pre-built files.";
-        if (!Directory.Exists(frontendBuildDirectory))
-        {
-            throw new DirectoryNotFoundException(
-                $"Expected frontend build directory '{frontendBuildDirectory}' to exist. {missingFilesErrorMessage}"
-            );
-        }
-
-        var appStaticFrontendDirectory = Path.Join(generatedDirectory, "App", "wwwroot", "altinn-app-frontend");
-        if (Directory.Exists(appStaticFrontendDirectory))
-            Directory.Delete(appStaticFrontendDirectory, true);
-        Directory.CreateDirectory(appStaticFrontendDirectory);
-
-        foreach (var sourceFile in Directory.GetFiles(frontendBuildDirectory, "*", SearchOption.AllDirectories))
-        {
-            var relativePath = Path.GetRelativePath(frontendBuildDirectory, sourceFile);
-            var destFile = Path.Join(appStaticFrontendDirectory, relativePath);
-            Directory.CreateDirectory(Path.GetDirectoryName(destFile)!);
-            logger.LogInformation("Copying {SourceFile} to {DestFile}", sourceFile, destFile);
-            await using var source = File.OpenRead(sourceFile);
             await using var destination = File.Create(destFile);
             await source.CopyToAsync(destination, cancellationToken);
         }

--- a/src/App/backend/test/Altinn.App.Integration.Tests/_fixture/AppFixture.cs
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/_fixture/AppFixture.cs
@@ -135,10 +135,8 @@ public sealed partial class AppFixture : IAsyncDisposable
         string? generatedAppDirectory = null;
         try
         {
-            await Task.WhenAll(
-                EnsureLibrariesPacked(logger, cancellationToken),
-                EnsureFrontendBuilt(logger, cancellationToken)
-            );
+            await EnsureFrontendBuilt(logger, cancellationToken);
+            await EnsureLibrariesPacked(logger, cancellationToken);
             var originalAppId = GetAppId(app);
             var appIdentity = AppIdentity.Create(originalAppId);
             var effectiveApp = $"{appIdentity.App}-f{fixtureInstance:0000}";
@@ -819,17 +817,11 @@ public sealed partial class AppFixture : IAsyncDisposable
             Directory.Delete(appStaticFrontendDirectory, true);
         Directory.CreateDirectory(appStaticFrontendDirectory);
 
-        string[] fileNamesToCopy = ["altinn-app-frontend.js", "altinn-app-frontend.css"];
-        var frontendBuildFiles = Directory.GetFiles(frontendBuildDirectory);
-        foreach (var fileName in fileNamesToCopy)
+        foreach (var sourceFile in Directory.GetFiles(frontendBuildDirectory, "*", SearchOption.AllDirectories))
         {
-            var sourceFile =
-                frontendBuildFiles.FirstOrDefault(file => Path.GetFileName(file) == fileName)
-                ?? throw new FileNotFoundException(
-                    $"Expected frontend file '{fileName}' not found in '{frontendBuildDirectory}'. {missingFilesErrorMessage}"
-                );
-
-            var destFile = Path.Join(appStaticFrontendDirectory, fileName);
+            var relativePath = Path.GetRelativePath(frontendBuildDirectory, sourceFile);
+            var destFile = Path.Join(appStaticFrontendDirectory, relativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(destFile)!);
             logger.LogInformation("Copying {SourceFile} to {DestFile}", sourceFile, destFile);
             await using var source = File.OpenRead(sourceFile);
             await using var destination = File.Create(destFile);

--- a/src/tools/releaser/README.md
+++ b/src/tools/releaser/README.md
@@ -5,6 +5,7 @@ Simple release flow for a component.
 ## Supported components
 
 - `studioctl`: uses a Go builder registered by the releaser CLI.
+- `app`: uses a Go builder registered by the releaser CLI.
 - `fileanalyzers`: has no releaser builder; the GitHub workflow handles package build and publish.
 
 ## Builders

--- a/src/tools/releaser/builder_00_register.go
+++ b/src/tools/releaser/builder_00_register.go
@@ -10,5 +10,8 @@ func registerBuilders() error {
 	if err := internal.RegisterComponentBuilder("studioctl", newStudioctlBuilder()); err != nil {
 		return fmt.Errorf("register studioctl builder: %w", err)
 	}
+	if err := internal.RegisterComponentBuilder("app", newAppBuilder()); err != nil {
+		return fmt.Errorf("register app builder: %w", err)
+	}
 	return nil
 }

--- a/src/tools/releaser/builder_app.go
+++ b/src/tools/releaser/builder_app.go
@@ -57,6 +57,11 @@ func (b *appBuilder) Build(ctx context.Context, ver *version.Version, outputDir 
 		return nil, fmt.Errorf("build app frontend: %w", err)
 	}
 
+	informationalVersion, err := appInformationalVersion(ctx, git, ver)
+	if err != nil {
+		return nil, err
+	}
+
 	b.log.Info("Packing app backend packages...")
 	if err := b.run(
 		ctx,
@@ -69,7 +74,9 @@ func (b *appBuilder) Build(ctx context.Context, ver *version.Version, outputDir 
 		"Release",
 		"--output",
 		outputDir,
-		"-p:MinVerVersionOverride="+ver.Num,
+		"-p:AppPackageVersion="+ver.Num,
+		fmt.Sprintf("-p:AppCompatVersion=%d.%d.%d.0", ver.Major, ver.Minor, ver.Patch),
+		"-p:AppInformationalVersion="+informationalVersion,
 		"-p:UseExperimentalPackageId=false",
 	); err != nil {
 		return nil, fmt.Errorf("pack app backend: %w", err)
@@ -83,6 +90,18 @@ func (b *appBuilder) Build(ctx context.Context, ver *version.Version, outputDir 
 		return nil, fmt.Errorf("no app package artifacts produced in %s", outputDir)
 	}
 	return artifacts, nil
+}
+
+func appInformationalVersion(ctx context.Context, git *internal.GitCLI, ver *version.Version) (string, error) {
+	sha, err := git.Run(ctx, "rev-parse", "--short=12", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("get app package informational version commit: %w", err)
+	}
+	sha = strings.TrimSpace(sha)
+	if sha == "" {
+		return "", fmt.Errorf("get app package informational version commit: empty SHA")
+	}
+	return ver.Num + "+" + sha, nil
 }
 
 func (b *appBuilder) run(ctx context.Context, dir string, env []string, name string, args ...string) error {

--- a/src/tools/releaser/builder_app.go
+++ b/src/tools/releaser/builder_app.go
@@ -111,7 +111,12 @@ func appInformationalVersion(ctx context.Context, git *internal.GitCLI, ver *ver
 }
 
 func (b *appBuilder) run(ctx context.Context, dir string, env []string, name string, args ...string) error {
-	//nolint:gosec // G204: commands are fixed release build tools with fixed local arguments.
+	switch name {
+	case "dotnet", "yarn":
+	default:
+		return fmt.Errorf("unsupported app build command: %s", name)
+	}
+
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/src/tools/releaser/builder_app.go
+++ b/src/tools/releaser/builder_app.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -11,6 +12,11 @@ import (
 
 	"altinn.studio/releaser/internal"
 	"altinn.studio/releaser/internal/version"
+)
+
+var (
+	errAppPackageArtifactsMissing         = errors.New("no app package artifacts produced")
+	errAppInformationalVersionCommitEmpty = errors.New("app package informational version commit is empty")
 )
 
 type appBuilder struct {
@@ -37,12 +43,12 @@ func (b *appBuilder) Build(ctx context.Context, ver *version.Version, outputDir 
 	frontendDir := filepath.Join(root, "src", "App", "frontend")
 	backendDir := filepath.Join(root, "src", "App", "backend")
 
-	if err := internal.EnsureDir(outputDir); err != nil {
-		return nil, fmt.Errorf("create output directory: %w", err)
+	if ensureErr := internal.EnsureDir(outputDir); ensureErr != nil {
+		return nil, fmt.Errorf("create output directory: %w", ensureErr)
 	}
 
 	b.log.Info("Building app frontend...")
-	if err := b.run(
+	if installErr := b.run(
 		ctx,
 		frontendDir,
 		appFrontendInstallEnv(),
@@ -50,11 +56,11 @@ func (b *appBuilder) Build(ctx context.Context, ver *version.Version, outputDir 
 		"install",
 		"--immutable",
 		"--inline-builds",
-	); err != nil {
-		return nil, fmt.Errorf("install app frontend dependencies: %w", err)
+	); installErr != nil {
+		return nil, fmt.Errorf("install app frontend dependencies: %w", installErr)
 	}
-	if err := b.run(ctx, frontendDir, nil, "yarn", "build"); err != nil {
-		return nil, fmt.Errorf("build app frontend: %w", err)
+	if buildErr := b.run(ctx, frontendDir, nil, "yarn", "build"); buildErr != nil {
+		return nil, fmt.Errorf("build app frontend: %w", buildErr)
 	}
 
 	informationalVersion, err := appInformationalVersion(ctx, git, ver)
@@ -63,7 +69,7 @@ func (b *appBuilder) Build(ctx context.Context, ver *version.Version, outputDir 
 	}
 
 	b.log.Info("Packing app backend packages...")
-	if err := b.run(
+	if packErr := b.run(
 		ctx,
 		backendDir,
 		nil,
@@ -75,11 +81,11 @@ func (b *appBuilder) Build(ctx context.Context, ver *version.Version, outputDir 
 		"--output",
 		outputDir,
 		"-p:AppPackageVersion="+ver.Num,
-		fmt.Sprintf("-p:AppCompatVersion=%d.%d.%d.0", ver.Major, ver.Minor, ver.Patch),
+		fmt.Sprintf("-p:AppAssemblyVersion=%d.%d.%d.0", ver.Major, ver.Minor, ver.Patch),
 		"-p:AppInformationalVersion="+informationalVersion,
 		"-p:UseExperimentalPackageId=false",
-	); err != nil {
-		return nil, fmt.Errorf("pack app backend: %w", err)
+	); packErr != nil {
+		return nil, fmt.Errorf("pack app backend: %w", packErr)
 	}
 
 	artifacts, err := appPackageArtifacts(outputDir)
@@ -87,7 +93,7 @@ func (b *appBuilder) Build(ctx context.Context, ver *version.Version, outputDir 
 		return nil, err
 	}
 	if len(artifacts) == 0 {
-		return nil, fmt.Errorf("no app package artifacts produced in %s", outputDir)
+		return nil, fmt.Errorf("%w in %s", errAppPackageArtifactsMissing, outputDir)
 	}
 	return artifacts, nil
 }
@@ -99,7 +105,7 @@ func appInformationalVersion(ctx context.Context, git *internal.GitCLI, ver *ver
 	}
 	sha = strings.TrimSpace(sha)
 	if sha == "" {
-		return "", fmt.Errorf("get app package informational version commit: empty SHA")
+		return "", errAppInformationalVersionCommitEmpty
 	}
 	return ver.Num + "+" + sha, nil
 }

--- a/src/tools/releaser/builder_app.go
+++ b/src/tools/releaser/builder_app.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"altinn.studio/releaser/internal"
+	"altinn.studio/releaser/internal/version"
+)
+
+type appBuilder struct {
+	log internal.Logger
+}
+
+func newAppBuilder() *appBuilder {
+	return &appBuilder{
+		log: internal.NopLogger{},
+	}
+}
+
+func (b *appBuilder) Build(ctx context.Context, ver *version.Version, outputDir string) ([]string, error) {
+	if b.log == nil {
+		b.log = internal.NopLogger{}
+	}
+
+	git := internal.NewGitCLI()
+	root, err := git.RepoRoot(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get repo root: %w", err)
+	}
+
+	frontendDir := filepath.Join(root, "src", "App", "frontend")
+	backendDir := filepath.Join(root, "src", "App", "backend")
+
+	if err := internal.EnsureDir(outputDir); err != nil {
+		return nil, fmt.Errorf("create output directory: %w", err)
+	}
+
+	b.log.Info("Building app frontend...")
+	if err := b.run(
+		ctx,
+		frontendDir,
+		appFrontendInstallEnv(),
+		"yarn",
+		"install",
+		"--immutable",
+		"--inline-builds",
+	); err != nil {
+		return nil, fmt.Errorf("install app frontend dependencies: %w", err)
+	}
+	if err := b.run(ctx, frontendDir, nil, "yarn", "build"); err != nil {
+		return nil, fmt.Errorf("build app frontend: %w", err)
+	}
+
+	b.log.Info("Packing app backend packages...")
+	if err := b.run(
+		ctx,
+		backendDir,
+		nil,
+		"dotnet",
+		"pack",
+		"solutions/Src.slnx",
+		"-c",
+		"Release",
+		"--output",
+		outputDir,
+		"-p:MinVerVersionOverride="+ver.Num,
+		"-p:UseExperimentalPackageId=false",
+	); err != nil {
+		return nil, fmt.Errorf("pack app backend: %w", err)
+	}
+
+	artifacts, err := appPackageArtifacts(outputDir)
+	if err != nil {
+		return nil, err
+	}
+	if len(artifacts) == 0 {
+		return nil, fmt.Errorf("no app package artifacts produced in %s", outputDir)
+	}
+	return artifacts, nil
+}
+
+func (b *appBuilder) run(ctx context.Context, dir string, env []string, name string, args ...string) error {
+	//nolint:gosec // G204: commands are fixed release build tools with fixed local arguments.
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Dir = dir
+	if len(env) > 0 {
+		cmd.Env = append(os.Environ(), env...)
+	}
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("run %s %s: %w", name, strings.Join(args, " "), err)
+	}
+	return nil
+}
+
+func appFrontendInstallEnv() []string {
+	return []string{
+		"HUSKY=0",
+		"PUPPETEER_SKIP_DOWNLOAD=true",
+		"YARN_ENABLE_GLOBAL_CACHE=false",
+		"YARN_NM_MODE=hardlinks-local",
+	}
+}
+
+func appPackageArtifacts(outputDir string) ([]string, error) {
+	patterns := []string{"*.nupkg", "*.snupkg"}
+	var artifacts []string
+	for _, pattern := range patterns {
+		matches, err := filepath.Glob(filepath.Join(outputDir, pattern))
+		if err != nil {
+			return nil, fmt.Errorf("glob app package artifacts: %w", err)
+		}
+		artifacts = append(artifacts, matches...)
+	}
+	sort.Strings(artifacts)
+	return artifacts, nil
+}

--- a/src/tools/releaser/builder_app.go
+++ b/src/tools/releaser/builder_app.go
@@ -48,18 +48,10 @@ func (b *appBuilder) Build(ctx context.Context, ver *version.Version, outputDir 
 	}
 
 	b.log.Info("Building app frontend...")
-	if installErr := b.run(
-		ctx,
-		frontendDir,
-		appFrontendInstallEnv(),
-		"yarn",
-		"install",
-		"--immutable",
-		"--inline-builds",
-	); installErr != nil {
+	if installErr := b.runYarnInstall(ctx, frontendDir); installErr != nil {
 		return nil, fmt.Errorf("install app frontend dependencies: %w", installErr)
 	}
-	if buildErr := b.run(ctx, frontendDir, nil, "yarn", "build"); buildErr != nil {
+	if buildErr := b.runYarnBuild(ctx, frontendDir); buildErr != nil {
 		return nil, fmt.Errorf("build app frontend: %w", buildErr)
 	}
 
@@ -69,22 +61,7 @@ func (b *appBuilder) Build(ctx context.Context, ver *version.Version, outputDir 
 	}
 
 	b.log.Info("Packing app backend packages...")
-	if packErr := b.run(
-		ctx,
-		backendDir,
-		nil,
-		"dotnet",
-		"pack",
-		"solutions/Src.slnx",
-		"-c",
-		"Release",
-		"--output",
-		outputDir,
-		"-p:AppPackageVersion="+ver.Num,
-		fmt.Sprintf("-p:AppAssemblyVersion=%d.%d.%d.0", ver.Major, ver.Minor, ver.Patch),
-		"-p:AppInformationalVersion="+informationalVersion,
-		"-p:UseExperimentalPackageId=false",
-	); packErr != nil {
+	if packErr := b.runDotnetPack(ctx, backendDir, outputDir, ver, informationalVersion); packErr != nil {
 		return nil, fmt.Errorf("pack app backend: %w", packErr)
 	}
 
@@ -110,23 +87,53 @@ func appInformationalVersion(ctx context.Context, git *internal.GitCLI, ver *ver
 	return ver.Num + "+" + sha, nil
 }
 
-func (b *appBuilder) run(ctx context.Context, dir string, env []string, name string, args ...string) error {
-	switch name {
-	case "dotnet", "yarn":
-	default:
-		return fmt.Errorf("unsupported app build command: %s", name)
-	}
-
-	cmd := exec.CommandContext(ctx, name, args...)
+func (b *appBuilder) runYarnInstall(ctx context.Context, dir string) error {
+	cmd := exec.CommandContext(ctx, "yarn", "install", "--immutable", "--inline-builds")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Dir = dir
-	if len(env) > 0 {
-		cmd.Env = append(os.Environ(), env...)
-	}
+	cmd.Env = append(os.Environ(), appFrontendInstallEnv()...)
 
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("run %s %s: %w", name, strings.Join(args, " "), err)
+		return fmt.Errorf("run yarn install --immutable --inline-builds: %w", err)
+	}
+	return nil
+}
+
+func (b *appBuilder) runYarnBuild(ctx context.Context, dir string) error {
+	cmd := exec.CommandContext(ctx, "yarn", "build")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Dir = dir
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("run yarn build: %w", err)
+	}
+	return nil
+}
+
+func (b *appBuilder) runDotnetPack(
+	ctx context.Context,
+	dir string,
+	outputDir string,
+	ver *version.Version,
+	informationalVersion string,
+) error {
+	cmd := exec.CommandContext(ctx, "dotnet", "pack", "solutions/Src.slnx", "-c", "Release", "--output")
+	cmd.Args = append(
+		cmd.Args,
+		outputDir,
+		"-p:AppPackageVersion="+ver.Num,
+		fmt.Sprintf("-p:AppAssemblyVersion=%d.%d.%d.0", ver.Major, ver.Minor, ver.Patch),
+		"-p:AppInformationalVersion="+informationalVersion,
+		"-p:UseExperimentalPackageId=false",
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Dir = dir
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("run dotnet pack: %w", err)
 	}
 	return nil
 }

--- a/src/tools/releaser/internal/component.go
+++ b/src/tools/releaser/internal/component.go
@@ -46,6 +46,12 @@ var components = map[string]*Component{
 		SourcePath:    "src/App/fileanalyzers",
 		Builder:       nil, // YAML handles dotnet pack/push
 	},
+	"app": {
+		Name:          "app",
+		ChangelogPath: "src/App/backend/CHANGELOG.md",
+		SourcePath:    "src/App/backend",
+		Builder:       nil, // registered by the releaser CLI
+	},
 }
 
 // RegisterComponentBuilder registers a builder for an existing component.

--- a/src/tools/releaser/internal/workflow_version_resolver.go
+++ b/src/tools/releaser/internal/workflow_version_resolver.go
@@ -27,6 +27,15 @@ type baseBranchSelector struct {
 	minor  int
 }
 
+// ResolveWorkflowVersion resolves the release version from the component changelog and base branch.
+func ResolveWorkflowVersion(componentName, baseBranch, repoRoot string) (string, error) {
+	component, err := GetComponent(componentName)
+	if err != nil {
+		return "", err
+	}
+	return resolveWorkflowVersion(component, baseBranch, repoRoot)
+}
+
 func resolveWorkflowVersion(component *Component, baseBranch, repoRoot string) (string, error) {
 	if component == nil {
 		return "", errComponentRequired

--- a/src/tools/releaser/main.go
+++ b/src/tools/releaser/main.go
@@ -40,6 +40,8 @@ func main() {
 		err = runBackport(os.Args[2:])
 	case "validate-changelog":
 		err = runValidateChangelog(os.Args[2:])
+	case "resolve-version":
+		err = runResolveVersion(os.Args[2:])
 	case "help", "-h", "--help":
 		printUsage()
 		return
@@ -65,6 +67,7 @@ Commands:
   prepare             Create a changelog promotion PR for release
   backport            Cherry-pick a commit to a release branch with changelog handling
   validate-changelog  Validate changelog was modified and release-ready
+  resolve-version     Print the release version resolved from a component changelog
 
 Notes:
   - workflow resolves the release version from CHANGELOG.md using -base-branch
@@ -131,6 +134,49 @@ Examples:
 	if err := internal.RunWorkflow(context.Background(), req, internal.NewConsoleLogger()); err != nil {
 		return fmt.Errorf("workflow: %w", err)
 	}
+	return nil
+}
+
+func runResolveVersion(args []string) error {
+	fs := flag.NewFlagSet("resolve-version", flag.ExitOnError)
+	component := fs.String("component", "", "Component name (e.g., studioctl)")
+	baseBranch := fs.String("base-branch", "", "Base branch (main or release/<component>/vX.Y)")
+	fs.Usage = func() {
+		fmt.Print(`Usage: releaser resolve-version -component <name> -base-branch <branch>
+
+Prints the release version resolved from the component changelog.
+
+Version behavior:
+  - base-branch=main -> latest prerelease version
+  - base-branch=release/<component>/vX.Y -> latest stable on that line
+
+Options:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return fmt.Errorf("parse flags: %w", err)
+	}
+	if *component == "" {
+		fs.Usage()
+		return errComponentRequired
+	}
+	if *baseBranch == "" {
+		fs.Usage()
+		return errBaseBranchRequired
+	}
+
+	git := internal.NewGitCLI()
+	root, err := git.RepoRoot(context.Background())
+	if err != nil {
+		return fmt.Errorf("get repo root: %w", err)
+	}
+
+	version, err := internal.ResolveWorkflowVersion(*component, *baseBranch, root)
+	if err != nil {
+		return fmt.Errorf("resolve version: %w", err)
+	}
+	fmt.Println(version)
 	return nil
 }
 

--- a/src/tools/releaser/main_test.go
+++ b/src/tools/releaser/main_test.go
@@ -76,6 +76,20 @@ func TestCLIArgValidation(t *testing.T) {
 			t.Fatalf("runValidateChangelog() error = %v, want %v", err, errBaseHeadRequired)
 		}
 	})
+
+	t.Run("resolve version requires component", func(t *testing.T) {
+		err := runResolveVersion([]string{"-base-branch", "main"})
+		if !errors.Is(err, errComponentRequired) {
+			t.Fatalf("runResolveVersion() error = %v, want %v", err, errComponentRequired)
+		}
+	})
+
+	t.Run("resolve version requires base branch", func(t *testing.T) {
+		err := runResolveVersion([]string{"-component", "studioctl"})
+		if !errors.Is(err, errBaseBranchRequired) {
+			t.Fatalf("runResolveVersion() error = %v, want %v", err, errBaseBranchRequired)
+		}
+	})
 }
 
 func TestWorkflowCommandRequiresCI(t *testing.T) {


### PR DESCRIPTION
## Description

Part of #18595.

Adds the first app v9 packaging/release slice:

- bundles the built app frontend into `Altinn.App.Api` and copies it into consuming apps under `wwwroot/altinn-app-frontend`
- updates generated app HTML to load app-local frontend assets from `/{org}/{app}/altinn-app-frontend`
- adds `app` as a releaser component with a backend changelog and Go builder
- adds the `release-app` workflow for app package releases
- replaces MinVer usage in app backend packages with explicit app version properties used by the releaser, while keeping runtime `altinnNugetVersion` numeric via assembly file version

The app packages intentionally use one backend changelog for this first release slice. `Altinn.App.Api`, `Altinn.App.Core`, and `Altinn.App.Clients.Fiks` are built and packed together by the app releaser component.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

Commands run after rebasing on latest `upstream/main`:

```bash
dotnet test test/Altinn.App.Core.Tests/Altinn.App.Core.Tests.csproj -v:m --filter "FullyQualifiedName~ApplicationMetdataTests|FullyQualifiedName~AppMetadataTest.GetApplicationMetadata_deserialize_serialize_unmapped_properties"
```

Result: passed, 5 tests.

```bash
cd src/tools/releaser && go test ./...
```

Result: passed.

```bash
actionlint .github/workflows/release-app.yaml
```

Result: passed.

```bash
dotnet pack solutions/Src.slnx -c Release --output /tmp/app-v9-pr-pack -p:AppPackageVersion=9.0.0-preview.1 -p:AppCompatVersion=9.0.0.0 -p:AppInformationalVersion=9.0.0-preview.1+prcheck -p:UseExperimentalPackageId=false -v:m
```

Result: produced `Altinn.App.Api`, `Altinn.App.Core`, and `Altinn.App.Clients.Fiks` `.nupkg`/`.snupkg` artifacts for `9.0.0-preview.1`.

Package inspection confirmed:

- `Altinn.App.Api.nuspec` has package version `9.0.0-preview.1`
- `Altinn.App.Api.nuspec` depends on `Altinn.App.Core` `9.0.0-preview.1`
- generated assembly attributes have `AssemblyVersion`/`FileVersion` `9.0.0.0` and `InformationalVersion` `9.0.0-preview.1+prcheck`
- `Altinn.App.Api.nupkg` includes `build/Altinn.App.Api.targets`
- `Altinn.App.Api.nupkg` includes bundled frontend assets such as `altinn-app-frontend.js` and `altinn-app-frontend.css`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated app release workflow for labelled PR merges with environment selection, manual dispatch and package publishing.
  * Release tooling and CLI now recognise and build the app component.

* **Chores**
  * App frontend is bundled into application packages and served by default; packaging will fail if bundled assets are missing.
  * Versioning now derives from git metadata at build time instead of a previous package-based tool.

* **Tests**
  * Tests updated to expect bundled frontend assets and runtime-derived versioning.

* **Documentation**
  * Releaser docs updated to include the app component.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio/pull/18947?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->