### PR TITLE
chore: update studioctl runtime images

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -12,6 +12,10 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 - Show resolved container runtime client/server versions in `studioctl doctor`.
 
+### Changed
+
+- Update localtest and workflow-engine images.
+
 ### Fixed
 
 - Ignore stale Podman container health status when no healthcheck command is configured.

--- a/src/cli/internal/config/config.yaml
+++ b/src/cli/internal/config/config.yaml
@@ -6,13 +6,13 @@ images:
   core:
     localtest:
       image: ghcr.io/altinn/altinn-studio/runtime-localtest
-      tag: "4863756293"
+      tag: "94897eff31"
     pdf3:
       image: ghcr.io/altinn/altinn-studio/runtime-pdf3-worker
       tag: "b885f9a75f"
     workflow-engine:
       image: ghcr.io/altinn/altinn-studio/runtime-workflow-engine-app
-      tag: "87caf8f862"
+      tag: "567e1be1f1"
     workflow-engine-db:
       image: postgres
       tag: "18.3"


### PR DESCRIPTION
## What changed

- Updated the embedded `studioctl` localtest image tag from `4863756293` to `94897eff31`.
- Updated the embedded `studioctl` workflow-engine image tag from `87caf8f862` to `567e1be1f1`.
- Added a `studioctl` changelog entry for the runtime image updates.

## Why

New runtime images have been published after recent runtime changes:

- `ghcr.io/altinn/altinn-studio/runtime-localtest:94897eff31` from the successful `Runtime - deploy localtest` run for `chore: Sync Localtest (#19043)`.
- `ghcr.io/altinn/altinn-studio/runtime-workflow-engine-app:567e1be1f1` from the successful image-push job in `Runtime - deploy workflow-engine-app` for `chore: Log workflow engine startup readiness (#19026)`.

`runtime-pdf3-worker` was also checked. `studioctl` already pins the newest GHCR tag found, `b885f9a75f`, so no pdf3 config change is needed.

## Verification

- Confirmed `upstream/main` is fetched and this branch is based on it.
- Confirmed GHCR contains `ghcr.io/altinn/altinn-studio/runtime-localtest:94897eff31`, created `2026-06-04T07:06:57Z`.
- Confirmed GHCR contains `ghcr.io/altinn/altinn-studio/runtime-workflow-engine-app:567e1be1f1`, created `2026-06-02T18:10:13Z`.
- Confirmed `runtime-pdf3-worker:b885f9a75f` is already the latest tagged GHCR version found.
- Ran `make fmt` in `src/cli`.
- Ran `make lint` in `src/cli`: `0 issues.`
- Ran `make build` in `src/cli`.
- Ran `make test` in `src/cli`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Updated default container images for local testing and the workflow engine to newer versions.

* **Documentation**
  * Changelog updated to reflect the image updates and recent configuration changes; added a missing numeric entry for completeness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->