### PR TITLE
fix: standardize v9 app launch settings

### DIFF
--- a/src/App/template/src/App/Properties/launchSettings.json
+++ b/src/App/template/src/App/Properties/launchSettings.json
@@ -1,23 +1,10 @@
 {
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:56226/",
-      "sslPort": 0
-    }
-  },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "AppRef": {
+    "App": {
       "commandName": "Project",
-      "launchBrowser": true,
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://local.altinn.cloud:8000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -11,6 +11,7 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 ### Fixed
 
 - Update `studioctl app upgrade v9` to target `net10.0` and resolve v9 app package versions from configured NuGet sources.
+- Update `studioctl app upgrade v9` to replace legacy IIS Express launch settings with the standard `App` project launch profile.
 
 ## [0.1.0-preview.12] - 2026-06-04
 

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/LaunchSettingsMigration.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/LaunchSettingsMigration.cs
@@ -1,0 +1,132 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Altinn.Studio.Cli.Upgrade.v8Tov9;
+
+internal static class LaunchSettingsMigration
+{
+    private const string AspNetCoreEnvironment = "ASPNETCORE_ENVIRONMENT";
+    private const string DevelopmentEnvironment = "Development";
+    private const string LocalAltinnHost = "local.altinn.cloud";
+    private const int LocalAltinnPort = 8000;
+    private static readonly string _applicationUrl = $"http://{LocalAltinnHost}:{LocalAltinnPort}";
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new() { WriteIndented = true };
+
+    internal static async Task Migrate(string projectFile)
+    {
+        var appDirectory = Path.GetDirectoryName(projectFile);
+        if (string.IsNullOrWhiteSpace(appDirectory))
+            throw new InvalidOperationException($"Unable to resolve app directory from project file: {projectFile}");
+
+        var propertiesDirectory = Path.Combine(appDirectory, "Properties");
+        Directory.CreateDirectory(propertiesDirectory);
+
+        var launchSettingsFile = Path.Combine(propertiesDirectory, "launchSettings.json");
+        var root = File.Exists(launchSettingsFile)
+            ? ParseLaunchSettings(await File.ReadAllTextAsync(launchSettingsFile), launchSettingsFile)
+            : new JsonObject();
+
+        Migrate(root);
+
+        await File.WriteAllTextAsync(
+            launchSettingsFile,
+            root.ToJsonString(_jsonSerializerOptions) + Environment.NewLine
+        );
+    }
+
+    private static JsonObject ParseLaunchSettings(string content, string launchSettingsFile)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+            return new JsonObject();
+
+        try
+        {
+            var root = JsonNode.Parse(content) as JsonObject;
+            if (root is not null)
+                return root;
+
+            UpgradeConsole.WriteLine(
+                $"Warning: {launchSettingsFile} does not contain a JSON object. Writing standard launch settings."
+            );
+            return new JsonObject();
+        }
+        catch (JsonException)
+        {
+            UpgradeConsole.WriteLine(
+                $"Warning: Could not parse {launchSettingsFile}. Writing standard launch settings."
+            );
+            return new JsonObject();
+        }
+    }
+
+    private static void Migrate(JsonObject root)
+    {
+        root.Remove("iisSettings");
+
+        var profiles = root["profiles"] as JsonObject;
+        if (profiles is null)
+        {
+            profiles = new JsonObject();
+            root["profiles"] = profiles;
+        }
+
+        RemoveIisProfiles(profiles);
+        var appProfile = ResolveAppProfile(profiles);
+
+        appProfile["applicationUrl"] = _applicationUrl;
+        if (!appProfile.ContainsKey("dotnetRunMessages"))
+            appProfile["dotnetRunMessages"] = true;
+    }
+
+    private static void RemoveIisProfiles(JsonObject profiles)
+    {
+        var profileNames = profiles
+            .Where(profile => IsIisProfile(profile.Key, profile.Value as JsonObject))
+            .Select(profile => profile.Key)
+            .ToList();
+
+        foreach (var profileName in profileNames)
+        {
+            profiles.Remove(profileName);
+        }
+    }
+
+    private static bool IsIisProfile(string profileName, JsonObject? profile)
+    {
+        if (profileName.Contains("IIS", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return string.Equals(GetString(profile?["commandName"]), "IISExpress", StringComparison.Ordinal);
+    }
+
+    private static JsonObject ResolveAppProfile(JsonObject profiles)
+    {
+        if (profiles["App"] is JsonObject appProfile)
+        {
+            profiles.Remove("AppRef");
+            return appProfile;
+        }
+
+        if (profiles["AppRef"] is JsonObject appRefProfile)
+        {
+            profiles.Remove("AppRef");
+            profiles["App"] = appRefProfile;
+            return appRefProfile;
+        }
+
+        var newAppProfile = new JsonObject
+        {
+            ["commandName"] = "Project",
+            ["dotnetRunMessages"] = true,
+            ["launchBrowser"] = false,
+            ["environmentVariables"] = new JsonObject { [AspNetCoreEnvironment] = DevelopmentEnvironment },
+        };
+        profiles["App"] = newAppProfile;
+        return newAppProfile;
+    }
+
+    private static string? GetString(JsonNode? node)
+    {
+        return node is JsonValue value && value.TryGetValue<string>(out var text) ? text : null;
+    }
+}

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/V8Tov9Upgrade.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/V8Tov9Upgrade.cs
@@ -77,6 +77,10 @@ internal static class V8Tov9Upgrade
 
         options.CancellationToken.ThrowIfCancellationRequested();
         if (returnCode == 0)
+            returnCode = await MigrateLaunchSettings(projectFile);
+
+        options.CancellationToken.ThrowIfCancellationRequested();
+        if (returnCode == 0)
             returnCode = await ConvertConditionalRenderingRules(projectFolder);
 
         options.CancellationToken.ThrowIfCancellationRequested();
@@ -124,6 +128,21 @@ internal static class V8Tov9Upgrade
         await rewriter.RemovePackageReference("Swashbuckle.AspNetCore");
         await UpgradeConsole.Out.WriteLineAsync("Swashbuckle.AspNetCore package reference removed");
         return 0;
+    }
+
+    static async Task<int> MigrateLaunchSettings(string projectFile)
+    {
+        try
+        {
+            await LaunchSettingsMigration.Migrate(projectFile);
+            await UpgradeConsole.Out.WriteLineAsync("Launch settings migrated");
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            await UpgradeConsole.Error.WriteLineAsync($"Error migrating launch settings: {ex.Message}");
+            return 1;
+        }
     }
 
     static async Task<int> ConvertToProjectReferences(

--- a/src/test/apps/anonymous-stateless-app/App/Properties/launchSettings.json
+++ b/src/test/apps/anonymous-stateless-app/App/Properties/launchSettings.json
@@ -1,27 +1,13 @@
 {
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:56226/",
-      "sslPort": 0
-    }
-  },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
+    "App": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://local.altinn.cloud:8000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
-    },
-    "AppRef": {
-      "commandName": "Project",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "http://localhost:56227/"
     }
   }
 }

--- a/src/test/apps/component-library/App/Properties/launchSettings.json
+++ b/src/test/apps/component-library/App/Properties/launchSettings.json
@@ -1,23 +1,10 @@
 {
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:56226/",
-      "sslPort": 0
-    }
-  },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "AppRef": {
+    "App": {
       "commandName": "Project",
-      "launchBrowser": true,
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://local.altinn.cloud:8000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/test/apps/expression-validation-test/App/Properties/launchSettings.json
+++ b/src/test/apps/expression-validation-test/App/Properties/launchSettings.json
@@ -1,23 +1,10 @@
 {
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:56226/",
-      "sslPort": 0
-    }
-  },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "AppRef": {
+    "App": {
       "commandName": "Project",
-      "launchBrowser": true,
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://local.altinn.cloud:8000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/test/apps/frontend-test/App/Properties/launchSettings.json
+++ b/src/test/apps/frontend-test/App/Properties/launchSettings.json
@@ -1,27 +1,13 @@
 {
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:56226/",
-      "sslPort": 0
-    }
-  },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
+    "App": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://local.altinn.cloud:8000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
-    },
-    "AppRef": {
-      "commandName": "Project",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "http://localhost:56227/"
     }
   }
 }

--- a/src/test/apps/multiple-datamodels-test/App/Properties/launchSettings.json
+++ b/src/test/apps/multiple-datamodels-test/App/Properties/launchSettings.json
@@ -1,23 +1,10 @@
 {
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:56226/",
-      "sslPort": 0
-    }
-  },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "AppRef": {
+    "App": {
       "commandName": "Project",
-      "launchBrowser": true,
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://local.altinn.cloud:8000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/test/apps/navigation-test-subform/App/Properties/launchSettings.json
+++ b/src/test/apps/navigation-test-subform/App/Properties/launchSettings.json
@@ -1,23 +1,10 @@
 {
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:56226/",
-      "sslPort": 0
-    }
-  },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "AppRef": {
+    "App": {
       "commandName": "Project",
-      "launchBrowser": true,
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://local.altinn.cloud:8000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/test/apps/payment-test/App/Properties/launchSettings.json
+++ b/src/test/apps/payment-test/App/Properties/launchSettings.json
@@ -1,23 +1,10 @@
 {
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:56226/",
-      "sslPort": 0
-    }
-  },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "AppRef": {
+    "App": {
       "commandName": "Project",
-      "launchBrowser": true,
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://local.altinn.cloud:8000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/test/apps/service-task/App/Properties/launchSettings.json
+++ b/src/test/apps/service-task/App/Properties/launchSettings.json
@@ -1,23 +1,10 @@
 {
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:56226/",
-      "sslPort": 0
-    }
-  },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "AppRef": {
+    "App": {
       "commandName": "Project",
-      "launchBrowser": true,
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://local.altinn.cloud:8000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/test/apps/signering-brukerstyrt/App/Properties/launchSettings.json
+++ b/src/test/apps/signering-brukerstyrt/App/Properties/launchSettings.json
@@ -1,23 +1,10 @@
 {
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:56226/",
-      "sslPort": 0
-    }
-  },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "AppRef": {
+    "App": {
       "commandName": "Project",
-      "launchBrowser": true,
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://local.altinn.cloud:8000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/test/apps/signing-test/App/Properties/launchSettings.json
+++ b/src/test/apps/signing-test/App/Properties/launchSettings.json
@@ -1,23 +1,10 @@
 {
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:56226/",
-      "sslPort": 0
-    }
-  },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "AppRef": {
+    "App": {
       "commandName": "Project",
-      "launchBrowser": true,
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://local.altinn.cloud:8000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/test/apps/stateless-app/App/Properties/launchSettings.json
+++ b/src/test/apps/stateless-app/App/Properties/launchSettings.json
@@ -1,27 +1,13 @@
 {
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:56226/",
-      "sslPort": 0
-    }
-  },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
+    "App": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://local.altinn.cloud:8000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
-    },
-    "AppRef": {
-      "commandName": "Project",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "http://localhost:56227/"
     }
   }
 }

--- a/src/test/apps/subform-test/App/Properties/launchSettings.json
+++ b/src/test/apps/subform-test/App/Properties/launchSettings.json
@@ -1,23 +1,10 @@
 {
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:56226/",
-      "sslPort": 0
-    }
-  },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "AppRef": {
+    "App": {
       "commandName": "Project",
-      "launchBrowser": true,
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://local.altinn.cloud:8000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
## Description

Standardizes v9 app launch settings for the app template and monorepo v9 test apps:

- replaces legacy `IIS Express`/`AppRef` profiles with a single `App` project profile
- removes `iisSettings`
- sets the local app URL to `http://local.altinn.cloud:8000`
- updates `studioctl app upgrade v9` to migrate launch settings safely instead of overwriting the whole file

The v9 upgrade migration:

- removes IIS-related settings and launch profiles
- renames `AppRef` to `App` when there is no existing `App` profile
- always sets `applicationUrl`
- only adds `dotnetRunMessages` when missing
- leaves other profile settings unchanged

The root subtree sync only pulls test app repositories with `git subtree pull`; it does not run `studioctl app upgrade`, so the migration is added directly to the v8-to-v9 upgrade path.

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

Commands run:

```sh
for f in src/App/template/src/App/Properties/launchSettings.json src/test/apps/*/App/Properties/launchSettings.json; do jq empty "$f" || exit 1; done

dotnet tool restore

dotnet csharpier format studioctl-server/Studioctl/Upgrade/v8Tov9/V8Tov9Upgrade.cs studioctl-server/Studioctl/Upgrade/v8Tov9/LaunchSettingsMigration.cs

dotnet build studioctl-server/studioctl-server.csproj -v minimal

make fmt
make lint
go test ./internal/cmd ./internal/cmd/app
make test
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Upgrade now migrates legacy IIS Express launch settings to a single, standard App launch profile, ensuring consistent startup behaviour.

* **Chores**
  * Standardised launch configuration across test apps: unified App profile, disabled browser auto-launch, enabled runtime messages and consistent local URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->