### PR TITLE
fix: studioctl - various podman issues

### DIFF
--- a/src/Runtime/devenv/pkg/container/dockerapi/docker_engine_api.go
+++ b/src/Runtime/devenv/pkg/container/dockerapi/docker_engine_api.go
@@ -69,6 +69,7 @@ func newClient(ctx context.Context, toolchain types.ContainerToolchain) (*Client
 		return nil, fmt.Errorf("failed to connect to docker daemon: %w", err)
 	}
 	toolchain = normalizeToolchain(toolchain, "")
+	toolchain = withVersionMetadata(ctx, cli, toolchain)
 	toolchain.SELinux = detectSELinuxEnabled(ctx, cli)
 
 	return &Client{
@@ -100,6 +101,7 @@ func newClientWithHost(ctx context.Context, toolchain types.ContainerToolchain, 
 		return nil, fmt.Errorf("failed to connect to docker daemon: %w", err)
 	}
 	toolchain = normalizeToolchain(toolchain, strings.TrimPrefix(host, "unix://"))
+	toolchain = withVersionMetadata(ctx, cli, toolchain)
 	toolchain.SELinux = detectSELinuxEnabled(ctx, cli)
 
 	return &Client{
@@ -112,6 +114,24 @@ func normalizeToolchain(toolchain types.ContainerToolchain, socketPath string) t
 	toolchain.AccessMode = types.AccessDockerEngineAPI
 	if socketPath != "" {
 		toolchain.SocketPath = socketPath
+	}
+	return toolchain
+}
+
+type versionClient interface {
+	ClientVersion() string
+	ServerVersion(ctx context.Context) (dockertypes.Version, error)
+}
+
+func withVersionMetadata(
+	ctx context.Context,
+	cli versionClient,
+	toolchain types.ContainerToolchain,
+) types.ContainerToolchain {
+	// ClientVersion is the negotiated Docker API version; ServerVersion is the daemon version.
+	toolchain.ClientVersion = cli.ClientVersion()
+	if version, err := cli.ServerVersion(ctx); err == nil {
+		toolchain.ServerVersion = version.Version
 	}
 	return toolchain
 }

--- a/src/Runtime/devenv/pkg/container/dockerapi/docker_engine_api_test.go
+++ b/src/Runtime/devenv/pkg/container/dockerapi/docker_engine_api_test.go
@@ -1,6 +1,7 @@
 package dockerapi
 
 import (
+	"context"
 	"errors"
 	"io"
 	"slices"
@@ -19,6 +20,7 @@ import (
 var errNetworkActiveEndpoints = errors.New(
 	`error response from daemon: error while removing network: network altinntestlocal_network has active endpoints`,
 )
+var errServerVersionUnavailable = errors.New("server version unavailable")
 
 func TestBuildMounts(t *testing.T) {
 	t.Parallel()
@@ -240,6 +242,52 @@ func TestInfoHasSELinux(t *testing.T) {
 				t.Fatalf("infoHasSELinux() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestWithVersionMetadata(t *testing.T) {
+	t.Parallel()
+
+	toolchain := withVersionMetadata(
+		t.Context(),
+		fakeVersionClient{
+			clientVersion: "1.51",
+			serverVersion: dockertypes.Version{
+				Version: "28.2.2",
+			},
+		},
+		types.ContainerToolchain{
+			Platform:   types.PlatformDocker,
+			AccessMode: types.AccessDockerEngineAPI,
+			Source:     types.SourceDefault,
+		},
+	)
+
+	if toolchain.ClientVersion != "1.51" {
+		t.Fatalf("withVersionMetadata() ClientVersion = %q, want 1.51", toolchain.ClientVersion)
+	}
+	if toolchain.ServerVersion != "28.2.2" {
+		t.Fatalf("withVersionMetadata() ServerVersion = %q, want 28.2.2", toolchain.ServerVersion)
+	}
+}
+
+func TestWithVersionMetadataIgnoresServerVersionError(t *testing.T) {
+	t.Parallel()
+
+	toolchain := withVersionMetadata(
+		t.Context(),
+		fakeVersionClient{
+			clientVersion: "1.51",
+			err:           errServerVersionUnavailable,
+		},
+		types.ContainerToolchain{},
+	)
+
+	if toolchain.ClientVersion != "1.51" {
+		t.Fatalf("withVersionMetadata() ClientVersion = %q, want 1.51", toolchain.ClientVersion)
+	}
+	if toolchain.ServerVersion != "" {
+		t.Fatalf("withVersionMetadata() ServerVersion = %q, want empty", toolchain.ServerVersion)
 	}
 }
 
@@ -634,4 +682,18 @@ func TestUpdateTrackedProgress_ReplacesProgressWhenPhaseChanges(t *testing.T) {
 	if got.phase != "Extracting" || got.current != 10 || got.total != 100 {
 		t.Fatalf("tracked progress = %+v, want phase=Extracting current=10 total=100", got)
 	}
+}
+
+type fakeVersionClient struct {
+	err           error
+	serverVersion dockertypes.Version
+	clientVersion string
+}
+
+func (c fakeVersionClient) ClientVersion() string {
+	return c.clientVersion
+}
+
+func (c fakeVersionClient) ServerVersion(context.Context) (dockertypes.Version, error) {
+	return c.serverVersion, c.err
 }

--- a/src/Runtime/devenv/pkg/container/podman/podman.go
+++ b/src/Runtime/devenv/pkg/container/podman/podman.go
@@ -279,7 +279,7 @@ func (c *Client) ContainerState(ctx context.Context, nameOrID string) (types.Con
 
 	return types.ContainerState{
 		Status:       state.Status,
-		HealthStatus: podmanHealthStatus(state.Health.Status, state.Healthcheck.Status),
+		HealthStatus: podmanStateHealthStatus(state.Health.Status, state.Healthcheck.Status),
 		Running:      state.Running,
 		Paused:       state.Paused,
 		ExitCode:     state.ExitCode,
@@ -438,7 +438,8 @@ func (c *Client) ImagePullWithProgress(
 
 type containerInspectInfo struct {
 	Config struct {
-		Labels map[string]string `json:"Labels"`
+		Labels      map[string]string       `json:"Labels"`
+		Healthcheck podmanHealthcheckConfig `json:"Healthcheck"`
 	} `json:"Config"`
 	ID              string `json:"Id"`
 	Name            string `json:"Name"`
@@ -466,6 +467,10 @@ type podmanHealthInfo struct {
 	Status string `json:"Status"`
 }
 
+type podmanHealthcheckConfig struct {
+	Test []string `json:"Test"`
+}
+
 func parseContainerInspect(output []byte) (types.ContainerInfo, error) {
 	var info []containerInspectInfo
 	if err := json.Unmarshal(output, &info); err != nil {
@@ -483,16 +488,35 @@ func parseContainerInspect(output []byte) (types.ContainerInfo, error) {
 		Labels:  info[0].Config.Labels,
 		Ports:   publishedPortsFromPodmanInspect(info[0].NetworkSettings.Ports),
 		State: types.ContainerState{
-			Status:       info[0].State.Status,
-			HealthStatus: podmanHealthStatus(info[0].State.Health.Status, info[0].State.Healthcheck.Status),
-			Running:      info[0].State.Running,
-			Paused:       info[0].State.Paused,
-			ExitCode:     info[0].State.ExitCode,
+			Status: info[0].State.Status,
+			HealthStatus: podmanHealthStatus(
+				info[0].Config.Healthcheck,
+				info[0].State.Health.Status,
+				info[0].State.Healthcheck.Status,
+			),
+			Running:  info[0].State.Running,
+			Paused:   info[0].State.Paused,
+			ExitCode: info[0].State.ExitCode,
 		},
 	}, nil
 }
 
-func podmanHealthStatus(health, healthcheck string) string {
+func podmanHealthStatus(config podmanHealthcheckConfig, health, healthcheck string) string {
+	if !podmanHealthcheckConfigured(config) {
+		// Config.Healthcheck is the effective healthcheck command configured for the container.
+		// State.Health.Status is the runtime result of that command. If no command is configured,
+		// Podman cannot run a healthcheck or transition the container to "healthy", even if
+		// State.Health.Status is present. Ignore the status in that case.
+		return ""
+	}
+	return podmanStateHealthStatus(health, healthcheck)
+}
+
+func podmanHealthcheckConfigured(config podmanHealthcheckConfig) bool {
+	return len(config.Test) > 0 && !strings.EqualFold(config.Test[0], "none")
+}
+
+func podmanStateHealthStatus(health, healthcheck string) string {
 	if health != "" {
 		return health
 	}

--- a/src/Runtime/devenv/pkg/container/podman/podman.go
+++ b/src/Runtime/devenv/pkg/container/podman/podman.go
@@ -65,14 +65,30 @@ func podmanVersion(ctx context.Context) (podmanVersionInfo, error) {
 		return podmanVersionInfo{}, fmt.Errorf("podman not responsive: %w", err)
 	}
 
-	var version map[string]map[string]string
-	if err := json.Unmarshal(output, &version); err != nil {
+	version, err := parsePodmanVersion(output)
+	if err != nil {
 		return podmanVersionInfo{}, fmt.Errorf("parse podman version: %w", err)
 	}
 
+	return version, nil
+}
+
+func parsePodmanVersion(output []byte) (podmanVersionInfo, error) {
+	var version struct {
+		Client struct {
+			Version string `json:"Version"`
+		} `json:"Client"`
+		Server struct {
+			Version string `json:"Version"`
+		} `json:"Server"`
+	}
+	if err := json.Unmarshal(output, &version); err != nil {
+		return podmanVersionInfo{}, fmt.Errorf("unmarshal podman version: %w", err)
+	}
+
 	return podmanVersionInfo{
-		ClientVersion: version["Client"]["Version"],
-		ServerVersion: version["Server"]["Version"],
+		ClientVersion: version.Client.Version,
+		ServerVersion: version.Server.Version,
 	}, nil
 }
 

--- a/src/Runtime/devenv/pkg/container/podman/podman.go
+++ b/src/Runtime/devenv/pkg/container/podman/podman.go
@@ -29,15 +29,16 @@ func New(ctx context.Context, toolchain types.ContainerToolchain) (*Client, erro
 	if _, err := exec.LookPath("podman"); err != nil {
 		return nil, fmt.Errorf("podman not found in PATH: %w", err)
 	}
-	// Verify podman is responsive
-	cmd := processutil.CommandContext(ctx, "podman", "version", "--format", "{{.Version}}")
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("podman not responsive: %w", err)
+	version, err := podmanVersion(ctx)
+	if err != nil {
+		return nil, err
 	}
 	toolchain.AccessMode = types.AccessPodmanCLI
 	if toolchain.Platform == types.PlatformUnknown {
 		toolchain.Platform = types.PlatformPodman
 	}
+	toolchain.ClientVersion = version.ClientVersion
+	toolchain.ServerVersion = version.ServerVersion
 	toolchain.SELinux = detectSELinuxEnabled(ctx)
 	return &Client{toolchain: toolchain}, nil
 }
@@ -50,6 +51,29 @@ func (c *Client) Close() error {
 // Toolchain returns the resolved platform and access mode metadata.
 func (c *Client) Toolchain() types.ContainerToolchain {
 	return c.toolchain
+}
+
+type podmanVersionInfo struct {
+	ClientVersion string
+	ServerVersion string
+}
+
+func podmanVersion(ctx context.Context) (podmanVersionInfo, error) {
+	cmd := processutil.CommandContext(ctx, "podman", "version", "--format", "json")
+	output, err := cmd.Output()
+	if err != nil {
+		return podmanVersionInfo{}, fmt.Errorf("podman not responsive: %w", err)
+	}
+
+	var version map[string]map[string]string
+	if err := json.Unmarshal(output, &version); err != nil {
+		return podmanVersionInfo{}, fmt.Errorf("parse podman version: %w", err)
+	}
+
+	return podmanVersionInfo{
+		ClientVersion: version["Client"]["Version"],
+		ServerVersion: version["Server"]["Version"],
+	}, nil
 }
 
 func reportProgress(onProgress types.ProgressHandler, progress types.ProgressUpdate) {

--- a/src/Runtime/devenv/pkg/container/podman/podman_test.go
+++ b/src/Runtime/devenv/pkg/container/podman/podman_test.go
@@ -123,6 +123,37 @@ func TestParseContainerInspect_IgnoresHealthStatusWithoutConfiguredHealthcheck(t
 	}
 }
 
+func TestParseContainerInspect_IgnoresHealthStatusForDisabledHealthcheck(t *testing.T) {
+	t.Parallel()
+
+	output := []byte(`[
+  {
+    "Id": "container-id",
+    "Name": "my-container",
+    "Image": "sha256:image-id",
+    "Config": {
+      "Labels": {},
+      "Healthcheck": { "Test": [ "NONE" ] }
+    },
+    "State": {
+      "Status": "running",
+      "Running": true,
+      "Paused": false,
+      "ExitCode": 0,
+      "Health": { "Status": "starting", "FailingStreak": 0, "Log": null }
+    }
+  }
+]`)
+
+	info, err := parseContainerInspect(output)
+	if err != nil {
+		t.Fatalf("parseContainerInspect() error: %v", err)
+	}
+	if info.State.HealthStatus != "" {
+		t.Fatalf("HealthStatus = %q, want empty", info.State.HealthStatus)
+	}
+}
+
 func TestParseContainerInspect_Empty_ReturnsNotFound(t *testing.T) {
 	t.Parallel()
 

--- a/src/Runtime/devenv/pkg/container/podman/podman_test.go
+++ b/src/Runtime/devenv/pkg/container/podman/podman_test.go
@@ -69,7 +69,10 @@ func TestParseContainerInspect_HealthStatus(t *testing.T) {
     "Id": "container-id",
     "Name": "my-container",
     "Image": "sha256:image-id",
-    "Config": { "Labels": {} },
+    "Config": {
+      "Labels": {},
+      "Healthcheck": { "Test": [ "CMD-SHELL", "wget -nv -t1 --spider http://localhost:5101/health || exit 1" ] }
+    },
     "State": {
       "Status": "running",
       "Running": true,
@@ -86,6 +89,37 @@ func TestParseContainerInspect_HealthStatus(t *testing.T) {
 	}
 	if info.State.HealthStatus != "healthy" {
 		t.Fatalf("HealthStatus = %q, want healthy", info.State.HealthStatus)
+	}
+}
+
+func TestParseContainerInspect_IgnoresHealthStatusWithoutConfiguredHealthcheck(t *testing.T) {
+	t.Parallel()
+
+	output := []byte(`[
+  {
+    "Id": "container-id",
+    "Name": "my-container",
+    "Image": "sha256:image-id",
+    "Config": {
+      "Labels": {},
+      "Healthcheck": {}
+    },
+    "State": {
+      "Status": "running",
+      "Running": true,
+      "Paused": false,
+      "ExitCode": 0,
+      "Health": { "Status": "starting", "FailingStreak": 0, "Log": null }
+    }
+  }
+]`)
+
+	info, err := parseContainerInspect(output)
+	if err != nil {
+		t.Fatalf("parseContainerInspect() error: %v", err)
+	}
+	if info.State.HealthStatus != "" {
+		t.Fatalf("HealthStatus = %q, want empty", info.State.HealthStatus)
 	}
 }
 

--- a/src/Runtime/devenv/pkg/container/podman/podman_test.go
+++ b/src/Runtime/devenv/pkg/container/podman/podman_test.go
@@ -38,6 +38,32 @@ func TestBuildCreateArgs_UserNamespaceAndRelabelBind(t *testing.T) {
 	}
 }
 
+func TestParsePodmanVersionIgnoresNonStringFields(t *testing.T) {
+	t.Parallel()
+
+	version, err := parsePodmanVersion([]byte(`{
+  "Client": {
+    "Version": "5.8.1",
+    "APIVersion": 5.8,
+    "Built": 1780000000
+  },
+  "Server": {
+    "Version": "5.8.2",
+    "APIVersion": 5.8,
+    "Built": 1780000001
+  }
+}`))
+	if err != nil {
+		t.Fatalf("parsePodmanVersion() error = %v", err)
+	}
+	if version.ClientVersion != "5.8.1" {
+		t.Fatalf("ClientVersion = %q, want 5.8.1", version.ClientVersion)
+	}
+	if version.ServerVersion != "5.8.2" {
+		t.Fatalf("ServerVersion = %q, want 5.8.2", version.ServerVersion)
+	}
+}
+
 func TestParseContainerInspect_ImageIDUsesImageNotDigest(t *testing.T) {
 	t.Parallel()
 

--- a/src/Runtime/devenv/pkg/container/types/types.go
+++ b/src/Runtime/devenv/pkg/container/types/types.go
@@ -185,7 +185,7 @@ type ContainerToolchain struct {
 	SocketPath string
 	// ClientVersion is the local CLI/client version when the access mode exposes one.
 	ClientVersion string
-	// ServerVersion is the remote daemon or Podman machine version when available.
+	// ServerVersion is the remote daemon/runtime version when available.
 	ServerVersion string
 	Platform      ContainerPlatform
 	AccessMode    ContainerAccessMode

--- a/src/Runtime/devenv/pkg/container/types/types.go
+++ b/src/Runtime/devenv/pkg/container/types/types.go
@@ -183,7 +183,7 @@ func (s DetectionSource) String() string {
 // ContainerToolchain describes the selected platform and how this package talks to it.
 type ContainerToolchain struct {
 	SocketPath string
-	// ClientVersion is the local CLI/client version when the access mode exposes one.
+	// ClientVersion is the local CLI version or negotiated API client version when available.
 	ClientVersion string
 	// ServerVersion is the remote daemon/runtime version when available.
 	ServerVersion string

--- a/src/Runtime/devenv/pkg/container/types/types.go
+++ b/src/Runtime/devenv/pkg/container/types/types.go
@@ -183,10 +183,14 @@ func (s DetectionSource) String() string {
 // ContainerToolchain describes the selected platform and how this package talks to it.
 type ContainerToolchain struct {
 	SocketPath string
-	Platform   ContainerPlatform
-	AccessMode ContainerAccessMode
-	Source     DetectionSource
-	SELinux    bool
+	// ClientVersion is the local CLI/client version when the access mode exposes one.
+	ClientVersion string
+	// ServerVersion is the remote daemon or Podman machine version when available.
+	ServerVersion string
+	Platform      ContainerPlatform
+	AccessMode    ContainerAccessMode
+	Source        DetectionSource
+	SELinux       bool
 }
 
 // PortMapping defines a container port binding.

--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -8,6 +8,16 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+### Added
+
+- Show resolved container runtime client/server versions in `studioctl doctor`.
+
+### Fixed
+
+- Ignore stale Podman container health status when no healthcheck command is configured.
+- Warn in `studioctl doctor` when the Podman CLI client/server versions differ.
+- Run localtest PDF and workflow-engine service containers with their image default user to avoid Podman `keep-id` group mapping failures on macOS.
+
 ## [0.1.0-preview.11] - 2026-05-29
 
 ### Added

--- a/src/cli/internal/cmd/doctor.go
+++ b/src/cli/internal/cmd/doctor.go
@@ -213,11 +213,11 @@ func (c *DoctorCommand) renderDoctorPrerequisitesSection(table *ui.Table, prereq
 	if prerequisites.ContainerResolved != "" {
 		doctorKeyValue(table, "Resolved", prerequisites.ContainerResolved)
 	}
-	if prerequisites.PodmanClient != "" {
-		doctorKeyValue(table, "Podman client", prerequisites.PodmanClient)
+	if prerequisites.ContainerClient != "" {
+		doctorKeyValue(table, "Client", prerequisites.ContainerClient)
 	}
-	if prerequisites.PodmanServer != "" {
-		doctorKeyValue(table, "Podman server", prerequisites.PodmanServer)
+	if prerequisites.ContainerServer != "" {
+		doctorKeyValue(table, "Server", prerequisites.ContainerServer)
 	}
 	if tools := doctorContainerToolsLabel(prerequisites.ContainerTools); tools != "" {
 		doctorKeyValue(table, "Tools", tools)

--- a/src/cli/internal/cmd/doctor.go
+++ b/src/cli/internal/cmd/doctor.go
@@ -201,10 +201,23 @@ func (c *DoctorCommand) renderDoctorPrerequisitesSection(table *ui.Table, prereq
 	if prerequisites.Container.OK {
 		doctorKeyValueStatus(table, true, "Container", containerValue)
 	} else {
-		doctorKeyValueStatus(table, false, "Container", "not found")
+		msg := "not found"
+		if containerValue != unknownValue {
+			msg = containerValue
+		}
+		doctorKeyValueStatus(table, false, "Container", msg)
+		if prerequisites.Container.Error != "" {
+			doctorKeyValue(table, "Error", prerequisites.Container.Error)
+		}
 	}
 	if prerequisites.ContainerResolved != "" {
 		doctorKeyValue(table, "Resolved", prerequisites.ContainerResolved)
+	}
+	if prerequisites.PodmanClient != "" {
+		doctorKeyValue(table, "Podman client", prerequisites.PodmanClient)
+	}
+	if prerequisites.PodmanServer != "" {
+		doctorKeyValue(table, "Podman server", prerequisites.PodmanServer)
 	}
 	if tools := doctorContainerToolsLabel(prerequisites.ContainerTools); tools != "" {
 		doctorKeyValue(table, "Tools", tools)

--- a/src/cli/internal/cmd/doctor/prereq.go
+++ b/src/cli/internal/cmd/doctor/prereq.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 
 	"altinn.studio/devenv/pkg/container"
 	"altinn.studio/studioctl/internal/osutil"
@@ -23,11 +24,13 @@ func (s *Service) collectPrerequisites(ctx context.Context) *Prerequisites {
 		OK:    dotnetErr == nil,
 	}
 
-	containerValue, containerResolved, containerTools, containerErr := s.probeContainerRuntime(ctx)
+	containerValue, containerResolved, containerTools, toolchain, containerErr := s.probeContainerRuntime(ctx)
 	prerequisites.ContainerValue = containerValue
 	prerequisites.ContainerResolved = containerResolved
 	prerequisites.ContainerTools = containerTools
 	prerequisites.ContainerHost = strings.TrimSpace(os.Getenv("DOCKER_HOST"))
+	prerequisites.PodmanClient = toolchain.ClientVersion
+	prerequisites.PodmanServer = toolchain.ServerVersion
 	prerequisites.Container = Check{
 		Error: errorString(containerErr),
 		OK:    containerErr == nil,
@@ -60,7 +63,9 @@ func (s *Service) probeDotnet(ctx context.Context) (string, error) {
 	return version, nil
 }
 
-func (s *Service) probeContainerRuntime(ctx context.Context) (string, string, []ContainerTool, error) {
+func (s *Service) probeContainerRuntime(
+	ctx context.Context,
+) (string, string, []ContainerTool, container.ContainerToolchain, error) {
 	tools := s.collectContainerTools(ctx)
 
 	detect := container.Detect
@@ -70,7 +75,11 @@ func (s *Service) probeContainerRuntime(ctx context.Context) (string, string, []
 
 	cli, err := detect(ctx)
 	if err != nil {
-		return "", "", tools, fmt.Errorf("%w: %w", errNoContainerRuntime, err)
+		return "", "", tools, container.ContainerToolchain{}, fmt.Errorf(
+			"%w: %w",
+			errNoContainerRuntime,
+			err,
+		)
 	}
 	defer func() {
 		if closeErr := cli.Close(); closeErr != nil {
@@ -90,7 +99,7 @@ func (s *Service) probeContainerRuntime(ctx context.Context) (string, string, []
 		resolved += " (" + toolchain.Source.String() + ")"
 	}
 
-	return platformName + " (" + version + ")", resolved, tools, nil
+	return platformName + " (" + version + ")", resolved, tools, toolchain, podmanToolchainError(toolchain)
 }
 
 func (s *Service) probeWindowsVersion(ctx context.Context) (string, error) {
@@ -134,6 +143,23 @@ func extractMajorVersion(version string) int {
 	return major
 }
 
+func podmanToolchainError(toolchain container.ContainerToolchain) error {
+	if toolchain.Platform != container.PlatformPodman ||
+		toolchain.AccessMode != container.AccessPodmanCLI ||
+		toolchain.ClientVersion == "" ||
+		toolchain.ServerVersion == "" ||
+		toolchain.ClientVersion == toolchain.ServerVersion {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"%w: client %s, server %s",
+		errPodmanVersionDiff,
+		toolchain.ClientVersion,
+		toolchain.ServerVersion,
+	)
+}
+
 func extractVersionFromOutput(output string) string {
 	// Handle "Docker version 24.0.7, build afdd53b" or "podman version 4.9.0"
 	parts := strings.Fields(output)
@@ -147,25 +173,38 @@ func extractVersionFromOutput(output string) string {
 
 func (s *Service) collectContainerTools(ctx context.Context) []ContainerTool {
 	toolNames := []string{"colima", "docker", "podman"}
-	tools := make([]ContainerTool, 0, len(toolNames))
+	results := make(chan ContainerTool, len(toolNames))
+	var wg sync.WaitGroup
 
 	for _, name := range toolNames {
 		if _, err := s.lookupPath(name); err != nil {
 			continue
 		}
 
-		version := unknownValue
-		output, err := s.runVersionOutput(ctx, name)
-		if err != nil {
-			s.debugf("%s --version failed: %v", name, err)
-		} else if parsed := extractVersionFromOutput(strings.TrimSpace(string(output))); parsed != "" {
-			version = parsed
-		}
+		wg.Go(func() {
+			version := unknownValue
+			output, err := s.runVersionOutput(ctx, name)
+			if err != nil {
+				s.debugf("%s --version failed: %v", name, err)
+			} else if parsed := extractVersionFromOutput(strings.TrimSpace(string(output))); parsed != "" {
+				version = parsed
+			}
 
-		tools = append(tools, ContainerTool{
-			Name:    name,
-			Version: version,
+			results <- ContainerTool{
+				Name:    name,
+				Version: version,
+			}
 		})
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	tools := make([]ContainerTool, 0, len(toolNames))
+	for tool := range results {
+		tools = append(tools, tool)
 	}
 
 	slices.SortFunc(tools, func(a, b ContainerTool) int {

--- a/src/cli/internal/cmd/doctor/prereq.go
+++ b/src/cli/internal/cmd/doctor/prereq.go
@@ -29,8 +29,8 @@ func (s *Service) collectPrerequisites(ctx context.Context) *Prerequisites {
 	prerequisites.ContainerResolved = containerResolved
 	prerequisites.ContainerTools = containerTools
 	prerequisites.ContainerHost = strings.TrimSpace(os.Getenv("DOCKER_HOST"))
-	prerequisites.PodmanClient = toolchain.ClientVersion
-	prerequisites.PodmanServer = toolchain.ServerVersion
+	prerequisites.ContainerClient = toolchain.ClientVersion
+	prerequisites.ContainerServer = toolchain.ServerVersion
 	prerequisites.Container = Check{
 		Error: errorString(containerErr),
 		OK:    containerErr == nil,

--- a/src/cli/internal/cmd/doctor/prereq.go
+++ b/src/cli/internal/cmd/doctor/prereq.go
@@ -90,6 +90,11 @@ func (s *Service) probeContainerRuntime(
 	toolchain := cli.Toolchain()
 	platformName := toolchain.Platform.String()
 	version := containerToolVersion(tools, platformToolVersionName(toolchain.Platform))
+	if (version == "" || version == unknownValue) &&
+		toolchain.Platform == container.PlatformPodman &&
+		toolchain.ClientVersion != "" {
+		version = toolchain.ClientVersion
+	}
 	if version == "" {
 		version = unknownValue
 	}

--- a/src/cli/internal/cmd/doctor/prereq_test.go
+++ b/src/cli/internal/cmd/doctor/prereq_test.go
@@ -232,11 +232,11 @@ func TestCollectPrerequisitesReportsPodmanClientServerMismatch(t *testing.T) {
 	if prereqs.Container.OK {
 		t.Fatal("collectPrerequisites() Container.OK = true, want false")
 	}
-	if prereqs.PodmanClient != "5.8.2" || prereqs.PodmanServer != "5.2.4" {
+	if prereqs.ContainerClient != "5.8.2" || prereqs.ContainerServer != "5.2.4" {
 		t.Fatalf(
-			"collectPrerequisites() podman versions = client %q server %q",
-			prereqs.PodmanClient,
-			prereqs.PodmanServer,
+			"collectPrerequisites() container versions = client %q server %q",
+			prereqs.ContainerClient,
+			prereqs.ContainerServer,
 		)
 	}
 	want := "podman client/server version mismatch: client 5.8.2, server 5.2.4"

--- a/src/cli/internal/cmd/doctor/prereq_test.go
+++ b/src/cli/internal/cmd/doctor/prereq_test.go
@@ -14,6 +14,7 @@ import (
 const (
 	colimaTool            = "colima"
 	dockerTool            = "docker"
+	dotnetTool            = "dotnet"
 	podmanTool            = "podman"
 	resolvedDockerDefault = "Docker Engine API -> Docker (Default)"
 )
@@ -30,7 +31,10 @@ func TestProbeContainerRuntime(t *testing.T) {
 		lookPath: func(string) (string, error) {
 			return "/bin/tool", nil
 		},
-		versionOutput: func(_ context.Context, name string) ([]byte, error) {
+		versionOutput: func(_ context.Context, name string, args ...string) ([]byte, error) {
+			if !testArgsEqual(args, "--version") {
+				return nil, errUnexpectedTool
+			}
 			switch name {
 			case dockerTool:
 				return []byte("Docker version 25.0.1, build deadbeef"), nil
@@ -47,9 +51,12 @@ func TestProbeContainerRuntime(t *testing.T) {
 		},
 	}
 
-	value, resolved, tools, err := svc.probeContainerRuntime(t.Context())
+	value, resolved, tools, toolchain, err := svc.probeContainerRuntime(t.Context())
 	if err != nil {
 		t.Fatalf("probeContainerRuntime() error = %v", err)
+	}
+	if toolchain.ClientVersion != "" || toolchain.ServerVersion != "" {
+		t.Fatalf("probeContainerRuntime() toolchain versions = %#v, want empty", toolchain)
 	}
 
 	if value != "Docker (25.0.1)" {
@@ -83,9 +90,12 @@ func TestCollectPrerequisitesIncludesDockerHost(t *testing.T) {
 			}
 			return "", errMissingTool
 		},
-		versionOutput: func(_ context.Context, name string) ([]byte, error) {
+		versionOutput: func(_ context.Context, name string, args ...string) ([]byte, error) {
+			if !testArgsEqual(args, "--version") {
+				return nil, errUnexpectedTool
+			}
 			switch name {
-			case "dotnet":
+			case dotnetTool:
 				return []byte("10.0.103"), nil
 			case dockerTool:
 				return []byte("Docker version 25.0.1, build deadbeef"), nil
@@ -118,7 +128,10 @@ func TestProbeContainerRuntimeReturnsDetectedToolsOnFailure(t *testing.T) {
 			}
 			return "", errMissingTool
 		},
-		versionOutput: func(_ context.Context, name string) ([]byte, error) {
+		versionOutput: func(_ context.Context, name string, args ...string) ([]byte, error) {
+			if !testArgsEqual(args, "--version") {
+				return nil, errUnexpectedTool
+			}
 			if name == dockerTool {
 				return []byte("Docker version 25.0.1, build deadbeef"), nil
 			}
@@ -129,7 +142,7 @@ func TestProbeContainerRuntimeReturnsDetectedToolsOnFailure(t *testing.T) {
 		},
 	}
 
-	value, resolved, tools, err := svc.probeContainerRuntime(t.Context())
+	value, resolved, tools, _, err := svc.probeContainerRuntime(t.Context())
 	if err == nil {
 		t.Fatal("probeContainerRuntime() error = nil, want non-nil")
 	}
@@ -147,7 +160,7 @@ func TestProbeContainerRuntime_APIWithoutCLIStillSucceeds(t *testing.T) {
 		lookPath: func(string) (string, error) {
 			return "", errMissingTool
 		},
-		versionOutput: func(_ context.Context, name string) ([]byte, error) {
+		versionOutput: func(_ context.Context, name string, args ...string) ([]byte, error) {
 			return nil, errUnexpectedTool
 		},
 		containerDetect: func(context.Context) (container.ContainerClient, error) {
@@ -164,7 +177,7 @@ func TestProbeContainerRuntime_APIWithoutCLIStillSucceeds(t *testing.T) {
 		},
 	}
 
-	value, resolved, tools, err := svc.probeContainerRuntime(t.Context())
+	value, resolved, tools, _, err := svc.probeContainerRuntime(t.Context())
 	if err != nil {
 		t.Fatalf("probeContainerRuntime() error = %v", err)
 	}
@@ -177,6 +190,71 @@ func TestProbeContainerRuntime_APIWithoutCLIStillSucceeds(t *testing.T) {
 	if len(tools) != 0 {
 		t.Fatalf("probeContainerRuntime() tools = %#v, want empty", tools)
 	}
+}
+
+func TestCollectPrerequisitesReportsPodmanClientServerMismatch(t *testing.T) {
+	svc := &Service{
+		debugf: func(string, ...any) {},
+		lookPath: func(name string) (string, error) {
+			if name == podmanTool {
+				return "/bin/podman", nil
+			}
+			return "", errMissingTool
+		},
+		versionOutput: func(_ context.Context, name string, args ...string) ([]byte, error) {
+			if !testArgsEqual(args, "--version") {
+				return nil, errUnexpectedTool
+			}
+			switch name {
+			case dotnetTool:
+				return []byte("10.0.103"), nil
+			case podmanTool:
+				return []byte("podman version 5.8.2"), nil
+			default:
+				return nil, errUnexpectedTool
+			}
+		},
+		containerDetect: func(context.Context) (container.ContainerClient, error) {
+			return &dockerEngineClient{
+				Client: containermock.New(),
+				toolchain: types.ContainerToolchain{
+					ClientVersion: "5.8.2",
+					ServerVersion: "5.2.4",
+					Platform:      types.PlatformPodman,
+					AccessMode:    types.AccessPodmanCLI,
+					Source:        types.SourcePodmanCLI,
+				},
+			}, nil
+		},
+	}
+
+	prereqs := svc.collectPrerequisites(t.Context())
+	if prereqs.Container.OK {
+		t.Fatal("collectPrerequisites() Container.OK = true, want false")
+	}
+	if prereqs.PodmanClient != "5.8.2" || prereqs.PodmanServer != "5.2.4" {
+		t.Fatalf(
+			"collectPrerequisites() podman versions = client %q server %q",
+			prereqs.PodmanClient,
+			prereqs.PodmanServer,
+		)
+	}
+	want := "podman client/server version mismatch: client 5.8.2, server 5.2.4"
+	if prereqs.Container.Error != want {
+		t.Fatalf("collectPrerequisites() Container.Error = %q, want %q", prereqs.Container.Error, want)
+	}
+}
+
+func testArgsEqual(got []string, want ...string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
 }
 
 type dockerEngineClient struct {

--- a/src/cli/internal/cmd/doctor/service.go
+++ b/src/cli/internal/cmd/doctor/service.go
@@ -93,8 +93,8 @@ type Prerequisites struct {
 	WindowsValue      string          `json:"-"`
 	ContainerResolved string          `json:"containerResolved,omitempty"`
 	ContainerHost     string          `json:"containerHost,omitempty"`
-	PodmanClient      string          `json:"podmanClient,omitempty"`
-	PodmanServer      string          `json:"podmanServer,omitempty"`
+	ContainerClient   string          `json:"containerClient,omitempty"`
+	ContainerServer   string          `json:"containerServer,omitempty"`
 	ContainerTools    []ContainerTool `json:"containerTools,omitempty"`
 	Windows           *Check          `json:"windows,omitempty"`
 	Dotnet            Check           `json:"dotnet"`

--- a/src/cli/internal/cmd/doctor/service.go
+++ b/src/cli/internal/cmd/doctor/service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os/exec"
 	"sort"
+	"strings"
 
 	"altinn.studio/devenv/pkg/container"
 	"altinn.studio/devenv/pkg/processutil"
@@ -37,6 +38,7 @@ const (
 var (
 	errDotnetVersionTooOld = errors.New("dotnet version too old")
 	errNoContainerRuntime  = errors.New("no container runtime found")
+	errPodmanVersionDiff   = errors.New("podman client/server version mismatch")
 	errUnsupportedCommand  = errors.New("unsupported command")
 	errWindowsVersionOld   = errors.New("windows version too old")
 	errWindowsVersionUnk   = errors.New("windows version unknown")
@@ -47,7 +49,7 @@ type Service struct {
 	cfg             *config.Config
 	debugf          func(format string, args ...any)
 	lookPath        func(file string) (string, error)
-	versionOutput   func(ctx context.Context, name string) ([]byte, error)
+	versionOutput   func(ctx context.Context, name string, args ...string) ([]byte, error)
 	containerDetect func(ctx context.Context) (container.ContainerClient, error)
 }
 
@@ -91,6 +93,8 @@ type Prerequisites struct {
 	WindowsValue      string          `json:"-"`
 	ContainerResolved string          `json:"containerResolved,omitempty"`
 	ContainerHost     string          `json:"containerHost,omitempty"`
+	PodmanClient      string          `json:"podmanClient,omitempty"`
+	PodmanServer      string          `json:"podmanServer,omitempty"`
 	ContainerTools    []ContainerTool `json:"containerTools,omitempty"`
 	Windows           *Check          `json:"windows,omitempty"`
 	Dotnet            Check           `json:"dotnet"`
@@ -201,25 +205,27 @@ func (s *Service) lookupPath(file string) (string, error) {
 	return path, nil
 }
 
-func (s *Service) runVersionOutput(ctx context.Context, name string) ([]byte, error) {
-	if s != nil && s.versionOutput != nil {
-		return s.versionOutput(ctx, name)
-	}
-
-	return commandVersionOutput(ctx, name)
-}
-
-func commandVersionOutput(ctx context.Context, name string) ([]byte, error) {
+func (s *Service) runVersionOutput(ctx context.Context, name string, args ...string) ([]byte, error) {
 	switch name {
 	case "dotnet", "docker", "podman", "colima":
-		output, err := processutil.CommandContext(ctx, name, "--version").Output()
-		if err != nil {
-			return nil, fmt.Errorf("run %s --version: %w", name, err)
+		if len(args) == 0 {
+			args = []string{"--version"}
 		}
-		return output, nil
+		if s != nil && s.versionOutput != nil {
+			return s.versionOutput(ctx, name, args...)
+		}
+		return commandVersionOutput(ctx, name, args...)
 	default:
 		return nil, fmt.Errorf("%w: %s", errUnsupportedCommand, name)
 	}
+}
+
+func commandVersionOutput(ctx context.Context, name string, args ...string) ([]byte, error) {
+	output, err := processutil.CommandContext(ctx, name, args...).Output()
+	if err != nil {
+		return nil, fmt.Errorf("run %s %s: %w", name, strings.Join(args, " "), err)
+	}
+	return output, nil
 }
 
 func (s *Service) buildAuth() *Auth {

--- a/src/cli/internal/cmd/env/localtest/components/pdf.go
+++ b/src/cli/internal/cmd/env/localtest/components/pdf.go
@@ -46,7 +46,7 @@ func pdfImage(ctx *Options) resource.ImageResource {
 }
 
 func pdfContainer(ctx *Options) *ContainerSpec {
-	return newContainerSpec(
+	spec := newContainerSpec(
 		ContainerPDF3,
 		// TODO: same as above, we only need host port mapping here because old
 		[]types.PortMapping{newPort("5300", "5031")},
@@ -56,6 +56,9 @@ func pdfContainer(ctx *Options) *ContainerSpec {
 		[]string{ContainerLocaltest},
 		nil,
 	)
+	// PDF runs as an internal service and has no host-writable mounts, so avoid host UID/GID remapping.
+	spec.UseDefaultUser = true
+	return spec
 }
 
 func pdfEnv(topology envtopology.Local) map[string]string {

--- a/src/cli/internal/cmd/env/localtest/components/workflow_engine.go
+++ b/src/cli/internal/cmd/env/localtest/components/workflow_engine.go
@@ -121,7 +121,7 @@ func workflowEngineDbContainer(ctx *Options) *ContainerSpec {
 }
 
 func workflowEngineContainer(ctx *Options) *ContainerSpec {
-	return newContainerSpec(
+	spec := newContainerSpec(
 		ContainerWorkflowEngine,
 		nil,
 		workflowEngineEnv(ctx.Topology),
@@ -130,6 +130,9 @@ func workflowEngineContainer(ctx *Options) *ContainerSpec {
 		[]string{ContainerWorkflowEngineDb, ContainerLocaltest},
 		nil,
 	)
+	// Workflow-engine has no host-writable mounts, so use the image user instead of host UID/GID remapping.
+	spec.UseDefaultUser = true
+	return spec
 }
 
 func workflowEngineEnv(topology envtopology.Local) map[string]string {

--- a/src/cli/internal/cmd/env/localtest/manifest_internal_test.go
+++ b/src/cli/internal/cmd/env/localtest/manifest_internal_test.go
@@ -28,6 +28,28 @@ func TestCoreContainers_ServiceCallbacksUseLocaltestNetworkAlias(t *testing.T) {
 	assertWorkflowEngineContainerConfig(t, mustContainerSpec(t, resources, components.ContainerWorkflowEngine))
 }
 
+func TestCoreContainers_ServiceContainersUseImageUser(t *testing.T) {
+	t.Setenv(config.EnvCI, "")
+
+	opts := newResourceBuildOptions(t.TempDir(), false)
+	opts.RuntimeUser = "501:20"
+	opts.RuntimeUsernsMode = "keep-id"
+
+	resources := mustManifest(t, opts).Resources
+	for _, name := range []string{components.ContainerPDF3, components.ContainerWorkflowEngine} {
+		container := findResource(resources, resource.ContainerID(name))
+		if container == nil {
+			t.Fatalf("manifest missing %q", name)
+		}
+		if container.User != "" {
+			t.Fatalf("%s.User = %q, want image default", name, container.User)
+		}
+		if container.UsernsMode != "" {
+			t.Fatalf("%s.UsernsMode = %q, want image default", name, container.UsernsMode)
+		}
+	}
+}
+
 func assertLocaltestContainerConfig(t *testing.T, localtest components.ContainerSpec, dataDir string) {
 	t.Helper()
 	topology := testTopology()


### PR DESCRIPTION
## Description

Fixes Podman-related `studioctl` readiness/diagnostic issues seen with `studioctl env up` on macOS Podman machine setups.

- Treat Podman `State.Health.Status` as absent when full container inspect shows no configured `Config.Healthcheck` command. This prevents `studioctl env up` from waiting for `healthy` when Podman reports `starting` even though no healthcheck can run.
- Add client/server version metadata to the shared `devenv` container toolchain for Podman CLI.
- Add Docker Engine API version metadata to the shared toolchain so Docker, Colima, and Podman-over-Docker-socket diagnostics expose the resolved client/server information too.
- Show the resolved container client/server versions in `studioctl doctor` and mark the container prerequisite with a red X when a Podman CLI client/server mismatch is detected.

The failing user debug output showed `localtest` running and serving `/health` with 200, while Podman reported `Config.Healthcheck={}` and `State.Health.Status=starting`; `podman healthcheck run localtest` also reported that no healthcheck was defined.

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

Command transcript:

```bash
cd src/Runtime/devenv
make fmt && make lint && make test

cd ../../cli
make fmt && make lint && make test

go run ./cmd/studioctl doctor
```

Results:

```text
src/Runtime/devenv: make fmt passed, make lint passed with 0 issues, make test passed.
src/cli: make fmt passed, make lint passed with 0 issues, make test passed.
```

Relevant local `studioctl doctor` excerpt for the Docker Engine API path:

```text
Prerequisites
  ✓ .NET SDK        10.0.300
  ✓ Container       Docker (29.5.2)
    Resolved        Docker Engine API -> Docker (Default)
    Client          1.51
    Server          29.5.2
    Tools           docker (29.5.2), podman (5.8.2)
```

Expected Podman CLI mismatch output shape from the same doctor renderer:

```text
Prerequisites
  ✗ Container       Podman (5.8.2)
    Error           podman client/server version mismatch: client 5.8.2, server 5.2.4
    Resolved        Podman CLI -> Podman (Podman CLI)
    Client          5.8.2
    Server          5.2.4
    Tools           colima (0.10.1), docker (5.8.2), podman (5.8.2)

Some issues were found. See above for details.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Doctor now reports container client and server versions, shows conditional error/resolution rows, and warns on Podman client/server mismatches.

* **Bug Fixes**
  * Health status detection ignores absent or disabled healthchecks to avoid false statuses.
  * Localtest PDF and workflow-engine services run with their image default user to prevent host UID/GID mapping issues.

* **Performance**
  * Container tool discovery now runs probes in parallel for faster prerequisite checks.

* **Tests**
  * Added tests covering healthcheck behaviour, version parsing/metadata and service container user defaults.

* **Documentation**
  * Updated changelog with these additions and fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
