### PR TITLE
fix: use trusted publishing user for app release

### DIFF
--- a/.github/workflows/release-app.yaml
+++ b/.github/workflows/release-app.yaml
@@ -138,7 +138,7 @@ jobs:
         id: nuget-login
         uses: NuGet/login@ebc737b6fc418a6ca0073cf116ec8dc156d8b81e # v1
         with:
-          user: altinn
+          user: ${{ vars.NUGET_TRUSTED_PUBLISHING_USER }}
 
       - name: Publish packages to NuGet
         env:


### PR DESCRIPTION
## Description

Use the repo-level `NUGET_TRUSTED_PUBLISHING_USER` variable when exchanging the GitHub OIDC token with NuGet trusted publishing.

This lets the release workflow use the NuGet username that created the trusted publishing policy instead of assuming the package owner name.

@coderabbitai ignore