### PR TITLE
fix: use deployment chart 3.10.1

### DIFF
--- a/src/App/azure-pipelines/deploy-app.yaml
+++ b/src/App/azure-pipelines/deploy-app.yaml
@@ -599,7 +599,7 @@ steps:
               retries: 1
           chart:
             spec:
-              version: 3.10.0
+              version: 3.10.1
               chart: deployment
               sourceRef:
                 kind: HelmRepository

--- a/src/Runtime/operator/test/e2e/__snapshots__/step0-initial-secret.snap
+++ b/src/Runtime/operator/test/e2e/__snapshots__/step0-initial-secret.snap
@@ -36,6 +36,7 @@
  "kind": "Secret",
  "metadata": {
   "annotations": {
+   "helm.sh/resource-policy": "keep",
    "meta.helm.sh/release-name": "ttd-localtestapp",
    "meta.helm.sh/release-namespace": "default"
   },

--- a/src/Runtime/operator/test/e2e/__snapshots__/step0-initial-secret.snap
+++ b/src/Runtime/operator/test/e2e/__snapshots__/step0-initial-secret.snap
@@ -43,7 +43,7 @@
   "labels": {
    "app": "ttd-localtestapp-deployment",
    "app.kubernetes.io/managed-by": "Helm",
-   "chart": "deployment-3.10.0",
+   "chart": "deployment-3.10.1",
    "helm.toolkit.fluxcd.io/name": "ttd-localtestapp",
    "helm.toolkit.fluxcd.io/namespace": "default",
    "heritage": "Helm",

--- a/src/Runtime/operator/test/e2e/__snapshots__/step1-reconciled-secret.snap
+++ b/src/Runtime/operator/test/e2e/__snapshots__/step1-reconciled-secret.snap
@@ -88,6 +88,7 @@
  "kind": "Secret",
  "metadata": {
   "annotations": {
+   "helm.sh/resource-policy": "keep",
    "meta.helm.sh/release-name": "ttd-localtestapp",
    "meta.helm.sh/release-namespace": "default"
   },

--- a/src/Runtime/operator/test/e2e/__snapshots__/step1-reconciled-secret.snap
+++ b/src/Runtime/operator/test/e2e/__snapshots__/step1-reconciled-secret.snap
@@ -95,7 +95,7 @@
   "labels": {
    "app": "ttd-localtestapp-deployment",
    "app.kubernetes.io/managed-by": "Helm",
-   "chart": "deployment-3.10.0",
+   "chart": "deployment-3.10.1",
    "helm.toolkit.fluxcd.io/name": "ttd-localtestapp",
    "helm.toolkit.fluxcd.io/namespace": "default",
    "heritage": "Helm",

--- a/src/Runtime/operator/test/e2e/__snapshots__/step2-scope-removed-secret.snap
+++ b/src/Runtime/operator/test/e2e/__snapshots__/step2-scope-removed-secret.snap
@@ -88,6 +88,7 @@
  "kind": "Secret",
  "metadata": {
   "annotations": {
+   "helm.sh/resource-policy": "keep",
    "meta.helm.sh/release-name": "ttd-localtestapp",
    "meta.helm.sh/release-namespace": "default"
   },

--- a/src/Runtime/operator/test/e2e/__snapshots__/step2-scope-removed-secret.snap
+++ b/src/Runtime/operator/test/e2e/__snapshots__/step2-scope-removed-secret.snap
@@ -95,7 +95,7 @@
   "labels": {
    "app": "ttd-localtestapp-deployment",
    "app.kubernetes.io/managed-by": "Helm",
-   "chart": "deployment-3.10.0",
+   "chart": "deployment-3.10.1",
    "helm.toolkit.fluxcd.io/name": "ttd-localtestapp",
    "helm.toolkit.fluxcd.io/namespace": "default",
    "heritage": "Helm",

--- a/src/Runtime/operator/test/e2e/__snapshots__/step2b-jwk-rotated-secret.snap
+++ b/src/Runtime/operator/test/e2e/__snapshots__/step2b-jwk-rotated-secret.snap
@@ -109,6 +109,7 @@
  "kind": "Secret",
  "metadata": {
   "annotations": {
+   "helm.sh/resource-policy": "keep",
    "meta.helm.sh/release-name": "ttd-localtestapp",
    "meta.helm.sh/release-namespace": "default"
   },

--- a/src/Runtime/operator/test/e2e/__snapshots__/step2b-jwk-rotated-secret.snap
+++ b/src/Runtime/operator/test/e2e/__snapshots__/step2b-jwk-rotated-secret.snap
@@ -116,7 +116,7 @@
   "labels": {
    "app": "ttd-localtestapp-deployment",
    "app.kubernetes.io/managed-by": "Helm",
-   "chart": "deployment-3.10.0",
+   "chart": "deployment-3.10.1",
    "helm.toolkit.fluxcd.io/name": "ttd-localtestapp",
    "helm.toolkit.fluxcd.io/namespace": "default",
    "heritage": "Helm",

--- a/src/Runtime/operator/test/e2e/__snapshots__/step2c-jwk-rotated-again-secret.snap
+++ b/src/Runtime/operator/test/e2e/__snapshots__/step2c-jwk-rotated-again-secret.snap
@@ -109,6 +109,7 @@
  "kind": "Secret",
  "metadata": {
   "annotations": {
+   "helm.sh/resource-policy": "keep",
    "meta.helm.sh/release-name": "ttd-localtestapp",
    "meta.helm.sh/release-namespace": "default"
   },

--- a/src/Runtime/operator/test/e2e/__snapshots__/step2c-jwk-rotated-again-secret.snap
+++ b/src/Runtime/operator/test/e2e/__snapshots__/step2c-jwk-rotated-again-secret.snap
@@ -116,7 +116,7 @@
   "labels": {
    "app": "ttd-localtestapp-deployment",
    "app.kubernetes.io/managed-by": "Helm",
-   "chart": "deployment-3.10.0",
+   "chart": "deployment-3.10.1",
    "helm.toolkit.fluxcd.io/name": "ttd-localtestapp",
    "helm.toolkit.fluxcd.io/namespace": "default",
    "heritage": "Helm",

--- a/src/Runtime/operator/test/e2e/__snapshots__/step3-deleted-secret.snap
+++ b/src/Runtime/operator/test/e2e/__snapshots__/step3-deleted-secret.snap
@@ -36,6 +36,7 @@
  "kind": "Secret",
  "metadata": {
   "annotations": {
+   "helm.sh/resource-policy": "keep",
    "meta.helm.sh/release-name": "ttd-localtestapp",
    "meta.helm.sh/release-namespace": "default"
   },

--- a/src/Runtime/operator/test/e2e/__snapshots__/step3-deleted-secret.snap
+++ b/src/Runtime/operator/test/e2e/__snapshots__/step3-deleted-secret.snap
@@ -43,7 +43,7 @@
   "labels": {
    "app": "ttd-localtestapp-deployment",
    "app.kubernetes.io/managed-by": "Helm",
-   "chart": "deployment-3.10.0",
+   "chart": "deployment-3.10.1",
    "helm.toolkit.fluxcd.io/name": "ttd-localtestapp",
    "helm.toolkit.fluxcd.io/namespace": "default",
    "heritage": "Helm",


### PR DESCRIPTION
## Description

Updates the app deployment pipeline HelmRelease template to use deployment chart `3.10.1`.

This picks up Altinn/altinn-studio-charts#73, which keeps the mutable app deployment Secret during Helm/Flux uninstall remediation and stops rendering an explicit empty `data: {}` map for that Secret.

Also updates the operator e2e snapshots that include the deployment chart label from `deployment-3.10.0` to `deployment-3.10.1` and the rendered Secret annotation `helm.sh/resource-policy: keep`.

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

Manual checks:

```bash
git diff --check
yq '.' src/App/azure-pipelines/deploy-app.yaml >/dev/null
rg -n 'deployment-3\.10\.0|deployment-3\.10\.1|version:\s*3\.10\.1|helm\.sh/resource-policy' \
  src/Runtime/operator/test/e2e/__snapshots__ \
  src/App/azure-pipelines/deploy-app.yaml
```

Results:

```text
yaml parse ok
src/App/azure-pipelines/deploy-app.yaml:602:              version: 3.10.1
src/Runtime/operator/test/e2e/__snapshots__/step3-deleted-secret.snap:39:   "helm.sh/resource-policy": "keep",
src/Runtime/operator/test/e2e/__snapshots__/step3-deleted-secret.snap:47:   "chart": "deployment-3.10.1",
src/Runtime/operator/test/e2e/__snapshots__/step2c-jwk-rotated-again-secret.snap:112:   "helm.sh/resource-policy": "keep",
src/Runtime/operator/test/e2e/__snapshots__/step2c-jwk-rotated-again-secret.snap:120:   "chart": "deployment-3.10.1",
src/Runtime/operator/test/e2e/__snapshots__/step2b-jwk-rotated-secret.snap:112:   "helm.sh/resource-policy": "keep",
src/Runtime/operator/test/e2e/__snapshots__/step2b-jwk-rotated-secret.snap:120:   "chart": "deployment-3.10.1",
src/Runtime/operator/test/e2e/__snapshots__/step2-scope-removed-secret.snap:91:   "helm.sh/resource-policy": "keep",
src/Runtime/operator/test/e2e/__snapshots__/step2-scope-removed-secret.snap:99:   "chart": "deployment-3.10.1",
src/Runtime/operator/test/e2e/__snapshots__/step1-reconciled-secret.snap:91:   "helm.sh/resource-policy": "keep",
src/Runtime/operator/test/e2e/__snapshots__/step1-reconciled-secret.snap:99:   "chart": "deployment-3.10.1",
src/Runtime/operator/test/e2e/__snapshots__/step0-initial-secret.snap:39:   "helm.sh/resource-policy": "keep",
src/Runtime/operator/test/e2e/__snapshots__/step0-initial-secret.snap:47:   "chart": "deployment-3.10.1",
```

Attempted local operator e2e:

```bash
cd src/Runtime/operator
make start
```

Result: fixture startup failed before tests because Docker `dotnet restore App.csproj` could not load `https://api.nuget.org/v3/index.json`. The partial kind/registry fixture was cleaned up manually afterward.
