### PR TITLE
chore: release studioctl v0.1.0-preview.11

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -8,6 +8,8 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+## [0.1.0-preview.11] - 2026-05-29
+
 ### Added
 
 - Add `apps search` for discovering app repositories in Altinn Studio.


### PR DESCRIPTION
## Description

Prepare release v0.1.0-preview.11

- [Added] Add `apps search` for discovering app repositories in Altinn Studio.
- [Fixed] Support starting localtest with rootless Podman setups where the host user has a large domain UID/GID outside the default subordinate ID mapping.
- [Fixed] Relabel localtest bind mounts on SELinux-enabled Podman setups so containers can read generated resources.

@coderabbitai ignore

**Full Changelog**: https://github.com/Altinn/altinn-studio/compare/studioctl/v0.1.0-preview.10...studioctl/v0.1.0-preview.11