### PR TITLE
fix: support rootless podman localtest startup

### DIFF
--- a/src/Runtime/devenv/pkg/container/detect.go
+++ b/src/Runtime/devenv/pkg/container/detect.go
@@ -132,6 +132,8 @@ func (d *detector) detectToolchain(ctx context.Context) (ContainerToolchain, err
 			Platform:   PlatformPodman,
 			AccessMode: AccessPodmanCLI,
 			Source:     SourcePodmanCLI,
+			SocketPath: "",
+			SELinux:    false,
 		}, nil
 	}
 
@@ -319,6 +321,7 @@ func (d *detector) newToolchain(
 		AccessMode: accessMode,
 		Source:     source,
 		SocketPath: socketPath,
+		SELinux:    false,
 	}
 }
 

--- a/src/Runtime/devenv/pkg/container/detect_test.go
+++ b/src/Runtime/devenv/pkg/container/detect_test.go
@@ -24,6 +24,11 @@ const (
 	testColimaSocketHost = "unix://" + testColimaSocketPath
 )
 
+func clearDockerHost(t *testing.T) {
+	t.Helper()
+	t.Setenv("DOCKER_HOST", "")
+}
+
 func mixedToolchainDetectorDeps(
 	t *testing.T,
 	defaultPlatform ContainerPlatform,
@@ -70,6 +75,8 @@ func mixedToolchainDetectorDeps(
 }
 
 func TestDetect_RetriesAfterTransientFailure(t *testing.T) {
+	clearDockerHost(t)
+
 	calls := 0
 	d := newDetector(detectorDeps{
 		detectPlatform: func(context.Context) (ContainerPlatform, error) {
@@ -85,6 +92,12 @@ func TestDetect_RetriesAfterTransientFailure(t *testing.T) {
 			}
 			return "", exec.ErrNotFound
 		},
+		dockerContextHost: func(context.Context) (string, error) {
+			return "", errTransientFailure
+		},
+		dockerSocketPaths: func() []string { return nil },
+		podmanSocketPaths: func() []string { return nil },
+		fileExists:        func(string) bool { return false },
 		newClient: func(context.Context, ContainerToolchain) (ContainerClient, error) {
 			return containermock.New(), nil
 		},
@@ -125,6 +138,8 @@ func TestDetectToolchain_DefaultDockerHostWithoutDockerCLISucceeds(t *testing.T)
 }
 
 func TestDetectToolchain_DockerContextClassifiesPodmanSocket(t *testing.T) {
+	clearDockerHost(t)
+
 	d := newDetector(detectorDeps{
 		detectPlatform: func(context.Context) (ContainerPlatform, error) {
 			return PlatformUnknown, errTransientFailure
@@ -165,6 +180,8 @@ func TestDetectToolchain_DockerContextClassifiesPodmanSocket(t *testing.T) {
 }
 
 func TestDetectToolchain_DockerSocketWithoutDockerCLISucceeds(t *testing.T) {
+	clearDockerHost(t)
+
 	d := newDetector(detectorDeps{
 		detectPlatform: func(context.Context) (ContainerPlatform, error) {
 			return PlatformUnknown, errTransientFailure
@@ -196,6 +213,8 @@ func TestDetectToolchain_DockerSocketWithoutDockerCLISucceeds(t *testing.T) {
 }
 
 func TestDetectToolchain_DockerContextClassifiesDockerWithDockerCLI(t *testing.T) {
+	clearDockerHost(t)
+
 	d := newDetector(detectorDeps{
 		detectPlatform: func(context.Context) (ContainerPlatform, error) {
 			return PlatformUnknown, errTransientFailure
@@ -232,6 +251,8 @@ func TestDetectToolchain_DockerContextClassifiesDockerWithDockerCLI(t *testing.T
 }
 
 func TestDetectToolchain_PodmanSocketFallbackClassifiesPodman(t *testing.T) {
+	clearDockerHost(t)
+
 	d := newDetector(detectorDeps{
 		detectPlatform: func(context.Context) (ContainerPlatform, error) {
 			return PlatformUnknown, errTransientFailure
@@ -268,6 +289,8 @@ func TestDetectToolchain_PodmanSocketFallbackClassifiesPodman(t *testing.T) {
 }
 
 func TestDetectToolchain_DockerContextColimaBeatsPodmanSocket(t *testing.T) {
+	clearDockerHost(t)
+
 	d := newDetector(detectorDeps{
 		detectPlatform: func(context.Context) (ContainerPlatform, error) {
 			return PlatformUnknown, errTransientFailure

--- a/src/Runtime/devenv/pkg/container/dockerapi/docker_engine_api.go
+++ b/src/Runtime/devenv/pkg/container/dockerapi/docker_engine_api.go
@@ -375,7 +375,7 @@ func buildRestartPolicy(policy string) dockercontainer.RestartPolicy {
 func buildMounts(volumes []types.VolumeMount) []dockermount.Mount {
 	mounts := make([]dockermount.Mount, 0, len(volumes))
 	for _, v := range volumes {
-		if v.SELinuxRelabel != types.SELinuxRelabelNone {
+		if v.Type == types.VolumeMountTypeBind && v.SELinuxRelabel != types.SELinuxRelabelNone {
 			continue
 		}
 		mounts = append(mounts, dockermount.Mount{
@@ -391,7 +391,7 @@ func buildMounts(volumes []types.VolumeMount) []dockermount.Mount {
 func buildVolumeBinds(volumes []types.VolumeMount) []string {
 	var binds []string
 	for _, v := range volumes {
-		if v.SELinuxRelabel == types.SELinuxRelabelNone {
+		if v.Type != types.VolumeMountTypeBind || v.SELinuxRelabel == types.SELinuxRelabelNone {
 			continue
 		}
 		options := make([]string, 0, 2)

--- a/src/Runtime/devenv/pkg/container/dockerapi/docker_engine_api.go
+++ b/src/Runtime/devenv/pkg/container/dockerapi/docker_engine_api.go
@@ -68,10 +68,12 @@ func newClient(ctx context.Context, toolchain types.ContainerToolchain) (*Client
 		closeBestEffort(cli)
 		return nil, fmt.Errorf("failed to connect to docker daemon: %w", err)
 	}
+	toolchain = normalizeToolchain(toolchain, "")
+	toolchain.SELinux = detectSELinuxEnabled(ctx, cli)
 
 	return &Client{
 		cli:       cli,
-		toolchain: normalizeToolchain(toolchain, ""),
+		toolchain: toolchain,
 	}, nil
 }
 
@@ -97,10 +99,12 @@ func newClientWithHost(ctx context.Context, toolchain types.ContainerToolchain, 
 		closeBestEffort(cli)
 		return nil, fmt.Errorf("failed to connect to docker daemon: %w", err)
 	}
+	toolchain = normalizeToolchain(toolchain, strings.TrimPrefix(host, "unix://"))
+	toolchain.SELinux = detectSELinuxEnabled(ctx, cli)
 
 	return &Client{
 		cli:       cli,
-		toolchain: normalizeToolchain(toolchain, strings.TrimPrefix(host, "unix://")),
+		toolchain: toolchain,
 	}, nil
 }
 
@@ -110,6 +114,14 @@ func normalizeToolchain(toolchain types.ContainerToolchain, socketPath string) t
 		toolchain.SocketPath = socketPath
 	}
 	return toolchain
+}
+
+func detectSELinuxEnabled(ctx context.Context, cli *client.Client) bool {
+	info, err := cli.Info(ctx)
+	if err != nil {
+		return false
+	}
+	return infoHasSELinux(info)
 }
 
 // DetectPlatform probes the daemon reached via environment configuration.
@@ -302,10 +314,12 @@ func buildDockerConfigs(
 
 	hostCfg := &dockercontainer.HostConfig{
 		PortBindings:  portBindings,
-		Mounts:        buildBindMounts(cfg.Volumes),
+		Binds:         buildVolumeBinds(cfg.Volumes),
+		Mounts:        buildMounts(cfg.Volumes),
 		ExtraHosts:    cfg.ExtraHosts,
 		RestartPolicy: buildRestartPolicy(cfg.RestartPolicy),
 		NetworkMode:   dockercontainer.NetworkMode(primaryNetwork),
+		UsernsMode:    dockercontainer.UsernsMode(cfg.UsernsMode),
 		CapAdd:        capAdd,
 	}
 
@@ -358,9 +372,12 @@ func buildRestartPolicy(policy string) dockercontainer.RestartPolicy {
 	return rp
 }
 
-func buildBindMounts(volumes []types.VolumeMount) []dockermount.Mount {
+func buildMounts(volumes []types.VolumeMount) []dockermount.Mount {
 	mounts := make([]dockermount.Mount, 0, len(volumes))
 	for _, v := range volumes {
+		if v.SELinuxRelabel != types.SELinuxRelabelNone {
+			continue
+		}
 		mounts = append(mounts, dockermount.Mount{
 			Type:     dockerMountType(v.Type),
 			Source:   v.HostPath,
@@ -369,6 +386,24 @@ func buildBindMounts(volumes []types.VolumeMount) []dockermount.Mount {
 		})
 	}
 	return mounts
+}
+
+func buildVolumeBinds(volumes []types.VolumeMount) []string {
+	var binds []string
+	for _, v := range volumes {
+		if v.SELinuxRelabel == types.SELinuxRelabelNone {
+			continue
+		}
+		options := make([]string, 0, 2)
+		if v.ReadOnly {
+			options = append(options, "ro")
+		}
+		options = append(options, string(v.SELinuxRelabel))
+
+		bind := v.HostPath + ":" + v.ContainerPath + ":" + strings.Join(options, ",")
+		binds = append(binds, bind)
+	}
+	return binds
 }
 
 func dockerMountType(mountType types.VolumeMountType) dockermount.Type {
@@ -434,6 +469,15 @@ func platformFromInfo(info systemtypes.Info) (types.ContainerPlatform, bool) {
 	values = append(values, info.SecurityOptions...)
 
 	return platformFromStrings(values...)
+}
+
+func infoHasSELinux(info systemtypes.Info) bool {
+	for _, option := range info.SecurityOptions {
+		if strings.Contains(strings.ToLower(option), "selinux") {
+			return true
+		}
+	}
+	return false
 }
 
 func platformFromStrings(values ...string) (types.ContainerPlatform, bool) {

--- a/src/Runtime/devenv/pkg/container/dockerapi/docker_engine_api_test.go
+++ b/src/Runtime/devenv/pkg/container/dockerapi/docker_engine_api_test.go
@@ -20,10 +20,10 @@ var errNetworkActiveEndpoints = errors.New(
 	`error response from daemon: error while removing network: network altinntestlocal_network has active endpoints`,
 )
 
-func TestBuildBindMounts(t *testing.T) {
+func TestBuildMounts(t *testing.T) {
 	t.Parallel()
 
-	got := buildBindMounts([]types.VolumeMount{
+	got := buildMounts([]types.VolumeMount{
 		{
 			HostPath:      "/Users/someuser/Library/Application Support/altinn-studio/data/testdata",
 			ContainerPath: "/testdata",
@@ -70,6 +70,48 @@ func TestBuildBindMounts(t *testing.T) {
 		if got[i] != want[i] {
 			t.Fatalf("buildBindMounts()[%d] = %#v, want %#v", i, got[i], want[i])
 		}
+	}
+}
+
+func TestBuildDockerConfigs_PodmanUserNamespaceAndRelabelBind(t *testing.T) {
+	t.Parallel()
+
+	cfg := types.ContainerConfig{
+		Image:      "alpine",
+		User:       "1000:1000",
+		UsernsMode: "keep-id",
+		Volumes: []types.VolumeMount{
+			{
+				HostPath:       "/tmp/config.sql",
+				ContainerPath:  "/docker-entrypoint-initdb.d/01-tuning.sql",
+				Type:           types.VolumeMountTypeBind,
+				SELinuxRelabel: types.SELinuxRelabelShared,
+				ReadOnly:       true,
+			},
+			{
+				HostPath:      "postgres-data",
+				ContainerPath: "/var/lib/postgresql",
+				Type:          types.VolumeMountTypeVolume,
+			},
+		},
+	}
+
+	_, hostCfg, _ := buildDockerConfigs(cfg, types.PlatformPodman)
+
+	if got := string(hostCfg.UsernsMode); got != "keep-id" {
+		t.Fatalf("hostCfg.UsernsMode = %q, want keep-id", got)
+	}
+	wantBinds := []string{"/tmp/config.sql:/docker-entrypoint-initdb.d/01-tuning.sql:ro,z"}
+	if !slices.Equal(hostCfg.Binds, wantBinds) {
+		t.Fatalf("hostCfg.Binds = %#v, want %#v", hostCfg.Binds, wantBinds)
+	}
+	wantMounts := []dockermount.Mount{{
+		Type:   dockermount.TypeVolume,
+		Source: "postgres-data",
+		Target: "/var/lib/postgresql",
+	}}
+	if !slices.Equal(hostCfg.Mounts, wantMounts) {
+		t.Fatalf("hostCfg.Mounts = %#v, want %#v", hostCfg.Mounts, wantMounts)
 	}
 }
 
@@ -167,12 +209,50 @@ func TestPlatformFromHost(t *testing.T) {
 	}
 }
 
+func TestInfoHasSELinux(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		info systemtypes.Info
+		want bool
+	}{
+		{
+			name: "selinux enabled",
+			info: systemtypes.Info{
+				SecurityOptions: []string{"name=seccomp,profile=default", "name=selinux"},
+			},
+			want: true,
+		},
+		{
+			name: "selinux absent",
+			info: systemtypes.Info{
+				SecurityOptions: []string{"name=seccomp,profile=default", "name=rootless"},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := infoHasSELinux(tt.info); got != tt.want {
+				t.Fatalf("infoHasSELinux() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestBuild_ColimaRequiresDockerCLIAtCallSite(t *testing.T) {
 	t.Setenv("PATH", "")
 
 	c := &Client{
 		toolchain: types.ContainerToolchain{
-			Platform: types.PlatformColima,
+			Platform:   types.PlatformColima,
+			AccessMode: types.AccessUnknown,
+			Source:     types.SourceUnknown,
+			SocketPath: "",
+			SELinux:    false,
 		},
 	}
 

--- a/src/Runtime/devenv/pkg/container/podman/podman.go
+++ b/src/Runtime/devenv/pkg/container/podman/podman.go
@@ -38,6 +38,7 @@ func New(ctx context.Context, toolchain types.ContainerToolchain) (*Client, erro
 	if toolchain.Platform == types.PlatformUnknown {
 		toolchain.Platform = types.PlatformPodman
 	}
+	toolchain.SELinux = detectSELinuxEnabled(ctx)
 	return &Client{toolchain: toolchain}, nil
 }
 
@@ -55,6 +56,26 @@ func reportProgress(onProgress types.ProgressHandler, progress types.ProgressUpd
 	if onProgress != nil {
 		onProgress(progress)
 	}
+}
+
+func detectSELinuxEnabled(ctx context.Context) bool {
+	cmd := processutil.CommandContext(ctx, "podman", "info", "--format", "json")
+	output, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+
+	var info struct {
+		Host struct {
+			Security struct {
+				SELinuxEnabled bool `json:"selinuxEnabled"`
+			} `json:"security"`
+		} `json:"host"`
+	}
+	if err := json.Unmarshal(output, &info); err != nil {
+		return false
+	}
+	return info.Host.Security.SELinuxEnabled
 }
 
 func runPodmanCommand(ctx context.Context, args []string) ([]byte, error) {
@@ -167,8 +188,9 @@ func buildCreateArgs(cfg types.ContainerConfig) []string {
 
 	for _, v := range cfg.Volumes {
 		volArg := fmt.Sprintf("%s:%s", v.HostPath, v.ContainerPath)
-		if v.ReadOnly {
-			volArg += ":ro"
+		options := volumeOptions(v)
+		if len(options) > 0 {
+			volArg += ":" + strings.Join(options, ",")
 		}
 		args = append(args, "-v", volArg)
 	}
@@ -188,6 +210,9 @@ func buildCreateArgs(cfg types.ContainerConfig) []string {
 	if cfg.User != "" {
 		args = append(args, "--user", cfg.User)
 	}
+	if cfg.UsernsMode != "" {
+		args = append(args, "--userns", cfg.UsernsMode)
+	}
 
 	caps := types.MergeCapabilities(types.DefaultPodmanCapabilities(), cfg.CapAdd)
 	for _, cap := range caps {
@@ -200,6 +225,17 @@ func buildCreateArgs(cfg types.ContainerConfig) []string {
 	args = append(args, cfg.Command...)
 
 	return args
+}
+
+func volumeOptions(v types.VolumeMount) []string {
+	options := make([]string, 0, 2)
+	if v.ReadOnly {
+		options = append(options, "ro")
+	}
+	if v.SELinuxRelabel != types.SELinuxRelabelNone {
+		options = append(options, string(v.SELinuxRelabel))
+	}
+	return options
 }
 
 // appendHealthCheckArgs appends health check CLI flags if configured.

--- a/src/Runtime/devenv/pkg/container/podman/podman.go
+++ b/src/Runtime/devenv/pkg/container/podman/podman.go
@@ -232,7 +232,7 @@ func volumeOptions(v types.VolumeMount) []string {
 	if v.ReadOnly {
 		options = append(options, "ro")
 	}
-	if v.SELinuxRelabel != types.SELinuxRelabelNone {
+	if v.Type == types.VolumeMountTypeBind && v.SELinuxRelabel != types.SELinuxRelabelNone {
 		options = append(options, string(v.SELinuxRelabel))
 	}
 	return options

--- a/src/Runtime/devenv/pkg/container/podman/podman_test.go
+++ b/src/Runtime/devenv/pkg/container/podman/podman_test.go
@@ -2,10 +2,41 @@ package podman
 
 import (
 	"errors"
+	"slices"
 	"testing"
 
 	"altinn.studio/devenv/pkg/container/types"
 )
+
+func TestBuildCreateArgs_UserNamespaceAndRelabelBind(t *testing.T) {
+	t.Parallel()
+
+	args := buildCreateArgs(types.ContainerConfig{
+		Name:       "localtest",
+		Image:      "alpine",
+		User:       "1000:1000",
+		UsernsMode: "keep-id",
+		Volumes: []types.VolumeMount{{
+			HostPath:       "/tmp/config.sql",
+			ContainerPath:  "/docker-entrypoint-initdb.d/01-tuning.sql",
+			Type:           types.VolumeMountTypeBind,
+			SELinuxRelabel: types.SELinuxRelabelShared,
+			ReadOnly:       true,
+		}},
+	})
+
+	for _, want := range []string{
+		"/tmp/config.sql:/docker-entrypoint-initdb.d/01-tuning.sql:ro,z",
+		"--userns",
+		"keep-id",
+		"--user",
+		"1000:1000",
+	} {
+		if !slices.Contains(args, want) {
+			t.Fatalf("buildCreateArgs() missing %q in %#v", want, args)
+		}
+	}
+}
 
 func TestParseContainerInspect_ImageIDUsesImageNotDigest(t *testing.T) {
 	t.Parallel()

--- a/src/Runtime/devenv/pkg/container/types/types.go
+++ b/src/Runtime/devenv/pkg/container/types/types.go
@@ -186,6 +186,7 @@ type ContainerToolchain struct {
 	Platform   ContainerPlatform
 	AccessMode ContainerAccessMode
 	Source     DetectionSource
+	SELinux    bool
 }
 
 // PortMapping defines a container port binding.
@@ -224,12 +225,23 @@ const (
 	VolumeMountTypeVolume VolumeMountType = "volume"
 )
 
+// SELinuxRelabel controls SELinux relabeling for bind mounts on runtimes that support it.
+type SELinuxRelabel string
+
+// Supported SELinux relabel modes.
+const (
+	SELinuxRelabelNone    SELinuxRelabel = ""
+	SELinuxRelabelShared  SELinuxRelabel = "z"
+	SELinuxRelabelPrivate SELinuxRelabel = "Z"
+)
+
 // VolumeMount defines a bind mount or named volume mount.
 type VolumeMount struct {
-	HostPath      string
-	ContainerPath string
-	Type          VolumeMountType
-	ReadOnly      bool
+	HostPath       string
+	ContainerPath  string
+	Type           VolumeMountType
+	SELinuxRelabel SELinuxRelabel
+	ReadOnly       bool
 }
 
 // HealthCheck defines a container health check configuration.
@@ -248,6 +260,7 @@ type ContainerConfig struct {
 	Name           string
 	Image          string
 	User           string
+	UsernsMode     string
 	RestartPolicy  string
 	ExtraHosts     []string
 	NetworkAliases []string

--- a/src/Runtime/devenv/pkg/resource/container.go
+++ b/src/Runtime/devenv/pkg/resource/container.go
@@ -22,6 +22,7 @@ type Container struct {
 	Name           string
 	RestartPolicy  string
 	User           string
+	UsernsMode     string
 	Networks       []ResourceRef
 	DependsOn      []ResourceRef
 	Ports          []types.PortMapping

--- a/src/Runtime/devenv/pkg/resource/executor.go
+++ b/src/Runtime/devenv/pkg/resource/executor.go
@@ -613,6 +613,7 @@ func (e *Executor) applyContainer(ctx context.Context, graphID GraphID, c *Conta
 			Labels:         desiredLabels,
 			Detach:         true,
 			User:           c.User,
+			UsernsMode:     c.UsernsMode,
 			Networks:       networks,
 		}
 

--- a/src/Runtime/devenv/pkg/resource/executor.go
+++ b/src/Runtime/devenv/pkg/resource/executor.go
@@ -901,6 +901,10 @@ func containerSpecHash(c *Container, imageID string, networks []string) string {
 	b.WriteString(c.User)
 	b.WriteByte('\n')
 
+	b.WriteString("usernsMode=")
+	b.WriteString(c.UsernsMode)
+	b.WriteByte('\n')
+
 	b.WriteString("restartPolicy=")
 	b.WriteString(c.RestartPolicy)
 	b.WriteByte('\n')

--- a/src/Runtime/devenv/pkg/resource/executor_test.go
+++ b/src/Runtime/devenv/pkg/resource/executor_test.go
@@ -113,6 +113,27 @@ func TestContainerSpecHash_ChangesOnNetworkAliasChange(t *testing.T) {
 	}
 }
 
+func TestContainerSpecHash_ChangesOnUsernsModeChange(t *testing.T) {
+	t.Parallel()
+
+	base := &Container{
+		Name:       "localtest",
+		Image:      RefID("image:localtest"),
+		User:       "1000:1000",
+		UsernsMode: "",
+	}
+
+	baseHash := containerSpecHash(base, "sha256:image-v1", []string{"bridge"})
+
+	modified := *base
+	modified.UsernsMode = "keep-id"
+	modifiedHash := containerSpecHash(&modified, "sha256:image-v1", []string{"bridge"})
+
+	if baseHash == modifiedHash {
+		t.Fatalf("container spec hash did not change when user namespace mode changed")
+	}
+}
+
 func TestContainerSpecHash_ChangesOnVolumeMountTypeChange(t *testing.T) {
 	t.Parallel()
 

--- a/src/cli/internal/cmd/app/run.go
+++ b/src/cli/internal/cmd/app/run.go
@@ -213,6 +213,7 @@ func (s *Service) BuildDockerRunSpec(
 			Name:           localtestAppContainerNamePrefix + appName,
 			Image:          imageTag,
 			User:           "",
+			UsernsMode:     "",
 			RestartPolicy:  "",
 			ExtraHosts:     nil,
 			NetworkAliases: nil,

--- a/src/cli/internal/cmd/doctor/prereq_test.go
+++ b/src/cli/internal/cmd/doctor/prereq_test.go
@@ -157,6 +157,8 @@ func TestProbeContainerRuntime_APIWithoutCLIStillSucceeds(t *testing.T) {
 					Platform:   types.PlatformDocker,
 					AccessMode: types.AccessDockerEngineAPI,
 					Source:     types.SourceDefault,
+					SocketPath: "",
+					SELinux:    false,
 				},
 			}, nil
 		},
@@ -191,5 +193,7 @@ func (c *dockerEngineClient) Toolchain() types.ContainerToolchain {
 		Platform:   types.PlatformDocker,
 		AccessMode: types.AccessDockerEngineAPI,
 		Source:     types.SourceDefault,
+		SocketPath: "",
+		SELinux:    false,
 	}
 }

--- a/src/cli/internal/cmd/env/localtest/components/manifest.go
+++ b/src/cli/internal/cmd/env/localtest/components/manifest.go
@@ -67,6 +67,8 @@ func (manifest *Manifest) addContainer(
 		image,
 		manifest.network,
 		opts.RuntimeUser,
+		opts.RuntimeUsernsMode,
+		opts.RelabelBinds,
 		resourceEnabledRef(enabled),
 	))
 }

--- a/src/cli/internal/cmd/env/localtest/components/resources.go
+++ b/src/cli/internal/cmd/env/localtest/components/resources.go
@@ -33,6 +33,7 @@ type ContainerSpec struct {
 type Options struct {
 	DevConfig         *DevImageConfig
 	RuntimeUser       string // "uid:gid" to run containers as (prevents root-owned bind mount files)
+	RuntimeUsernsMode string
 	Images            config.ImagesConfig
 	Paths             Paths
 	Topology          envtopology.Local
@@ -40,6 +41,7 @@ type Options struct {
 	DevWorkflowEngine bool
 	IncludeMonitoring bool
 	IncludePgAdmin    bool
+	RelabelBinds      bool
 }
 
 // Paths contains localtest data paths used by component resources.
@@ -80,28 +82,31 @@ func newPort(hostPort, containerPort string) types.PortMapping {
 
 func newVolume(hostPath, containerPath string) types.VolumeMount {
 	return types.VolumeMount{
-		HostPath:      hostPath,
-		ContainerPath: containerPath,
-		ReadOnly:      false,
-		Type:          types.VolumeMountTypeBind,
+		HostPath:       hostPath,
+		ContainerPath:  containerPath,
+		Type:           types.VolumeMountTypeBind,
+		SELinuxRelabel: types.SELinuxRelabelNone,
+		ReadOnly:       false,
 	}
 }
 
 func newReadOnlyVolume(hostPath, containerPath string) types.VolumeMount {
 	return types.VolumeMount{
-		HostPath:      hostPath,
-		ContainerPath: containerPath,
-		ReadOnly:      true,
-		Type:          types.VolumeMountTypeBind,
+		HostPath:       hostPath,
+		ContainerPath:  containerPath,
+		Type:           types.VolumeMountTypeBind,
+		SELinuxRelabel: types.SELinuxRelabelNone,
+		ReadOnly:       true,
 	}
 }
 
 func newNamedVolume(name, containerPath string) types.VolumeMount {
 	return types.VolumeMount{
-		HostPath:      name,
-		ContainerPath: containerPath,
-		ReadOnly:      false,
-		Type:          types.VolumeMountTypeVolume,
+		HostPath:       name,
+		ContainerPath:  containerPath,
+		Type:           types.VolumeMountTypeVolume,
+		SELinuxRelabel: types.SELinuxRelabelNone,
+		ReadOnly:       false,
 	}
 }
 
@@ -163,11 +168,14 @@ func newContainerResource(
 	imageRes resource.ImageResource,
 	network resource.ResourceRef,
 	user string,
+	usernsMode string,
+	relabelBinds bool,
 	enabled *bool,
 ) *resource.Container {
 	containerUser := user
 	if spec.UseDefaultUser {
 		containerUser = ""
+		usernsMode = ""
 	}
 
 	return &resource.Container{
@@ -178,7 +186,7 @@ func newContainerResource(
 		Networks:    []resource.ResourceRef{network},
 		DependsOn:   containerDependencyRefs(spec.Dependencies),
 		Ports:       spec.Ports,
-		Volumes:     spec.Volumes,
+		Volumes:     relabelBindMounts(spec.Volumes, relabelBinds),
 		Env:         toEnvSlice(spec.Environment),
 		Labels:      nil,
 		Command:     spec.Command,
@@ -193,7 +201,24 @@ func newContainerResource(
 		NetworkAliases: spec.NetworkAliases,
 		RestartPolicy:  "",
 		User:           containerUser,
+		UsernsMode:     usernsMode,
 	}
+}
+
+func relabelBindMounts(volumes []types.VolumeMount, relabel bool) []types.VolumeMount {
+	if len(volumes) == 0 {
+		return nil
+	}
+	result := slices.Clone(volumes)
+	if !relabel {
+		return result
+	}
+	for i, volume := range result {
+		if volume.Type == types.VolumeMountTypeBind {
+			result[i].SELinuxRelabel = types.SELinuxRelabelShared
+		}
+	}
+	return result
 }
 
 func containerDependencyRefs(names []string) []resource.ResourceRef {

--- a/src/cli/internal/cmd/env/localtest/env.go
+++ b/src/cli/internal/cmd/env/localtest/env.go
@@ -97,9 +97,15 @@ func (e *Env) Up(ctx context.Context, opts envtypes.UpOptions) error {
 	if runtime.GOOS != osutil.OSWindows {
 		runtimeUser = fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid())
 	}
+	runtimeUsernsMode := ""
+	relabelBinds := false
+	if toolchain.Platform == containertypes.PlatformPodman {
+		runtimeUsernsMode = "keep-id"
+		relabelBinds = toolchain.SELinux
+	}
 	topology := envtopology.NewLocal(envtopology.DefaultIngressPortString())
 
-	buildOpts, err := e.buildResourceOptions(ctx, runtimeUser, topology, opts)
+	buildOpts, err := e.buildResourceOptions(ctx, runtimeUser, runtimeUsernsMode, relabelBinds, topology, opts)
 	if err != nil {
 		return err
 	}
@@ -534,6 +540,8 @@ func (e *Env) releaseOptions(includeMonitoring, includePgAdmin, devWorkflowEngin
 		Paths:             e.paths,
 		Images:            e.cfg.Images,
 		RuntimeUser:       "",
+		RuntimeUsernsMode: "",
+		RelabelBinds:      false,
 		Topology:          envtopology.NewLocal(envtopology.DefaultIngressPortString()),
 		ImageMode:         components.ReleaseMode,
 		DevWorkflowEngine: devWorkflowEngine,
@@ -580,20 +588,26 @@ func (e *Env) removeWorkflowEngineDbVolume(ctx context.Context) error {
 
 func (e *Env) cleanupWorkflowEngineDbData(ctx context.Context, targetAbs string) error {
 	helperName := fmt.Sprintf("studioctl-reset-workflow-engine-db-%d", time.Now().UnixNano())
+	relabel := containertypes.SELinuxRelabelNone
+	if e.client.Toolchain().SELinux {
+		relabel = containertypes.SELinuxRelabelShared
+	}
 	containerCfg := containertypes.ContainerConfig{
 		Labels:         nil,
 		HealthCheck:    nil,
 		Name:           helperName,
 		Image:          e.cfg.Images.Core.WorkflowEngineDb.Ref(),
 		User:           "",
+		UsernsMode:     "",
 		RestartPolicy:  "",
 		ExtraHosts:     nil,
 		NetworkAliases: nil,
 		Volumes: []containertypes.VolumeMount{{
-			HostPath:      targetAbs,
-			ContainerPath: "/cleanup",
-			Type:          containertypes.VolumeMountTypeBind,
-			ReadOnly:      false,
+			HostPath:       targetAbs,
+			ContainerPath:  "/cleanup",
+			Type:           containertypes.VolumeMountTypeBind,
+			SELinuxRelabel: relabel,
+			ReadOnly:       false,
 		}},
 		Networks: nil,
 		Ports:    nil,
@@ -722,6 +736,8 @@ func buildResourceGraph(resources []resource.Resource) (*resource.Graph, error) 
 func (e *Env) buildResourceOptions(
 	ctx context.Context,
 	runtimeUser string,
+	runtimeUsernsMode string,
+	relabelBinds bool,
 	topology envtopology.Local,
 	upOpts envtypes.UpOptions,
 ) (*components.Options, error) {
@@ -742,6 +758,8 @@ func (e *Env) buildResourceOptions(
 	return &components.Options{
 		Paths:             e.paths,
 		RuntimeUser:       runtimeUser,
+		RuntimeUsernsMode: runtimeUsernsMode,
+		RelabelBinds:      relabelBinds,
 		DevConfig:         devConfig,
 		Images:            e.cfg.Images,
 		Topology:          topology,

--- a/src/cli/internal/cmd/env/localtest/env.go
+++ b/src/cli/internal/cmd/env/localtest/env.go
@@ -589,7 +589,7 @@ func (e *Env) removeWorkflowEngineDbVolume(ctx context.Context) error {
 func (e *Env) cleanupWorkflowEngineDbData(ctx context.Context, targetAbs string) error {
 	helperName := fmt.Sprintf("studioctl-reset-workflow-engine-db-%d", time.Now().UnixNano())
 	relabel := containertypes.SELinuxRelabelNone
-	if e.client.Toolchain().SELinux {
+	if e.client.Toolchain().Platform == containertypes.PlatformPodman && e.client.Toolchain().SELinux {
 		relabel = containertypes.SELinuxRelabelShared
 	}
 	containerCfg := containertypes.ContainerConfig{

--- a/src/cli/internal/cmd/run.go
+++ b/src/cli/internal/cmd/run.go
@@ -1066,6 +1066,7 @@ func containerRunProgressResources(spec appsvc.DockerRunSpec, flags runFlags) []
 		Name:           spec.Config.Name,
 		RestartPolicy:  "",
 		User:           "",
+		UsernsMode:     "",
 		Networks:       nil,
 		DependsOn:      nil,
 		Ports:          nil,


### PR DESCRIPTION
## Description

Fixes `studioctl env up` on rootless Podman setups where the host user has a large domain UID/GID outside the default subordinate ID mapping.

The localtest containers still run as the host user for predictable bind-mount ownership, but Podman now also gets `keep-id` user namespace mode. `devenv` now carries that setting through both the Docker Engine API and Podman CLI backends.

For SELinux-enabled Podman backends, localtest-owned bind mounts are relabeled with the shared SELinux label so containers can read generated resources such as the workflow-engine Postgres init script. Relabeling is gated on runtime SELinux metadata, so non-SELinux Podman environments such as typical Desktop setups do not depend on `:z` being accepted as a no-op.

The change also makes container-runtime detection tests independent from a developer machine’s real `DOCKER_HOST`/Podman socket state.

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

Automated checks:

```sh
cd /data/home/code/altinn-studio/src/Runtime/devenv
make fmt && make lint && make test

cd /data/home/code/altinn-studio/src/cli
make fmt && make lint && make test
```

Results:

```text
src/Runtime/devenv: format OK, 0 lint issues, all tests passed
src/cli: format OK, 0 lint issues, go test -race -count=1 ./... passed
```

`studioctl doctor` output from this agent repro environment:

```text
studioctl doctor

studioctl
    Version         v0.1.0-preview.0

System
    OS              linux
    Architecture    amd64
    OS Name         Rocky Linux 9.7 (Blue Onyx)
    OS Version      5.14.0-611.5.1.el9_7.x86_64
    Terminal        dumb
    Color           disabled
    TTY             no

Prerequisites
  ✓ .NET SDK        10.0.300
  ✓ Container       Podman (5.6.0)
    Resolved        Docker Engine API -> Podman (DOCKER_HOST)
    Tools           docker (5.6.0), podman (5.6.0)
    DOCKER_HOST     unix:///run/user/1199049453/podman/podman.sock

Auth
    Status          logged in (3 env)
    dev             bot_ttd_martinothamar_agent_ee1c @ dev.altinn.studio
    prod            bot_ttd_martinothamar_agent_837e @ altinn.studio
    staging         bot_ttd_martinothamar_agent_410d @ staging.altinn.studio

Disk
  ✓ home_dir          ready (/data/home/.config/altinn-studio)
  ✓ socket_dir        ready (/data/home/.config/altinn-studio)
  ✓ log_dir           ready (/data/home/.config/altinn-studio/logs)
  ✓ data_dir          ready (/data/home/.config/altinn-studio/data)
  ✓ bin_dir           ready (/data/home/.config/altinn-studio/bin)
  ✓ credentials_file  valid (3 environment entries) (/data/home/.config/altinn-studio/credentials.yaml)
  ✓ appmgr_binary     present (/data/home/.config/altinn-studio/bin/studioctl-server/studioctl-server)
  ✓ appmgr_state      pid and socket files are consistent (/data/home/.config/altinn-studio)

Env - localtest
    localtest        
  ✓   DNS:           local.altinn.cloud -> A 127.0.0.1
    pdf              
  ✓   DNS:           pdf.local.altinn.cloud -> A 127.0.0.1
    workflow-engine  
  ✓   DNS:           workflow-engine.local.altinn.cloud -> A 127.0.0.1

App
    App             not detected in current directory

All checks passed!
```

Manual localtest transcript from this RHEL/Rocky-style Podman repro environment:

```sh
cd /data/home/code/altinn-studio/src/cli
make user-install
studioctl doctor
studioctl -v env up
studioctl env status
curl http://local.altinn.cloud:8000/
```

Key output:

```text
Using container toolchain: Podman via Docker Engine API
Image mode: release
Starting localtest environment...
localtest: ready
localtest-workflow-engine-db: ready
localtest-workflow-engine: ready
localtest-pdf3: ready
Environment started

localtest is running.

Container                     Status
localtest                     running
localtest-pdf3                running
localtest-workflow-engine     running
localtest-workflow-engine-db  running
```

`curl http://local.altinn.cloud:8000/` returned the localtest HTML page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SELinux detection and handling added for Docker and Podman
  * User namespace mode configuration supported for containers
  * SELinux relabel options added for bind-mounted volumes and related runtime wiring

* **Tests**
  * Expanded coverage for SELinux detection, mount/build args, relabelled binds and userns behaviour
  * New tests ensuring spec-hash and detection behaviours account for userns/SELinux settings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio/pull/18977?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
