### PR TITLE
fix(resource-adm): add max-width to resource title cell in resource table

### DIFF
--- a/src/Designer/frontend/resourceadm/components/ResourceTable/ResourceTable.module.css
+++ b/src/Designer/frontend/resourceadm/components/ResourceTable/ResourceTable.module.css
@@ -13,3 +13,9 @@
   flex-wrap: wrap;
   gap: var(--ds-size-1);
 }
+
+.titleCell {
+  max-width: 20rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/src/Designer/frontend/resourceadm/components/ResourceTable/ResourceTable.tsx
+++ b/src/Designer/frontend/resourceadm/components/ResourceTable/ResourceTable.tsx
@@ -148,6 +148,7 @@ export const ResourceTable = ({
       accessor: 'title',
       heading: t('dashboard.resource_table_header_name'),
       sortable: true,
+      bodyCellClass: classes.titleCell,
     },
     {
       accessor: 'identifier',


### PR DESCRIPTION
## Description
- Add max-width to resource title cell in resource table, to prevent long horizontal scrollbar in title with no spacing

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved resource table title presentation with text truncation. Long titles now display with ellipsis and are constrained to a fixed width, preventing overflow and maintaining consistent table layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->