### PR TITLE
test: install frontend dependencies in app fixture

### DIFF
--- a/src/App/backend/test/Altinn.App.Integration.Tests/_fixture/AppFixture.cs
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/_fixture/AppFixture.cs
@@ -715,6 +715,14 @@ public sealed partial class AppFixture : IAsyncDisposable
             await EnsureYarnAvailable(logger, cancellationToken);
 
             var frontendDirectory = Path.Join(_repoSourceDirectory, "App", "frontend");
+            logger.LogInformation("Installing frontend dependencies");
+            await new Command(
+                "yarn",
+                "install --immutable",
+                frontendDirectory,
+                logger,
+                CancellationToken: cancellationToken
+            );
             await new Command("yarn", "build", frontendDirectory, logger, CancellationToken: cancellationToken);
 
             VerifyFrontendBuilt(logger);


### PR DESCRIPTION
## Description

Makes the App backend integration-test fixture run `yarn install --immutable` before `yarn build` when it builds the local app frontend itself.

This improves local DX for fresh checkouts where `src/App/frontend/dist` and frontend dependencies are not already present. CI behavior remains unchanged for the integration-test job because it downloads the built frontend artifact and runs with `SKIP_FRONTEND_BUILD=true`.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

Command run without `SKIP_FRONTEND_BUILD`:

```bash
cd src/App/backend
dotnet test test/Altinn.App.Integration.Tests/Altinn.App.Integration.Tests.csproj --filter "FullyQualifiedName~BasicAppTests.HostedServices" --logger "console;verbosity=detailed"
```

Result: `1 tests passed, 0 warnings in 1 projects`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated frontend build process to include dependency installation step before build execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->