### PR TITLE
chore: Log workflow engine startup readiness

### DIFF
--- a/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/appsettings.json
+++ b/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/appsettings.json
@@ -2,6 +2,7 @@
   "Logging": {
     "LogLevel": {
       "Default": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information",
       "Microsoft.AspNetCore": "Warning",
       "Microsoft.EntityFrameworkCore": "Warning",
       "WorkflowEngine.Data.Services": "Information"


### PR DESCRIPTION
The workflow engine app suppressed `Microsoft.Hosting.Lifetime` (it inherited `Default: Warning`), so startup logged no readiness signal -- neither the `Now listening on:` line nor `Application started.`.

This sets that category to `Information` so the standard host-lifetime lines appear on boot (and at shutdown), matching the convention already used by `operator` and `localtest`.

`Microsoft.AspNetCore` and `Microsoft.EntityFrameworkCore` stay at `Warning`, so there is no per-request / SQL noise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated logging configuration to capture additional diagnostic information during application startup and runtime operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->