### PR TITLE
chore: add studioctl preview changelog entry

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -8,6 +8,10 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+### Changed
+
+- Update localtest PDF worker image.
+
 ## [0.1.0-preview.13] - 2026-06-05
 
 ### Added


### PR DESCRIPTION
## Description

Adds the missing studioctl changelog entry for the next preview release.

This is a prerequisite for running the normal releaser prepare flow for v0.1.0-preview.14, because the prepare command reads [Unreleased] from origin/main.

## Verification

```sh
go run . validate-changelog -component studioctl -base origin/main -head HEAD
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PDF worker configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->