### PR TITLE
fix: recover repository sync from stale remote refs

### DIFF
--- a/src/Designer/backend/src/Designer/Services/Implementation/SourceControlService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/SourceControlService.cs
@@ -221,7 +221,7 @@ public class SourceControlService(
                     }
                     catch (LibGit2SharpException ex)
                     {
-                        // Libgit2 applies prune too late for branch shape changes like origin/develop/test -> origin/develop.
+                        // Libgit2 applies prune too late for branch shape changes like origin/develop/test <-> origin/develop.
                         // Remove only blocking stale remote-tracking refs before retrying fetch.
                         if (!RemoveRemoteTrackingRefsBlockingFetch(repo, remote, ex))
                         {
@@ -241,27 +241,13 @@ public class SourceControlService(
         LibGit2SharpException exception
     )
     {
-        const string CannotLockRefMessagePrefix = "cannot lock ref '";
-        int refNameStart = exception.Message.IndexOf(CannotLockRefMessagePrefix, StringComparison.Ordinal);
-        if (refNameStart < 0)
+        string? blockedRef = GetBlockedRemoteTrackingRef(repo, remote, exception.Message);
+        if (blockedRef is null)
         {
             return false;
         }
 
-        refNameStart += CannotLockRefMessagePrefix.Length;
-        int refNameEnd = exception.Message.IndexOf('\'', refNameStart);
-        if (refNameEnd < 0)
-        {
-            return false;
-        }
-
-        string blockedRef = exception.Message[refNameStart..refNameEnd];
         string remoteTrackingPrefix = $"refs/remotes/{remote.Name}/";
-        if (!blockedRef.StartsWith(remoteTrackingPrefix, StringComparison.Ordinal))
-        {
-            return false;
-        }
-
         string staleChildRefPrefix = $"{blockedRef}/";
         List<string> refsToRemove = repo
             .Refs.Where(reference =>
@@ -290,6 +276,79 @@ public class SourceControlService(
         }
 
         return refsToRemove.Count > 0;
+    }
+
+    private static string? GetBlockedRemoteTrackingRef(
+        LibGit2Sharp.Repository repo,
+        Remote remote,
+        string exceptionMessage
+    )
+    {
+        const string CannotLockRefMessagePrefix = "cannot lock ref '";
+        const string CannotLockRefMessageSuffix = "', there are refs beneath that folder";
+        string? canonicalRef = ExtractQuotedValue(
+            exceptionMessage,
+            CannotLockRefMessagePrefix,
+            CannotLockRefMessageSuffix
+        );
+        if (IsRemoteTrackingRefForRemote(canonicalRef, remote))
+        {
+            return canonicalRef;
+        }
+
+        const string CouldNotRemoveDirectoryPrefix = "could not remove directory '";
+        const string ParentIsNotDirectorySuffix = "': parent is not directory";
+        string? path = ExtractQuotedValue(exceptionMessage, CouldNotRemoveDirectoryPrefix, ParentIsNotDirectorySuffix);
+        canonicalRef = GetRemoteTrackingRefFromPath(repo, remote, path);
+        if (IsRemoteTrackingRefForRemote(canonicalRef, remote))
+        {
+            return canonicalRef;
+        }
+
+        return null;
+    }
+
+    private static bool IsRemoteTrackingRefForRemote(string? canonicalRef, Remote remote)
+    {
+        string remoteTrackingPrefix = $"refs/remotes/{remote.Name}/";
+        return canonicalRef?.StartsWith(remoteTrackingPrefix, StringComparison.Ordinal) == true;
+    }
+
+    private static string? ExtractQuotedValue(string message, string prefix, string suffix)
+    {
+        int valueStart = message.IndexOf(prefix, StringComparison.Ordinal);
+        if (valueStart < 0)
+        {
+            return null;
+        }
+
+        valueStart += prefix.Length;
+        int valueEnd = message.LastIndexOf(suffix, StringComparison.Ordinal);
+        if (valueEnd < valueStart)
+        {
+            return null;
+        }
+
+        return message[valueStart..valueEnd];
+    }
+
+    private static string? GetRemoteTrackingRefFromPath(LibGit2Sharp.Repository repo, Remote remote, string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        string normalizedPath = path.Replace('\\', '/');
+        string normalizedGitDirectory = repo.Info.Path.Replace('\\', '/').TrimEnd('/');
+        string remoteTrackingPathPrefix = $"{normalizedGitDirectory}/refs/remotes/{remote.Name}/";
+        if (!normalizedPath.StartsWith(remoteTrackingPathPrefix, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        string refName = normalizedPath[remoteTrackingPathPrefix.Length..];
+        return string.IsNullOrWhiteSpace(refName) ? null : $"refs/remotes/{remote.Name}/{refName}";
     }
 
     /// <inheritdoc/>

--- a/src/Designer/backend/src/Designer/Services/Implementation/SourceControlService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/SourceControlService.cs
@@ -209,15 +209,87 @@ public class SourceControlService(
                 {
                     CredentialsProvider = self.GetCredentialsHandler(authenticatedContext),
                     CustomHeaders = self.GetAuthCustomHeaders(authenticatedContext),
+                    Prune = true,
                 };
 
                 foreach (Remote remote in repo.Network.Remotes)
                 {
                     IEnumerable<string> refSpecs = remote.FetchRefSpecs.Select(x => x.Specification);
-                    Commands.Fetch(repo, remote.Name, refSpecs, fetchOptions, logMessage);
+                    try
+                    {
+                        Commands.Fetch(repo, remote.Name, refSpecs, fetchOptions, logMessage);
+                    }
+                    catch (LibGit2SharpException ex)
+                    {
+                        // Libgit2 applies prune too late for branch shape changes like origin/develop/test -> origin/develop.
+                        // Remove only blocking stale remote-tracking refs before retrying fetch.
+                        if (!RemoveRemoteTrackingRefsBlockingFetch(repo, remote, ex))
+                        {
+                            throw;
+                        }
+
+                        Commands.Fetch(repo, remote.Name, refSpecs, fetchOptions, logMessage);
+                    }
                 }
             }
         );
+    }
+
+    private static bool RemoveRemoteTrackingRefsBlockingFetch(
+        LibGit2Sharp.Repository repo,
+        Remote remote,
+        LibGit2SharpException exception
+    )
+    {
+        const string CannotLockRefMessagePrefix = "cannot lock ref '";
+        int refNameStart = exception.Message.IndexOf(CannotLockRefMessagePrefix, StringComparison.Ordinal);
+        if (refNameStart < 0)
+        {
+            return false;
+        }
+
+        refNameStart += CannotLockRefMessagePrefix.Length;
+        int refNameEnd = exception.Message.IndexOf('\'', refNameStart);
+        if (refNameEnd < 0)
+        {
+            return false;
+        }
+
+        string blockedRef = exception.Message[refNameStart..refNameEnd];
+        string remoteTrackingPrefix = $"refs/remotes/{remote.Name}/";
+        if (!blockedRef.StartsWith(remoteTrackingPrefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        string staleChildRefPrefix = $"{blockedRef}/";
+        List<string> refsToRemove = repo
+            .Refs.Where(reference =>
+                reference.IsRemoteTrackingBranch
+                && reference.CanonicalName.StartsWith(staleChildRefPrefix, StringComparison.Ordinal)
+            )
+            .Select(reference => reference.CanonicalName)
+            .ToList();
+
+        for (
+            int slashIndex = blockedRef.LastIndexOf('/');
+            slashIndex > remoteTrackingPrefix.Length;
+            slashIndex = blockedRef.LastIndexOf('/', slashIndex - 1)
+        )
+        {
+            string staleParentRef = blockedRef[..slashIndex];
+            if (repo.Refs[staleParentRef]?.IsRemoteTrackingBranch == true)
+            {
+                refsToRemove.Add(staleParentRef);
+            }
+        }
+
+        foreach (string refToRemove in refsToRemove.Distinct())
+        {
+            repo.Refs.Remove(refToRemove);
+        }
+
+        return refsToRemove.Count > 0;
     }
 
     /// <inheritdoc/>

--- a/src/Designer/backend/src/Designer/Services/Implementation/SourceControlService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/SourceControlService.cs
@@ -43,6 +43,13 @@ public class SourceControlService(
 
     private const string DefaultBranch = General.DefaultBranch;
 
+    // LibGit2Sharp does not expose the blocked ref/path structurally, so these patterns document
+    // the libgit2 v1.8.4 fetch error messages this targeted stale-ref recovery understands.
+    private const string CannotLockRefMessagePrefix = "cannot lock ref '";
+    private const string CannotLockRefMessageSuffix = "', there are refs beneath that folder";
+    private const string CouldNotRemoveDirectoryPrefix = "could not remove directory '";
+    private const string ParentIsNotDirectorySuffix = "': parent is not directory";
+
     /// <inheritdoc/>
     public string CloneRemoteRepository(AltinnAuthenticatedRepoEditingContext authenticatedContext)
     {
@@ -284,8 +291,6 @@ public class SourceControlService(
         string exceptionMessage
     )
     {
-        const string CannotLockRefMessagePrefix = "cannot lock ref '";
-        const string CannotLockRefMessageSuffix = "', there are refs beneath that folder";
         string? canonicalRef = ExtractQuotedValue(
             exceptionMessage,
             CannotLockRefMessagePrefix,
@@ -296,8 +301,6 @@ public class SourceControlService(
             return canonicalRef;
         }
 
-        const string CouldNotRemoveDirectoryPrefix = "could not remove directory '";
-        const string ParentIsNotDirectorySuffix = "': parent is not directory";
         string? path = ExtractQuotedValue(exceptionMessage, CouldNotRemoveDirectoryPrefix, ParentIsNotDirectorySuffix);
         canonicalRef = GetRemoteTrackingRefFromPath(repo, remote, path);
         if (IsRemoteTrackingRefForRemote(canonicalRef, remote))

--- a/src/Designer/backend/src/Designer/Services/Implementation/SourceControlService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/SourceControlService.cs
@@ -323,7 +323,7 @@ public class SourceControlService(
         }
 
         valueStart += prefix.Length;
-        int valueEnd = message.LastIndexOf(suffix, StringComparison.Ordinal);
+        int valueEnd = message.IndexOf(suffix, valueStart, StringComparison.Ordinal);
         if (valueEnd < valueStart)
         {
             return null;

--- a/src/Designer/backend/src/Designer/Services/Implementation/SourceControlService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/SourceControlService.cs
@@ -49,6 +49,8 @@ public class SourceControlService(
     private const string CannotLockRefMessageSuffix = "', there are refs beneath that folder";
     private const string CouldNotRemoveDirectoryPrefix = "could not remove directory '";
     private const string ParentIsNotDirectorySuffix = "': parent is not directory";
+    private const string ReferenceCollisionMessagePrefix = "path to reference '";
+    private const string ReferenceCollisionMessageSuffix = "' collides with existing one";
 
     /// <inheritdoc/>
     public string CloneRemoteRepository(AltinnAuthenticatedRepoEditingContext authenticatedContext)
@@ -141,10 +143,15 @@ public class SourceControlService(
                 try
                 {
                     Tree head = repo.Head.Tip.Tree;
-                    MergeResult mergeResult = Commands.Pull(
+                    MergeResult mergeResult = ExecuteWithStaleRemoteTrackingRefRecovery(
                         repo,
-                        self.GetDeveloperSignature(ctx.authenticatedContext.Developer),
-                        pullOptions
+                        repo.Network.Remotes,
+                        () =>
+                            Commands.Pull(
+                                repo,
+                                self.GetDeveloperSignature(ctx.authenticatedContext.Developer),
+                                pullOptions
+                            )
                     );
                     mergeStatus = mergeResult.Status.ToString();
 
@@ -216,73 +223,119 @@ public class SourceControlService(
                 {
                     CredentialsProvider = self.GetCredentialsHandler(authenticatedContext),
                     CustomHeaders = self.GetAuthCustomHeaders(authenticatedContext),
-                    Prune = true,
                 };
 
                 foreach (Remote remote in repo.Network.Remotes)
                 {
                     IEnumerable<string> refSpecs = remote.FetchRefSpecs.Select(x => x.Specification);
-                    try
-                    {
-                        Commands.Fetch(repo, remote.Name, refSpecs, fetchOptions, logMessage);
-                    }
-                    catch (LibGit2SharpException ex)
-                    {
-                        // Libgit2 applies prune too late for branch shape changes like origin/develop/test <-> origin/develop.
-                        // Remove only blocking stale remote-tracking refs before retrying fetch.
-                        if (!RemoveRemoteTrackingRefsBlockingFetch(repo, remote, ex))
-                        {
-                            throw;
-                        }
-
-                        Commands.Fetch(repo, remote.Name, refSpecs, fetchOptions, logMessage);
-                    }
+                    ExecuteWithStaleRemoteTrackingRefRecovery(
+                        repo,
+                        [remote],
+                        () => Commands.Fetch(repo, remote.Name, refSpecs, fetchOptions, logMessage)
+                    );
                 }
             }
         );
     }
 
-    private static bool RemoveRemoteTrackingRefsBlockingFetch(
+    private static void ExecuteWithStaleRemoteTrackingRefRecovery(
         LibGit2Sharp.Repository repo,
-        Remote remote,
-        LibGit2SharpException exception
+        IEnumerable<Remote> remotes,
+        Action operation
     )
     {
-        string? blockedRef = GetBlockedRemoteTrackingRef(repo, remote, exception.Message);
-        if (blockedRef is null)
-        {
-            return false;
-        }
-
-        string remoteTrackingPrefix = $"refs/remotes/{remote.Name}/";
-        string staleChildRefPrefix = $"{blockedRef}/";
-        List<string> refsToRemove = repo
-            .Refs.Where(reference =>
-                reference.IsRemoteTrackingBranch
-                && reference.CanonicalName.StartsWith(staleChildRefPrefix, StringComparison.Ordinal)
-            )
-            .Select(reference => reference.CanonicalName)
-            .ToList();
-
-        for (
-            int slashIndex = blockedRef.LastIndexOf('/');
-            slashIndex > remoteTrackingPrefix.Length;
-            slashIndex = blockedRef.LastIndexOf('/', slashIndex - 1)
-        )
-        {
-            string staleParentRef = blockedRef[..slashIndex];
-            if (repo.Refs[staleParentRef]?.IsRemoteTrackingBranch == true)
+        ExecuteWithStaleRemoteTrackingRefRecovery(
+            repo,
+            remotes,
+            () =>
             {
-                refsToRemove.Add(staleParentRef);
+                operation();
+                return true;
+            }
+        );
+    }
+
+    private static T ExecuteWithStaleRemoteTrackingRefRecovery<T>(
+        LibGit2Sharp.Repository repo,
+        IEnumerable<Remote> remotes,
+        Func<T> operation
+    )
+    {
+        List<Remote> remoteList = remotes.ToList();
+        HashSet<string> attemptedRecoveries = new(StringComparer.Ordinal);
+
+        while (true)
+        {
+            try
+            {
+                return operation();
+            }
+            catch (LibGit2SharpException ex)
+            {
+                if (!TryRemoveRemoteTrackingRefsBlockingFetch(repo, remoteList, ex, attemptedRecoveries))
+                {
+                    throw;
+                }
             }
         }
+    }
 
-        foreach (string refToRemove in refsToRemove.Distinct())
+    private static bool TryRemoveRemoteTrackingRefsBlockingFetch(
+        LibGit2Sharp.Repository repo,
+        IEnumerable<Remote> remotes,
+        LibGit2SharpException exception,
+        HashSet<string> attemptedRecoveries
+    )
+    {
+        foreach (Remote remote in remotes)
         {
-            repo.Refs.Remove(refToRemove);
+            string? blockedRef = GetBlockedRemoteTrackingRef(repo, remote, exception.Message);
+            if (blockedRef is null || !attemptedRecoveries.Add(blockedRef))
+            {
+                continue;
+            }
+
+            string remoteTrackingPrefix = $"refs/remotes/{remote.Name}/";
+            string staleChildRefPrefix = $"{blockedRef}/";
+            List<string> refsToRemove = repo
+                .Refs.Where(reference =>
+                    reference.IsRemoteTrackingBranch
+                    && reference.CanonicalName.StartsWith(staleChildRefPrefix, StringComparison.Ordinal)
+                )
+                .Select(reference => reference.CanonicalName)
+                .ToList();
+
+            for (
+                int slashIndex = blockedRef.LastIndexOf('/');
+                slashIndex > remoteTrackingPrefix.Length;
+                slashIndex = blockedRef.LastIndexOf('/', slashIndex - 1)
+            )
+            {
+                string staleParentRef = blockedRef[..slashIndex];
+                if (repo.Refs[staleParentRef]?.IsRemoteTrackingBranch == true)
+                {
+                    refsToRemove.Add(staleParentRef);
+                }
+            }
+
+            foreach (string refToRemove in refsToRemove.Distinct())
+            {
+                try
+                {
+                    repo.Refs.Remove(refToRemove);
+                }
+                catch (NotFoundException)
+                {
+                    // Another request already removed the same stale tracking ref.
+                }
+            }
+
+            // A concurrent request or libgit2's partial fetch may already have removed the blocker.
+            // Retry once for each distinct blocked ref even when no stale ref remains visible.
+            return true;
         }
 
-        return refsToRemove.Count > 0;
+        return false;
     }
 
     private static string? GetBlockedRemoteTrackingRef(
@@ -295,6 +348,16 @@ public class SourceControlService(
             exceptionMessage,
             CannotLockRefMessagePrefix,
             CannotLockRefMessageSuffix
+        );
+        if (IsRemoteTrackingRefForRemote(canonicalRef, remote))
+        {
+            return canonicalRef;
+        }
+
+        canonicalRef = ExtractQuotedValue(
+            exceptionMessage,
+            ReferenceCollisionMessagePrefix,
+            ReferenceCollisionMessageSuffix
         );
         if (IsRemoteTrackingRefForRemote(canonicalRef, remote))
         {

--- a/src/Designer/backend/tests/Designer.Tests/Services/SourceControlServiceTest.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/SourceControlServiceTest.cs
@@ -419,10 +419,7 @@ public class SourceControlServiceTest : IDisposable
         }
         finally
         {
-            if (Directory.Exists(remoteRepoDir))
-            {
-                Directory.Delete(remoteRepoDir, true);
-            }
+            DeleteDirectoryIfExists(remoteRepoDir);
         }
     }
 
@@ -543,11 +540,17 @@ public class SourceControlServiceTest : IDisposable
         {
             return;
         }
+
+        DeleteDirectoryIfExists(_repoDir);
+    }
+
+    private static void DeleteDirectoryIfExists(string directory)
+    {
         try
         {
-            if (Directory.Exists(_repoDir))
+            if (Directory.Exists(directory))
             {
-                Directory.Delete(_repoDir, true);
+                Directory.Delete(directory, true);
             }
         }
         catch (Exception ex)

--- a/src/Designer/backend/tests/Designer.Tests/Services/SourceControlServiceTest.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/SourceControlServiceTest.cs
@@ -54,7 +54,7 @@ public class SourceControlServiceTest : IDisposable
         _sourceControlService = new SourceControlService(
             _settings,
             _giteaClientMock.Object,
-            new Mock<IGitServerAuthHeadersProvider>().Object
+            CreateAuthHeadersProvider()
         );
     }
 
@@ -515,13 +515,17 @@ public class SourceControlServiceTest : IDisposable
                 + Path.DirectorySeparatorChar,
         };
 
-        SourceControlService service = new(
-            repoSettings,
-            giteaMock.Object,
-            new Mock<IGitServerAuthHeadersProvider>().Object
-        );
+        SourceControlService service = new(repoSettings, giteaMock.Object, CreateAuthHeadersProvider());
 
         return service;
+    }
+
+    private static IGitServerAuthHeadersProvider CreateAuthHeadersProvider()
+    {
+        Mock<IGitServerAuthHeadersProvider> authHeadersProvider = new();
+        authHeadersProvider.Setup(provider => provider.GetAuthHeaders()).Returns(new Dictionary<string, string>());
+
+        return authHeadersProvider.Object;
     }
 
     private AltinnRepoEditingContext CreateTestRepository(string repoName, string additionalBranch = null)

--- a/src/Designer/backend/tests/Designer.Tests/Services/SourceControlServiceTest.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/SourceControlServiceTest.cs
@@ -375,6 +375,8 @@ public class SourceControlServiceTest : IDisposable
         string repoName = TestDataHelper.GenerateTestRepoName();
         string remoteRepoDir = TestDataHelper.GetTestDataRepositoryDirectory(_org, $"{repoName}-remote", _developer);
         _repoDir = TestDataHelper.GetTestDataRepositoryDirectory(_org, repoName, _developer);
+        const string staleRemoteBranchName = "develop'/test";
+        const string replacementRemoteBranchName = "develop'";
         var editingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(_org, repoName, _developer);
         AltinnAuthenticatedRepoEditingContext authenticatedContext =
             AltinnAuthenticatedRepoEditingContext.FromEditingContext(editingContext, "dummytoken");
@@ -392,21 +394,21 @@ public class SourceControlServiceTest : IDisposable
                     "test.txt",
                     "Initial content"
                 );
-                remoteRepo.CreateBranch("develop/test", initialCommit);
+                remoteRepo.CreateBranch(staleRemoteBranchName, initialCommit);
             }
 
             Repository.Clone(remoteRepoDir, _repoDir);
 
             using (var clonedRepo = new Repository(_repoDir))
             {
-                Assert.NotNull(clonedRepo.Branches["origin/develop/test"]);
-                Assert.Null(clonedRepo.Branches["origin/develop"]);
+                Assert.NotNull(clonedRepo.Branches[$"origin/{staleRemoteBranchName}"]);
+                Assert.Null(clonedRepo.Branches[$"origin/{replacementRemoteBranchName}"]);
             }
 
             using (var remoteRepo = new Repository(remoteRepoDir))
             {
-                remoteRepo.Branches.Remove("develop/test");
-                remoteRepo.CreateBranch("develop", remoteRepo.Head.Tip);
+                remoteRepo.Branches.Remove(staleRemoteBranchName);
+                remoteRepo.CreateBranch(replacementRemoteBranchName, remoteRepo.Head.Tip);
             }
 
             // Act
@@ -414,8 +416,64 @@ public class SourceControlServiceTest : IDisposable
 
             // Assert
             using var repo = new Repository(_repoDir);
-            Assert.Null(repo.Branches["origin/develop/test"]);
-            Assert.NotNull(repo.Branches["origin/develop"]);
+            Assert.Null(repo.Branches[$"origin/{staleRemoteBranchName}"]);
+            Assert.NotNull(repo.Branches[$"origin/{replacementRemoteBranchName}"]);
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(remoteRepoDir);
+        }
+    }
+
+    [Fact]
+    public void FetchRemoteChanges_RemoteParentBranchReplacedByChildBranch_PrunesStaleRemoteTrackingBranch()
+    {
+        // Arrange
+        Setup();
+        string repoName = TestDataHelper.GenerateTestRepoName();
+        string remoteRepoDir = TestDataHelper.GetTestDataRepositoryDirectory(_org, $"{repoName}-remote", _developer);
+        _repoDir = TestDataHelper.GetTestDataRepositoryDirectory(_org, repoName, _developer);
+        var editingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(_org, repoName, _developer);
+        AltinnAuthenticatedRepoEditingContext authenticatedContext =
+            AltinnAuthenticatedRepoEditingContext.FromEditingContext(editingContext, "dummytoken");
+
+        try
+        {
+            Directory.CreateDirectory(remoteRepoDir);
+            Repository.Init(remoteRepoDir);
+
+            using (var remoteRepo = new Repository(remoteRepoDir))
+            {
+                LibGit2Sharp.Commit initialCommit = CommitFile(
+                    remoteRepo,
+                    remoteRepoDir,
+                    "test.txt",
+                    "Initial content"
+                );
+                remoteRepo.CreateBranch("develop", initialCommit);
+            }
+
+            Repository.Clone(remoteRepoDir, _repoDir);
+
+            using (var clonedRepo = new Repository(_repoDir))
+            {
+                Assert.NotNull(clonedRepo.Branches["origin/develop"]);
+                Assert.Null(clonedRepo.Branches["origin/develop/test"]);
+            }
+
+            using (var remoteRepo = new Repository(remoteRepoDir))
+            {
+                remoteRepo.Branches.Remove("develop");
+                remoteRepo.CreateBranch("develop/test", remoteRepo.Head.Tip);
+            }
+
+            // Act
+            _sourceControlService.FetchRemoteChanges(authenticatedContext);
+
+            // Assert
+            using var repo = new Repository(_repoDir);
+            Assert.Null(repo.Branches["origin/develop"]);
+            Assert.NotNull(repo.Branches["origin/develop/test"]);
         }
         finally
         {

--- a/src/Designer/backend/tests/Designer.Tests/Services/SourceControlServiceTest.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/SourceControlServiceTest.cs
@@ -367,6 +367,65 @@ public class SourceControlServiceTest : IDisposable
         Assert.Empty(result);
     }
 
+    [Fact]
+    public void FetchRemoteChanges_RemoteBranchReplacedByParentBranch_PrunesStaleRemoteTrackingBranch()
+    {
+        // Arrange
+        Setup();
+        string repoName = TestDataHelper.GenerateTestRepoName();
+        string remoteRepoDir = TestDataHelper.GetTestDataRepositoryDirectory(_org, $"{repoName}-remote", _developer);
+        _repoDir = TestDataHelper.GetTestDataRepositoryDirectory(_org, repoName, _developer);
+        var editingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(_org, repoName, _developer);
+        AltinnAuthenticatedRepoEditingContext authenticatedContext =
+            AltinnAuthenticatedRepoEditingContext.FromEditingContext(editingContext, "dummytoken");
+
+        try
+        {
+            Directory.CreateDirectory(remoteRepoDir);
+            Repository.Init(remoteRepoDir);
+
+            using (var remoteRepo = new Repository(remoteRepoDir))
+            {
+                LibGit2Sharp.Commit initialCommit = CommitFile(
+                    remoteRepo,
+                    remoteRepoDir,
+                    "test.txt",
+                    "Initial content"
+                );
+                remoteRepo.CreateBranch("develop/test", initialCommit);
+            }
+
+            Repository.Clone(remoteRepoDir, _repoDir);
+
+            using (var clonedRepo = new Repository(_repoDir))
+            {
+                Assert.NotNull(clonedRepo.Branches["origin/develop/test"]);
+                Assert.Null(clonedRepo.Branches["origin/develop"]);
+            }
+
+            using (var remoteRepo = new Repository(remoteRepoDir))
+            {
+                remoteRepo.Branches.Remove("develop/test");
+                remoteRepo.CreateBranch("develop", remoteRepo.Head.Tip);
+            }
+
+            // Act
+            _sourceControlService.FetchRemoteChanges(authenticatedContext);
+
+            // Assert
+            using var repo = new Repository(_repoDir);
+            Assert.Null(repo.Branches["origin/develop/test"]);
+            Assert.NotNull(repo.Branches["origin/develop"]);
+        }
+        finally
+        {
+            if (Directory.Exists(remoteRepoDir))
+            {
+                Directory.Delete(remoteRepoDir, true);
+            }
+        }
+    }
+
     private static HttpContext GetHttpContextForTestUser(string userName)
     {
         List<Claim> claims = new();
@@ -442,6 +501,21 @@ public class SourceControlServiceTest : IDisposable
         string filePath = Path.Join(_repoDir, filename ?? "new-file.txt");
         string content = "this is the content of the file.";
         File.WriteAllText(filePath, content);
+    }
+
+    private static LibGit2Sharp.Commit CommitFile(
+        Repository repo,
+        string repoDirectory,
+        string fileName,
+        string content,
+        string commitMessage = "Initial commit"
+    )
+    {
+        string filePath = Path.Join(repoDirectory, fileName);
+        File.WriteAllText(filePath, content);
+        Commands.Stage(repo, fileName);
+        var signature = new LibGit2Sharp.Signature("testUser", "testUser@test.com", DateTimeOffset.Now);
+        return repo.Commit(commitMessage, signature, signature);
     }
 
     private string GetHeadBranchName()

--- a/src/Designer/backend/tests/Designer.Tests/Services/SourceControlServiceTest.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/SourceControlServiceTest.cs
@@ -375,6 +375,7 @@ public class SourceControlServiceTest : IDisposable
         string repoName = TestDataHelper.GenerateTestRepoName();
         string remoteRepoDir = TestDataHelper.GetTestDataRepositoryDirectory(_org, $"{repoName}-remote", _developer);
         _repoDir = TestDataHelper.GetTestDataRepositoryDirectory(_org, repoName, _developer);
+        // The apostrophe is deliberate; it verifies parsing does not stop at quotes inside valid branch names.
         const string staleRemoteBranchName = "develop'/test";
         const string replacementRemoteBranchName = "develop'";
         var editingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(_org, repoName, _developer);

--- a/src/Designer/backend/tests/Designer.Tests/Services/SourceControlServiceTest.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/SourceControlServiceTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Security.Claims;
@@ -368,7 +369,7 @@ public class SourceControlServiceTest : IDisposable
     }
 
     [Fact]
-    public void FetchRemoteChanges_RemoteBranchReplacedByParentBranch_PrunesStaleRemoteTrackingBranch()
+    public void FetchRemoteChanges_RemoteBranchReplacedByParentBranch_RemovesOnlyBlockingRemoteTrackingBranch()
     {
         // Arrange
         Setup();
@@ -396,6 +397,7 @@ public class SourceControlServiceTest : IDisposable
                     "Initial content"
                 );
                 remoteRepo.CreateBranch(staleRemoteBranchName, initialCommit);
+                remoteRepo.CreateBranch("unrelated-deleted-branch", initialCommit);
             }
 
             Repository.Clone(remoteRepoDir, _repoDir);
@@ -404,11 +406,13 @@ public class SourceControlServiceTest : IDisposable
             {
                 Assert.NotNull(clonedRepo.Branches[$"origin/{staleRemoteBranchName}"]);
                 Assert.Null(clonedRepo.Branches[$"origin/{replacementRemoteBranchName}"]);
+                Assert.NotNull(clonedRepo.Branches["origin/unrelated-deleted-branch"]);
             }
 
             using (var remoteRepo = new Repository(remoteRepoDir))
             {
                 remoteRepo.Branches.Remove(staleRemoteBranchName);
+                remoteRepo.Branches.Remove("unrelated-deleted-branch");
                 remoteRepo.CreateBranch(replacementRemoteBranchName, remoteRepo.Head.Tip);
             }
 
@@ -419,6 +423,7 @@ public class SourceControlServiceTest : IDisposable
             using var repo = new Repository(_repoDir);
             Assert.Null(repo.Branches[$"origin/{staleRemoteBranchName}"]);
             Assert.NotNull(repo.Branches[$"origin/{replacementRemoteBranchName}"]);
+            Assert.NotNull(repo.Branches["origin/unrelated-deleted-branch"]);
         }
         finally
         {
@@ -427,7 +432,7 @@ public class SourceControlServiceTest : IDisposable
     }
 
     [Fact]
-    public void FetchRemoteChanges_RemoteParentBranchReplacedByChildBranch_PrunesStaleRemoteTrackingBranch()
+    public void FetchRemoteChanges_RemoteParentBranchReplacedByChildBranch_RemovesBlockingRemoteTrackingBranch()
     {
         // Arrange
         Setup();
@@ -479,6 +484,153 @@ public class SourceControlServiceTest : IDisposable
         finally
         {
             DeleteDirectoryIfExists(remoteRepoDir);
+        }
+    }
+
+    [Fact]
+    public void FetchRemoteChanges_MultipleRemoteBranchShapeChanges_RemovesAllBlockingRemoteTrackingBranches()
+    {
+        // Arrange
+        Setup();
+        string repoName = TestDataHelper.GenerateTestRepoName();
+        string remoteRepoDir = TestDataHelper.GetTestDataRepositoryDirectory(_org, $"{repoName}-remote", _developer);
+        _repoDir = TestDataHelper.GetTestDataRepositoryDirectory(_org, repoName, _developer);
+        var editingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(_org, repoName, _developer);
+        AltinnAuthenticatedRepoEditingContext authenticatedContext =
+            AltinnAuthenticatedRepoEditingContext.FromEditingContext(editingContext, "dummytoken");
+
+        try
+        {
+            Directory.CreateDirectory(remoteRepoDir);
+            Repository.Init(remoteRepoDir);
+
+            using (var remoteRepo = new Repository(remoteRepoDir))
+            {
+                LibGit2Sharp.Commit initialCommit = CommitFile(
+                    remoteRepo,
+                    remoteRepoDir,
+                    "test.txt",
+                    "Initial content"
+                );
+                remoteRepo.CreateBranch("develop/test", initialCommit);
+                remoteRepo.CreateBranch("release", initialCommit);
+            }
+
+            Repository.Clone(remoteRepoDir, _repoDir);
+
+            using (var remoteRepo = new Repository(remoteRepoDir))
+            {
+                remoteRepo.Branches.Remove("develop/test");
+                remoteRepo.Branches.Remove("release");
+                remoteRepo.CreateBranch("develop", remoteRepo.Head.Tip);
+                remoteRepo.CreateBranch("release/test", remoteRepo.Head.Tip);
+            }
+
+            // Act
+            _sourceControlService.FetchRemoteChanges(authenticatedContext);
+
+            // Assert
+            using var repo = new Repository(_repoDir);
+            Assert.Null(repo.Branches["origin/develop/test"]);
+            Assert.NotNull(repo.Branches["origin/develop"]);
+            Assert.Null(repo.Branches["origin/release"]);
+            Assert.NotNull(repo.Branches["origin/release/test"]);
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(remoteRepoDir);
+        }
+    }
+
+    [Theory]
+    [InlineData("develop", "develop/test", false)]
+    [InlineData("develop/test", "develop", false)]
+    [InlineData("develop", "develop/test", true)]
+    [InlineData("develop/test", "develop", true)]
+    public void PullRemoteChanges_RemoteBranchShapeChangedByPush_RemovesBlockingRemoteTrackingBranch(
+        string staleRemoteBranchName,
+        string replacementRemoteBranchName,
+        bool packRefs
+    )
+    {
+        // Arrange
+        Setup();
+        string repoName = TestDataHelper.GenerateTestRepoName();
+        string remoteRepoDir = TestDataHelper.GetTestDataRepositoryDirectory(_org, $"{repoName}-remote", _developer);
+        string publisherRepoDir = TestDataHelper.GetTestDataRepositoryDirectory(
+            _org,
+            $"{repoName}-publisher",
+            _developer
+        );
+        _repoDir = TestDataHelper.GetTestDataRepositoryDirectory(_org, repoName, _developer);
+        var editingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(_org, repoName, _developer);
+        AltinnAuthenticatedRepoEditingContext authenticatedContext =
+            AltinnAuthenticatedRepoEditingContext.FromEditingContext(editingContext, "dummytoken");
+
+        try
+        {
+            Directory.CreateDirectory(remoteRepoDir);
+            Repository.Init(remoteRepoDir, true);
+            Directory.CreateDirectory(publisherRepoDir);
+            Repository.Init(publisherRepoDir);
+
+            using (var publisherRepo = new Repository(publisherRepoDir))
+            {
+                LibGit2Sharp.Commit initialCommit = CommitFile(
+                    publisherRepo,
+                    publisherRepoDir,
+                    "test.txt",
+                    "Initial content"
+                );
+                EnsureServiceDefaultBranch(publisherRepo);
+                publisherRepo.CreateBranch(staleRemoteBranchName, initialCommit);
+                Remote remote = publisherRepo.Network.Remotes.Add("origin", remoteRepoDir);
+                publisherRepo.Network.Push(remote, "refs/heads/master:refs/heads/master", new PushOptions());
+                publisherRepo.Network.Push(
+                    remote,
+                    $"refs/heads/{staleRemoteBranchName}:refs/heads/{staleRemoteBranchName}",
+                    new PushOptions()
+                );
+            }
+
+            Repository.Clone(remoteRepoDir, _repoDir);
+
+            using (var clonedRepo = new Repository(_repoDir))
+            {
+                Assert.NotNull(clonedRepo.Branches[$"origin/{staleRemoteBranchName}"]);
+                Assert.Null(clonedRepo.Branches[$"origin/{replacementRemoteBranchName}"]);
+            }
+
+            if (packRefs)
+            {
+                PackRefs(_repoDir);
+            }
+
+            using (var publisherRepo = new Repository(publisherRepoDir))
+            {
+                Remote remote = publisherRepo.Network.Remotes["origin"];
+                publisherRepo.Network.Push(remote, $":refs/heads/{staleRemoteBranchName}", new PushOptions());
+                publisherRepo.Branches.Remove(staleRemoteBranchName);
+                publisherRepo.CreateBranch(replacementRemoteBranchName, publisherRepo.Head.Tip);
+                publisherRepo.Network.Push(
+                    remote,
+                    $"refs/heads/{replacementRemoteBranchName}:refs/heads/{replacementRemoteBranchName}",
+                    new PushOptions()
+                );
+            }
+
+            // Act
+            _sourceControlService.PullRemoteChanges(authenticatedContext);
+
+            // Assert
+            using var repo = new Repository(_repoDir);
+            Assert.Null(repo.Branches[$"origin/{staleRemoteBranchName}"]);
+            Assert.NotNull(repo.Branches[$"origin/{replacementRemoteBranchName}"]);
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(remoteRepoDir);
+            DeleteDirectoryIfExists(publisherRepoDir);
         }
     }
 
@@ -576,6 +728,25 @@ public class SourceControlServiceTest : IDisposable
         Commands.Stage(repo, fileName);
         var signature = new LibGit2Sharp.Signature("testUser", "testUser@test.com", DateTimeOffset.Now);
         return repo.Commit(commitMessage, signature, signature);
+    }
+
+    private static void PackRefs(string repositoryDirectory)
+    {
+        ProcessStartInfo startInfo = new("git")
+        {
+            WorkingDirectory = repositoryDirectory,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add("pack-refs");
+        startInfo.ArgumentList.Add("--all");
+
+        using Process process = Process.Start(startInfo);
+        string standardError = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        Assert.True(process.ExitCode == 0, standardError);
     }
 
     private string GetHeadBranchName()


### PR DESCRIPTION
## Description

Fixes Designer repository synchronization when a remote branch changes between parent and child names, for example `develop/test` to `develop` or the inverse.

Recovery now applies to both explicit fetches and the implicit fetch inside `Commands.Pull`. It recognizes the constrained loose- and packed-ref collision errors, removes only the blocking remote-tracking refs, and retries while each failure identifies a new blocker. Unrelated deleted tracking refs are not pruned.

A live dev reproduction confirmed that the inverse transition reached Gitea successfully but Designer's `/pull` endpoint failed in `Commands.Pull -> Commands.Fetch`. The new bare-remote regression test reproduced the same exception and stack before the fix.

## Verification

- [ ] Related issues are connected (not applicable)
- [x] Code compiles as part of the focused test run
- [ ] Post-fix manual verification in dev is pending
- [x] Relevant automated tests added

Commands run:

```bash
dotnet test tests/Designer.Tests/Designer.Tests.csproj --filter "FullyQualifiedName~SourceControlServiceTest"
dotnet csharpier check src/Designer/Services/Implementation/SourceControlService.cs tests/Designer.Tests/Services/SourceControlServiceTest.cs
git diff --check
```

Results:

- 19 SourceControlService tests passed
- both changed files pass CSharpier
- loose and packed refs are covered in both transition directions
- multiple simultaneous collisions are covered
- an unrelated deleted tracking ref is preserved
