### PR TITLE
fix: Resolves CodeQL warnings related to path traversal security

### DIFF
--- a/src/Designer/backend/src/Designer/Infrastructure/GitRepository/AltinnAppGitRepository.cs
+++ b/src/Designer/backend/src/Designer/Infrastructure/GitRepository/AltinnAppGitRepository.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Serialization;
@@ -18,6 +19,7 @@ using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Models.App;
 using Altinn.Studio.Designer.TypedHttpClients.Exceptions;
 using LibGit2Sharp;
+using Microsoft.AspNetCore.Http;
 using JsonSerializer = System.Text.Json.JsonSerializer;
 using LayoutSets = Altinn.Studio.Designer.Models.LayoutSets;
 
@@ -74,6 +76,9 @@ public class AltinnAppGitRepository : AltinnGitRepository
         ["$schema"] = LayoutSettingsSchemaUrl,
         ["pages"] = new JsonObject { ["order"] = new JsonArray([InitialLayoutFileName]) },
     };
+
+    private static readonly Regex s_layoutSetNameRegex = new(@"^[a-zA-Z0-9_\-]{2,28}$", RegexOptions.Compiled);
+    private static readonly Regex s_layoutNameRegex = new(@"^[a-zA-Z0-9_\-]{1,128}$", RegexOptions.Compiled);
 
     private static readonly JsonSerializerOptions s_jsonOptions = new()
     {
@@ -1037,9 +1042,43 @@ public class AltinnAppGitRepository : AltinnGitRepository
             : Path.Combine(ConfigFolderPath, LanguageResourceFolderName, fileName);
     }
 
+    private static string ValidateLayoutSetName(string layoutSetName)
+    {
+        if (string.IsNullOrEmpty(layoutSetName))
+        {
+            return layoutSetName;
+        }
+        if (
+            layoutSetName.Contains("..", StringComparison.Ordinal)
+            || layoutSetName.Contains('/')
+            || layoutSetName.Contains('\\')
+            || !s_layoutSetNameRegex.IsMatch(layoutSetName)
+        )
+        {
+            throw new BadHttpRequestException("Invalid layout set name.");
+        }
+        return layoutSetName;
+    }
+
+    private static string ValidateLayoutName(string layoutName)
+    {
+        if (
+            string.IsNullOrEmpty(layoutName)
+            || layoutName.Contains("..", StringComparison.Ordinal)
+            || layoutName.Contains('/')
+            || layoutName.Contains('\\')
+            || !s_layoutNameRegex.IsMatch(layoutName)
+        )
+        {
+            throw new BadHttpRequestException("Invalid layout name.");
+        }
+        return layoutName;
+    }
+
     // can be null if app does not use layout set
     private static string GetPathToLayoutSet(string layoutSetName, bool excludeLayoutsFolderName = false)
     {
+        layoutSetName = ValidateLayoutSetName(layoutSetName);
         var layoutFolderName = excludeLayoutsFolderName ? string.Empty : LayoutsInSetFolderName;
         return string.IsNullOrEmpty(layoutSetName)
             ? Path.Combine(LayoutsFolderName, layoutFolderName)
@@ -1049,6 +1088,8 @@ public class AltinnAppGitRepository : AltinnGitRepository
     // can be null if app does not use layout set
     private static string GetPathToLayoutFile(string layoutSetName, string layoutName)
     {
+        layoutSetName = ValidateLayoutSetName(layoutSetName);
+        layoutName = ValidateLayoutName(layoutName);
         return string.IsNullOrEmpty(layoutSetName)
             ? Path.Combine(LayoutsFolderName, LayoutsInSetFolderName, $"{layoutName}.json")
             : Path.Combine(LayoutsFolderName, layoutSetName, LayoutsInSetFolderName, $"{layoutName}.json");
@@ -1057,6 +1098,7 @@ public class AltinnAppGitRepository : AltinnGitRepository
     // can be null if app does not use layout set
     private static string GetPathToLayoutSettings(string layoutSetName)
     {
+        layoutSetName = ValidateLayoutSetName(layoutSetName);
         return string.IsNullOrEmpty(layoutSetName)
             ? Path.Combine(LayoutsFolderName, SettingsFilename)
             : Path.Combine(LayoutsFolderName, layoutSetName, SettingsFilename);
@@ -1079,6 +1121,7 @@ public class AltinnAppGitRepository : AltinnGitRepository
 
     private static string GetPathToRuleHandler(string layoutSetName)
     {
+        layoutSetName = ValidateLayoutSetName(layoutSetName);
         return string.IsNullOrEmpty(layoutSetName)
             ? Path.Combine(LayoutsFolderName, RuleHandlerFilename)
             : Path.Combine(LayoutsFolderName, layoutSetName, RuleHandlerFilename);
@@ -1086,6 +1129,7 @@ public class AltinnAppGitRepository : AltinnGitRepository
 
     private static string GetPathToRuleConfiguration(string layoutSetName)
     {
+        layoutSetName = ValidateLayoutSetName(layoutSetName);
         return string.IsNullOrEmpty(layoutSetName)
             ? Path.Combine(LayoutsFolderName, RuleConfigurationFilename)
             : Path.Combine(LayoutsFolderName, layoutSetName, RuleConfigurationFilename);

--- a/src/Designer/backend/src/Designer/Infrastructure/GitRepository/GitRepository.cs
+++ b/src/Designer/backend/src/Designer/Infrastructure/GitRepository/GitRepository.cs
@@ -9,6 +9,7 @@ using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Helpers;
+using Microsoft.AspNetCore.Http;
 
 namespace Altinn.Studio.Designer.Infrastructure.GitRepository;
 
@@ -442,17 +443,26 @@ public class GitRepository
     /// <param name="relativeFilePath">Relative path to the file to get the absolute path for.</param>
     protected string GetAbsoluteFileOrDirectoryPathSanitized(string relativeFilePath)
     {
-        if (relativeFilePath.StartsWith("/") || relativeFilePath.StartsWith("\\"))
+        Guard.AssertNotNullOrEmpty(relativeFilePath, nameof(relativeFilePath));
+        // Normalize separators first so rooted-path checks are consistent across platforms.
+        relativeFilePath = relativeFilePath.Replace('\\', Path.DirectorySeparatorChar);
+        // Reject absolute/rooted input from callers. Only repository-relative paths are allowed.
+
+        if (Path.IsPathRooted(relativeFilePath))
         {
-            relativeFilePath = relativeFilePath[1..];
+            throw new BadHttpRequestException("Invalid file path.");
         }
 
-        // We do this to avoid paths like c:\altinn\repositories\developer\org\repo\..\..\somefile.txt
-        // By first combining the paths, the getting the full path you will get c:\altinn\repositories\developer\org\repo\somefile.txt
-        // This also makes it easier to avoid people trying to get outside their repository directory.
-        relativeFilePath = relativeFilePath.Replace('\\', Path.DirectorySeparatorChar);
-        string absoluteFilePath = Path.Combine(RepositoryDirectory, relativeFilePath);
-        absoluteFilePath = Path.GetFullPath(absoluteFilePath);
+        string repositoryRoot = Path.GetFullPath(RepositoryDirectory);
+        string absoluteFilePath = Path.GetFullPath(Path.Combine(repositoryRoot, relativeFilePath));
+        string repositoryRootWithSeparator = repositoryRoot.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        if (
+            !absoluteFilePath.Equals(repositoryRoot, StringComparison.Ordinal)
+            && !absoluteFilePath.StartsWith(repositoryRootWithSeparator, StringComparison.Ordinal)
+        )
+        {
+            throw new BadHttpRequestException("Invalid file path.");
+        }
         return absoluteFilePath;
     }
 

--- a/src/Designer/backend/src/Designer/Infrastructure/GitRepository/GitRepository.cs
+++ b/src/Designer/backend/src/Designer/Infrastructure/GitRepository/GitRepository.cs
@@ -9,7 +9,6 @@ using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Helpers;
-using Microsoft.AspNetCore.Http;
 
 namespace Altinn.Studio.Designer.Infrastructure.GitRepository;
 
@@ -218,8 +217,7 @@ public class GitRepository
             CreateDirectory(absoluteFilePath);
         }
 
-        cancellationToken.ThrowIfCancellationRequested();
-        await File.WriteAllTextAsync(absoluteFilePath, text, Encoding.UTF8, cancellationToken);
+        await WriteTextAsync(absoluteFilePath, text, cancellationToken);
     }
 
     /// <summary>
@@ -375,7 +373,10 @@ public class GitRepository
     {
         string absoluteFilePath = GetAbsoluteFileOrDirectoryPathSanitized(relativeFilePath);
 
-        Guard.AssertFilePathWithinParentDirectory(RepositoryDirectory, absoluteFilePath);
+        if (!absoluteFilePath.StartsWith(RepositoryDirectory))
+        {
+            return false;
+        }
 
         return File.Exists(absoluteFilePath);
     }
@@ -388,7 +389,10 @@ public class GitRepository
     {
         string absoluteDirectoryPath = GetAbsoluteFileOrDirectoryPathSanitized(relativeDirectoryPath);
 
-        Guard.AssertFilePathWithinParentDirectory(RepositoryDirectory, absoluteDirectoryPath);
+        if (!absoluteDirectoryPath.StartsWith(RepositoryDirectory))
+        {
+            return false;
+        }
 
         return Directory.Exists(absoluteDirectoryPath);
     }
@@ -443,26 +447,17 @@ public class GitRepository
     /// <param name="relativeFilePath">Relative path to the file to get the absolute path for.</param>
     protected string GetAbsoluteFileOrDirectoryPathSanitized(string relativeFilePath)
     {
-        Guard.AssertNotNullOrEmpty(relativeFilePath, nameof(relativeFilePath));
-        // Normalize separators first so rooted-path checks are consistent across platforms.
+        if (relativeFilePath.StartsWith("/") || relativeFilePath.StartsWith("\\"))
+        {
+            relativeFilePath = relativeFilePath[1..];
+        }
+
+        // We do this to avoid paths like c:\altinn\repositories\developer\org\repo\..\..\somefile.txt
+        // By first combining the paths, the getting the full path you will get c:\altinn\repositories\developer\org\repo\somefile.txt
+        // This also makes it easier to avoid people trying to get outside their repository directory.
         relativeFilePath = relativeFilePath.Replace('\\', Path.DirectorySeparatorChar);
-        // Reject absolute/rooted input from callers. Only repository-relative paths are allowed.
-
-        if (Path.IsPathRooted(relativeFilePath))
-        {
-            throw new BadHttpRequestException("Invalid file path.");
-        }
-
-        string repositoryRoot = Path.GetFullPath(RepositoryDirectory);
-        string absoluteFilePath = Path.GetFullPath(Path.Combine(repositoryRoot, relativeFilePath));
-        string repositoryRootWithSeparator = repositoryRoot.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
-        if (
-            !absoluteFilePath.Equals(repositoryRoot, StringComparison.Ordinal)
-            && !absoluteFilePath.StartsWith(repositoryRootWithSeparator, StringComparison.Ordinal)
-        )
-        {
-            throw new BadHttpRequestException("Invalid file path.");
-        }
+        string absoluteFilePath = Path.Combine(RepositoryDirectory, relativeFilePath);
+        absoluteFilePath = Path.GetFullPath(absoluteFilePath);
         return absoluteFilePath;
     }
 
@@ -497,6 +492,25 @@ public class GitRepository
         }
 
         return sb.ToString();
+    }
+
+    private static async Task WriteTextAsync(
+        string absoluteFilePath,
+        string text,
+        CancellationToken cancellationToken = default
+    )
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        byte[] encodedText = Encoding.UTF8.GetBytes(text);
+        await using FileStream sourceStream = new(
+            absoluteFilePath,
+            FileMode.Create,
+            FileAccess.Write,
+            FileShare.None,
+            bufferSize: 4096,
+            useAsync: true
+        );
+        await sourceStream.WriteAsync(encodedText.AsMemory(0, encodedText.Length), cancellationToken);
     }
 
     private static async Task WriteAsync(

--- a/src/Designer/backend/src/Designer/Infrastructure/GitRepository/GitRepository.cs
+++ b/src/Designer/backend/src/Designer/Infrastructure/GitRepository/GitRepository.cs
@@ -217,7 +217,8 @@ public class GitRepository
             CreateDirectory(absoluteFilePath);
         }
 
-        await WriteTextAsync(absoluteFilePath, text, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+        await File.WriteAllTextAsync(absoluteFilePath, text, Encoding.UTF8, cancellationToken);
     }
 
     /// <summary>
@@ -373,10 +374,7 @@ public class GitRepository
     {
         string absoluteFilePath = GetAbsoluteFileOrDirectoryPathSanitized(relativeFilePath);
 
-        if (!absoluteFilePath.StartsWith(RepositoryDirectory))
-        {
-            return false;
-        }
+        Guard.AssertFilePathWithinParentDirectory(RepositoryDirectory, absoluteFilePath);
 
         return File.Exists(absoluteFilePath);
     }
@@ -389,10 +387,7 @@ public class GitRepository
     {
         string absoluteDirectoryPath = GetAbsoluteFileOrDirectoryPathSanitized(relativeDirectoryPath);
 
-        if (!absoluteDirectoryPath.StartsWith(RepositoryDirectory))
-        {
-            return false;
-        }
+        Guard.AssertFilePathWithinParentDirectory(RepositoryDirectory, absoluteDirectoryPath);
 
         return Directory.Exists(absoluteDirectoryPath);
     }
@@ -492,25 +487,6 @@ public class GitRepository
         }
 
         return sb.ToString();
-    }
-
-    private static async Task WriteTextAsync(
-        string absoluteFilePath,
-        string text,
-        CancellationToken cancellationToken = default
-    )
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        byte[] encodedText = Encoding.UTF8.GetBytes(text);
-        await using FileStream sourceStream = new(
-            absoluteFilePath,
-            FileMode.Create,
-            FileAccess.Write,
-            FileShare.None,
-            bufferSize: 4096,
-            useAsync: true
-        );
-        await sourceStream.WriteAsync(encodedText.AsMemory(0, encodedText.Length), cancellationToken);
     }
 
     private static async Task WriteAsync(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Resolves CodeQL warnings related to path traversal security in `AltinnAppGitRepository`.

Added input validation for `layoutSetName `and `layoutName `in path-building helper methods (`GetPathToLayoutSet`, `GetPathToLayoutFile`, `GetPathToLayoutSettings`, `GetPathToRuleHandler`, `GetPathToRuleConfiguration`).
The validation rejects names containing `.., /, or \`, and requires them to match an allowed character set to prevent path traversal.

<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
