### PR TITLE
perf: schedule devenv resources when ready

### DIFF
--- a/src/Runtime/devenv/pkg/resource/executor/backend.go
+++ b/src/Runtime/devenv/pkg/resource/executor/backend.go
@@ -20,7 +20,7 @@ type BackendContext struct {
 	GraphID resource.GraphID
 }
 
-// Outputs returns a snapshot of outputs produced by resources applied before the current level.
+// Outputs returns a snapshot of outputs produced by resources completed before the current resource started.
 func (c BackendContext) Outputs() Outputs {
 	return c.outputs
 }

--- a/src/Runtime/devenv/pkg/resource/executor/executor.go
+++ b/src/Runtime/devenv/pkg/resource/executor/executor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 
 	"golang.org/x/sync/errgroup"
 
@@ -40,15 +41,14 @@ func (e *Executor) SetObserver(o Observer) {
 }
 
 // Apply creates/updates all resources in the graph in dependency order.
-// Resources at the same dependency level are applied in parallel.
+// Resources are scheduled as soon as their dependencies have completed.
 func (e *Executor) Apply(ctx context.Context, g *resource.Graph, opts ...ApplyOption) (Outputs, error) {
 	if err := validateGraphID(g); err != nil {
 		return Outputs{}, err
 	}
 	options := newApplyOptions(opts)
-	levels, err := g.TopologicalOrder()
-	if err != nil {
-		return Outputs{}, fmt.Errorf("sort graph resources: %w", err)
+	if _, err := g.TopologicalOrder(); err != nil {
+		return Outputs{}, fmt.Errorf("validate graph dependencies: %w", err)
 	}
 	actual, err := e.Status(ctx, g)
 	if err != nil {
@@ -65,11 +65,11 @@ func (e *Executor) Apply(ctx context.Context, g *resource.Graph, opts ...ApplyOp
 		return Outputs{}, err
 	}
 
-	return e.executeApplyPlan(ctx, g, levels, plan)
+	return e.executeApplyPlan(ctx, g, plan)
 }
 
 // Destroy removes all resources in the graph in reverse dependency order.
-// Resources at the same dependency level are destroyed in parallel.
+// Resources are scheduled as soon as their dependents have been destroyed.
 func (e *Executor) Destroy(ctx context.Context, g *resource.Graph, opts ...DestroyOption) error {
 	if err := validateGraphID(g); err != nil {
 		return err
@@ -100,15 +100,25 @@ func (e *Executor) Status(ctx context.Context, g *resource.Graph, opts ...Status
 		Resources: make(map[resource.ResourceID]ObservedResource, len(resources)),
 	}
 
+	var mu sync.Mutex
+	eg, groupCtx := errgroup.WithContext(ctx)
 	for _, r := range resources {
 		if options.skipResource(r) {
 			continue
 		}
-		observed, err := e.observeResource(ctx, g.ID(), r)
-		if err != nil {
-			return Snapshot{}, fmt.Errorf("status %s: %w", r.ID(), err)
-		}
-		snapshot.Resources[r.ID()] = observed
+		eg.Go(func() error {
+			observed, err := e.observeResource(groupCtx, g.ID(), r)
+			if err != nil {
+				return fmt.Errorf("status %s: %w", r.ID(), err)
+			}
+			mu.Lock()
+			snapshot.Resources[r.ID()] = observed
+			mu.Unlock()
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return Snapshot{}, fmt.Errorf("observe graph resources: %w", err)
 	}
 
 	if err := e.discoverGraphResources(ctx, &snapshot); err != nil {
@@ -121,36 +131,29 @@ func (e *Executor) Status(ctx context.Context, g *resource.Graph, opts ...Status
 func (e *Executor) executeApplyPlan(
 	ctx context.Context,
 	g *resource.Graph,
-	levels [][]resource.Resource,
 	plan applyPlan,
 ) (Outputs, error) {
-	applyIDs := resourceIDSet(plan.reconcile)
-
 	e.outputs.Reset()
 
-	for _, level := range levels {
-		eg, groupCtx := errgroup.WithContext(ctx)
-		for _, r := range level {
-			if _, ok := applyIDs[r.ID()]; !ok {
-				continue
-			}
-			eg.Go(func() error {
-				e.notify(EventApplyStart, r.ID(), nil)
-				output, err := e.applyResource(groupCtx, g.ID(), r)
-				if err != nil {
-					e.notify(EventApplyFailed, r.ID(), err)
-					return fmt.Errorf("apply %s: %w", r.ID(), err)
-				}
-				if output != nil && !isNoOutput(output) {
-					e.outputs.Set(r.ID(), output)
-				}
-				e.notify(EventApplyDone, r.ID(), nil)
-				return nil
-			})
+	resources, err := schedulerResources(g, plan.reconcile)
+	if err != nil {
+		return Outputs{}, err
+	}
+	scheduler := newResourceScheduler(resources, scheduleDependenciesFirst)
+	if err := runResourceScheduler(ctx, scheduler, func(ctx context.Context, r resource.Resource) error {
+		e.notify(EventApplyStart, r.ID(), nil)
+		output, err := e.applyResource(ctx, g.ID(), r)
+		if err != nil {
+			e.notify(EventApplyFailed, r.ID(), err)
+			return fmt.Errorf("apply %s: %w", r.ID(), err)
 		}
-		if err := eg.Wait(); err != nil {
-			return Outputs{}, fmt.Errorf("apply level: %w", err)
+		if output != nil && !isNoOutput(output) {
+			e.outputs.Set(r.ID(), output)
 		}
+		e.notify(EventApplyDone, r.ID(), nil)
+		return nil
+	}); err != nil {
+		return Outputs{}, err
 	}
 	return e.outputs.Snapshot(), nil
 }
@@ -163,34 +166,22 @@ func (e *Executor) executeDestroyPlan(ctx context.Context, actual Snapshot, ids 
 	if err != nil {
 		return err
 	}
-	levels, err := graph.ReverseTopologicalOrderSubset(ids)
+	resources, err := schedulerResources(graph, ids)
 	if err != nil {
 		return fmt.Errorf("sort observed graph resources: %w", err)
 	}
-	for _, level := range levels {
-		eg, groupCtx := errgroup.WithContext(ctx)
-		for _, r := range level {
-			eg.Go(func() error {
-				observed, ok := actual.Resources[r.ID()]
-				if !ok {
-					return fmt.Errorf("%w: %q", errGraphResourceNotFound, r.ID())
-				}
-				return e.destroyObservedResource(groupCtx, r.ID(), observed)
-			})
+
+	scheduler := newResourceScheduler(resources, scheduleDependentsFirst)
+	if err := runResourceScheduler(ctx, scheduler, func(ctx context.Context, r resource.Resource) error {
+		observed, ok := actual.Resources[r.ID()]
+		if !ok {
+			return fmt.Errorf("%w: %q", errGraphResourceNotFound, r.ID())
 		}
-		if err := eg.Wait(); err != nil {
-			return fmt.Errorf("destroy level: %w", err)
-		}
+		return e.destroyObservedResource(ctx, r.ID(), observed)
+	}); err != nil {
+		return fmt.Errorf("destroy resources: %w", err)
 	}
 	return nil
-}
-
-func resourceIDSet(ids []resource.ResourceID) map[resource.ResourceID]struct{} {
-	set := make(map[resource.ResourceID]struct{}, len(ids))
-	for _, id := range ids {
-		set[id] = struct{}{}
-	}
-	return set
 }
 
 func validateGraphID(g *resource.Graph) error {

--- a/src/Runtime/devenv/pkg/resource/executor/scheduler.go
+++ b/src/Runtime/devenv/pkg/resource/executor/scheduler.go
@@ -1,0 +1,230 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+
+	"golang.org/x/sync/errgroup"
+
+	"altinn.studio/devenv/pkg/resource"
+)
+
+var errResourceScheduleBlocked = errors.New("resource schedule is blocked")
+
+type scheduleOrder uint8
+
+const (
+	scheduleDependenciesFirst scheduleOrder = iota
+	scheduleDependentsFirst
+)
+
+type resourceScheduler struct {
+	resources map[resource.ResourceID]resource.Resource
+	blockedBy map[resource.ResourceID]int
+	unblocks  map[resource.ResourceID][]resource.ResourceID
+	order     []resource.ResourceID
+}
+
+type scheduleResult struct {
+	err error
+	id  resource.ResourceID
+}
+
+type resourceScheduleRunner struct {
+	group     *errgroup.Group
+	scheduler *resourceScheduler
+	done      chan scheduleResult
+	ready     []resource.ResourceID
+	running   int
+}
+
+func schedulerResources(g *resource.Graph, ids []resource.ResourceID) ([]resource.Resource, error) {
+	resources := make([]resource.Resource, 0, len(ids))
+	for _, id := range ids {
+		r := g.Get(id)
+		if r == nil {
+			return nil, fmt.Errorf("%w: %q", errGraphResourceNotFound, id)
+		}
+		resources = append(resources, r)
+	}
+	return resources, nil
+}
+
+func newResourceScheduler(resources []resource.Resource, order scheduleOrder) *resourceScheduler {
+	scheduler := &resourceScheduler{
+		resources: make(map[resource.ResourceID]resource.Resource, len(resources)),
+		blockedBy: make(map[resource.ResourceID]int, len(resources)),
+		unblocks:  make(map[resource.ResourceID][]resource.ResourceID, len(resources)),
+		order:     make([]resource.ResourceID, 0, len(resources)),
+	}
+	for _, r := range resources {
+		id := r.ID()
+		scheduler.resources[id] = r
+		scheduler.blockedBy[id] = 0
+		scheduler.order = append(scheduler.order, id)
+	}
+	slices.Sort(scheduler.order)
+
+	for _, id := range scheduler.order {
+		r := scheduler.resources[id]
+		for _, ref := range r.Dependencies() {
+			depID := ref.ID()
+			if _, ok := scheduler.resources[depID]; !ok {
+				continue
+			}
+			switch order {
+			case scheduleDependenciesFirst:
+				scheduler.blockedBy[id]++
+				scheduler.unblocks[depID] = append(scheduler.unblocks[depID], id)
+			case scheduleDependentsFirst:
+				scheduler.blockedBy[depID]++
+				scheduler.unblocks[id] = append(scheduler.unblocks[id], depID)
+			}
+		}
+	}
+	for id := range scheduler.unblocks {
+		slices.Sort(scheduler.unblocks[id])
+	}
+	return scheduler
+}
+
+func (s *resourceScheduler) len() int {
+	return len(s.resources)
+}
+
+func (s *resourceScheduler) ready() []resource.ResourceID {
+	ready := make([]resource.ResourceID, 0)
+	for _, id := range s.order {
+		if s.blockedBy[id] == 0 {
+			ready = append(ready, id)
+		}
+	}
+	return ready
+}
+
+func (s *resourceScheduler) resource(id resource.ResourceID) resource.Resource {
+	return s.resources[id]
+}
+
+func (s *resourceScheduler) complete(id resource.ResourceID) []resource.ResourceID {
+	delete(s.blockedBy, id)
+
+	ready := make([]resource.ResourceID, 0)
+	for _, unblockedID := range s.unblocks[id] {
+		remaining, ok := s.blockedBy[unblockedID]
+		if !ok {
+			continue
+		}
+		remaining--
+		s.blockedBy[unblockedID] = remaining
+		if remaining == 0 {
+			ready = append(ready, unblockedID)
+		}
+	}
+	return ready
+}
+
+func newResourceScheduleRunner(
+	ctx context.Context,
+	scheduler *resourceScheduler,
+) (*resourceScheduleRunner, context.Context) {
+	eg, groupCtx := errgroup.WithContext(ctx)
+	return &resourceScheduleRunner{
+		group:     eg,
+		scheduler: scheduler,
+		done:      make(chan scheduleResult, scheduler.len()),
+		ready:     scheduler.ready(),
+	}, groupCtx
+}
+
+func (r *resourceScheduleRunner) startReady(
+	ctx context.Context,
+	run func(context.Context, resource.Resource) error,
+) {
+	for len(r.ready) > 0 && ctx.Err() == nil {
+		id := r.ready[0]
+		r.ready = r.ready[1:]
+		r.start(ctx, id, run)
+	}
+}
+
+func (r *resourceScheduleRunner) start(
+	ctx context.Context,
+	id resource.ResourceID,
+	run func(context.Context, resource.Resource) error,
+) {
+	r.running++
+	res := r.scheduler.resource(id)
+	r.group.Go(func() error {
+		err := run(ctx, res)
+		r.done <- scheduleResult{id: id, err: err}
+		return err
+	})
+}
+
+func (r *resourceScheduleRunner) waitForCompletion(ctx context.Context) (bool, error) {
+	if r.running == 0 {
+		if err := ctx.Err(); err != nil {
+			return false, r.waitAfterCancel(err)
+		}
+		return false, errResourceScheduleBlocked
+	}
+
+	result := <-r.done
+	r.running--
+	if result.err != nil {
+		return false, r.waitAfterError(result.err)
+	}
+	r.ready = append(r.ready, r.scheduler.complete(result.id)...)
+	return true, nil
+}
+
+func (r *resourceScheduleRunner) waitAfterCancel(err error) error {
+	if waitErr := r.group.Wait(); waitErr != nil && !errors.Is(waitErr, err) {
+		return errors.Join(
+			fmt.Errorf("resource schedule canceled: %w", err),
+			fmt.Errorf("wait for scheduled resources: %w", waitErr),
+		)
+	}
+	return fmt.Errorf("resource schedule canceled: %w", err)
+}
+
+func (r *resourceScheduleRunner) waitAfterError(err error) error {
+	if waitErr := r.group.Wait(); waitErr != nil && !errors.Is(waitErr, err) {
+		return errors.Join(err, fmt.Errorf("wait for scheduled resources: %w", waitErr))
+	}
+	return err
+}
+
+func (r *resourceScheduleRunner) wait() error {
+	if err := r.group.Wait(); err != nil {
+		return fmt.Errorf("wait for scheduled resources: %w", err)
+	}
+	return nil
+}
+
+func runResourceScheduler(
+	ctx context.Context,
+	scheduler *resourceScheduler,
+	run func(context.Context, resource.Resource) error,
+) error {
+	if scheduler.len() == 0 {
+		return nil
+	}
+
+	runner, groupCtx := newResourceScheduleRunner(ctx, scheduler)
+	completed := 0
+	for completed < scheduler.len() {
+		runner.startReady(groupCtx, run)
+		ok, err := runner.waitForCompletion(groupCtx)
+		if err != nil {
+			return err
+		}
+		if ok {
+			completed++
+		}
+	}
+	return runner.wait()
+}

--- a/src/Runtime/devenv/pkg/resource/executor/scheduler_test.go
+++ b/src/Runtime/devenv/pkg/resource/executor/scheduler_test.go
@@ -1,0 +1,320 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"altinn.studio/devenv/pkg/resource"
+)
+
+const schedulerTestTimeout = 2 * time.Second
+
+var errSchedulerTestApply = errors.New("apply failed")
+var errSchedulerTestOutputMissing = errors.New("dependency output missing")
+
+type schedulerTestResource struct {
+	id   ResourceID
+	deps []ResourceRef
+}
+
+func (r schedulerTestResource) ID() ResourceID {
+	return r.id
+}
+
+func (r schedulerTestResource) Dependencies() []ResourceRef {
+	return r.deps
+}
+
+type schedulerTestBackend struct {
+	apply   func(context.Context, BackendContext, Resource) (Output, error)
+	observe func(context.Context, BackendContext, Resource) (ObservedResource, error)
+	destroy func(context.Context, ResourceID, ObservedResource) error
+}
+
+func (b schedulerTestBackend) Supports(r Resource) bool {
+	_, ok := r.(schedulerTestResource)
+	return ok
+}
+
+func (b schedulerTestBackend) Apply(ctx context.Context, backendCtx BackendContext, r Resource) (Output, error) {
+	if b.apply == nil {
+		return NoOutput{}, nil
+	}
+	return b.apply(ctx, backendCtx, r)
+}
+
+func (b schedulerTestBackend) Observe(
+	ctx context.Context,
+	backendCtx BackendContext,
+	r Resource,
+) (ObservedResource, error) {
+	if b.observe != nil {
+		return b.observe(ctx, backendCtx, r)
+	}
+	return ObservedResource{
+		Resource:  r,
+		RuntimeID: r.ID().String(),
+		Status:    StatusDestroyed,
+		Type:      ResourceTypeUnknown,
+		Managed:   false,
+	}, nil
+}
+
+func (b schedulerTestBackend) Destroy(ctx context.Context, id ResourceID, observed ObservedResource) error {
+	if b.destroy == nil {
+		return nil
+	}
+	return b.destroy(ctx, id, observed)
+}
+
+func TestExecutor_ApplySchedulesDependentsBeforeUnrelatedResourcesFinish(t *testing.T) {
+	graph := NewGraph(testGraphID)
+	a := schedulerTestResource{id: "a"}
+	b := schedulerTestResource{id: "b", deps: []ResourceRef{Ref(a)}}
+	c := schedulerTestResource{id: "c"}
+	mustAddResource(t, graph, a)
+	mustAddResource(t, graph, b)
+	mustAddResource(t, graph, c)
+
+	cStarted := make(chan struct{})
+	releaseC := make(chan struct{})
+	bStarted := make(chan struct{})
+	releaseCClosed := false
+	defer func() {
+		if !releaseCClosed {
+			close(releaseC)
+		}
+	}()
+
+	executor := New()
+	if err := executor.RegisterBackend(schedulerTestBackend{
+		apply: func(ctx context.Context, backendCtx BackendContext, r Resource) (Output, error) {
+			switch r.ID() {
+			case "a":
+				return ImageOutput{ImageID: "image-a"}, nil
+			case "b":
+				if _, ok := backendCtx.Outputs().Image(a.ID()); !ok {
+					return nil, errSchedulerTestOutputMissing
+				}
+				close(bStarted)
+			case "c":
+				close(cStarted)
+				if err := waitForSchedulerContext(ctx, releaseC); err != nil {
+					return nil, err
+				}
+			}
+			return NoOutput{}, nil
+		},
+	}); err != nil {
+		t.Fatalf("RegisterBackend() error = %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := executor.Apply(t.Context(), graph)
+		errCh <- err
+	}()
+
+	waitForSchedulerSignal(t.Context(), t, cStarted, "c start")
+	waitForSchedulerSignal(t.Context(), t, bStarted, "b start")
+	close(releaseC)
+	releaseCClosed = true
+
+	if err := receiveSchedulerError(t, errCh); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+}
+
+func TestExecutor_DestroySchedulesDependenciesBeforeUnrelatedResourcesFinish(t *testing.T) {
+	graph := NewGraph(testGraphID)
+	a := schedulerTestResource{id: "a"}
+	b := schedulerTestResource{id: "b", deps: []ResourceRef{Ref(a)}}
+	c := schedulerTestResource{id: "c"}
+	mustAddResource(t, graph, a)
+	mustAddResource(t, graph, b)
+	mustAddResource(t, graph, c)
+
+	cStarted := make(chan struct{})
+	releaseC := make(chan struct{})
+	aStarted := make(chan struct{})
+	releaseCClosed := false
+	defer func() {
+		if !releaseCClosed {
+			close(releaseC)
+		}
+	}()
+
+	executor := New()
+	if err := executor.RegisterBackend(schedulerTestBackend{
+		observe: readyManagedResource,
+		destroy: func(ctx context.Context, id ResourceID, _ ObservedResource) error {
+			switch id {
+			case "a":
+				close(aStarted)
+			case "c":
+				close(cStarted)
+				if err := waitForSchedulerContext(ctx, releaseC); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}); err != nil {
+		t.Fatalf("RegisterBackend() error = %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- executor.Destroy(t.Context(), graph)
+	}()
+
+	waitForSchedulerSignal(t.Context(), t, cStarted, "c destroy start")
+	waitForSchedulerSignal(t.Context(), t, aStarted, "a destroy start")
+	close(releaseC)
+	releaseCClosed = true
+
+	if err := receiveSchedulerError(t, errCh); err != nil {
+		t.Fatalf("Destroy() error = %v", err)
+	}
+}
+
+func TestExecutor_StatusObservesResourcesConcurrently(t *testing.T) {
+	graph := NewGraph(testGraphID)
+	mustAddResource(t, graph, schedulerTestResource{id: "a"})
+	mustAddResource(t, graph, schedulerTestResource{id: "b"})
+	mustAddResource(t, graph, schedulerTestResource{id: "c"})
+
+	started := make(chan ResourceID, 3)
+	release := make(chan struct{})
+	releaseClosed := false
+	defer func() {
+		if !releaseClosed {
+			close(release)
+		}
+	}()
+
+	executor := New()
+	if err := executor.RegisterBackend(schedulerTestBackend{
+		observe: func(ctx context.Context, _ BackendContext, r Resource) (ObservedResource, error) {
+			started <- r.ID()
+			if err := waitForSchedulerContext(ctx, release); err != nil {
+				return ObservedResource{}, err
+			}
+			return readyManagedResource(ctx, BackendContext{}, r)
+		},
+	}); err != nil {
+		t.Fatalf("RegisterBackend() error = %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := executor.Status(t.Context(), graph)
+		errCh <- err
+	}()
+
+	waitForSchedulerStarts(t, started, 3)
+	close(release)
+	releaseClosed = true
+
+	if err := receiveSchedulerError(t, errCh); err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+}
+
+func TestExecutor_ApplyDoesNotStartDependentsAfterDependencyFailure(t *testing.T) {
+	graph := NewGraph(testGraphID)
+	a := schedulerTestResource{id: "a"}
+	b := schedulerTestResource{id: "b", deps: []ResourceRef{Ref(a)}}
+	mustAddResource(t, graph, a)
+	mustAddResource(t, graph, b)
+
+	var mu sync.Mutex
+	started := make(map[ResourceID]bool)
+
+	executor := New()
+	if err := executor.RegisterBackend(schedulerTestBackend{
+		apply: func(_ context.Context, _ BackendContext, r Resource) (Output, error) {
+			mu.Lock()
+			started[r.ID()] = true
+			mu.Unlock()
+
+			if r.ID() == a.ID() {
+				return nil, errSchedulerTestApply
+			}
+			return NoOutput{}, nil
+		},
+	}); err != nil {
+		t.Fatalf("RegisterBackend() error = %v", err)
+	}
+
+	_, err := executor.Apply(t.Context(), graph)
+	if !errors.Is(err, errSchedulerTestApply) {
+		t.Fatalf("Apply() error = %v, want %v", err, errSchedulerTestApply)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if started[b.ID()] {
+		t.Fatalf("dependent %s started after dependency failure", b.ID())
+	}
+}
+
+func readyManagedResource(_ context.Context, _ BackendContext, r Resource) (ObservedResource, error) {
+	return ObservedResource{
+		Resource:  r,
+		RuntimeID: r.ID().String(),
+		Status:    StatusReady,
+		Type:      ResourceTypeUnknown,
+		Managed:   true,
+	}, nil
+}
+
+func waitForSchedulerStarts(t *testing.T, started <-chan ResourceID, count int) {
+	t.Helper()
+	seen := make(map[ResourceID]bool, count)
+	for len(seen) < count {
+		select {
+		case id := <-started:
+			seen[id] = true
+		case <-time.After(schedulerTestTimeout):
+			t.Fatalf("timed out waiting for %d status observations; saw %v", count, seen)
+		}
+	}
+}
+
+func waitForSchedulerSignal(ctx context.Context, t *testing.T, ch <-chan struct{}, name string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-ctx.Done():
+		t.Fatalf("context canceled waiting for %s: %v", name, ctx.Err())
+	case <-time.After(schedulerTestTimeout):
+		t.Fatalf("timed out waiting for %s", name)
+	}
+}
+
+func waitForSchedulerContext(ctx context.Context, ch <-chan struct{}) error {
+	select {
+	case <-ch:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("wait for scheduler signal: %w", ctx.Err())
+	}
+}
+
+func receiveSchedulerError(t *testing.T, errCh <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-errCh:
+		return err
+	case <-time.After(schedulerTestTimeout):
+		t.Fatal("timed out waiting for operation to finish")
+		return nil
+	}
+}
+
+var _ resource.Resource = schedulerTestResource{}


### PR DESCRIPTION
## Description

Improves devenv resource graph executor scheduling:

- replaces level-at-a-time apply/destroy execution with a ready-queue DAG scheduler
- starts resources as soon as their own dependencies/dependents are satisfied
- observes desired resources concurrently during `Status()` while keeping discovery sequential
- updates output visibility docs to the new completed-before-resource-start semantics
- adds focused scheduler tests for apply, destroy, status concurrency, output visibility, and dependency failure behavior

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

Commands run:

```sh
cd src/Runtime/devenv && make fmt
cd src/Runtime/devenv && make lint
cd src/Runtime/devenv && make build
cd src/Runtime/devenv && make test
cd src/Runtime/devenv && go test ./pkg/resource/executor/...
cd src/Runtime/devenv && go test -race ./pkg/resource/executor/...
cd src/Runtime/pdf3 && go test ./internal/... ./cmd/...
cd src/Runtime/gateway && go test ./...
cd src/cli && make test
cd src/cli && make lint
```

Reviewer subagent reviewed the staged diff and reported no actionable correctness, race, deadlock, cancellation, dependency-order, destroy-order, or output-visibility findings.

Known local limitation: `cd src/Runtime/operator && go test ./...` is not a valid standalone check in this VM without the org registry fake on `localhost:8052` and a running kind runtime; it failed for those harness prerequisites, not for executor behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Refactor**
  * Improved resource execution scheduling with concurrent dependency-aware processing
  * Enhanced status observation with parallel resource monitoring
  * Strengthened error handling and resource ordering

* **Tests**
  * Added comprehensive scheduler and executor tests covering dependency ordering and failure scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->