### PR TITLE
test: scrub app backend version height in integration snapshot

### DIFF
--- a/src/App/backend/test/Altinn.App.Integration.Tests/PartyTypesAllowed/SubunitOnlyAppTests.cs
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/PartyTypesAllowed/SubunitOnlyAppTests.cs
@@ -47,6 +47,14 @@ public class SubunitOnlyAppTests(ITestOutputHelper _output, AppFixtureClassFixtu
 
         Assert.True(response.Response.IsSuccessStatusCode);
         using var applicationMetadata = await response.Read<ApplicationMetadata>();
+        if (
+            applicationMetadata.Data.Model?.AltinnNugetVersion is { } altinnNugetVersion
+            && Version.TryParse(altinnNugetVersion, out var parsedVersion)
+        )
+        {
+            applicationMetadata.Data.Model.AltinnNugetVersion = parsedVersion.Major.ToString();
+        }
+
         await verifier.Verify<ApplicationMetadata>(applicationMetadata);
 
         await verifier.Verify(await fixture.GetSnapshotAppLogs(), snapshotName: "Logs");

--- a/src/App/backend/test/Altinn.App.Integration.Tests/PartyTypesAllowed/_snapshots/SubunitOnlyAppTests.ApplicationMetadata_0.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/PartyTypesAllowed/_snapshots/SubunitOnlyAppTests.ApplicationMetadata_0.verified.txt
@@ -61,7 +61,7 @@
       Org: ttd,
       App: basic
     },
-    AltinnNugetVersion: 9.0.0.0,
+    AltinnNugetVersion: 9,
     ExternalApiIds: [
       tracing-external-api
     ],


### PR DESCRIPTION
## Description

Normalizes `ApplicationMetadata.AltinnNugetVersion` to its major version before verifying the `SubunitOnlyAppTests.ApplicationMetadata` integration snapshot. This keeps the relevant v9 compatibility signal in the snapshot while avoiding drift from git version height after app backend release tags.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

Commands run:

```bash
cd src/App/frontend && yarn install --immutable && yarn run build
cd ../backend && SKIP_FRONTEND_BUILD=true dotnet test test/Altinn.App.Integration.Tests/Altinn.App.Integration.Tests.csproj --filter "FullyQualifiedName~SubunitOnlyAppTests.ApplicationMetadata" --logger "console;verbosity=detailed"
```

Result: frontend build completed successfully but emitted existing Yarn peer-dependency/Browserslist warnings. Targeted integration test passed: `1 tests passed, 0 warnings in 1 projects`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test verification for application metadata by normalising version values before snapshot comparison to reduce brittle failures.
  * Updated snapshot output to reflect the normalised version format and minor formatting fixes, improving snapshot reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->