### PR TITLE
chore: release studioctl v0.1.0-preview.12

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -8,6 +8,8 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+## [0.1.0-preview.12] - 2026-06-04
+
 ### Added
 
 - Show resolved container runtime client/server versions in `studioctl doctor`.


### PR DESCRIPTION
## Description

Prepare release v0.1.0-preview.12

- [Added] Show resolved container runtime client/server versions in `studioctl doctor`.
- [Changed] Update localtest and workflow-engine images.
- [Fixed] Ignore stale Podman container health status when no healthcheck command is configured.
- [Fixed] Warn in `studioctl doctor` when the Podman CLI client/server versions differ.
- [Fixed] Run localtest PDF and workflow-engine service containers with their image default user to avoid Podman `keep-id` group mapping failures on macOS.

@coderabbitai ignore

**Full Changelog**: https://github.com/Altinn/altinn-studio/compare/studioctl/v0.1.0-preview.11...studioctl/v0.1.0-preview.12