### PR TITLE
fix: add missing studioctl changelog entry

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -11,6 +11,7 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 ### Fixed
 
 - Support starting localtest with rootless Podman setups where the host user has a large domain UID/GID outside the default subordinate ID mapping.
+- Relabel localtest bind mounts on SELinux-enabled Podman setups so containers can read generated resources.
 
 ## [0.1.0-preview.10] - 2026-05-22
 

--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -8,6 +8,10 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+### Fixed
+
+- Support starting localtest with rootless Podman setups where the host user has a large domain UID/GID outside the default subordinate ID mapping.
+
 ## [0.1.0-preview.10] - 2026-05-22
 
 ### Changed


### PR DESCRIPTION
## Description

Adds the missing `studioctl` changelog entry for #18977 under `Unreleased`.

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

Verification performed:

```sh
git diff --check
```

Result: no whitespace errors. No code tests were run because this is a changelog-only change.
