### PR TITLE
fix: use deployment chart 3.11.0 for app deploys

### DIFF
--- a/src/App/azure-pipelines/deploy-app.yaml
+++ b/src/App/azure-pipelines/deploy-app.yaml
@@ -599,7 +599,7 @@ steps:
               retries: 1
           chart:
             spec:
-              version: 3.10.1
+              version: 3.11.0
               chart: deployment
               sourceRef:
                 kind: HelmRepository

--- a/src/Runtime/operator/config/local-minimal/localtestapp.yaml
+++ b/src/Runtime/operator/config/local-minimal/localtestapp.yaml
@@ -37,7 +37,7 @@ spec:
     ipv6:
       enabled: false
     linkerd:
-      enabled: true
+      enabled: false
     volumeMounts: []
     volumes: []
     ingressRoute:

--- a/src/Runtime/operator/test/e2e/__snapshots__/step0-initial-secret.snap
+++ b/src/Runtime/operator/test/e2e/__snapshots__/step0-initial-secret.snap
@@ -44,7 +44,7 @@
   "labels": {
    "app": "ttd-localtestapp-deployment",
    "app.kubernetes.io/managed-by": "Helm",
-   "chart": "deployment-3.10.1",
+   "chart": "deployment-3.11.0",
    "helm.toolkit.fluxcd.io/name": "ttd-localtestapp",
    "helm.toolkit.fluxcd.io/namespace": "default",
    "heritage": "Helm",

--- a/src/Runtime/operator/test/e2e/__snapshots__/step1-reconciled-secret.snap
+++ b/src/Runtime/operator/test/e2e/__snapshots__/step1-reconciled-secret.snap
@@ -96,7 +96,7 @@
   "labels": {
    "app": "ttd-localtestapp-deployment",
    "app.kubernetes.io/managed-by": "Helm",
-   "chart": "deployment-3.10.1",
+   "chart": "deployment-3.11.0",
    "helm.toolkit.fluxcd.io/name": "ttd-localtestapp",
    "helm.toolkit.fluxcd.io/namespace": "default",
    "heritage": "Helm",

--- a/src/Runtime/operator/test/e2e/__snapshots__/step2-scope-removed-secret.snap
+++ b/src/Runtime/operator/test/e2e/__snapshots__/step2-scope-removed-secret.snap
@@ -96,7 +96,7 @@
   "labels": {
    "app": "ttd-localtestapp-deployment",
    "app.kubernetes.io/managed-by": "Helm",
-   "chart": "deployment-3.10.1",
+   "chart": "deployment-3.11.0",
    "helm.toolkit.fluxcd.io/name": "ttd-localtestapp",
    "helm.toolkit.fluxcd.io/namespace": "default",
    "heritage": "Helm",

--- a/src/Runtime/operator/test/e2e/__snapshots__/step2b-jwk-rotated-secret.snap
+++ b/src/Runtime/operator/test/e2e/__snapshots__/step2b-jwk-rotated-secret.snap
@@ -117,7 +117,7 @@
   "labels": {
    "app": "ttd-localtestapp-deployment",
    "app.kubernetes.io/managed-by": "Helm",
-   "chart": "deployment-3.10.1",
+   "chart": "deployment-3.11.0",
    "helm.toolkit.fluxcd.io/name": "ttd-localtestapp",
    "helm.toolkit.fluxcd.io/namespace": "default",
    "heritage": "Helm",

--- a/src/Runtime/operator/test/e2e/__snapshots__/step2c-jwk-rotated-again-secret.snap
+++ b/src/Runtime/operator/test/e2e/__snapshots__/step2c-jwk-rotated-again-secret.snap
@@ -117,7 +117,7 @@
   "labels": {
    "app": "ttd-localtestapp-deployment",
    "app.kubernetes.io/managed-by": "Helm",
-   "chart": "deployment-3.10.1",
+   "chart": "deployment-3.11.0",
    "helm.toolkit.fluxcd.io/name": "ttd-localtestapp",
    "helm.toolkit.fluxcd.io/namespace": "default",
    "heritage": "Helm",

--- a/src/Runtime/operator/test/e2e/__snapshots__/step3-deleted-secret.snap
+++ b/src/Runtime/operator/test/e2e/__snapshots__/step3-deleted-secret.snap
@@ -44,7 +44,7 @@
   "labels": {
    "app": "ttd-localtestapp-deployment",
    "app.kubernetes.io/managed-by": "Helm",
-   "chart": "deployment-3.10.1",
+   "chart": "deployment-3.11.0",
    "helm.toolkit.fluxcd.io/name": "ttd-localtestapp",
    "helm.toolkit.fluxcd.io/namespace": "default",
    "heritage": "Helm",


### PR DESCRIPTION
## Description

Bumps generated app deployments to the `deployment` Helm chart `3.11.0`, following `Altinn/altinn-studio-charts#74`.

This makes `deploy-app.yaml` emit HelmReleases using the chart version that includes the Linkerd service/server protocol configuration changes. The operator e2e secret snapshots are updated for the resulting chart label change from `deployment-3.10.1` to `deployment-3.11.0`.

The operator `local-minimal` fixture now disables Linkerd for its local test app. The minimal fixture does not install Linkerd CRDs, while chart `3.11.0` renders `policy.linkerd.io` resources when `linkerd.enabled=true`.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

Commands run:

```sh
git diff --check
go test ./test/e2e -run '^$'
```

Manual fixture verification:

```text
ttd-localtestapp Ready=True with chart deployment@3.11.0
Server ttd-localtestapp-deployment protocol HTTP/1
ServerAuthorization ttd-localtestapp-deployment exists
```

No new automated test was added because this is a chart version/configuration bump with generated snapshot updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart version to 3.11.0 for application deployment.
  * Disabled Linkerd in the local minimal test configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->