### PR TITLE
accept select several pages or layoutsets

### DIFF
--- a/src/Designer/backend/src/Designer/Controllers/UiFoldersController.cs
+++ b/src/Designer/backend/src/Designer/Controllers/UiFoldersController.cs
@@ -66,7 +66,11 @@ public class UiFoldersController : Controller
         if (pages == null || pages.Count == 0)
         {
             return Ok(
-                await _uiFoldersService.GetLayoutSetsValidationOnNavigation(editingContext, layoutSets, cancellationToken)
+                await _uiFoldersService.GetLayoutSetsValidationOnNavigation(
+                    editingContext,
+                    layoutSets,
+                    cancellationToken
+                )
             );
         }
 
@@ -77,7 +81,12 @@ public class UiFoldersController : Controller
         }
 
         return Ok(
-            await _uiFoldersService.GetPagesValidationOnNavigation(editingContext, layoutSets[0], pages, cancellationToken)
+            await _uiFoldersService.GetPagesValidationOnNavigation(
+                editingContext,
+                layoutSets[0],
+                pages,
+                cancellationToken
+            )
         );
     }
 
@@ -102,7 +111,12 @@ public class UiFoldersController : Controller
 
         if (pages == null || pages.Count == 0)
         {
-            await _uiFoldersService.SaveLayoutSetsValidationOnNavigation(editingContext, layoutSets, config, cancellationToken);
+            await _uiFoldersService.SaveLayoutSetsValidationOnNavigation(
+                editingContext,
+                layoutSets,
+                config,
+                cancellationToken
+            );
             return Ok();
         }
 
@@ -112,7 +126,13 @@ public class UiFoldersController : Controller
             return BadRequest("Exactly one layoutSet must be specified when saving pages.");
         }
 
-        await _uiFoldersService.SavePagesValidationOnNavigation(editingContext, layoutSets[0], pages, config, cancellationToken);
+        await _uiFoldersService.SavePagesValidationOnNavigation(
+            editingContext,
+            layoutSets[0],
+            pages,
+            config,
+            cancellationToken
+        );
         return Ok();
     }
 
@@ -135,7 +155,12 @@ public class UiFoldersController : Controller
 
         if (pages == null || pages.Count == 0)
         {
-            await _uiFoldersService.SaveLayoutSetsValidationOnNavigation(editingContext, layoutSets, null, cancellationToken);
+            await _uiFoldersService.SaveLayoutSetsValidationOnNavigation(
+                editingContext,
+                layoutSets,
+                null,
+                cancellationToken
+            );
             return Ok();
         }
 
@@ -145,7 +170,13 @@ public class UiFoldersController : Controller
             return BadRequest("Exactly one layoutSet must be specified when deleting pages.");
         }
 
-        await _uiFoldersService.SavePagesValidationOnNavigation(editingContext, layoutSets[0], pages, null, cancellationToken);
+        await _uiFoldersService.SavePagesValidationOnNavigation(
+            editingContext,
+            layoutSets[0],
+            pages,
+            null,
+            cancellationToken
+        );
         return Ok();
     }
 

--- a/src/Designer/backend/src/Designer/Controllers/UiFoldersController.cs
+++ b/src/Designer/backend/src/Designer/Controllers/UiFoldersController.cs
@@ -51,27 +51,33 @@ public class UiFoldersController : Controller
     public async Task<IActionResult> GetValidationOnNavigation(
         string org,
         string app,
-        [FromQuery] string? layoutSet,
-        [FromQuery] string? page,
+        [FromQuery] List<string>? layoutSets,
+        [FromQuery] List<string>? pages,
         CancellationToken cancellationToken
     )
     {
         AltinnRepoEditingContext editingContext = CreateContext(org, app);
 
-        if (layoutSet == null)
+        if (layoutSets == null || layoutSets.Count == 0)
         {
             return Ok(await _uiFoldersService.GetGlobalValidationOnNavigation(editingContext, cancellationToken));
         }
 
-        if (page == null)
+        if (pages == null || pages.Count == 0)
         {
             return Ok(
-                await _uiFoldersService.GetLayoutSetValidationOnNavigation(editingContext, layoutSet, cancellationToken)
+                await _uiFoldersService.GetLayoutSetsValidationOnNavigation(editingContext, layoutSets, cancellationToken)
             );
         }
 
+        //if page-level config is being used, only one layoutSet can be selected each time.
+        if (layoutSets.Count != 1)
+        {
+            return BadRequest("Exactly one layoutSet must be specified when querying pages.");
+        }
+
         return Ok(
-            await _uiFoldersService.GetPageValidationOnNavigation(editingContext, layoutSet, page, cancellationToken)
+            await _uiFoldersService.GetPagesValidationOnNavigation(editingContext, layoutSets[0], pages, cancellationToken)
         );
     }
 
@@ -80,38 +86,33 @@ public class UiFoldersController : Controller
     public async Task<IActionResult> SaveValidationOnNavigation(
         string org,
         string app,
-        [FromQuery] string? layoutSet,
-        [FromQuery] string? page,
+        [FromQuery] List<string>? layoutSets,
+        [FromQuery] List<string>? pages,
         [FromBody] ValidationOnNavigation config,
         CancellationToken cancellationToken
     )
     {
         AltinnRepoEditingContext editingContext = CreateContext(org, app);
 
-        if (layoutSet == null)
+        if (layoutSets == null || layoutSets.Count == 0)
         {
             await _uiFoldersService.SaveGlobalValidationOnNavigation(editingContext, config, cancellationToken);
             return Ok();
         }
 
-        if (page == null)
+        if (pages == null || pages.Count == 0)
         {
-            await _uiFoldersService.SaveLayoutSetValidationOnNavigation(
-                editingContext,
-                layoutSet,
-                config,
-                cancellationToken
-            );
+            await _uiFoldersService.SaveLayoutSetsValidationOnNavigation(editingContext, layoutSets, config, cancellationToken);
             return Ok();
         }
 
-        await _uiFoldersService.SavePageValidationOnNavigation(
-            editingContext,
-            layoutSet,
-            page,
-            config,
-            cancellationToken
-        );
+        //if page-level config is being used, only one layoutSet can be selected each time.
+        if (layoutSets.Count != 1)
+        {
+            return BadRequest("Exactly one layoutSet must be specified when saving pages.");
+        }
+
+        await _uiFoldersService.SavePagesValidationOnNavigation(editingContext, layoutSets[0], pages, config, cancellationToken);
         return Ok();
     }
 
@@ -119,37 +120,32 @@ public class UiFoldersController : Controller
     public async Task<IActionResult> DeleteValidationOnNavigation(
         string org,
         string app,
-        [FromQuery] string? layoutSet,
-        [FromQuery] string? page,
+        [FromQuery] List<string>? layoutSets,
+        [FromQuery] List<string>? pages,
         CancellationToken cancellationToken
     )
     {
         AltinnRepoEditingContext editingContext = CreateContext(org, app);
 
-        if (layoutSet == null)
+        if (layoutSets == null || layoutSets.Count == 0)
         {
             await _uiFoldersService.SaveGlobalValidationOnNavigation(editingContext, null, cancellationToken);
             return Ok();
         }
 
-        if (page == null)
+        if (pages == null || pages.Count == 0)
         {
-            await _uiFoldersService.SaveLayoutSetValidationOnNavigation(
-                editingContext,
-                layoutSet,
-                null,
-                cancellationToken
-            );
+            await _uiFoldersService.SaveLayoutSetsValidationOnNavigation(editingContext, layoutSets, null, cancellationToken);
             return Ok();
         }
 
-        await _uiFoldersService.SavePageValidationOnNavigation(
-            editingContext,
-            layoutSet,
-            page,
-            null,
-            cancellationToken
-        );
+        //if page-level config is being used, only one layoutSet can be selected each time.
+        if (layoutSets.Count != 1)
+        {
+            return BadRequest("Exactly one layoutSet must be specified when deleting pages.");
+        }
+
+        await _uiFoldersService.SavePagesValidationOnNavigation(editingContext, layoutSets[0], pages, null, cancellationToken);
         return Ok();
     }
 

--- a/src/Designer/backend/src/Designer/Services/Implementation/UiFoldersService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/UiFoldersService.cs
@@ -127,70 +127,86 @@ public class UiFoldersService : IUiFoldersService
         await altinnAppGitRepository.SaveGlobalSettingsFile(globalSettingsFile);
     }
 
-    public async Task<ValidationOnNavigation?> GetLayoutSetValidationOnNavigation(
+    public async Task<Dictionary<string, ValidationOnNavigation?>> GetLayoutSetsValidationOnNavigation(
         AltinnRepoEditingContext editingContext,
-        string layoutSetId,
+        IEnumerable<string> layoutSetIds,
         CancellationToken cancellationToken
     )
     {
         cancellationToken.ThrowIfCancellationRequested();
         AltinnAppGitRepository repository = GetRepository(editingContext);
-        LayoutSettings layoutSettings = await repository.GetLayoutSettings(layoutSetId, cancellationToken);
-        return layoutSettings.Pages?.ValidationOnNavigation;
+        Dictionary<string, ValidationOnNavigation?> results = [];
+        foreach (string layoutSetId in layoutSetIds)
+        {
+            LayoutSettings layoutSettings = await repository.GetLayoutSettings(layoutSetId, cancellationToken);
+            results[layoutSetId] = layoutSettings.Pages?.ValidationOnNavigation;
+        }
+        return results;
     }
 
-    public async Task SaveLayoutSetValidationOnNavigation(
+    public async Task SaveLayoutSetsValidationOnNavigation(
         AltinnRepoEditingContext editingContext,
-        string layoutSetId,
+        IEnumerable<string> layoutSetIds,
         ValidationOnNavigation? config,
         CancellationToken cancellationToken
     )
     {
         cancellationToken.ThrowIfCancellationRequested();
         AltinnAppGitRepository repository = GetRepository(editingContext);
-        LayoutSettings layoutSettings = await repository.GetLayoutSettings(layoutSetId, cancellationToken);
-        layoutSettings.Pages ??= new Pages();
-        layoutSettings.Pages.ValidationOnNavigation = config;
-        await repository.SaveLayoutSettings(layoutSetId, layoutSettings);
+        foreach (string layoutSetId in layoutSetIds)
+        {
+            LayoutSettings layoutSettings = await repository.GetLayoutSettings(layoutSetId, cancellationToken);
+            layoutSettings.Pages ??= new Pages();
+            layoutSettings.Pages.ValidationOnNavigation = config;
+            await repository.SaveLayoutSettings(layoutSetId, layoutSettings);
+        }
     }
 
-    public async Task<ValidationOnNavigation?> GetPageValidationOnNavigation(
+    public async Task<Dictionary<string, ValidationOnNavigation?>> GetPagesValidationOnNavigation(
         AltinnRepoEditingContext editingContext,
         string layoutSetId,
-        string pageId,
+        IEnumerable<string> pageIds,
         CancellationToken cancellationToken
     )
     {
         cancellationToken.ThrowIfCancellationRequested();
         AltinnAppGitRepository repository = GetRepository(editingContext);
-        JsonNode layout = await repository.GetLayout(layoutSetId, pageId, cancellationToken);
-        return layout["data"]?["validationOnNavigation"]?.Deserialize<ValidationOnNavigation>();
+        Dictionary<string, ValidationOnNavigation?> results = [];
+        foreach (string pageId in pageIds)
+        {
+            JsonNode layout = await repository.GetLayout(layoutSetId, pageId, cancellationToken);
+            results[pageId] = layout["data"]?["validationOnNavigation"]?.Deserialize<ValidationOnNavigation>();
+        }
+        return results;
     }
 
-    public async Task SavePageValidationOnNavigation(
+    public async Task SavePagesValidationOnNavigation(
         AltinnRepoEditingContext editingContext,
         string layoutSetId,
-        string pageId,
+        IEnumerable<string> pageIds,
         ValidationOnNavigation? config,
         CancellationToken cancellationToken
     )
     {
         cancellationToken.ThrowIfCancellationRequested();
         AltinnAppGitRepository repository = GetRepository(editingContext);
-        JsonNode layout = await repository.GetLayout(layoutSetId, pageId, cancellationToken);
-
-        if (config == null)
+        foreach (string pageId in pageIds)
         {
-            layout["data"]?.AsObject().Remove("validationOnNavigation");
-        }
-        else
-        {
-            JsonObject data = layout["data"]?.AsObject() ?? [];
-            data["validationOnNavigation"] = JsonSerializer.SerializeToNode(config);
-            layout["data"] = data;
-        }
+            JsonNode layout = await repository.GetLayout(layoutSetId, pageId, cancellationToken);
 
-        await repository.SaveLayout(layoutSetId, pageId, layout, cancellationToken);
+            if (config == null)
+            {
+                layout["data"]?.AsObject().Remove("validationOnNavigation");
+            }
+            else
+            {
+                JsonObject data = layout["data"]?.AsObject() ?? [];
+                data["validationOnNavigation"] = JsonSerializer.SerializeToNode(config);
+                layout["data"] = data;
+            }
+
+            await repository.SaveLayout(layoutSetId, pageId, layout, cancellationToken);
+        }
     }
 
     public async Task<IEnumerable<TaskNavigationGroupDto>> GetGlobalTaskNavigationDto(

--- a/src/Designer/backend/src/Designer/Services/Interfaces/IUiFoldersService.cs
+++ b/src/Designer/backend/src/Designer/Services/Interfaces/IUiFoldersService.cs
@@ -24,30 +24,30 @@ public interface IUiFoldersService
         CancellationToken cancellationToken
     );
 
-    public Task<ValidationOnNavigation?> GetLayoutSetValidationOnNavigation(
+    public Task<Dictionary<string, ValidationOnNavigation?>> GetLayoutSetsValidationOnNavigation(
         AltinnRepoEditingContext editingContext,
-        string layoutSetId,
+        IEnumerable<string> layoutSetIds,
         CancellationToken cancellationToken
     );
 
-    public Task SaveLayoutSetValidationOnNavigation(
+    public Task SaveLayoutSetsValidationOnNavigation(
         AltinnRepoEditingContext editingContext,
-        string layoutSetId,
+        IEnumerable<string> layoutSetIds,
         ValidationOnNavigation? config,
         CancellationToken cancellationToken
     );
 
-    public Task<ValidationOnNavigation?> GetPageValidationOnNavigation(
+    public Task<Dictionary<string, ValidationOnNavigation?>> GetPagesValidationOnNavigation(
         AltinnRepoEditingContext editingContext,
         string layoutSetId,
-        string pageId,
+        IEnumerable<string> pageIds,
         CancellationToken cancellationToken
     );
 
-    public Task SavePageValidationOnNavigation(
+    public Task SavePagesValidationOnNavigation(
         AltinnRepoEditingContext editingContext,
         string layoutSetId,
-        string pageId,
+        IEnumerable<string> pageIds,
         ValidationOnNavigation? config,
         CancellationToken cancellationToken
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
LayoutSetValidationOnNavigation and PageValidationOnNavigation did only handle one item (layout or layoutset). But in frontend user can select several pages or layoutsets. The queru should be a list string instead of single string.

We should consider whether the code below is necessary in the controller, as Studio only allows selecting one layout set at the page level, and the save button is disabled until one is selected:
```
if (layoutSets.Count != 1)
        {
            return BadRequest("Exactly one layoutSet must be specified when deleting pages.");
        }
```

<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
