### PR TITLE
fix(resource-adm): Set dates to disable Altinn 2 resource operations using SBLBridge implementations

### DIFF
--- a/src/Designer/frontend/resourceadm/components/ImportResourceModal/ImportResourceModal.tsx
+++ b/src/Designer/frontend/resourceadm/components/ImportResourceModal/ImportResourceModal.tsx
@@ -25,6 +25,7 @@ import {
   getValidIdentifierPrefixes,
 } from '../../utils/resourceUtils';
 import { ResourceAdmDialogContent } from '../ResourceAdmDialogContent/ResourceAdmDialogContent';
+import { isProdSBLBridgeEnabled, isTT02SBLBridgeEnabled } from 'resourceadm/utils/userUtils';
 
 export type ImportResourceModalProps = {
   onClose: () => void;
@@ -151,11 +152,20 @@ export const ImportResourceModal = forwardRef<HTMLDialogElement, ImportResourceM
               <StudioSelect.Option value={''} disabled>
                 {t('resourceadm.dashboard_import_modal_select_env_option')}
               </StudioSelect.Option>
-              {environmentOptions.map((env) => (
-                <StudioSelect.Option key={env.id} value={env.id}>
-                  {t(env.label)}
-                </StudioSelect.Option>
-              ))}
+              {environmentOptions
+                .filter((env) => {
+                  if (env.id === 'tt02') {
+                    return isTT02SBLBridgeEnabled();
+                  } else if (env.id === 'prod') {
+                    return isProdSBLBridgeEnabled();
+                  }
+                  return true;
+                })
+                .map((env) => (
+                  <StudioSelect.Option key={env.id} value={env.id}>
+                    {t(env.label)}
+                  </StudioSelect.Option>
+                ))}
             </StudioSelect>
             {selectedEnv && (
               <div>

--- a/src/Designer/frontend/resourceadm/pages/MigrationPage/MigrationPage.test.tsx
+++ b/src/Designer/frontend/resourceadm/pages/MigrationPage/MigrationPage.test.tsx
@@ -14,6 +14,12 @@ const defaultProps: MigrationPageProps = {
   serviceEdition: '2',
 };
 
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({
+    org: 'ttd',
+  }),
+}));
 jest.mock('../../utils/userUtils/userUtils', () => ({
   ...jest.requireActual('../../utils/userUtils/userUtils'),
   isTT02SBLBridgeEnabled: jest.fn().mockReturnValue(true),
@@ -72,7 +78,7 @@ describe('MigrationPage', () => {
               environment: 'at23',
             },
             {
-              version: null,
+              version: '1',
               environment: 'at24',
             },
             {

--- a/src/Designer/frontend/resourceadm/pages/MigrationPage/MigrationPage.test.tsx
+++ b/src/Designer/frontend/resourceadm/pages/MigrationPage/MigrationPage.test.tsx
@@ -14,6 +14,12 @@ const defaultProps: MigrationPageProps = {
   serviceEdition: '2',
 };
 
+jest.mock('../../utils/userUtils/userUtils', () => ({
+  ...jest.requireActual('../../utils/userUtils/userUtils'),
+  isTT02SBLBridgeEnabled: jest.fn().mockReturnValue(true),
+  isProdSBLBridgeEnabled: jest.fn().mockReturnValue(true),
+}));
+
 describe('MigrationPage', () => {
   it('Should show status alerts for migration ready status', async () => {
     renderMigrationPage({

--- a/src/Designer/frontend/resourceadm/pages/MigrationPage/MigrationPage.tsx
+++ b/src/Designer/frontend/resourceadm/pages/MigrationPage/MigrationPage.tsx
@@ -7,6 +7,7 @@ import { useUrlParams } from '../../hooks/useUrlParams';
 import { getAvailableEnvironments } from '../../utils/resourceUtils';
 import { MigrationPanel } from '../../components/MigrationPanel';
 import { altinnDocsUrl } from 'app-shared/ext-urls';
+import { isTT02SBLBridgeEnabled, isProdSBLBridgeEnabled } from 'resourceadm/utils/userUtils';
 
 export type MigrationPageProps = {
   id: string;
@@ -82,18 +83,27 @@ export const MigrationPage = ({
           </StudioHeading>
           <StudioParagraph>{t('resourceadm.migration_select_environment_body')}</StudioParagraph>
           <div className={classes.environmentWrapper}>
-            {envPublishStatus.map((env) => {
-              const isPublishedInEnv = env.isResourcePublished;
-              return (
-                <MigrationPanel
-                  key={env.id}
-                  serviceCode={serviceCode}
-                  serviceEdition={serviceEdition}
-                  env={env}
-                  isPublishedInEnv={isPublishedInEnv}
-                />
-              );
-            })}
+            {envPublishStatus
+              .filter((env) => {
+                if (env.id === 'tt02') {
+                  return isTT02SBLBridgeEnabled();
+                } else if (env.id === 'prod') {
+                  return isProdSBLBridgeEnabled();
+                }
+                return false;
+              })
+              .map((env) => {
+                const isPublishedInEnv = env.isResourcePublished;
+                return (
+                  <MigrationPanel
+                    key={env.id}
+                    serviceCode={serviceCode}
+                    serviceEdition={serviceEdition}
+                    env={env}
+                    isPublishedInEnv={isPublishedInEnv}
+                  />
+                );
+              })}
           </div>
         </div>
       </>

--- a/src/Designer/frontend/resourceadm/pages/MigrationPage/MigrationPage.tsx
+++ b/src/Designer/frontend/resourceadm/pages/MigrationPage/MigrationPage.tsx
@@ -90,7 +90,7 @@ export const MigrationPage = ({
                 } else if (env.id === 'prod') {
                   return isProdSBLBridgeEnabled();
                 }
-                return false;
+                return true;
               })
               .map((env) => {
                 const isPublishedInEnv = env.isResourcePublished;

--- a/src/Designer/frontend/resourceadm/pages/ResourceDashboardPage/ResourceDashboardPage.test.tsx
+++ b/src/Designer/frontend/resourceadm/pages/ResourceDashboardPage/ResourceDashboardPage.test.tsx
@@ -65,6 +65,12 @@ jest.mock('react-router-dom', () => ({
   }),
 }));
 
+jest.mock('../../utils/userUtils/userUtils', () => ({
+  ...jest.requireActual('../../utils/userUtils/userUtils'),
+  isTT02SBLBridgeEnabled: jest.fn().mockReturnValue(true),
+  isProdSBLBridgeEnabled: jest.fn().mockReturnValue(true),
+}));
+
 describe('ResourceDashBoardPage', () => {
   afterEach(() => {
     jest.clearAllMocks();

--- a/src/Designer/frontend/resourceadm/pages/ResourceDashboardPage/ResourceDashboardPage.tsx
+++ b/src/Designer/frontend/resourceadm/pages/ResourceDashboardPage/ResourceDashboardPage.tsx
@@ -18,6 +18,7 @@ import { ImportAltinn3ResourceModal } from '../../components/ImportAltinn3Resour
 import { useImportResourceFromAltinn3Mutation } from '../../hooks/mutations/useImportResourceFromAltinn3Mutation';
 import type { EnvId } from '../../utils/resourceUtils';
 import type { Resource } from 'app-shared/types/ResourceAdm';
+import { isProdSBLBridgeEnabled, isTT02SBLBridgeEnabled } from 'resourceadm/utils/userUtils';
 
 /**
  * @component
@@ -136,15 +137,19 @@ export const ResourceDashboardPage = (): React.JSX.Element => {
             <strong>{t('resourceadm.dashboard_change_organization_lists')}</strong>
           </StudioButton>
           <div className={classes.verticalDivider} data-color='neutral' />
-          <StudioButton
-            variant='tertiary'
-            onClick={() => importAltinn2ServiceModalRef.current.showModal()}
-            data-size='md'
-            icon={<MigrationIcon />}
-          >
-            <strong>{t('resourceadm.dashboard_import_resource')}</strong>
-          </StudioButton>
-          <div className={classes.verticalDivider} data-color='neutral' />
+          {(isTT02SBLBridgeEnabled() || isProdSBLBridgeEnabled()) && (
+            <>
+              <StudioButton
+                variant='tertiary'
+                onClick={() => importAltinn2ServiceModalRef.current.showModal()}
+                data-size='md'
+                icon={<MigrationIcon />}
+              >
+                <strong>{t('resourceadm.dashboard_import_resource')}</strong>
+              </StudioButton>
+              <div className={classes.verticalDivider} data-color='neutral' />
+            </>
+          )}
           <StudioButton
             variant='tertiary'
             onClick={() => createResourceModalRef.current?.showModal()}

--- a/src/Designer/frontend/resourceadm/pages/ResourcePage/ResourcePage.test.tsx
+++ b/src/Designer/frontend/resourceadm/pages/ResourcePage/ResourcePage.test.tsx
@@ -50,6 +50,12 @@ jest.mock('react-router-dom', () => ({
   }),
 }));
 
+jest.mock('../../utils/userUtils/userUtils', () => ({
+  ...jest.requireActual('../../utils/userUtils/userUtils'),
+  isTT02SBLBridgeEnabled: jest.fn().mockReturnValue(true),
+  isProdSBLBridgeEnabled: jest.fn().mockReturnValue(true),
+}));
+
 describe('ResourcePage', () => {
   afterEach(() => {
     jest.clearAllMocks();

--- a/src/Designer/frontend/resourceadm/pages/ResourcePage/ResourcePage.tsx
+++ b/src/Designer/frontend/resourceadm/pages/ResourcePage/ResourcePage.tsx
@@ -28,6 +28,7 @@ import { useUrlParams } from '../../hooks/useUrlParams';
 import { StudioContentMenu, StudioSpinner } from '@studio/components';
 import type { StudioContentMenuButtonTabProps } from '@studio/components';
 import { useGetConsentTemplates } from '../../hooks/queries/useGetConsentTemplates';
+import { isProdSBLBridgeEnabled, isTT02SBLBridgeEnabled } from 'resourceadm/utils/userUtils';
 
 /**
  * @component
@@ -169,7 +170,11 @@ export const ResourcePage = (): React.JSX.Element => {
    * Decide if the migration page should be accessible or not
    */
   const isMigrateEnabled = (): boolean => {
-    return !!altinn2References && resourceData.resourceType === 'GenericAccessResource';
+    return (
+      !!altinn2References &&
+      resourceData.resourceType === 'GenericAccessResource' &&
+      (isTT02SBLBridgeEnabled() || isProdSBLBridgeEnabled())
+    );
   };
 
   const aboutPageId = 'about';

--- a/src/Designer/frontend/resourceadm/utils/userUtils/index.ts
+++ b/src/Designer/frontend/resourceadm/utils/userUtils/index.ts
@@ -1,1 +1,6 @@
-export { userHasAccessToOrganization, getOrgNameByUsername } from './userUtils';
+export {
+  userHasAccessToOrganization,
+  getOrgNameByUsername,
+  isTT02SBLBridgeEnabled,
+  isProdSBLBridgeEnabled,
+} from './userUtils';

--- a/src/Designer/frontend/resourceadm/utils/userUtils/userUtils.ts
+++ b/src/Designer/frontend/resourceadm/utils/userUtils/userUtils.ts
@@ -14,3 +14,11 @@ export const getOrgNameByUsername = (username: string, orgs: Organization[]) => 
   const org = orgs?.find((o) => o.username === username);
   return org?.full_name || org?.username;
 };
+
+export const isTT02SBLBridgeEnabled = () => {
+  return new Date() <= new Date('2026-06-05T00:00:00Z');
+};
+
+export const isProdSBLBridgeEnabled = () => {
+  return new Date() <= new Date('2026-06-20T00:00:00Z');
+};


### PR DESCRIPTION
## Description
- Disable option to import link service from Altinn 2, and migrate delegations on the given dates:
    - TT02: 05.06.26 00:00
    - PROD: 20.06.26 00:00
    
These are the times when SBL Bridge is disabled in the given environment

## Issue
- https://github.com/Altinn/altinn-authorization-tmp/issues/3256

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resource migration and import options now appear only when the corresponding environment bridge is enabled, allowing controlled rollout in TT02 and production.

* **Tests**
  * Test suites updated to account for the environment bridge enablement during validation of migration and dashboard behaviours.

* **Chores**
  * Added internal feature-flag checks to support conditional rendering of migration/import UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->