### PR TITLE
feat: allow overriding studio container toolchain

### DIFF
--- a/src/Runtime/devenv/pkg/container/detect.go
+++ b/src/Runtime/devenv/pkg/container/detect.go
@@ -18,6 +18,9 @@ import (
 
 const dockerContextTimeout = 5 * time.Second
 
+// EnvContainerToolchain overrides automatic container toolchain detection.
+const EnvContainerToolchain = "STUDIO_CONTAINER_TOOLCHAIN"
+
 type detectorDeps struct {
 	lookupPath             func(string) (string, error)
 	detectPlatform         func(context.Context) (ContainerPlatform, error)
@@ -39,7 +42,19 @@ type detector struct {
 var (
 	defaultDetector       = newDetector(detectorDeps{})
 	errNoContainerRuntime = errors.New("no container runtime found")
+	errUnsupportedTool    = errors.New("unsupported container toolchain")
 	errUnknownTransport   = errors.New("unknown container transport")
+)
+
+type toolchainPreference string
+
+const (
+	toolchainPreferenceAuto                  toolchainPreference = "auto"
+	toolchainPreferenceDocker                toolchainPreference = "docker"
+	toolchainPreferenceColima                toolchainPreference = "colima"
+	toolchainPreferencePodman                toolchainPreference = "podman"
+	toolchainPreferencePodmanCLI             toolchainPreference = "podman-cli"
+	toolchainPreferencePodmanDockerEngineAPI toolchainPreference = "podman-docker-engine-api"
 )
 
 // Detect detects which container runtime is available on the system.
@@ -105,6 +120,64 @@ func newDetector(deps detectorDeps) *detector {
 }
 
 func (d *detector) detectToolchain(ctx context.Context) (ContainerToolchain, error) {
+	preference, err := toolchainPreferenceFromEnv()
+	if err != nil {
+		return ContainerToolchain{}, err
+	}
+
+	switch preference {
+	case toolchainPreferenceAuto:
+		return d.detectAutoToolchain(ctx)
+	case toolchainPreferenceDocker:
+		return d.detectDockerEngineAPIPlatform(ctx, preference, PlatformDocker)
+	case toolchainPreferenceColima:
+		return d.detectDockerEngineAPIPlatform(ctx, preference, PlatformColima)
+	case toolchainPreferencePodman:
+		if toolchain, err := d.detectDockerEngineAPIPlatform(ctx, preference, PlatformPodman); err == nil {
+			return toolchain, nil
+		}
+		if toolchain, ok := d.detectPodmanCLIToolchain(); ok {
+			return toolchain, nil
+		}
+		return ContainerToolchain{}, noRuntimeForPreference(preference)
+	case toolchainPreferencePodmanCLI:
+		if toolchain, ok := d.detectPodmanCLIToolchain(); ok {
+			return toolchain, nil
+		}
+		return ContainerToolchain{}, noRuntimeForPreference(preference)
+	case toolchainPreferencePodmanDockerEngineAPI:
+		return d.detectDockerEngineAPIPlatform(ctx, preference, PlatformPodman)
+	default:
+		return ContainerToolchain{}, noRuntimeForPreference(preference)
+	}
+}
+
+func toolchainPreferenceFromEnv() (toolchainPreference, error) {
+	raw := strings.TrimSpace(os.Getenv(EnvContainerToolchain))
+	if raw == "" {
+		return toolchainPreferenceAuto, nil
+	}
+
+	preference := toolchainPreference(strings.ToLower(raw))
+	switch preference {
+	case toolchainPreferenceAuto,
+		toolchainPreferenceDocker,
+		toolchainPreferenceColima,
+		toolchainPreferencePodman,
+		toolchainPreferencePodmanCLI,
+		toolchainPreferencePodmanDockerEngineAPI:
+		return preference, nil
+	default:
+		return "", fmt.Errorf(
+			"%w: %s=%q (supported: auto, docker, colima, podman, podman-cli, podman-docker-engine-api)",
+			errUnsupportedTool,
+			EnvContainerToolchain,
+			raw,
+		)
+	}
+}
+
+func (d *detector) detectAutoToolchain(ctx context.Context) (ContainerToolchain, error) {
 	dockerHost := strings.TrimSpace(os.Getenv("DOCKER_HOST"))
 	if dockerHost != "" {
 		if toolchain, ok := d.detectDefaultToolchain(ctx, true); ok {
@@ -141,6 +214,46 @@ func (d *detector) detectToolchain(ctx context.Context) (ContainerToolchain, err
 		"%w (tried Docker API, docker context, Docker-compatible sockets, Podman socket, Podman CLI)",
 		errNoContainerRuntime,
 	)
+}
+
+func (d *detector) detectDockerEngineAPIPlatform(
+	ctx context.Context,
+	preference toolchainPreference,
+	platform ContainerPlatform,
+) (ContainerToolchain, error) {
+	dockerHost := strings.TrimSpace(os.Getenv("DOCKER_HOST"))
+	if toolchain, ok := d.detectDefaultToolchain(ctx, dockerHost != ""); ok && toolchain.Platform == platform {
+		return toolchain, nil
+	}
+	if toolchain, ok := d.tryDockerContext(ctx); ok && toolchain.Platform == platform {
+		return toolchain, nil
+	}
+	if toolchain, ok := d.findDockerSocketPlatform(ctx, platform); ok {
+		return toolchain, nil
+	}
+	if toolchain, ok := d.findPodmanSocket(ctx); ok && toolchain.Platform == platform {
+		return toolchain, nil
+	}
+
+	return ContainerToolchain{}, noRuntimeForPreference(preference)
+}
+
+func (d *detector) detectPodmanCLIToolchain() (ContainerToolchain, bool) {
+	if _, err := d.deps.lookupPath("podman"); err != nil {
+		return ContainerToolchain{}, false
+	}
+
+	return ContainerToolchain{
+		Platform:   PlatformPodman,
+		AccessMode: AccessPodmanCLI,
+		Source:     SourcePodmanCLI,
+		SocketPath: "",
+		SELinux:    false,
+	}, true
+}
+
+func noRuntimeForPreference(preference toolchainPreference) error {
+	return fmt.Errorf("%w for %s=%q", errNoContainerRuntime, EnvContainerToolchain, preference)
 }
 
 func newClientForTransport(ctx context.Context, toolchain ContainerToolchain) (ContainerClient, error) {
@@ -195,6 +308,23 @@ func (d *detector) findDockerSocket(ctx context.Context) (ContainerToolchain, bo
 
 		toolchain, ok := d.detectHostToolchain(ctx, "unix://"+socketPath, SourceKnownSocket)
 		if ok {
+			return toolchain, true
+		}
+	}
+	return ContainerToolchain{}, false
+}
+
+func (d *detector) findDockerSocketPlatform(
+	ctx context.Context,
+	platform ContainerPlatform,
+) (ContainerToolchain, bool) {
+	for _, socketPath := range d.deps.dockerSocketPaths() {
+		if !d.deps.fileExists(socketPath) {
+			continue
+		}
+
+		toolchain, ok := d.detectHostToolchain(ctx, "unix://"+socketPath, SourceKnownSocket)
+		if ok && toolchain.Platform == platform {
 			return toolchain, true
 		}
 	}

--- a/src/Runtime/devenv/pkg/container/detect_test.go
+++ b/src/Runtime/devenv/pkg/container/detect_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os/exec"
+	"strings"
 	"testing"
 
 	containermock "altinn.studio/devenv/pkg/container/mock"
@@ -27,6 +28,7 @@ const (
 func clearDockerHost(t *testing.T) {
 	t.Helper()
 	t.Setenv("DOCKER_HOST", "")
+	t.Setenv(EnvContainerToolchain, "")
 }
 
 func mixedToolchainDetectorDeps(
@@ -117,6 +119,7 @@ func TestDetect_RetriesAfterTransientFailure(t *testing.T) {
 }
 
 func TestDetectToolchain_DefaultDockerHostWithoutDockerCLISucceeds(t *testing.T) {
+	t.Setenv(EnvContainerToolchain, "")
 	t.Setenv("DOCKER_HOST", testDockerSocketHost)
 
 	d := newDetector(detectorDeps{
@@ -334,6 +337,7 @@ func TestDetectToolchain_DockerContextColimaBeatsPodmanSocket(t *testing.T) {
 }
 
 func TestDetectToolchain_ExplicitDockerHostBeatsOtherCandidates(t *testing.T) {
+	t.Setenv(EnvContainerToolchain, "")
 	t.Setenv("DOCKER_HOST", testPodmanSocketHost)
 
 	d := newDetector(mixedToolchainDetectorDeps(t, PlatformPodman))
@@ -348,6 +352,7 @@ func TestDetectToolchain_ExplicitDockerHostBeatsOtherCandidates(t *testing.T) {
 }
 
 func TestDetectToolchain_ExplicitDockerHostDoesNotFallBack(t *testing.T) {
+	t.Setenv(EnvContainerToolchain, "")
 	t.Setenv("DOCKER_HOST", testDockerSocketHost)
 
 	d := newDetector(mixedToolchainDetectorDeps(t, PlatformUnknown))
@@ -355,5 +360,227 @@ func TestDetectToolchain_ExplicitDockerHostDoesNotFallBack(t *testing.T) {
 	_, err := d.detectToolchain(t.Context())
 	if !errors.Is(err, errNoContainerRuntime) {
 		t.Fatalf("detectToolchain() error = %v, want %v", err, errNoContainerRuntime)
+	}
+}
+
+func TestDetectToolchain_OverrideAutoKeepsDefaultDetection(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "")
+	t.Setenv(EnvContainerToolchain, "auto")
+
+	d := newDetector(detectorDeps{
+		detectPlatform: func(context.Context) (ContainerPlatform, error) {
+			return PlatformDocker, nil
+		},
+		lookupPath: func(string) (string, error) {
+			return "", exec.ErrNotFound
+		},
+	})
+
+	got, err := d.detectToolchain(t.Context())
+	if err != nil {
+		t.Fatalf("detectToolchain() error = %v", err)
+	}
+	if got.Platform != PlatformDocker || got.AccessMode != AccessDockerEngineAPI || got.Source != SourceDefault {
+		t.Fatalf("detectToolchain() = %#v", got)
+	}
+}
+
+func TestDetectToolchain_OverridePodmanCLIBeatsDefaultDocker(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "")
+	t.Setenv(EnvContainerToolchain, "podman-cli")
+
+	d := newDetector(detectorDeps{
+		detectPlatform: func(context.Context) (ContainerPlatform, error) {
+			return PlatformDocker, nil
+		},
+		lookupPath: func(file string) (string, error) {
+			if file == testPodmanBinary {
+				return testPodmanBinaryPath, nil
+			}
+			return "", exec.ErrNotFound
+		},
+	})
+
+	got, err := d.detectToolchain(t.Context())
+	if err != nil {
+		t.Fatalf("detectToolchain() error = %v", err)
+	}
+	if got.Platform != PlatformPodman || got.AccessMode != AccessPodmanCLI || got.Source != SourcePodmanCLI {
+		t.Fatalf("detectToolchain() = %#v", got)
+	}
+}
+
+func TestDetectToolchain_OverridePodmanPrefersDockerEngineAPI(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "")
+	t.Setenv(EnvContainerToolchain, "podman")
+
+	d := newDetector(mixedToolchainDetectorDeps(t, PlatformDocker))
+
+	got, err := d.detectToolchain(t.Context())
+	if err != nil {
+		t.Fatalf("detectToolchain() error = %v", err)
+	}
+	if got.Platform != PlatformPodman || got.AccessMode != AccessDockerEngineAPI ||
+		got.Source != SourceKnownSocket || got.SocketPath != testPodmanSocketPath {
+		t.Fatalf("detectToolchain() = %#v", got)
+	}
+}
+
+func TestDetectToolchain_OverridePodmanFallsBackToCLI(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "")
+	t.Setenv(EnvContainerToolchain, "podman")
+
+	d := newDetector(detectorDeps{
+		detectPlatform: func(context.Context) (ContainerPlatform, error) {
+			return PlatformDocker, nil
+		},
+		dockerContextHost: func(context.Context) (string, error) {
+			return "", errTransientFailure
+		},
+		detectPlatformWithHost: func(_ context.Context, host string) (ContainerPlatform, error) {
+			if host != testPodmanSocketHost {
+				t.Fatalf("unexpected host %q", host)
+			}
+			return PlatformUnknown, errTransientFailure
+		},
+		lookupPath: func(file string) (string, error) {
+			if file == testPodmanBinary {
+				return testPodmanBinaryPath, nil
+			}
+			return "", exec.ErrNotFound
+		},
+		dockerSocketPaths: func() []string { return nil },
+		podmanSocketPaths: func() []string { return []string{testPodmanSocketPath} },
+		fileExists:        func(path string) bool { return path == testPodmanSocketPath },
+	})
+
+	got, err := d.detectToolchain(t.Context())
+	if err != nil {
+		t.Fatalf("detectToolchain() error = %v", err)
+	}
+	if got.Platform != PlatformPodman || got.AccessMode != AccessPodmanCLI || got.Source != SourcePodmanCLI {
+		t.Fatalf("detectToolchain() = %#v", got)
+	}
+}
+
+func TestDetectToolchain_OverridePodmanDockerEngineAPI(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "")
+	t.Setenv(EnvContainerToolchain, "podman-docker-engine-api")
+
+	d := newDetector(mixedToolchainDetectorDeps(t, PlatformDocker))
+
+	got, err := d.detectToolchain(t.Context())
+	if err != nil {
+		t.Fatalf("detectToolchain() error = %v", err)
+	}
+	if got.Platform != PlatformPodman || got.AccessMode != AccessDockerEngineAPI ||
+		got.Source != SourceKnownSocket || got.SocketPath != testPodmanSocketPath {
+		t.Fatalf("detectToolchain() = %#v", got)
+	}
+}
+
+func TestDetectToolchain_OverrideDockerSkipsDefaultPodman(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "")
+	t.Setenv(EnvContainerToolchain, "docker")
+
+	d := newDetector(detectorDeps{
+		detectPlatform: func(context.Context) (ContainerPlatform, error) {
+			return PlatformPodman, nil
+		},
+		dockerContextHost: func(context.Context) (string, error) {
+			return "", errTransientFailure
+		},
+		detectPlatformWithHost: func(_ context.Context, host string) (ContainerPlatform, error) {
+			if host != testDockerSocketHost {
+				t.Fatalf("unexpected host %q", host)
+			}
+			return PlatformDocker, nil
+		},
+		lookupPath: func(string) (string, error) {
+			return "", exec.ErrNotFound
+		},
+		dockerSocketPaths: func() []string { return []string{testDockerSocketPath} },
+		podmanSocketPaths: func() []string { return nil },
+		fileExists:        func(path string) bool { return path == testDockerSocketPath },
+	})
+
+	got, err := d.detectToolchain(t.Context())
+	if err != nil {
+		t.Fatalf("detectToolchain() error = %v", err)
+	}
+	if got.Platform != PlatformDocker || got.AccessMode != AccessDockerEngineAPI || got.Source != SourceKnownSocket {
+		t.Fatalf("detectToolchain() = %#v", got)
+	}
+}
+
+func TestDetectToolchain_OverrideDockerSkipsColimaSocket(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "")
+	t.Setenv(EnvContainerToolchain, "docker")
+
+	d := newDetector(detectorDeps{
+		detectPlatform: func(context.Context) (ContainerPlatform, error) {
+			return PlatformPodman, nil
+		},
+		dockerContextHost: func(context.Context) (string, error) {
+			return "", errTransientFailure
+		},
+		detectPlatformWithHost: func(_ context.Context, host string) (ContainerPlatform, error) {
+			switch host {
+			case testColimaSocketHost:
+				return PlatformColima, nil
+			case testDockerSocketHost:
+				return PlatformDocker, nil
+			default:
+				t.Fatalf("unexpected host %q", host)
+				return PlatformUnknown, nil
+			}
+		},
+		lookupPath: func(string) (string, error) {
+			return "", exec.ErrNotFound
+		},
+		dockerSocketPaths: func() []string { return []string{testColimaSocketPath, testDockerSocketPath} },
+		podmanSocketPaths: func() []string { return nil },
+		fileExists: func(path string) bool {
+			return path == testColimaSocketPath || path == testDockerSocketPath
+		},
+	})
+
+	got, err := d.detectToolchain(t.Context())
+	if err != nil {
+		t.Fatalf("detectToolchain() error = %v", err)
+	}
+	if got.Platform != PlatformDocker || got.AccessMode != AccessDockerEngineAPI ||
+		got.Source != SourceKnownSocket || got.SocketPath != testDockerSocketPath {
+		t.Fatalf("detectToolchain() = %#v", got)
+	}
+}
+
+func TestDetectToolchain_OverrideColimaUsesDockerContext(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "")
+	t.Setenv(EnvContainerToolchain, "colima")
+
+	d := newDetector(mixedToolchainDetectorDeps(t, PlatformDocker))
+
+	got, err := d.detectToolchain(t.Context())
+	if err != nil {
+		t.Fatalf("detectToolchain() error = %v", err)
+	}
+	if got.Platform != PlatformColima || got.AccessMode != AccessDockerEngineAPI || got.Source != SourceDockerContext {
+		t.Fatalf("detectToolchain() = %#v", got)
+	}
+}
+
+func TestDetectToolchain_OverrideInvalidValueReturnsError(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "")
+	t.Setenv(EnvContainerToolchain, "containerd")
+
+	d := newDetector(detectorDeps{})
+
+	_, err := d.detectToolchain(t.Context())
+	if err == nil {
+		t.Fatal("detectToolchain() expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), EnvContainerToolchain) {
+		t.Fatalf("detectToolchain() error = %v, want %s mention", err, EnvContainerToolchain)
 	}
 }


### PR DESCRIPTION
## Description

Adds `STUDIO_CONTAINER_TOOLCHAIN` as an environment-variable override for the shared devenv container runtime detection.

Supported values:
- `auto` or unset: keep the existing Docker-first automatic detection behavior
- `docker`: select Docker via Docker Engine API
- `colima`: select Colima via Docker Engine API
- `podman`: prefer Podman through the Docker-compatible Engine API, fall back to Podman CLI
- `podman-cli`: require Podman CLI
- `podman-docker-engine-api`: require Podman through the Docker-compatible Engine API

This is intentionally implemented in `src/Runtime/devenv` rather than as a studioctl-only option so other devenv consumers can use the same override.

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

Commands run:

```sh
go test -count=1 ./pkg/container
make lint
make test
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New environment override to explicitly select the preferred container runtime (auto, docker, colima, podman, podman-cli, podman-docker-engine-api) with clear validation and consistent errors for unsupported values.
  * Detection now honours requested platform constraints when choosing a runtime.

* **Tests**
  * Expanded test coverage for override behaviours, preferences and fallback paths to improve detection reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio/pull/18999?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->