### PR TITLE
chore: release studioctl v0.1.0-preview.10

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -8,6 +8,8 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+## [0.1.0-preview.10] - 2026-05-22
+
 ### Changed
 
 - Update localtest image.


### PR DESCRIPTION
## Description

Prepare release v0.1.0-preview.10

- [Changed] Update localtest image.
- [Fixed] Fix Windows PowerShell installer architecture detection.
- [Fixed] Make Windows installs fall back to the default location when no usable interactive prompt is available.
- [Fixed] Support `studioctl self update` and `studioctl self uninstall` on Windows by completing binary replacement/removal after the running process exits.
- [Fixed] Render plain output in Windows PowerShell ISE to avoid unreadable ANSI codes and spinner/status glyphs.
- [Fixed] Clean up stale `studioctl` update artifacts from the Windows install directory during uninstall.

@coderabbitai ignore

**Full Changelog**: https://github.com/Altinn/altinn-studio/compare/studioctl/v0.1.0-preview.9...studioctl/v0.1.0-preview.10