### PR TITLE
chore: release studioctl v0.1.0-preview.13

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -8,6 +8,8 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+## [0.1.0-preview.13] - 2026-06-05
+
 ### Added
 
 - Add `studioctl app env` for printing the local app harness environment, with `--json` output for app startup integration.


### PR DESCRIPTION
## Description

Prepare release v0.1.0-preview.13

- [Added] Add `studioctl app env` for printing the local app harness environment, with `--json` output for app startup integration.
- [Fixed] Update `studioctl app upgrade v9` to target `net10.0` and resolve v9 app package versions from configured NuGet sources.
- [Fixed] Update `studioctl app upgrade v9` to replace legacy IIS Express launch settings with the standard `App` project launch profile.

@coderabbitai ignore

**Full Changelog**: https://github.com/Altinn/altinn-studio/compare/studioctl/v0.1.0-preview.12...studioctl/v0.1.0-preview.13