### PR TITLE
chore: update studioctl runtime image tags

### DIFF
--- a/src/cli/internal/config/config.yaml
+++ b/src/cli/internal/config/config.yaml
@@ -9,7 +9,7 @@ images:
       tag: "94897eff31"
     pdf3:
       image: ghcr.io/altinn/altinn-studio/runtime-pdf3-worker
-      tag: "b885f9a75f"
+      tag: "694406e93c"
     workflow-engine:
       image: ghcr.io/altinn/altinn-studio/runtime-workflow-engine-app
       tag: "567e1be1f1"


### PR DESCRIPTION
## Description

Updates the embedded studioctl default image tags in `src/cli/internal/config/config.yaml` for runtime components that were behind the latest published image tags:

- `runtime-pdf3-worker`: `b885f9a75f` -> `694406e93c`
- `runtime-workflow-engine-app`: unchanged at `567e1be1f1` after rechecking the latest published image

`runtime-localtest` was checked against the latest successful deploy workflow and is already current at `94897eff31`.

Notes:

- `runtime-pdf3-worker:694406e93c` comes from #19075. The deploy workflow is still `waiting` because ring tagging jobs are waiting on environment approval, but the `Push pdf3 as OCI artifact` job succeeded and the GHCR image is available.
- `runtime-workflow-engine-app:567e1be1f1` comes from #19026. The deploy workflow is still `waiting` because ring tagging jobs are waiting on environment approval, but the `Push workflow-engine-app as OCI artifact` job succeeded and the GHCR image is available.

Workflow/tag checks:

```sh
gh run list --repo Altinn/altinn-studio --workflow deploy-runtime-localtest.yaml --branch main --status success --limit 10 --json databaseId,headSha,displayTitle,createdAt,updatedAt,event,status,conclusion,url
gh run view 27015390494 --repo Altinn/altinn-studio --json databaseId,headSha,displayTitle,createdAt,updatedAt,status,conclusion,url,jobs
gh run view 26838481797 --repo Altinn/altinn-studio --json databaseId,headSha,displayTitle,createdAt,updatedAt,status,conclusion,url,jobs
```

GHCR manifest checks:

```sh
docker manifest inspect ghcr.io/altinn/altinn-studio/runtime-localtest:94897eff31 >/dev/null && echo localtest:94897eff31 OK
docker manifest inspect ghcr.io/altinn/altinn-studio/runtime-pdf3-worker:694406e93c >/dev/null && echo pdf3-worker:694406e93c OK
docker manifest inspect ghcr.io/altinn/altinn-studio/runtime-workflow-engine-app:567e1be1f1 >/dev/null && echo workflow-engine-app:567e1be1f1 OK
```

## Verification

- [x] Related issues are connected (if applicable): N/A
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required): checked deploy workflow jobs, verified GHCR manifests, and manually completed `ttd/martinotest` through Localtest
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out): config-only tag update, no new test added

Automated verification:

```sh
go test ./internal/config
make test
```

Manual verification:

```sh
cd /data/home/code/altinn-studio/src/cli
make user-install

cd /data/home/code/apps/martinotest
studioctl env up
studioctl run
```

Confirmed `localtest-pdf3` used `runtime-pdf3-worker:694406e93c`, had `studio-ca-bundle` imported in Chromium's NSS DB, generated `martinotest.pdf`, and reached receipt page `ProcessEnd`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core service container image to the latest build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->