### PR TITLE
refactor: Create translate context in form component library

### DIFF
--- a/libs/form-component/src/LanguageTranslatorProvider.tsx
+++ b/libs/form-component/src/LanguageTranslatorProvider.tsx
@@ -1,0 +1,37 @@
+import { createContext, type JSX, type PropsWithChildren, useContext } from 'react';
+
+type TranslationParams = (string | number | undefined)[];
+type TranslateFn = (key: string, params?: TranslationParams) => string;
+type TranslateComponent = (args: {
+  tKey: string;
+  params?: TranslationParams;
+}) => string | JSX.Element | JSX.Element[] | null;
+
+type LanguageTranslatorContextProps = {
+  translate: TranslateFn;
+  TranslateComponent: TranslateComponent;
+};
+
+const contextNoTranslate: LanguageTranslatorContextProps = {
+  translate: (key) => key,
+  TranslateComponent: ({ tKey }) => tKey,
+};
+
+const LanguageTranslatorContext = createContext<LanguageTranslatorContextProps>(contextNoTranslate);
+
+export function LanguageTranslatorProvider({
+  translate,
+  TranslateComponent,
+  children,
+}: PropsWithChildren<LanguageTranslatorContextProps>) {
+  return (
+    <LanguageTranslatorContext.Provider value={{ translate, TranslateComponent }}>
+      {children}
+    </LanguageTranslatorContext.Provider>
+  );
+}
+
+export function useTranslation(): LanguageTranslatorContextProps {
+  const context = useContext(LanguageTranslatorContext);
+  return context;
+}

--- a/libs/form-component/src/app-components/Input/Input.stories.tsx
+++ b/libs/form-component/src/app-components/Input/Input.stories.tsx
@@ -61,9 +61,9 @@ export const WithCharacterLimit: Story = {
   args: {
     label: 'Short bio',
     characterLimit: {
-      limit: 50,
-      under: 'characters remaining',
-      over: 'characters too many',
+      limit: 30,
+      under: '%d characters remaining',
+      over: '%d characters too many',
     },
   },
 };

--- a/libs/form-component/src/index.ts
+++ b/libs/form-component/src/index.ts
@@ -8,4 +8,6 @@ export type {
 export { FormComponentActionType } from './types/FormComponentActionType';
 export type { DataModelBinding } from './types/DataModelBinding';
 
+export { LanguageTranslatorProvider } from './LanguageTranslatorProvider';
+
 export * from './app-components';

--- a/src/App/frontend/src/AppLanguageTranslatorProvider.tsx
+++ b/src/App/frontend/src/AppLanguageTranslatorProvider.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import type { PropsWithChildren } from 'react';
+
+import { LanguageTranslatorProvider } from '@app/form-component';
+
+import { Lang } from 'src/features/language/Lang';
+import { useLanguage } from 'src/features/language/useLanguage';
+
+export function AppLanguageTranslatorProvider({ children }: PropsWithChildren) {
+  const { langAsString } = useLanguage();
+
+  return (
+    <LanguageTranslatorProvider
+      translate={langAsString}
+      TranslateComponent={({ tKey, params }) => (
+        <Lang
+          id={tKey}
+          params={params}
+        />
+      )}
+    >
+      {children}
+    </LanguageTranslatorProvider>
+  );
+}

--- a/src/App/frontend/src/AppLayout.tsx
+++ b/src/App/frontend/src/AppLayout.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Outlet, ScrollRestoration } from 'react-router';
 import { Slide, ToastContainer } from 'react-toastify';
 
+import { AppLanguageTranslatorProvider } from 'src/AppLanguageTranslatorProvider';
 import { ErrorBoundary } from 'src/components/ErrorBoundary';
 import { ViewportWrapper } from 'src/components/ViewportWrapper';
 import { KeepAliveProvider } from 'src/core/auth/KeepAliveProvider';
@@ -14,28 +15,30 @@ import { PartyPrefetcher } from 'src/queries/partyPrefetcher';
 export function AppLayout() {
   return (
     <>
-      <NavigationFocusStateProvider>
-        <ErrorBoundary>
-          <ViewportWrapper>
-            <UiConfigProvider>
-              <GlobalFormDataReadersProvider>
-                <PartyProvider>
-                  <KeepAliveProvider>
-                    <Outlet />
-                    <ToastContainer
-                      position='top-center'
-                      theme='colored'
-                      transition={Slide}
-                      draggable={false}
-                    />
-                  </KeepAliveProvider>
-                </PartyProvider>
-                <PartyPrefetcher />
-              </GlobalFormDataReadersProvider>
-            </UiConfigProvider>
-          </ViewportWrapper>
-        </ErrorBoundary>
-      </NavigationFocusStateProvider>
+      <AppLanguageTranslatorProvider>
+        <NavigationFocusStateProvider>
+          <ErrorBoundary>
+            <ViewportWrapper>
+              <UiConfigProvider>
+                <GlobalFormDataReadersProvider>
+                  <PartyProvider>
+                    <KeepAliveProvider>
+                      <Outlet />
+                      <ToastContainer
+                        position='top-center'
+                        theme='colored'
+                        transition={Slide}
+                        draggable={false}
+                      />
+                    </KeepAliveProvider>
+                  </PartyProvider>
+                  <PartyPrefetcher />
+                </GlobalFormDataReadersProvider>
+              </UiConfigProvider>
+            </ViewportWrapper>
+          </ErrorBoundary>
+        </NavigationFocusStateProvider>
+      </AppLanguageTranslatorProvider>
       <ScrollRestoration />
     </>
   );


### PR DESCRIPTION
Add a context that provided methods to use for translating text

## Description

Add a LanguageTranslator context which has methods for translating the text.
The motivation behind this is that AppLayout components can now translate text by using values from this context. This enables us to render AppLayout components as standalone components in unit test or storybook by providing a dummy implementation of the translate function.

The implemented pattern is very similar to what was previously done in AppComponentBridge. One difference is that we currently provide a default value of the context, so components can render in unittest etc without having to set up a context provider.

## Verification

- [x] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
