### PR TITLE
fix: persist mockporten login token between k6 runs

### DIFF
--- a/src/test/K6/src/gettoken.js
+++ b/src/test/K6/src/gettoken.js
@@ -1,0 +1,13 @@
+import * as setUpData from './setup.js';
+
+export const options = {
+  thresholds: {
+    checks: ['rate==1.0'],
+  },
+};
+
+export default function () {
+  const runtimeToken = setUpData.getAltinnTokenForUser();
+  // Sets environment variable in Azure DevOps pipeline.
+  console.log(`##vso[task.setvariable variable=runtimetoken;issecret=true]${runtimeToken}`);
+}

--- a/src/test/K6/src/gettoken.js
+++ b/src/test/K6/src/gettoken.js
@@ -1,3 +1,4 @@
+import { check } from 'k6';
 import * as setUpData from './setup.js';
 
 export const options = {
@@ -7,7 +8,17 @@ export const options = {
 };
 
 export default function () {
-  const runtimeToken = setUpData.getAltinnTokenForUser();
-  // Sets environment variable in Azure DevOps pipeline.
-  console.log(`##vso[task.setvariable variable=runtimetoken;issecret=true]${runtimeToken}`);
+  let runtimeToken;
+  try {
+    runtimeToken = setUpData.getAltinnTokenForUser();
+  } catch (e) {
+    runtimeToken = null;
+  }
+  const success = check(runtimeToken, {
+    'Acquired token is a JWT': (t) => typeof t === 'string' && t.split('.').length === 3,
+  });
+  if (success) {
+    // Sets environment variable in Azure DevOps pipeline.
+    console.log(`##vso[task.setvariable variable=runtimetoken;issecret=true]${runtimeToken}`);
+  }
 }

--- a/src/test/K6/src/setup.js
+++ b/src/test/K6/src/setup.js
@@ -105,6 +105,9 @@ export function loginWithMockporten(pid, password) {
 
 //Returns an AltinnstudioRuntime token for an end user (mockporten in test, Altinn 2 login in prod)
 export function getAltinnTokenForUser() {
+  if (__ENV.runtimetoken) {
+    return __ENV.runtimetoken;
+  }
   if (environment === 'prod') {
     var aspxauthCookie = authenticateUser(__ENV.username, __ENV.userpwd);
     return getAltinnStudioRuntimeToken(aspxauthCookie);

--- a/src/test/K6/src/tests/platform/authentication/authentication.js
+++ b/src/test/K6/src/tests/platform/authentication/authentication.js
@@ -16,8 +16,7 @@ export const options = {
 
 //Tests for platform authentication
 export default function () {
-  const runtimeToken = setUpData.getAltinnTokenForUser();
-  console.log(runtimeToken);
+  setUpData.getAltinnTokenForUser();
 }
 
 export function handleSummary(data) {

--- a/src/test/K6/src/tests/platform/authentication/authentication.js
+++ b/src/test/K6/src/tests/platform/authentication/authentication.js
@@ -16,7 +16,8 @@ export const options = {
 
 //Tests for platform authentication
 export default function () {
-  setUpData.getAltinnTokenForUser();
+  const runtimeToken = setUpData.getAltinnTokenForUser();
+  console.log(runtimeToken);
 }
 
 export function handleSummary(data) {

--- a/src/test/K6/use-cases.yaml
+++ b/src/test/K6/use-cases.yaml
@@ -7,6 +7,9 @@ trigger: none
 
 pr: none
 
+variables:
+  runtimetoken: ''
+
 schedules:
 - cron: "*/15 * * * *"
   displayName: Bruksmønster
@@ -23,6 +26,7 @@ steps:
     Contents: |
       *.xml
       result.txt
+      token.txt
       /src/test/K6/src/reports/*
   condition: succeededOrFailed()
 
@@ -46,7 +50,11 @@ steps:
   displayName: 'Check availability'
 
 - script: |
-   k6 run  --quiet $(pwd)/src/tests/platform/authentication/authentication.js -e env=$(environment) -e pid=$(pid) -e testidppwd=$(testidppwd) -e appsaccesskey=$(appsAccessSubsKey)
+   set -e
+
+   k6 run  --quiet --logformat raw --console-output=$(Build.SourcesDirectory)/token.txt $(pwd)/src/tests/platform/authentication/authentication.js -e env=$(environment) -e pid=$(pid) -e testidppwd=$(testidppwd) -e appsaccesskey=$(appsAccessSubsKey)
+
+   echo "##vso[task.setvariable variable=runtimetoken;issecret=true]`cat $(Build.SourcesDirectory)/token.txt`"
 
   workingDirectory: '$(Build.SourcesDirectory)/src/test/K6'
   displayName: 'Authentication'
@@ -54,35 +62,35 @@ steps:
   condition: and(succeeded(), eq(variables['availability'], 'up'))
 
 - script: |
-   k6 run  --quiet $(pwd)/src/tests/app/portalsimulation.js -e env=$(environment) -e org=$(org) -e level2app=$(level2app) -e pid=$(pid) -e testidppwd=$(testidppwd) -e appsaccesskey=$(appsAccessSubsKey)
+   k6 run  --quiet $(pwd)/src/tests/app/portalsimulation.js -e env=$(environment) -e org=$(org) -e level2app=$(level2app) -e pid=$(pid) -e testidppwd=$(testidppwd) -e runtimetoken=$(runtimetoken) -e appsaccesskey=$(appsAccessSubsKey)
 
   workingDirectory: '$(Build.SourcesDirectory)/src/test/K6'
   displayName: 'Portal simulation'
   condition: and(succeededOrFailed(), eq(variables['availability'], 'up'))
 
 - script: |
-   k6 run  --quiet $(pwd)/src/tests/app/multipartdata.js -e env=$(environment) -e org=$(org) -e level2app=$(level2app) -e pid=$(pid) -e testidppwd=$(testidppwd) -e appsaccesskey=$(appsAccessSubsKey) -e sblaccesskey=$(sblAccessSubsKey)
+   k6 run  --quiet $(pwd)/src/tests/app/multipartdata.js -e env=$(environment) -e org=$(org) -e level2app=$(level2app) -e pid=$(pid) -e testidppwd=$(testidppwd) -e runtimetoken=$(runtimetoken) -e appsaccesskey=$(appsAccessSubsKey) -e sblaccesskey=$(sblAccessSubsKey)
 
   workingDirectory: '$(Build.SourcesDirectory)/src/test/K6'
   displayName: 'Multipart data'
   condition: and(succeededOrFailed(), eq(variables['availability'], 'up'))
 
 - script: |
-   k6 run  --quiet $(pwd)/src/tests/platform/register/register.js -e env=$(environment) -e org=$(org) -e level2app=$(level2app) -e pid=$(pid) -e testidppwd=$(testidppwd) -e appsaccesskey=$(appsAccessSubsKey)
+   k6 run  --quiet $(pwd)/src/tests/platform/register/register.js -e env=$(environment) -e org=$(org) -e level2app=$(level2app) -e pid=$(pid) -e testidppwd=$(testidppwd) -e runtimetoken=$(runtimetoken) -e appsaccesskey=$(appsAccessSubsKey)
 
   workingDirectory: '$(Build.SourcesDirectory)/src/test/K6'
   displayName: 'Register'
   condition: and(succeededOrFailed(), eq(variables['availability'], 'up'))
 
 - script: |
-   k6 run  --quiet $(pwd)/src/tests/platform/receipt/receipt.js -e env=$(environment) -e org=$(org) -e level2app=$(level2app) -e pid=$(pid) -e testidppwd=$(testidppwd) -e appsaccesskey=$(appsAccessSubsKey)
+   k6 run  --quiet $(pwd)/src/tests/platform/receipt/receipt.js -e env=$(environment) -e org=$(org) -e level2app=$(level2app) -e pid=$(pid) -e testidppwd=$(testidppwd) -e runtimetoken=$(runtimetoken) -e appsaccesskey=$(appsAccessSubsKey)
 
   workingDirectory: '$(Build.SourcesDirectory)/src/test/K6'
   displayName: 'Receipt'
   condition: and(succeededOrFailed(), eq(variables['availability'], 'up'))
 
 - script: |
-   k6 run  --quiet $(pwd)/src/tests/platform/storage/deleteinstances.js -e env=$(environment) -e org=$(org) -e level2app=$(level2app) -e pid=$(pid) -e testidppwd=$(testidppwd) -e appsaccesskey=$(appsAccessSubsKey) -e sblaccesskey=$(sblAccessSubsKey)
+   k6 run  --quiet $(pwd)/src/tests/platform/storage/deleteinstances.js -e env=$(environment) -e org=$(org) -e level2app=$(level2app) -e pid=$(pid) -e testidppwd=$(testidppwd) -e runtimetoken=$(runtimetoken) -e appsaccesskey=$(appsAccessSubsKey) -e sblaccesskey=$(sblAccessSubsKey)
 
   workingDirectory: '$(Build.SourcesDirectory)/src/test/K6'
   displayName: 'Delete instances'

--- a/src/test/K6/use-cases.yaml
+++ b/src/test/K6/use-cases.yaml
@@ -61,6 +61,7 @@ steps:
 
   workingDirectory: '$(Build.SourcesDirectory)/src/test/K6'
   displayName: 'Get token'
+  continueOnError: false
   condition: and(succeeded(), eq(variables['availability'], 'up'))
 
 - script: |

--- a/src/test/K6/use-cases.yaml
+++ b/src/test/K6/use-cases.yaml
@@ -26,7 +26,6 @@ steps:
     Contents: |
       *.xml
       result.txt
-      token.txt
       /src/test/K6/src/reports/*
   condition: succeededOrFailed()
 
@@ -50,15 +49,18 @@ steps:
   displayName: 'Check availability'
 
 - script: |
-   set -e
-
-   k6 run  --quiet --logformat raw --console-output=$(Build.SourcesDirectory)/token.txt $(pwd)/src/tests/platform/authentication/authentication.js -e env=$(environment) -e pid=$(pid) -e testidppwd=$(testidppwd) -e appsaccesskey=$(appsAccessSubsKey)
-
-   echo "##vso[task.setvariable variable=runtimetoken;issecret=true]`cat $(Build.SourcesDirectory)/token.txt`"
+   k6 run  --quiet $(pwd)/src/tests/platform/authentication/authentication.js -e env=$(environment) -e pid=$(pid) -e testidppwd=$(testidppwd) -e appsaccesskey=$(appsAccessSubsKey)
 
   workingDirectory: '$(Build.SourcesDirectory)/src/test/K6'
   displayName: 'Authentication'
   continueOnError: false
+  condition: and(succeeded(), eq(variables['availability'], 'up'))
+
+- script: |
+   k6 run --quiet --log-output=stdout --log-format=raw $(pwd)/src/gettoken.js -e env=$(environment) -e pid=$(pid) -e testidppwd=$(testidppwd)
+
+  workingDirectory: '$(Build.SourcesDirectory)/src/test/K6'
+  displayName: 'Get token'
   condition: and(succeeded(), eq(variables['availability'], 'up'))
 
 - script: |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We're currently logging in each step of the tests, and therefore getting rate-limited.
This PR sets an environment variable with the login token to persist it between k6 runs.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced automated testing: added support for supplying a runtime token to test runs and a dedicated step to capture it.
  * Token validation and secure storage of the captured token as a secret variable in the pipeline.
  * Strengthened test checks to enforce successful token acquisition before downstream tests run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->