### PR TITLE
chore: add studioctl release note instructions

### DIFF
--- a/src/cli/RELEASE_NOTES_INTRO.md
+++ b/src/cli/RELEASE_NOTES_INTRO.md
@@ -1,0 +1,21 @@
+## Install or update
+
+Update an existing installation:
+
+```sh
+studioctl self update
+```
+
+Install:
+
+Linux and macOS:
+
+```sh
+curl -sSL https://altinn.studio/designer/api/v1/studioctl/install.sh | sh
+```
+
+Windows PowerShell:
+
+```powershell
+iwr https://altinn.studio/designer/api/v1/studioctl/install.ps1 -useb | iex
+```

--- a/src/tools/releaser/internal/errors.go
+++ b/src/tools/releaser/internal/errors.go
@@ -21,6 +21,7 @@ var (
 	errBackportNoEntries      = errors.New("no changelog entries found in commit")
 	errBackportInvalidVersion = errors.New("invalid branch version format (expected vX.Y)")
 	errUnsafeCleanDirPath     = errors.New("refusing to clean unsafe directory path")
+	errUnsafeReleaseNotesPath = errors.New("release notes intro path outside repo root")
 	errNoExistingParentPath   = errors.New("path has no existing parent directory")
 	errPromptIORequired       = errors.New("prompt input/output is required")
 

--- a/src/tools/releaser/internal/workflow.go
+++ b/src/tools/releaser/internal/workflow.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -516,8 +517,7 @@ func (w *Workflow) withComponentReleaseNotesIntro(notes string) (string, error) 
 	if err != nil {
 		return "", err
 	}
-	//nolint:gosec // G304: path is built from trusted component metadata and validated under repo root.
-	intro, err := os.ReadFile(introPath)
+	intro, err := fs.ReadFile(os.DirFS(w.config.RepoRoot), introPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return strings.TrimSpace(notes), nil
@@ -536,7 +536,11 @@ func (w *Workflow) componentReleaseNotesIntroPath() (string, error) {
 	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return "", fmt.Errorf("%w: %s", errUnsafeReleaseNotesPath, introPath)
 	}
-	return introPath, nil
+	rel = filepath.ToSlash(rel)
+	if !fs.ValidPath(rel) {
+		return "", fmt.Errorf("%w: %s", errUnsafeReleaseNotesPath, introPath)
+	}
+	return rel, nil
 }
 
 func withReleaseNotesIntro(notes, intro string) string {

--- a/src/tools/releaser/internal/workflow.go
+++ b/src/tools/releaser/internal/workflow.go
@@ -552,5 +552,5 @@ func withReleaseNotesIntro(notes, intro string) string {
 	if notes == "" {
 		return intro
 	}
-	return intro + "\n\n" + notes
+	return intro + "\n\n## Changelog\n\n" + notes
 }

--- a/src/tools/releaser/internal/workflow.go
+++ b/src/tools/releaser/internal/workflow.go
@@ -407,6 +407,10 @@ func (w *Workflow) createGitHubRelease(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("extract release notes: %w", err)
 	}
+	notes, err = w.withComponentReleaseNotesIntro(notes)
+	if err != nil {
+		return fmt.Errorf("read release notes intro: %w", err)
+	}
 	if w.config.Draft {
 		previousVersion := previousReleasedVersion(w.parsedChangelog, verStr)
 		previousTag := ""
@@ -503,4 +507,46 @@ func (w *Workflow) printSummary() {
 		w.log.Info("")
 		w.log.Success("Release workflow completed successfully!")
 	}
+}
+
+const releaseNotesIntroFile = "RELEASE_NOTES_INTRO.md"
+
+func (w *Workflow) withComponentReleaseNotesIntro(notes string) (string, error) {
+	introPath, err := w.componentReleaseNotesIntroPath()
+	if err != nil {
+		return "", err
+	}
+	//nolint:gosec // G304: path is built from trusted component metadata and validated under repo root.
+	intro, err := os.ReadFile(introPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return strings.TrimSpace(notes), nil
+		}
+		return "", fmt.Errorf("read %s: %w", introPath, err)
+	}
+	return withReleaseNotesIntro(notes, string(intro)), nil
+}
+
+func (w *Workflow) componentReleaseNotesIntroPath() (string, error) {
+	introPath := filepath.Join(w.config.RepoRoot, w.component.SourcePath, releaseNotesIntroFile)
+	rel, err := filepath.Rel(w.config.RepoRoot, introPath)
+	if err != nil {
+		return "", fmt.Errorf("evaluate release notes intro path: %w", err)
+	}
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("%w: %s", errUnsafeReleaseNotesPath, introPath)
+	}
+	return introPath, nil
+}
+
+func withReleaseNotesIntro(notes, intro string) string {
+	intro = strings.TrimSpace(intro)
+	notes = strings.TrimSpace(notes)
+	if intro == "" {
+		return notes
+	}
+	if notes == "" {
+		return intro
+	}
+	return intro + "\n\n" + notes
 }

--- a/src/tools/releaser/internal/workflow_version_resolver_test.go
+++ b/src/tools/releaser/internal/workflow_version_resolver_test.go
@@ -108,9 +108,10 @@ func TestRunWorkflow_SelectsLatestPrereleaseForMain(t *testing.T) {
 		"studioctl self update",
 		"https://altinn.studio/designer/api/v1/studioctl/install.sh",
 		"https://altinn.studio/designer/api/v1/studioctl/install.ps1",
+		"## Changelog\n\n### Added",
 	} {
 		if !strings.Contains(string(content), want) {
-			t.Fatalf("release notes missing studioctl install/update text %q:\n%s", want, string(content))
+			t.Fatalf("release notes missing expected content %q:\n%s", want, string(content))
 		}
 	}
 	const prereleaseCompare = "**Full Changelog**: https://github.com/Altinn/altinn-studio/compare/studioctl/v1.2.0-preview.1...studioctl/v1.2.0-preview.2"

--- a/src/tools/releaser/internal/workflow_version_resolver_test.go
+++ b/src/tools/releaser/internal/workflow_version_resolver_test.go
@@ -103,6 +103,16 @@ func TestRunWorkflow_SelectsLatestPrereleaseForMain(t *testing.T) {
 	if !strings.Contains(string(content), "Latest preview notes") {
 		t.Fatalf("release notes did not use latest prerelease:\n%s", string(content))
 	}
+	for _, want := range []string{
+		"## Install or update",
+		"studioctl self update",
+		"https://altinn.studio/designer/api/v1/studioctl/install.sh",
+		"https://altinn.studio/designer/api/v1/studioctl/install.ps1",
+	} {
+		if !strings.Contains(string(content), want) {
+			t.Fatalf("release notes missing studioctl install/update text %q:\n%s", want, string(content))
+		}
+	}
 	const prereleaseCompare = "**Full Changelog**: https://github.com/Altinn/altinn-studio/compare/studioctl/v1.2.0-preview.1...studioctl/v1.2.0-preview.2"
 	if !strings.Contains(string(content), prereleaseCompare) {
 		t.Fatalf("release notes missing compare link %q:\n%s", prereleaseCompare, string(content))
@@ -256,6 +266,28 @@ func createStudioctlWorkflowRepo(t *testing.T, changelog string) string {
 	runGitCmd(t, repoDir, "config", "user.name", "Test User")
 
 	writeRepoFile(t, repoDir, "src/cli/CHANGELOG.md", changelog)
+	writeRepoFile(t, repoDir, "src/cli/RELEASE_NOTES_INTRO.md", `## Install or update
+
+Update an existing installation:
+
+~~~sh
+studioctl self update
+~~~
+
+Install a new copy:
+
+Linux and macOS:
+
+~~~sh
+curl -sSL https://altinn.studio/designer/api/v1/studioctl/install.sh | sh
+~~~
+
+Windows PowerShell:
+
+~~~powershell
+iwr https://altinn.studio/designer/api/v1/studioctl/install.ps1 -useb | iex
+~~~
+`)
 	writeRepoFile(t, repoDir, "README.md", "test\n")
 
 	runGitCmd(t, repoDir, "add", ".")


### PR DESCRIPTION
## What changed

- Added `src/cli/RELEASE_NOTES_INTRO.md` with compact studioctl install/update instructions.
- Updated the releaser workflow to prepend an optional `<component.SourcePath>/RELEASE_NOTES_INTRO.md` file to generated GitHub release notes.
- Added test coverage that verifies generated studioctl release notes include the install/update text.

## Why

The generated studioctl GitHub release notes should include the practical update/install commands without hard-coding long component-specific markdown into the releaser component registry.

## Verification

Ran in `src/tools/releaser`:

- `make fmt`
- `make test`
- `make build`
- `make lint` (`0 issues`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Release notes now prepend component-specific introductory text and include platform-specific CLI installation and update instructions (Linux/macOS and Windows PowerShell), improving clarity for end users.

* **Tests**
  * Updated test expectations to verify the inclusion of the new install/update section in generated release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->