### PR TITLE
feat: add studioctl app env command

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -8,6 +8,10 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+### Added
+
+- Add `studioctl app env` for printing the local app harness environment, with `--json` output for app startup integration.
+
 ### Fixed
 
 - Update `studioctl app upgrade v9` to target `net10.0` and resolve v9 app package versions from configured NuGet sources.

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -56,6 +56,7 @@ studioctl auth login --env dev --with-token < token.txt
 
 `studioctl app run` wraps `dotnet run --project <app>/App` and auto-detects the app directory.
 `studioctl run` is a short alias for the same operation.
+`studioctl app env --json` prints the local harness environment used by v9 app startup when running from an IDE.
 
 ## Core commands
 
@@ -63,6 +64,7 @@ studioctl auth login --env dev --with-token < token.txt
 - `studioctl apps search`: search app repositories in Altinn Studio
 - `studioctl app clone`: clone `org/repo` from the selected Altinn Studio environment
 - `studioctl app run`: run app locally
+- `studioctl app env`: print local app harness environment as KEY=value text (`--json` for JSON output)
 - `studioctl env up`: start localtest
 - `studioctl env down`: stop localtest
 - `studioctl env status`: show runtime/container status

--- a/src/cli/internal/cmd/app.go
+++ b/src/cli/internal/cmd/app.go
@@ -16,6 +16,7 @@ import (
 	appsvc "altinn.studio/studioctl/internal/cmd/app"
 	"altinn.studio/studioctl/internal/config"
 	repocontext "altinn.studio/studioctl/internal/context"
+	"altinn.studio/studioctl/internal/envtopology"
 	"altinn.studio/studioctl/internal/osutil"
 	"altinn.studio/studioctl/internal/studio"
 	"altinn.studio/studioctl/internal/studioctlserver"
@@ -99,6 +100,7 @@ func (c *AppCommand) Usage() string {
 		"Subcommands:",
 		"  build     Build an app container image",
 		"  clone     Clone an app repository from Altinn Studio",
+		"  env       Print app environment for local development",
 		"  logs      Stream app logs",
 		"  ps        List running apps",
 		"  run       Run app locally",
@@ -125,6 +127,8 @@ func (c *AppCommand) Run(ctx context.Context, args []string) error {
 		return c.runBuild(ctx, subArgs)
 	case "clone":
 		return c.runClone(ctx, subArgs)
+	case "env":
+		return c.runEnv(ctx, subArgs)
 	case appLogsSubcommand:
 		return c.logs.run(ctx, subArgs)
 	case "ps":
@@ -245,6 +249,123 @@ func (c *AppCommand) appBuildUsage() string {
 		"  --json                Output as JSON",
 		"  -h, --help            Show this help",
 	)
+}
+
+type appEnvFlags struct {
+	appPath        string
+	devFrontend    bool
+	jsonOutput     bool
+	randomHostPort bool
+}
+
+func (c *AppCommand) runEnv(ctx context.Context, args []string) error {
+	flags, help, err := c.parseAppEnvFlags(args)
+	if err != nil {
+		return err
+	}
+	if help {
+		c.out.Print(c.appEnvUsage())
+		return nil
+	}
+
+	result, err := repocontext.DetectFromCwd(ctx, flags.appPath)
+	if err != nil {
+		return fmt.Errorf("detect app: %w", err)
+	}
+	if !result.InAppRepo {
+		return fmt.Errorf("%w: run from an app directory or use -p to specify path", ErrNoAppFound)
+	}
+
+	topology := envtopology.NewLocal(envtopology.DefaultIngressPortString())
+	spec, err := c.service.BuildDotnetRunSpec(
+		ctx,
+		result.AppRoot,
+		nil,
+		nil,
+		topology,
+		appsvc.DotnetRunOptions{
+			AppFrontendAssetBaseUrl: appEnvFrontendAssetBaseURL(topology, flags),
+			RandomHostPort:          flags.randomHostPort,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("build app environment: %w", err)
+	}
+
+	return printAppEnv(c.out, spec.Env, flags.jsonOutput)
+}
+
+func (c *AppCommand) parseAppEnvFlags(args []string) (appEnvFlags, bool, error) {
+	fs := flag.NewFlagSet("app env", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+
+	var flags appEnvFlags
+	fs.StringVar(&flags.appPath, "p", "", "App directory path")
+	fs.StringVar(&flags.appPath, "path", "", "App directory path")
+	fs.StringVar(&flags.appPath, "project", "", "App project or directory path")
+	fs.BoolVar(&flags.devFrontend, "dev-frontend", false, "Use frontend dev server assets")
+	fs.BoolVar(&flags.jsonOutput, "json", false, "Output as JSON")
+	fs.BoolVar(&flags.randomHostPort, "random-host-port", true, "Use a random host port")
+
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return flags, true, nil
+		}
+		return flags, false, fmt.Errorf("parsing flags: %w", err)
+	}
+
+	return flags, false, nil
+}
+
+func appEnvFrontendAssetBaseURL(topology envtopology.Local, flags appEnvFlags) string {
+	if !flags.devFrontend {
+		return ""
+	}
+	return topology.PublicBaseURL(envtopology.ComponentFrontendDevServer)
+}
+
+func (c *AppCommand) appEnvUsage() string {
+	return joinLines(
+		fmt.Sprintf(
+			"Usage: %s app env [-p PATH] [--project PATH] [--random-host-port] [--dev-frontend] [--json]",
+			osutil.CurrentBin(),
+		),
+		"",
+		"Prints the local development environment that studioctl uses to run an app.",
+		"",
+		"Options:",
+		"  -p, --path PATH       App directory path",
+		"  --project PATH        App project or directory path",
+		"  --random-host-port    Use a random host port (default: true)",
+		"  --dev-frontend        Use frontend dev server assets",
+		"  --json                Output as JSON",
+		"  -h, --help            Show this help",
+	)
+}
+
+func printAppEnv(out *ui.Output, env []string, jsonOutput bool) error {
+	if jsonOutput {
+		return printJSONOutput(out, "app env", envMap(env))
+	}
+	for _, entry := range env {
+		out.Println(entry)
+	}
+	return nil
+}
+
+// The JSON shape from `studioctl app env --json` is consumed by Altinn.App.Api
+// during local Development startup. Keep it as a flat string map of environment
+// variable names to values; add new keys freely, but coordinate renames/removals
+// with app-lib compatibility.
+func envMap(env []string) map[string]string {
+	values := make(map[string]string, len(env))
+	for _, entry := range env {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok && key != "" {
+			values[key] = value
+		}
+	}
+	return values
 }
 
 func (c *AppCommand) runUpdate(ctx context.Context, args []string) error {

--- a/src/cli/internal/cmd/app/env.go
+++ b/src/cli/internal/cmd/app/env.go
@@ -39,6 +39,7 @@ func newAppEnv(current []string) appEnv {
 func (e appEnv) addRunDefaults(kestrelURL string, topology envtopology.Local, appFrontendAssetBaseUrl string) {
 	endpoints := newAppEndpointConfig(topology)
 
+	e.values["STUDIOCTL_APP_RUN"] = "1"
 	e.setDefault("ASPNETCORE_ENVIRONMENT", "Development")
 	e.setDefault("Kestrel__EndPoints__Http__Url", kestrelURL)
 	if appFrontendAssetBaseUrl != "" {

--- a/src/cli/internal/cmd/app_internal_test.go
+++ b/src/cli/internal/cmd/app_internal_test.go
@@ -4,9 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	appsvc "altinn.studio/studioctl/internal/cmd/app"
+	"altinn.studio/studioctl/internal/config"
 	"altinn.studio/studioctl/internal/ui"
 )
 
@@ -51,6 +55,72 @@ func TestAppBuildOutputPrintJSON(t *testing.T) {
 	if got.ImageTag != output.ImageTag || !got.Pushed {
 		t.Fatalf("output = %+v, want image tag and pushed true", got)
 	}
+}
+
+func TestRunEnvPrintsHarnessEnvironment(t *testing.T) {
+	t.Parallel()
+
+	appRoot := writeEnvCommandApp(t)
+	command, out := newEnvCommand()
+
+	if err := command.runEnv(t.Context(), []string{"-p", appRoot, "--json"}); err != nil {
+		t.Fatalf("runEnv() error = %v", err)
+	}
+
+	var got map[string]string
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out.String())), &got); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	assertEnvCommandValue(t, got, "ASPNETCORE_ENVIRONMENT", "Development")
+	assertEnvCommandValue(t, got, "Kestrel__EndPoints__Http__Url", "http://127.0.0.1:0")
+	assertEnvCommandValue(t, got, "STUDIOCTL_APP_RUN", "1")
+	assertEnvCommandValue(
+		t,
+		got,
+		"PlatformSettings__ApiStorageEndpoint",
+		"http://local.altinn.cloud:8000/storage/api/v1/",
+	)
+}
+
+func TestRunEnvPrintsTextByDefault(t *testing.T) {
+	t.Parallel()
+
+	appRoot := writeEnvCommandApp(t)
+	command, out := newEnvCommand()
+
+	if err := command.runEnv(t.Context(), []string{"-p", appRoot}); err != nil {
+		t.Fatalf("runEnv() error = %v", err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "ASPNETCORE_ENVIRONMENT=Development") {
+		t.Fatalf("output = %q, want ASPNETCORE_ENVIRONMENT line", got)
+	}
+	if !strings.Contains(got, "STUDIOCTL_APP_RUN=1") {
+		t.Fatalf("output = %q, want STUDIOCTL_APP_RUN line", got)
+	}
+}
+
+func TestRunEnvCanUseStableHostPort(t *testing.T) {
+	t.Parallel()
+
+	appRoot := writeEnvCommandApp(t)
+	command, out := newEnvCommand()
+
+	if err := command.runEnv(
+		t.Context(),
+		[]string{"--project", filepath.Join(appRoot, "App", "App.csproj"), "--random-host-port=false", "--json"},
+	); err != nil {
+		t.Fatalf("runEnv() error = %v", err)
+	}
+
+	var got map[string]string
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out.String())), &got); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	assertEnvCommandValue(t, got, "Kestrel__EndPoints__Http__Url", "http://127.0.0.1:5005")
 }
 
 func TestParseAppUpgradeFlagsAcceptsSupportedKinds(t *testing.T) {
@@ -99,5 +169,43 @@ func TestParseAppUpgradeFlagsRejectsUnsupportedKind(t *testing.T) {
 	_, _, err := (&AppCommand{}).parseAppUpgradeFlags([]string{"backend-v9"})
 	if err == nil {
 		t.Fatal("parseAppUpgradeFlags() error = nil, want error")
+	}
+}
+
+func newEnvCommand() (*AppCommand, *bytes.Buffer) {
+	var out bytes.Buffer
+	return &AppCommand{
+		out:     ui.NewOutput(&out, io.Discard, false),
+		service: appsvc.NewService(&config.Config{Version: config.NewVersion("test-version")}),
+	}, &out
+}
+
+func writeEnvCommandApp(t *testing.T) string {
+	t.Helper()
+
+	appRoot := t.TempDir()
+	configDir := filepath.Join(appRoot, "App", "config")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(configDir, "applicationmetadata.json"),
+		[]byte(`{"id":"ttd/test-app"}`),
+		0o600,
+	); err != nil {
+		t.Fatalf("WriteFile(applicationmetadata.json) error = %v", err)
+	}
+	project := `<Project Sdk="Microsoft.NET.Sdk.Web"><ItemGroup><PackageReference Include="Altinn.App.Core" Version="9.0.0" /></ItemGroup></Project>`
+	if err := os.WriteFile(filepath.Join(appRoot, "App", "App.csproj"), []byte(project), 0o600); err != nil {
+		t.Fatalf("WriteFile(App.csproj) error = %v", err)
+	}
+	return appRoot
+}
+
+func assertEnvCommandValue(t *testing.T, values map[string]string, key, want string) {
+	t.Helper()
+
+	if got := values[key]; got != want {
+		t.Fatalf("%s = %q, want %q", key, got, want)
 	}
 }


### PR DESCRIPTION
## Description

Adds `studioctl app env`, which prints the local app harness environment that `studioctl app run` uses for process-mode app startup.

The command defaults to readable `KEY=value` output and supports `--json` for app startup integration. It reuses the existing app run environment builder so runtime config values stay owned by studioctl. The generated environment now includes `STUDIOCTL_APP_RUN=1` as an explicit marker for studioctl-launched apps.

## Planned follow-ups

- Merge the v9 launchSettings PR (#19065: https://github.com/Altinn/altinn-studio/pull/19065) and publish a new studioctl release.
- Move app startup integration through app-lib-dotnet v8 and publish a patch release.
- Subtree/sync the app-lib backend changes into v9 apps afterward.

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

Commands run:

```sh
cd src/cli
make fmt
make lint
go test ./internal/cmd ./internal/cmd/app
make test
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `studioctl app env` command to display the complete local development environment configuration
  * Supports both text and JSON output formats via the `--json` flag
  * Automatically detects the target application and includes all relevant environment variables

* **Tests**
  * Comprehensive test coverage added for the new command, including JSON output verification and host/port configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
