### PR TITLE
chore: Map useLayoutCollection to correct prop in form store to fix unit test

### DIFF
--- a/src/App/frontend/monorepo-changed-paths.txt
+++ b/src/App/frontend/monorepo-changed-paths.txt
@@ -37,6 +37,7 @@ src/app-components/loading/AltinnContentLoader/
 src/app-components/loading/LoadingEmpty/LoadingEmpty.tsx
 src/app-components/loading/LoadingWrapper/LoadingWrapper.tsx
 src/app-components/loading/Spinner/Spinner.tsx
+src/app-components/readme.md
 src/codegen/schemas/layout-sets.schema.v1.ts
 src/components/presentation/Header.tsx
 src/core/contexts/hookContext.tsx

--- a/src/App/frontend/src/features/formBootstrap/FormBootstrap.tsx
+++ b/src/App/frontend/src/features/formBootstrap/FormBootstrap.tsx
@@ -12,7 +12,7 @@ export const formBootstrapHooks = {
     const out = FormStore.raw.useLaxSelector((s) => s.bootstrap.processedLayouts);
     return out === ContextNotProvided ? undefined : out;
   },
-  useLayoutCollection: () => FormStore.raw.useSelector((s) => s.bootstrap.layoutLookups),
+  useLayoutCollection: () => FormStore.raw.useSelector((s) => s.bootstrap.layouts),
   useLayoutLookups: () => FormStore.raw.useSelector((s) => s.bootstrap.layoutLookups),
   useHiddenLayoutsExpressions: () => FormStore.raw.useSelector((s) => s.bootstrap.hiddenLayoutsExpressions),
   useLaxHiddenLayoutsExpressions: () => {


### PR DESCRIPTION
The unit test for NavigationButtons were failing (src/layout/NavigationButtons/NavigationButtonsComponent.test.tsx)
It seems it started failing in after #18652
It only failed locally and not in github action

## Description

Details from AI : 
Reason that test passes in CI, but not locally : 
Node 22 and Node 24 differ subtly in microtask/setTimeout scheduling (and userEvent/RTL pump promises in a way that's sensitive to that). On Node 22, the rendered "next" still happens to be observable at the assertion points; on Node 24, navigation completes before the assertions land and the test sees the post-navigation DOM (only "back" present).

Breaking commit: [8ad2a97a0a](https://github.com/altinn/altinn-studio/commit/8ad2a97a0a) — refactor: simplifying FormStore (#18652)

Root cause: Copy-paste typo in [src/App/frontend/src/features/formBootstrap/FormBootstrap.tsx:15](vscode-webview://13ohf1cf3hduqgrqgebd4v7q0j5ombspjslhh275h8l2lit5nvm5/src/App/frontend/src/features/formBootstrap/FormBootstrap.tsx#L15). When the bootstrap hooks were rewritten to read from the zustand store directly, useLayoutCollection was wired to s.bootstrap.layoutLookups instead of s.bootstrap.layouts — i.e. it returns the same thing as useLayoutLookups.

In [usePageValidation.ts:17-18](vscode-webview://13ohf1cf3hduqgrqgebd4v7q0j5ombspjslhh275h8l2lit5nvm5/src/App/frontend/src/hooks/usePageValidation.ts#L17-L18), useLayoutCollection() is indexed as layoutCollection[pageKey].data.validationOnNavigation. That structure only exists on layouts, not layoutLookups, so the per-page validationOnNavigation config was silently always undefined. The three failing tests rely on that config to block navigation, so they navigated through and lost the next button.

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Adjusted internal layout data handling to improve reliability of form layout rendering.

* **Documentation**
  * Added a new tracked README entry to the frontend monorepo paths to aid developer guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio/pull/18976?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->