### PR TITLE
fix: upgrade v9 apps to resolved package version

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -8,6 +8,10 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+### Fixed
+
+- Update `studioctl app upgrade v9` to target `net10.0` and resolve v9 app package versions from configured NuGet sources.
+
 ## [0.1.0-preview.12] - 2026-06-04
 
 ### Added

--- a/src/cli/studioctl-server/Platform/ProcessUtil.cs
+++ b/src/cli/studioctl-server/Platform/ProcessUtil.cs
@@ -18,4 +18,15 @@ internal static class ProcessUtil
 
         return startInfo;
     }
+
+    public static ProcessStartInfo CreateStartInfo(string fileName, params string[] arguments)
+    {
+        var startInfo = CreateStartInfo(fileName);
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        return startInfo;
+    }
 }

--- a/src/cli/studioctl-server/Studioctl/AppUpgradeService.cs
+++ b/src/cli/studioctl-server/Studioctl/AppUpgradeService.cs
@@ -7,6 +7,7 @@ namespace Altinn.Studio.StudioctlServer.Studioctl;
 
 internal sealed class AppUpgradeService : IDisposable
 {
+    // TODO: split into per-version upgrade services.
     private const string DefaultProjectFile = "App/App.csproj";
     private const string DefaultProcessFile = "App/config/process/process.bpmn";
     private const string DefaultAppSettingsFolder = "App";

--- a/src/cli/studioctl-server/Studioctl/AppUpgradeService.cs
+++ b/src/cli/studioctl-server/Studioctl/AppUpgradeService.cs
@@ -7,11 +7,12 @@ namespace Altinn.Studio.StudioctlServer.Studioctl;
 
 internal sealed class AppUpgradeService : IDisposable
 {
-    // TODO: split into per-version, separate tfm for v9 etc...
     private const string DefaultProjectFile = "App/App.csproj";
     private const string DefaultProcessFile = "App/config/process/process.bpmn";
     private const string DefaultAppSettingsFolder = "App";
-    private const string DefaultTargetFramework = "net8.0";
+    private const string DefaultBackendTargetFramework = "net8.0";
+    private const string DefaultV9TargetFramework = "net10.0";
+    private const int DefaultV9TargetMajorVersion = 9;
     private const string DefaultFrontendTargetVersion = "4";
     private const string DefaultBackendTargetVersion = "8.7.0";
     private const string DefaultIndexFile = "App/views/Home/Index.cshtml";
@@ -109,7 +110,7 @@ internal sealed class AppUpgradeService : IDisposable
                     ProcessFile: DefaultProcessFile,
                     AppSettingsFolder: DefaultAppSettingsFolder,
                     TargetVersion: DefaultBackendTargetVersion,
-                    TargetFramework: DefaultTargetFramework,
+                    TargetFramework: DefaultBackendTargetFramework,
                     SkipCodeUpgrade: false,
                     SkipProcessUpgrade: false,
                     SkipCsprojUpgrade: false,
@@ -124,7 +125,8 @@ internal sealed class AppUpgradeService : IDisposable
                 new V8Tov9UpgradeOptions(
                     ProjectFolder: request.ProjectFolder,
                     ProjectFile: DefaultProjectFile,
-                    TargetFramework: DefaultTargetFramework,
+                    TargetMajorVersion: DefaultV9TargetMajorVersion,
+                    TargetFramework: DefaultV9TargetFramework,
                     SkipCsprojUpgrade: false,
                     ConvertPackageReferences: request.ConvertPackageReferences,
                     StudioRoot: request.StudioRoot,

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/V8Tov9Upgrade.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/V8Tov9Upgrade.cs
@@ -11,6 +11,7 @@ namespace Altinn.Studio.Cli.Upgrade.v8Tov9;
 internal sealed record V8Tov9UpgradeOptions(
     string ProjectFolder,
     string ProjectFile,
+    int TargetMajorVersion,
     string TargetFramework,
     bool SkipCsprojUpgrade,
     bool ConvertPackageReferences,
@@ -51,14 +52,23 @@ internal static class V8Tov9Upgrade
         if (!options.SkipCsprojUpgrade)
         {
             if (options.ConvertPackageReferences)
+            {
                 returnCode = await ConvertToProjectReferences(
                     projectFolder,
                     projectFile,
                     options.TargetFramework,
                     options.StudioRoot
                 );
+            }
             else
-                returnCode = await UpgradeProjectFile(projectFile, options.TargetFramework);
+            {
+                var targetVersion = await V9PackageVersionResolver.ResolveLatestTargetVersion(
+                    projectFolder,
+                    options.TargetMajorVersion,
+                    options.CancellationToken
+                );
+                returnCode = await UpgradeProjectFile(projectFile, targetVersion, options.TargetFramework);
+            }
         }
 
         options.CancellationToken.ThrowIfCancellationRequested();
@@ -93,12 +103,12 @@ internal static class V8Tov9Upgrade
         return returnCode;
     }
 
-    static async Task<int> UpgradeProjectFile(string projectFile, string targetFramework)
+    static async Task<int> UpgradeProjectFile(string projectFile, string targetVersion, string targetFramework)
     {
         try
         {
-            var rewriter = new ProjectFileRewriter(projectFile, targetFramework: targetFramework);
-            await rewriter.SetTargetFramework();
+            var rewriter = new ProjectFileRewriter(projectFile, targetVersion, targetFramework);
+            await rewriter.Upgrade();
             return 0;
         }
         catch (Exception ex)

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/V9PackageVersionResolver.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/V9PackageVersionResolver.cs
@@ -1,0 +1,199 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Altinn.Studio.StudioctlServer.Platform;
+
+namespace Altinn.Studio.Cli.Upgrade.v8Tov9;
+
+internal static class V9PackageVersionResolver
+{
+    public static async Task<string> ResolveLatestTargetVersion(
+        string projectFolder,
+        int targetMajorVersion,
+        CancellationToken cancellationToken
+    )
+    {
+        var apiVersions = await SearchPackageVersions("Altinn.App.Api", projectFolder, cancellationToken);
+        var coreVersions = await SearchPackageVersions("Altinn.App.Core", projectFolder, cancellationToken);
+        return ResolveLatestTargetVersion(apiVersions, coreVersions, targetMajorVersion);
+    }
+
+    internal static string ResolveLatestTargetVersion(
+        IReadOnlyCollection<string> apiVersions,
+        IReadOnlyCollection<string> coreVersions,
+        int targetMajorVersion
+    )
+    {
+        var coreVersionSet = coreVersions.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var latest = apiVersions
+            .Where(coreVersionSet.Contains)
+            .Select(NuGetPackageVersion.TryParse)
+            .OfType<NuGetPackageVersion>()
+            .Where(v => v.Major == targetMajorVersion)
+            .OrderDescending()
+            .FirstOrDefault();
+
+        if (latest is null)
+        {
+            throw new InvalidOperationException(
+                $"Could not find a common Altinn.App.Api/Altinn.App.Core version with major version {targetMajorVersion} "
+                    + "in the configured NuGet package sources."
+            );
+        }
+
+        return latest.Original;
+    }
+
+    private static async Task<IReadOnlyList<string>> SearchPackageVersions(
+        string packageId,
+        string projectFolder,
+        CancellationToken cancellationToken
+    )
+    {
+        var startInfo = ProcessUtil.CreateStartInfo(
+            "dotnet",
+            "package",
+            "search",
+            packageId,
+            "--exact-match",
+            "--prerelease",
+            "--format",
+            "json"
+        );
+        startInfo.WorkingDirectory = projectFolder;
+        startInfo.RedirectStandardOutput = true;
+        startInfo.RedirectStandardError = true;
+
+        using var process =
+            Process.Start(startInfo) ?? throw new InvalidOperationException("Failed to start dotnet package search.");
+        var stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+        await process.WaitForExitAsync(cancellationToken);
+        var stdout = await stdoutTask;
+        var stderr = await stderrTask;
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"dotnet package search failed for {packageId} with exit code {process.ExitCode}: {stderr.Trim()}"
+            );
+        }
+
+        return ParsePackageSearchResult(stdout, packageId);
+    }
+
+    internal static IReadOnlyList<string> ParsePackageSearchResult(string json, string packageId)
+    {
+        using var document = JsonDocument.Parse(json);
+        if (!document.RootElement.TryGetProperty("searchResult", out var searchResult))
+        {
+            throw new InvalidOperationException($"Could not parse dotnet package search output for {packageId}.");
+        }
+
+        var versions = new List<string>();
+        foreach (var source in searchResult.EnumerateArray())
+        {
+            if (!source.TryGetProperty("packages", out var packages))
+                continue;
+
+            foreach (var package in packages.EnumerateArray())
+            {
+                if (
+                    package.TryGetProperty("id", out var id)
+                    && package.TryGetProperty("version", out var version)
+                    && string.Equals(id.GetString(), packageId, StringComparison.OrdinalIgnoreCase)
+                    && version.GetString() is { } versionValue
+                )
+                {
+                    versions.Add(versionValue);
+                }
+            }
+        }
+
+        return versions.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+    }
+
+    private sealed record NuGetPackageVersion(
+        string Original,
+        int Major,
+        int Minor,
+        int Patch,
+        IReadOnlyList<string> Prerelease
+    ) : IComparable<NuGetPackageVersion>
+    {
+        public static NuGetPackageVersion? TryParse(string value)
+        {
+            var versionAndMetadata = value.Split('+', 2)[0];
+            var versionParts = versionAndMetadata.Split('-', 2);
+            var numericParts = versionParts[0].Split('.');
+            if (
+                numericParts.Length < 3
+                || !int.TryParse(numericParts[0], out var major)
+                || !int.TryParse(numericParts[1], out var minor)
+                || !int.TryParse(numericParts[2], out var patch)
+            )
+            {
+                return null;
+            }
+
+            var prerelease =
+                versionParts.Length == 2 ? versionParts[1].Split('.', StringSplitOptions.RemoveEmptyEntries) : [];
+
+            return new NuGetPackageVersion(value, major, minor, patch, prerelease);
+        }
+
+        public int CompareTo(NuGetPackageVersion? other)
+        {
+            if (other is null)
+                return 1;
+
+            var numericComparison = Major.CompareTo(other.Major);
+            if (numericComparison != 0)
+                return numericComparison;
+
+            numericComparison = Minor.CompareTo(other.Minor);
+            if (numericComparison != 0)
+                return numericComparison;
+
+            numericComparison = Patch.CompareTo(other.Patch);
+            if (numericComparison != 0)
+                return numericComparison;
+
+            return ComparePrerelease(Prerelease, other.Prerelease);
+        }
+
+        private static int ComparePrerelease(IReadOnlyList<string> left, IReadOnlyList<string> right)
+        {
+            if (left.Count == 0 && right.Count == 0)
+                return 0;
+            if (left.Count == 0)
+                return 1;
+            if (right.Count == 0)
+                return -1;
+
+            for (var i = 0; i < Math.Min(left.Count, right.Count); i++)
+            {
+                var leftIsNumber = int.TryParse(left[i], out var leftNumber);
+                var rightIsNumber = int.TryParse(right[i], out var rightNumber);
+
+                if (leftIsNumber && rightIsNumber)
+                {
+                    var numberComparison = leftNumber.CompareTo(rightNumber);
+                    if (numberComparison != 0)
+                        return numberComparison;
+                    continue;
+                }
+
+                if (leftIsNumber)
+                    return -1;
+                if (rightIsNumber)
+                    return 1;
+
+                var textComparison = string.Compare(left[i], right[i], StringComparison.OrdinalIgnoreCase);
+                if (textComparison != 0)
+                    return textComparison;
+            }
+
+            return left.Count.CompareTo(right.Count);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Fixes `studioctl app upgrade v9` for apps outside the Altinn Studio repo that should stay on `PackageReference`.

The v9 upgrade now:

- targets `net10.0`
- resolves the newest common v9 `Altinn.App.Api` / `Altinn.App.Core` version from the app's configured NuGet sources using `dotnet package search`
- updates app package references to the resolved version
- keeps the existing ProjectReference conversion path for apps inside the Altinn Studio repo

## Verification

Ran in `src/cli`:

```text
dotnet build studioctl-server/studioctl-server.csproj
make fmt
make test
make lint
make user-install
```

Results:

```text
dotnet build: Build succeeded, 0 warnings, 0 errors
make fmt: completed
make test: passed
make lint: 0 issues
make user-install: completed
```

Manual app upgrade check:

```text
App: /tmp/martinotest-upgrade-v9-package-fix
NuGet.Config: local-v9 source /tmp/app-v9-local-feed + nuget.org
Command: studioctl app upgrade v9
```

Observed rewrite:

```text
<TargetFramework>net10.0</TargetFramework>
<PackageReference Include="Altinn.App.Api" Version="9.0.0-preview.1.local.84775083f498" />
<PackageReference Include="Altinn.App.Core" Version="9.0.0-preview.1.local.84775083f498" />
```

Then ran:

```text
dotnet build App/App.csproj
```

Result:

```text
Build succeeded, 1 warning, 0 errors
```

The warning is from existing app code in `InstanceValidation.cs` (`CS9113`, unread parameter).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed v8→v9 application upgrade to target .NET 10.0 and to automatically resolve the latest compatible v9 package versions from configured NuGet sources, improving upgrade reliability.

* **Documentation**
  * Updated changelog to record the v9 upgrade target and package resolution behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->