### PR TITLE
fix: limit releaser changelog output

### DIFF
--- a/src/tools/releaser/internal/preflight_test.go
+++ b/src/tools/releaser/internal/preflight_test.go
@@ -1,6 +1,7 @@
 package internal_test
 
 import (
+	"bytes"
 	"errors"
 	"os"
 	"path/filepath"
@@ -190,6 +191,47 @@ func TestRunPrepareWithDeps_PRBodyFormat(t *testing.T) {
 			t.Fatalf("PR body missing snippet %q\nbody:\n%s", snippet, gh.prBody)
 		}
 	}
+}
+
+func TestRunPrepareWithDeps_DryRunLogsOnlyPromotedReleaseSection(t *testing.T) {
+	repo := createStudioctlWorkflowRepo(t, changelogWithPreviousRelease())
+	t.Chdir(repo)
+
+	var output bytes.Buffer
+	logger := internal.NewConsoleLogger(internal.WithWriters(&output, &output))
+	git := internal.NewGitCLI(internal.WithWorkdir(repo), internal.WithLogger(internal.NopLogger{}))
+	gh := &fakeGH{}
+
+	err := internal.RunPrepareWithDeps(t.Context(), internal.PrepareRequest{
+		Component: "studioctl",
+		Version:   "v0.1.0-preview.2",
+		DryRun:    true,
+	}, git, gh, logger)
+	if err != nil {
+		t.Fatalf("RunPrepareWithDeps() error = %v", err)
+	}
+
+	assertPromotedReleaseLog(t, output.String())
+}
+
+func TestRunPrepareWithDeps_LogsOnlyPromotedReleaseSectionWhenUpdatingChangelog(t *testing.T) {
+	repo := createStudioctlWorkflowRepo(t, changelogWithPreviousRelease())
+	t.Chdir(repo)
+
+	var output bytes.Buffer
+	logger := internal.NewConsoleLogger(internal.WithWriters(&output, &output))
+	git := internal.NewGitCLI(internal.WithWorkdir(repo), internal.WithLogger(internal.NopLogger{}))
+	gh := &fakeGH{}
+
+	err := internal.RunPrepareWithDeps(t.Context(), internal.PrepareRequest{
+		Component: "studioctl",
+		Version:   "v0.1.0-preview.2",
+	}, git, gh, logger)
+	if err != nil {
+		t.Fatalf("RunPrepareWithDeps() error = %v", err)
+	}
+
+	assertPromotedReleaseLog(t, output.String())
 }
 
 func TestRunPrepareWithDeps_PRBodyIncludesCompareLink(t *testing.T) {
@@ -463,4 +505,58 @@ func (p *scriptedPrompter) Confirm(action string, details []string) (bool, error
 
 func containsDetail(details []string, want string) bool {
 	return slices.Contains(details, want)
+}
+
+func changelogWithPreviousRelease() string {
+	return `# Changelog
+
+All notable changes to studioctl will be documented in this file.
+
+## [Unreleased]
+
+### Added
+
+- New local harness command
+
+### Fixed
+
+- Launch profile migration
+
+## [0.1.0-preview.1] - 2025-01-01
+
+### Added
+
+- Previous release entry
+`
+}
+
+func assertPromotedReleaseLog(t *testing.T, output string) {
+	t.Helper()
+
+	wantSnippets := []string{
+		"Promoted release changelog:",
+		"## [0.1.0-preview.2] - ",
+		"### Added",
+		"- New local harness command",
+		"### Fixed",
+		"- Launch profile migration",
+	}
+	for _, snippet := range wantSnippets {
+		if !strings.Contains(output, snippet) {
+			t.Fatalf("output missing %q:\n%s", snippet, output)
+		}
+	}
+
+	unwantedSnippets := []string{
+		"# Changelog",
+		"All notable changes to studioctl will be documented in this file.",
+		"## [Unreleased]",
+		"## [0.1.0-preview.1]",
+		"- Previous release entry",
+	}
+	for _, snippet := range unwantedSnippets {
+		if strings.Contains(output, snippet) {
+			t.Fatalf("output should not contain %q:\n%s", snippet, output)
+		}
+	}
 }

--- a/src/tools/releaser/internal/prepare.go
+++ b/src/tools/releaser/internal/prepare.go
@@ -23,6 +23,7 @@ type releasePrepConfig struct {
 	prTitle             string
 	prBody              string
 	promoted            string
+	promotedSection     string
 	createReleaseBranch bool
 }
 
@@ -163,6 +164,10 @@ func prepareReleasePrepConfig(
 	}
 	previousVersion := previousReleasedVersion(promotedCl, verStr)
 	promoted := promotedCl.String()
+	promotedSection, err := promotedReleaseSection(promotedCl, verStr)
+	if err != nil {
+		return nil, fmt.Errorf("format promoted release section: %w", err)
+	}
 	prBody, err := buildPreparePRBody(comp, verStr, promotedCl)
 	if err != nil {
 		return nil, fmt.Errorf("build PR body: %w", err)
@@ -179,6 +184,7 @@ func prepareReleasePrepConfig(
 		prTitle:             "chore: release " + comp.ReleaseTitle(verStr),
 		prBody:              prBody,
 		promoted:            promoted,
+		promotedSection:     promotedSection,
 	}, nil
 }
 
@@ -278,12 +284,37 @@ func printReleasePrepDryRun(log Logger, cfg *releasePrepConfig) {
 	log.Info("Would create PR targeting: %s", cfg.baseBranch)
 	log.Info("Would set PR title: %s", cfg.prTitle)
 	log.Info("Would add label: %s", cfg.component.ReleaseLabel())
-	logPromotedChangelog(log, cfg.promoted)
+	logPromotedReleaseSection(log, cfg.promotedSection)
 }
 
-func logPromotedChangelog(log Logger, promoted string) {
-	log.Info("Promoted changelog:")
-	for line := range strings.SplitSeq(strings.TrimRight(promoted, "\n"), "\n") {
+func promotedReleaseSection(promotedCl *changelog.Changelog, version string) (string, error) {
+	if promotedCl == nil {
+		return "", errChangelogNil
+	}
+	section := promotedCl.GetVersion(version)
+	if section == nil {
+		return "", fmt.Errorf("%w: %s", changelog.ErrVersionNotFound, version)
+	}
+
+	var b strings.Builder
+	b.WriteString("## [")
+	b.WriteString(section.Version.Num)
+	b.WriteString("]")
+	if !section.Date.IsZero() {
+		b.WriteString(" - ")
+		b.WriteString(section.Date.Format("2006-01-02"))
+	}
+	content := section.String()
+	if content != "" {
+		b.WriteString("\n\n")
+		b.WriteString(content)
+	}
+	return b.String(), nil
+}
+
+func logPromotedReleaseSection(log Logger, section string) {
+	log.Info("Promoted release changelog:")
+	for line := range strings.SplitSeq(strings.TrimRight(section, "\n"), "\n") {
 		log.Info("  %s", line)
 	}
 }
@@ -325,7 +356,7 @@ func executeReleasePrepare(
 	if err := os.WriteFile(changelogFile, []byte(cfg.promoted), perm.FilePermDefault); err != nil {
 		return fmt.Errorf("write changelog: %w", err)
 	}
-	logPromotedChangelog(log, cfg.promoted)
+	logPromotedReleaseSection(log, cfg.promotedSection)
 
 	log.Step("Committing changelog")
 	if err := git.RunWrite(ctx, "add", clPath); err != nil {


### PR DESCRIPTION
## Description

Limit `releaser prepare` console output to the promoted release section instead of printing the whole promoted changelog file.

## What changed

- Keep writing the full promoted changelog to disk unchanged.
- Render a separate promoted release section for dry-run and real prepare logging.
- Add tests for dry-run and real prepare output to ensure the preamble, `[Unreleased]`, and previous releases are not logged.

## Codepaths checked

- `prepare`: fixed full-file console output.
- `backport`: already logs extracted changelog entries only.
- `workflow`: extracts release notes for the selected version and writes them to release artifacts; it does not dump the full changelog to console.
- `validate-changelog`: validates changelog changes only; no changelog dump.

## Verification

```sh
cd src/tools/releaser
make fmt
go test ./internal -run 'TestRunPrepareWithDeps_(DryRunLogsOnlyPromotedReleaseSection|LogsOnlyPromotedReleaseSectionWhenUpdatingChangelog)' -count=1
make lint
make test
go run . prepare -component studioctl -version v0.1.0-preview.13 -dry-run
make build
git diff --check
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release preparation workflow now logs only the promoted release section during dry runs and changelog updates, providing clearer, more focused output instead of displaying the entire changelog.

* **Tests**
  * Added comprehensive tests to verify correct logging behaviour during dry-run and changelog-update scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->