### PR TITLE
fix: target releaser tags at checked out commit

### DIFF
--- a/src/tools/releaser/internal/git.go
+++ b/src/tools/releaser/internal/git.go
@@ -35,6 +35,8 @@ type GitRunner interface {
 	PushWithUpstream(ctx context.Context, remote, branch string) error
 	// RepoRoot returns the git repository root directory.
 	RepoRoot(ctx context.Context) (string, error)
+	// HeadCommit returns the current HEAD commit SHA.
+	HeadCommit(ctx context.Context) (string, error)
 	// WorkingTreeClean checks if working tree has no uncommitted changes.
 	WorkingTreeClean(ctx context.Context) (bool, error)
 }
@@ -135,6 +137,11 @@ func (g *GitCLI) PushWithUpstream(ctx context.Context, remote, branch string) er
 // Run executes a git command and returns stdout.
 func (g *GitCLI) Run(ctx context.Context, args ...string) (string, error) {
 	return g.run(ctx, args...)
+}
+
+// HeadCommit returns the current HEAD commit SHA.
+func (g *GitCLI) HeadCommit(ctx context.Context) (string, error) {
+	return g.Run(ctx, "rev-parse", "HEAD")
 }
 
 // RepoRoot returns the git repository root directory.

--- a/src/tools/releaser/internal/workflow.go
+++ b/src/tools/releaser/internal/workflow.go
@@ -19,6 +19,7 @@ var (
 	ErrChangelogMissing     = errors.New("changelog version section not found")
 	ErrBuildFailed          = errors.New("build failed")
 	ErrReleaseBranchMissing = errors.New("release branch does not exist for stable release")
+	errReleaseTargetMissing = errors.New("release target commit is empty")
 )
 
 // WorkflowConfig configures the release workflow.
@@ -430,12 +431,15 @@ func (w *Workflow) createGitHubRelease(ctx context.Context) error {
 
 	assets := append([]string(nil), w.artifacts...)
 
-	target := w.determineTargetBranch()
+	target, err := w.determineReleaseTarget(ctx)
+	if err != nil {
+		return err
+	}
 	tagFull := w.tag.Full()
 	title := w.component.ReleaseTitle(verStr)
 
 	w.log.Info("Creating release with %d assets...", len(assets))
-	w.log.Detail("Target branch", target)
+	w.log.Detail("Target commit", target)
 
 	if w.config.DryRun {
 		w.log.Info("(dry-run) Would create release:")
@@ -471,12 +475,16 @@ func (w *Workflow) createGitHubRelease(ctx context.Context) error {
 	return nil
 }
 
-// determineTargetBranch returns the branch where the tag should be created.
-func (w *Workflow) determineTargetBranch() string {
-	if w.tag.Version.IsPrerelease {
-		return mainBranch
+func (w *Workflow) determineReleaseTarget(ctx context.Context) (string, error) {
+	target, err := w.git.HeadCommit(ctx)
+	if err != nil {
+		return "", fmt.Errorf("resolve release target commit: %w", err)
 	}
-	return w.tag.ReleaseBranch()
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return "", errReleaseTargetMissing
+	}
+	return target, nil
 }
 
 func (w *Workflow) printSummary() {

--- a/src/tools/releaser/internal/workflow_test.go
+++ b/src/tools/releaser/internal/workflow_test.go
@@ -12,6 +12,8 @@ import (
 	"altinn.studio/releaser/internal/version"
 )
 
+const fakeHeadCommit = "1234567890abcdef1234567890abcdef12345678"
+
 func TestWorkflow_Run_TagExists(t *testing.T) {
 	t.Parallel()
 
@@ -220,8 +222,57 @@ func TestWorkflow_Run_StableChecksOutReleaseBranch(t *testing.T) {
 	if git.pullCount != 1 {
 		t.Fatalf("expected pull to be called once, got %d", git.pullCount)
 	}
-	if gh.target != "release/studioctl/v1.2" {
-		t.Fatalf("target = %s, want release/studioctl/v1.2", gh.target)
+	if gh.target != fakeHeadCommit {
+		t.Fatalf("target = %s, want %s", gh.target, fakeHeadCommit)
+	}
+}
+
+func TestWorkflow_Run_PrereleaseTargetsHeadCommit(t *testing.T) {
+	t.Parallel()
+
+	changelogPath := writeChangelog(t, `# Changelog
+
+## [Unreleased]
+
+## [v1.2.3-preview.1] - 2025-01-01
+
+### Added
+
+- Test entry
+`)
+
+	const headCommit = "abcdef1234567890abcdef1234567890abcdef12"
+	builder := &fakeBuilder{}
+	gh := &fakeGH{}
+	git := &fakeGit{
+		currentBranch:    "main",
+		headCommit:       headCommit,
+		workingTreeClean: true,
+	}
+
+	cfg := internal.WorkflowConfig{
+		Component:     "studioctl",
+		Version:       "v1.2.3-preview.1",
+		ChangelogPath: changelogPath,
+		OutputDir:     t.TempDir(),
+		DryRun:        false,
+		Draft:         true,
+		RepoRoot:      os.TempDir(),
+	}
+
+	workflow, err := internal.NewWorkflow(t.Context(), cfg, git, gh, builder, internal.NopLogger{})
+	if err != nil {
+		t.Fatalf("NewWorkflow() error: %v", err)
+	}
+	if err := workflow.Run(t.Context()); err != nil {
+		t.Fatalf("workflow.Run() error: %v", err)
+	}
+
+	if gh.target != headCommit {
+		t.Fatalf("target = %s, want %s", gh.target, headCommit)
+	}
+	if !gh.prerelease {
+		t.Fatal("expected prerelease GitHub release")
 	}
 }
 
@@ -474,6 +525,7 @@ func TestNewWorkflow_OutputDirSafety_RejectsSymlinkEscape(t *testing.T) {
 
 type fakeGit struct {
 	currentBranch      string
+	headCommit         string
 	lastCheckout       string
 	lastPull           string
 	checkoutCount      int
@@ -520,6 +572,13 @@ func (g *fakeGit) PushWithUpstream(_ context.Context, _, _ string) error {
 
 func (g *fakeGit) RepoRoot(_ context.Context) (string, error) {
 	return ".", nil
+}
+
+func (g *fakeGit) HeadCommit(_ context.Context) (string, error) {
+	if g.headCommit == "" {
+		return fakeHeadCommit, nil
+	}
+	return g.headCommit, nil
 }
 
 func (g *fakeGit) WorkingTreeClean(_ context.Context) (bool, error) {

--- a/src/tools/releaser/test/e2e/workflow_test.go
+++ b/src/tools/releaser/test/e2e/workflow_test.go
@@ -113,13 +113,13 @@ func TestReleaseWorkflow_LocalRepo(t *testing.T) {
 	// 1) Release v1.0.0-preview.1 from main.
 	promoted := s.prepareAndMerge(previewV100p1, mainBranchName)
 	assertVersionSectionContains(t, promoted, previewV100p1, "First stable feature")
-	s.release(previewV100p1, mainBranchName, true)
+	s.release(previewV100p1, true)
 
 	// 2) Stabilize v1.0.0 by promoting the existing prerelease history.
 	promoted = s.prepareAndMerge(stableV100, releaseV100)
 	assertVersionOrder(t, promoted, stableV100, previewV100p1)
 	assertVersionSectionContains(t, promoted, stableV100, "First stable feature")
-	s.release(stableV100, releaseV100, false)
+	s.release(stableV100, false)
 
 	v110, previewV110p1 := v110.nextPrerelease(t, 1)
 	v110, previewV110p2 := v110.nextPrerelease(t, 2)
@@ -141,7 +141,7 @@ func TestReleaseWorkflow_LocalRepo(t *testing.T) {
 	// 3) Release v1.1.0-preview.1 on main.
 	promoted = s.prepareAndMerge(previewV110p1, mainBranchName)
 	assertVersionOrder(t, promoted, previewV110p1, stableV100)
-	s.release(previewV110p1, mainBranchName, true)
+	s.release(previewV110p1, true)
 
 	// 4) Bugfix on main.
 	s.landFeature(
@@ -163,14 +163,14 @@ func TestReleaseWorkflow_LocalRepo(t *testing.T) {
 	promoted = s.prepareAndMerge(previewV110p2, mainBranchName)
 	assertVersionOrder(t, promoted, previewV110p2, previewV110p1)
 	assertVersionOrder(t, promoted, previewV110p1, stableV100)
-	s.release(previewV110p2, mainBranchName, true)
+	s.release(previewV110p2, true)
 
 	// 6) Backport bugfix, then release v1.0.1 from release branch.
 	s.backportAndMerge(bugfixSHA, v100.lineVersion(), releaseV100, "Merge backport PR")
 	v100, patchV101 := v100.nextPatch(t, 1)
 	promoted = s.prepareAndMerge(patchV101, releaseV100)
 	assertVersionOrder(t, promoted, patchV101, stableV100)
-	s.release(patchV101, releaseV100, false)
+	s.release(patchV101, false)
 
 	runFinalizeAndNextPreviewSequence(t, s, finalizeAndPreviewArgs{
 		releaseV100:   releaseV100,
@@ -656,9 +656,10 @@ func (s *workflowScenario) headSHA() string {
 	return strings.TrimSpace(runGit(s.t, s.log, s.repo.dir, "rev-parse", "HEAD"))
 }
 
-func (s *workflowScenario) release(version, target string, prerelease bool) {
+func (s *workflowScenario) release(version string, prerelease bool) {
 	s.t.Helper()
 	s.gh.reset()
+	target := s.headSHA()
 	workflow, err := internal.NewWorkflow(
 		s.t.Context(),
 		internal.WorkflowConfig{
@@ -728,7 +729,7 @@ func runFinalizeV110AndFirstV120Preview(t *testing.T, s *workflowScenario, args 
 	assertVersionSectionContains(
 		t, promotedStable110, args.stableV110, "Preview track feature", "Critical bugfix",
 	)
-	s.release(args.stableV110, args.releaseV110, false)
+	s.release(args.stableV110, false)
 
 	s.landFeature(
 		"feature/v120-preview1",
@@ -747,7 +748,7 @@ func runFinalizeV110AndFirstV120Preview(t *testing.T, s *workflowScenario, args 
 	)
 	promotedPreview120p1 := s.prepareAndMerge(args.previewV120p1, mainBranchName)
 	assertVersionOrder(t, promotedPreview120p1, args.previewV120p1, args.stableV110)
-	s.release(args.previewV120p1, mainBranchName, true)
+	s.release(args.previewV120p1, true)
 
 	s.landFeature(
 		"feature/v120-bugfix2",
@@ -785,7 +786,7 @@ func runBackportsAndSecondV120Preview(
 	promotedPreview120p2 := s.prepareAndMerge(args.previewV120p2, mainBranchName)
 	assertVersionOrder(t, promotedPreview120p2, args.previewV120p2, args.previewV120p1)
 	assertVersionOrder(t, promotedPreview120p2, args.previewV120p1, args.stableV110)
-	s.release(args.previewV120p2, mainBranchName, true)
+	s.release(args.previewV120p2, true)
 }
 
 func squashMergeBranch(t *testing.T, log internal.Logger, repoDir, sourceBranch, commitMsg string) {


### PR DESCRIPTION
## Description

Updates the releaser workflow so GitHub release tags are created at the currently checked-out `HEAD` commit instead of a moving branch name.

This keeps behavior consistent for all releaser consumers and prevents a release tag from drifting if `main` or a release branch advances while artifacts are being built.

Changes:
- Adds `HeadCommit` to the releaser git abstraction.
- Resolves the release target from `git rev-parse HEAD` during release creation.
- Uses that commit SHA as `gh release create --target`.
- Adds coverage for prerelease and stable release target behavior.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

Command transcript:

```text
$ make test
go test -race -count=1 altinn.studio/releaser altinn.studio/releaser/internal altinn.studio/releaser/internal/changelog altinn.studio/releaser/internal/perm altinn.studio/releaser/internal/version
ok  	altinn.studio/releaser	1.009s
ok  	altinn.studio/releaser/internal	2.565s
ok  	altinn.studio/releaser/internal/changelog	1.025s
?   	altinn.studio/releaser/internal/perm	[no test files]
ok  	altinn.studio/releaser/internal/version	1.014s

$ make build
go build -o build/releaser .

$ make fmt
"/data/home/code/altinn-studio-releaser-target-head/src/tools/releaser/bin/golangci-lint" fmt

$ make lint
"/data/home/code/altinn-studio-releaser-target-head/src/tools/releaser/bin/golangci-lint" run ./...
0 issues.

$ git diff --check
# no output
```
