### PR TITLE
chore: disable failing validation test

### DIFF
--- a/src/test/K6/src/tests/app/portalsimulation.js
+++ b/src/test/K6/src/tests/app/portalsimulation.js
@@ -115,17 +115,18 @@ export default function (data) {
   }
 
   //Test to get validate instance; a fresh instance returns no validation issues (empty array) on the new app backend
-  res = appInstances.getValidateInstance(runtimeToken, partyId, instanceId, appOwner, level2App);
-  check(res, {
-    'E2E App GET Validate Instance returns no issues on a fresh instance': (r) => {
-      try {
-        var issues = JSON.parse(r.body);
-        return r.status === 200 && Array.isArray(issues) && issues.length === 0;
-      } catch (e) {
-        return false;
-      }
-    },
-  });
+  // DISABLED: This test fails in production. Possibly a test data issue, or the premise of this test is wrong. Needs investigation.
+  // res = appInstances.getValidateInstance(runtimeToken, partyId, instanceId, appOwner, level2App);
+  // check(res, {
+  //   'E2E App GET Validate Instance returns no issues on a fresh instance': (r) => {
+  //     try {
+  //       var issues = JSON.parse(r.body);
+  //       return r.status === 200 && Array.isArray(issues) && issues.length === 0;
+  //     } catch (e) {
+  //       return false;
+  //     }
+  //   },
+  // });
 
   //Test to edit a form data in an instance with App APi and validate the response
   res = appData.putDataById(runtimeToken, partyId, instanceId, dataId, null, instanceFormDataXml, appOwner, level2App);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The disabled test is failing in production. Seems to be working in TT02, although use case tests are failing there due to some authentication issues. 
As this does not seem to be a critical test we are disabling it until monday when we can investigate further, to avoid cluttering the alerts-channel with unnecessary noise.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Disabled validation test for fresh instance checks. The test asserting no issues are returned on a fresh instance has been commented out, with associated validation logic removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->