### PR TITLE
fix(studioctl v8→v9): keep subform-referenced layout sets out of task-folder migration

### DIFF
--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/LayoutSetsMigration/LayoutSetsToTaskUiMigrator.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/LayoutSetsMigration/LayoutSetsToTaskUiMigrator.cs
@@ -54,7 +54,8 @@ internal sealed class LayoutSetsToTaskUiMigrator : IDisposable
             throw new InvalidOperationException("layout-sets.json is missing a 'sets' array.");
         }
 
-        var plans = BuildPlans(uiPath, sets);
+        var subformReferencedSets = CollectSubformLayoutSetReferences(uiPath);
+        var plans = BuildPlans(uiPath, sets, subformReferencedSets);
         ValidateCollisions(uiPath, plans);
 
         var touchedFolders = new HashSet<string>(StringComparer.Ordinal);
@@ -187,7 +188,11 @@ internal sealed class LayoutSetsToTaskUiMigrator : IDisposable
         }
     }
 
-    private static List<LayoutSetMigrationPlan> BuildPlans(string uiPath, JsonArray sets)
+    private static List<LayoutSetMigrationPlan> BuildPlans(
+        string uiPath,
+        JsonArray sets,
+        HashSet<string> subformReferencedSets
+    )
     {
         var plans = new List<LayoutSetMigrationPlan>();
         foreach (var setNode in sets)
@@ -209,17 +214,97 @@ internal sealed class LayoutSetsToTaskUiMigrator : IDisposable
                 throw new InvalidOperationException($"Missing UI folder for layout set '{sourceId}' ({sourcePath}).");
             }
 
+            // A set referenced by a Subform component is never bound to a task — the v9 task-folder
+            // layout is for top-level layouts. Ignore any 'tasks' it has and keep the folder name.
+            var tasksArray = setObject["tasks"] as JsonArray;
+            if (subformReferencedSets.Contains(sourceId) && tasksArray is { Count: > 0 })
+            {
+                UpgradeConsole.WriteLine(
+                    $"Layout set '{sourceId}' is referenced by a Subform component; ignoring its 'tasks' entry and keeping it as a subform folder."
+                );
+                tasksArray = null;
+            }
+
             plans.Add(
                 new LayoutSetMigrationPlan(
                     sourceId,
                     sourcePath,
-                    ResolveDestinationFolderIds(sourceId, setObject["tasks"] as JsonArray),
+                    ResolveDestinationFolderIds(sourceId, tasksArray),
                     setObject["dataType"]?.GetValue<string>()
                 )
             );
         }
 
         return plans;
+    }
+
+    /// <summary>
+    /// Scans every layout JSON under <paramref name="uiPath"/> for Subform components and returns
+    /// the set of <c>layoutSet</c> ids they reference. Tolerant of malformed files — they're skipped.
+    /// </summary>
+    private static HashSet<string> CollectSubformLayoutSetReferences(string uiPath)
+    {
+        var refs = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var setFolder in Directory.GetDirectories(uiPath))
+        {
+            var layoutsFolder = Path.Combine(setFolder, "layouts");
+            if (!Directory.Exists(layoutsFolder))
+            {
+                continue;
+            }
+
+            foreach (var file in Directory.GetFiles(layoutsFolder, "*.json"))
+            {
+                JsonNode? root;
+                try
+                {
+                    root = JsonNode.Parse(File.ReadAllText(file));
+                }
+                catch
+                {
+                    continue;
+                }
+
+                if (root?["data"]?["layout"] is not JsonArray layoutArray)
+                {
+                    continue;
+                }
+
+                CollectSubformReferencesFromNode(layoutArray, refs);
+            }
+        }
+
+        return refs;
+    }
+
+    private static void CollectSubformReferencesFromNode(JsonNode? node, HashSet<string> refs)
+    {
+        switch (node)
+        {
+            case JsonArray array:
+                foreach (var item in array)
+                {
+                    CollectSubformReferencesFromNode(item, refs);
+                }
+                break;
+            case JsonObject obj:
+                if (
+                    obj["type"] is JsonValue typeValue
+                    && typeValue.TryGetValue<string>(out var typeName)
+                    && string.Equals(typeName, "Subform", StringComparison.Ordinal)
+                    && obj["layoutSet"] is JsonValue layoutSetValue
+                    && layoutSetValue.TryGetValue<string>(out var layoutSetId)
+                    && !string.IsNullOrWhiteSpace(layoutSetId)
+                )
+                {
+                    refs.Add(layoutSetId);
+                }
+                foreach (var kvp in obj)
+                {
+                    CollectSubformReferencesFromNode(kvp.Value, refs);
+                }
+                break;
+        }
     }
 
     private static void ValidateCollisions(string uiPath, List<LayoutSetMigrationPlan> plans)

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/LayoutSetsMigration/LayoutSetsToTaskUiMigrator.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/LayoutSetsMigration/LayoutSetsToTaskUiMigrator.cs
@@ -291,7 +291,7 @@ internal sealed class LayoutSetsToTaskUiMigrator : IDisposable
                 if (
                     obj["type"] is JsonValue typeValue
                     && typeValue.TryGetValue<string>(out var typeName)
-                    && string.Equals(typeName, "Subform", StringComparison.Ordinal)
+                    && string.Equals(typeName, "Subform", StringComparison.OrdinalIgnoreCase)
                     && obj["layoutSet"] is JsonValue layoutSetValue
                     && layoutSetValue.TryGetValue<string>(out var layoutSetId)
                     && !string.IsNullOrWhiteSpace(layoutSetId)


### PR DESCRIPTION
## Description

The `studioctl app upgrade v9` layout-sets migrator renames every set's UI folder to its first `tasks` id. That fails when two sets target the same task — even when one of them is actually a subform referenced via `layoutSet` from a `Subform` component in the other:

```
Error migrating layout-sets.json: Cannot migrate layout sets 'hovedskjema' and 'underskjema'
to 'Utfylling'. Multiple layout sets target the same destination folder.
```

v9 doesn't bind subform layouts to tasks, so the `tasks` entry on those sets is meaningless config v8 happened to tolerate. As one of the frontend devs put it:

> Den burde sikkert se gjennom layout-filene og ikke endre navn på en mappe om det er brukt fra en underskjema-komponent. Egentlig er det vel appen som ikke skulle ha konfigurert noe i layout-sets.json for det underskjemaet, jeg mener vi ikke har lagt opp til at man knytter et underskjema til en task.

### Change

In `LayoutSetsToTaskUiMigrator`:

- Before building migration plans, recursively scan every `<ui>/<set>/layouts/*.json` for `{"type": "Subform", "layoutSet": "..."}` components and collect the referenced set ids.
- When building the plan for a set whose id is in that collected set, ignore its `tasks` array — keep the source folder name (subform behavior) instead of folding it into a task folder.
- Print a one-line notice via `UpgradeConsole` so the developer sees why the set wasn't folded.
- Layout-scan is tolerant: malformed or non-layout JSON files are skipped, not fatal.

Apps with correctly-configured subforms (no `tasks` array) are unaffected — they already hit the `tasks` is null/empty branch and keep their folder name.

## Verification

- [x] Builds clean (`dotnet build` on `studioctl-server.csproj` — 0 warnings, 0 errors)
- [x] Manual testing: drove the migrator directly against a synthesized fixture mirroring the failing real-world case (two sets `hovedskjema`/`underskjema` both targeting task `Utfylling`, with a Subform component in `hovedskjema` referencing `underskjema`, plus a third set `Signering` on task `Signering`). Result: `hovedskjema/` → `Utfylling/`, `underskjema/` kept as-is, `Signering/` unchanged, notice printed, no collision.
- [x] Regression check: existing two-app upgrade runs (no subforms in `layout-sets.json`) still produce the same task-folder migrations they did before — the new branch only kicks in when a set's id is actually referenced by a Subform component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of subform-referenced layouts during system upgrades to ensure correct migration of associated layout configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->