### PR TITLE
fix: exclude app packages from release assets

### DIFF
--- a/.github/workflows/release-app.yaml
+++ b/.github/workflows/release-app.yaml
@@ -177,10 +177,10 @@ jobs:
 
           if [[ -d "build/release" ]]; then
             {
-              echo "### Assets"
+              echo "### NuGet packages"
               echo '```'
             } >> "$GITHUB_STEP_SUMMARY"
-            ls -la build/release/ >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || echo "No assets found"
+            ls -la build/release/ >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || echo "No packages found"
             echo '```' >> "$GITHUB_STEP_SUMMARY"
           fi
         env:

--- a/.github/workflows/release-app.yaml
+++ b/.github/workflows/release-app.yaml
@@ -180,7 +180,7 @@ jobs:
               echo "### NuGet packages"
               echo '```'
             } >> "$GITHUB_STEP_SUMMARY"
-            ls -la build/release/ >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || echo "No packages found"
+            ls -la build/release/ >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || echo "No packages found" >> "$GITHUB_STEP_SUMMARY"
             echo '```' >> "$GITHUB_STEP_SUMMARY"
           fi
         env:

--- a/src/tools/releaser/builder_app.go
+++ b/src/tools/releaser/builder_app.go
@@ -65,11 +65,12 @@ func (b *appBuilder) Build(ctx context.Context, ver *version.Version, outputDir 
 		return nil, fmt.Errorf("pack app backend: %w", packErr)
 	}
 
-	releaseAssets, err := appReleaseAssets(outputDir)
-	if err != nil {
+	if err := validateAppPackageArtifacts(outputDir); err != nil {
 		return nil, err
 	}
-	return releaseAssets, nil
+
+	// App packages are published to NuGet by the workflow, not attached to the GitHub release.
+	return nil, nil
 }
 
 func appInformationalVersion(ctx context.Context, git *internal.GitCLI, ver *version.Version) (string, error) {
@@ -158,15 +159,14 @@ func appPackageArtifacts(outputDir string) ([]string, error) {
 	return artifacts, nil
 }
 
-func appReleaseAssets(outputDir string) ([]string, error) {
+func validateAppPackageArtifacts(outputDir string) error {
 	packages, err := appPackageArtifacts(outputDir)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if len(packages) == 0 {
-		return nil, fmt.Errorf("%w in %s", errAppPackageArtifactsMissing, outputDir)
+		return fmt.Errorf("%w in %s", errAppPackageArtifactsMissing, outputDir)
 	}
 
-	// App packages are published to NuGet by the workflow, not attached to the GitHub release.
-	return nil, nil
+	return nil
 }

--- a/src/tools/releaser/builder_app.go
+++ b/src/tools/releaser/builder_app.go
@@ -65,14 +65,11 @@ func (b *appBuilder) Build(ctx context.Context, ver *version.Version, outputDir 
 		return nil, fmt.Errorf("pack app backend: %w", packErr)
 	}
 
-	artifacts, err := appPackageArtifacts(outputDir)
+	releaseAssets, err := appReleaseAssets(outputDir)
 	if err != nil {
 		return nil, err
 	}
-	if len(artifacts) == 0 {
-		return nil, fmt.Errorf("%w in %s", errAppPackageArtifactsMissing, outputDir)
-	}
-	return artifacts, nil
+	return releaseAssets, nil
 }
 
 func appInformationalVersion(ctx context.Context, git *internal.GitCLI, ver *version.Version) (string, error) {
@@ -159,4 +156,17 @@ func appPackageArtifacts(outputDir string) ([]string, error) {
 	}
 	sort.Strings(artifacts)
 	return artifacts, nil
+}
+
+func appReleaseAssets(outputDir string) ([]string, error) {
+	packages, err := appPackageArtifacts(outputDir)
+	if err != nil {
+		return nil, err
+	}
+	if len(packages) == 0 {
+		return nil, fmt.Errorf("%w in %s", errAppPackageArtifactsMissing, outputDir)
+	}
+
+	// App packages are published to NuGet by the workflow, not attached to the GitHub release.
+	return nil, nil
 }

--- a/src/tools/releaser/builder_app_test.go
+++ b/src/tools/releaser/builder_app_test.go
@@ -7,24 +7,20 @@ import (
 	"testing"
 )
 
-func TestAppReleaseAssetsExcludesNuGetPackages(t *testing.T) {
+func TestValidateAppPackageArtifactsAcceptsNuGetPackages(t *testing.T) {
 	outputDir := t.TempDir()
 	writeTestFile(t, outputDir, "Altinn.App.Api.9.0.0-preview.1.nupkg")
 	writeTestFile(t, outputDir, "Altinn.App.Api.9.0.0-preview.1.snupkg")
 
-	assets, err := appReleaseAssets(outputDir)
-	if err != nil {
-		t.Fatalf("appReleaseAssets() unexpected error: %v", err)
-	}
-	if len(assets) != 0 {
-		t.Fatalf("appReleaseAssets() returned %d assets, want 0: %v", len(assets), assets)
+	if err := validateAppPackageArtifacts(outputDir); err != nil {
+		t.Fatalf("validateAppPackageArtifacts() unexpected error: %v", err)
 	}
 }
 
-func TestAppReleaseAssetsRequiresNuGetPackages(t *testing.T) {
-	_, err := appReleaseAssets(t.TempDir())
+func TestValidateAppPackageArtifactsRequiresNuGetPackages(t *testing.T) {
+	err := validateAppPackageArtifacts(t.TempDir())
 	if !errors.Is(err, errAppPackageArtifactsMissing) {
-		t.Fatalf("appReleaseAssets() error = %v, want %v", err, errAppPackageArtifactsMissing)
+		t.Fatalf("validateAppPackageArtifacts() error = %v, want %v", err, errAppPackageArtifactsMissing)
 	}
 }
 

--- a/src/tools/releaser/builder_app_test.go
+++ b/src/tools/releaser/builder_app_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAppReleaseAssetsExcludesNuGetPackages(t *testing.T) {
+	outputDir := t.TempDir()
+	writeTestFile(t, outputDir, "Altinn.App.Api.9.0.0-preview.1.nupkg")
+	writeTestFile(t, outputDir, "Altinn.App.Api.9.0.0-preview.1.snupkg")
+
+	assets, err := appReleaseAssets(outputDir)
+	if err != nil {
+		t.Fatalf("appReleaseAssets() unexpected error: %v", err)
+	}
+	if len(assets) != 0 {
+		t.Fatalf("appReleaseAssets() returned %d assets, want 0: %v", len(assets), assets)
+	}
+}
+
+func TestAppReleaseAssetsRequiresNuGetPackages(t *testing.T) {
+	_, err := appReleaseAssets(t.TempDir())
+	if !errors.Is(err, errAppPackageArtifactsMissing) {
+		t.Fatalf("appReleaseAssets() error = %v, want %v", err, errAppPackageArtifactsMissing)
+	}
+}
+
+func writeTestFile(t *testing.T, dir string, name string) {
+	t.Helper()
+
+	if err := os.WriteFile(filepath.Join(dir, name), []byte("test"), 0o644); err != nil {
+		t.Fatalf("write test file %s: %v", name, err)
+	}
+}


### PR DESCRIPTION
## Description

App releases publish `Altinn.App.*` packages through NuGet, so the generated `.nupkg` and `.snupkg` files should not also be attached as GitHub Release assets.

This PR keeps the app package build validation in place, leaves the packages in `build/release` for the NuGet publish step, and returns no GitHub Release assets from the app builder. The app release workflow summary now labels the directory contents as NuGet packages instead of release assets.

## Verification

```bash
cd src/tools/releaser
go test ./...
```

Result: passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release workflow now adds a “NuGet packages” section to the summary and lists built packages (or shows “No packages found”).
  * Clarified release asset handling so NuGet packages are recognised as published to NuGet rather than attached to GitHub releases.
* **Tests**
  * Added unit tests covering package-detection and missing-package behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->