### PR TITLE
feat: Added version control class

### DIFF
--- a/src/Designer/backend/src/Designer/Infrastructure/ServiceRegistration.cs
+++ b/src/Designer/backend/src/Designer/Infrastructure/ServiceRegistration.cs
@@ -10,7 +10,6 @@ using Altinn.Studio.Designer.Configuration;
 using Altinn.Studio.Designer.Configuration.Extensions;
 using Altinn.Studio.Designer.Evaluators;
 using Altinn.Studio.Designer.Factories;
-using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Repository;
 using Altinn.Studio.Designer.Repository.Implementation;
 using Altinn.Studio.Designer.Repository.ORMImplementation;
@@ -109,6 +108,7 @@ public static class ServiceRegistration
         services.AddScoped<StudioctlAuthService>();
         services.AddHttpClient<IOrgService, OrgService>();
         services.AddHttpClient<ImageClient>();
+        services.AddTransient<IAppVersionService, AppVersionService>();
         services.AddTransient<IAppDevelopmentService, AppDevelopmentService>();
         services.AddTransient<IUiFoldersService, UiFoldersService>();
         services.AddTransient<ITaskNavigationService, TaskNavigationService>();

--- a/src/Designer/backend/src/Designer/Services/Implementation/AppVersionService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/AppVersionService.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.IO;
+using Altinn.Studio.Designer.Helpers;
+using Altinn.Studio.Designer.Infrastructure.GitRepository;
+using Altinn.Studio.Designer.Models;
+using Altinn.Studio.Designer.Services.Interfaces;
+using NuGet.Versioning;
+
+namespace Altinn.Studio.Designer.Services.Implementation;
+
+public class AppVersionService : IAppVersionService
+{
+    private readonly IAltinnGitRepositoryFactory _altinnGitRepositoryFactory;
+
+    private static readonly string[] s_appLibPackageNames = ["Altinn.App.Api", "Altinn.App.Api.Experimental"];
+
+    public AppVersionService(IAltinnGitRepositoryFactory altinnGitRepositoryFactory)
+    {
+        _altinnGitRepositoryFactory = altinnGitRepositoryFactory;
+    }
+
+    public SemanticVersion GetAppLibVersion(AltinnRepoEditingContext altinnRepoEditingContext)
+    {
+        AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(
+            altinnRepoEditingContext.Org,
+            altinnRepoEditingContext.Repo,
+            altinnRepoEditingContext.Developer
+        );
+
+        IEnumerable<string> csprojFiles = altinnAppGitRepository.FindFiles(["*.csproj"]);
+
+        foreach (string csprojFile in csprojFiles)
+        {
+            if (PackageVersionHelper.TryGetPackageVersionFromCsprojFile(csprojFile, s_appLibPackageNames, out SemanticVersion version))
+            {
+                return version;
+            }
+        }
+
+        throw new FileNotFoundException("Unable to extract the version of the app-lib from csproj files.");
+    }
+}

--- a/src/Designer/backend/src/Designer/Services/Implementation/AppVersionService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/AppVersionService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Altinn.Studio.Designer.Helpers;
 using Altinn.Studio.Designer.Infrastructure.GitRepository;
 using Altinn.Studio.Designer.Models;
@@ -21,22 +22,26 @@ public class AppVersionService : IAppVersionService
 
     public SemanticVersion GetAppLibVersion(AltinnRepoEditingContext altinnRepoEditingContext)
     {
-        AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(
+        AltinnAppGitRepository repository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(
             altinnRepoEditingContext.Org,
             altinnRepoEditingContext.Repo,
             altinnRepoEditingContext.Developer
         );
 
-        IEnumerable<string> csprojFiles = altinnAppGitRepository.FindFiles(["*.csproj"]);
-
-        foreach (string csprojFile in csprojFiles)
-        {
-            if (PackageVersionHelper.TryGetPackageVersionFromCsprojFile(csprojFile, s_appLibPackageNames, out SemanticVersion version))
-            {
-                return version;
-            }
-        }
-
-        throw new FileNotFoundException("Unable to extract the version of the app-lib from csproj files.");
+        return FindVersion(repository.FindFiles(["*.csproj"]))
+            ?? throw new FileNotFoundException("Unable to extract the version of the app-lib from csproj files.");
     }
+
+    private static SemanticVersion? FindVersion(IEnumerable<string> csprojFiles) =>
+        csprojFiles
+            .Select(file =>
+                PackageVersionHelper.TryGetPackageVersionFromCsprojFile(
+                    file,
+                    s_appLibPackageNames,
+                    out SemanticVersion version
+                )
+                    ? version
+                    : null
+            )
+            .FirstOrDefault(v => v is not null);
 }

--- a/src/Designer/backend/src/Designer/Services/Interfaces/IAppVersionService.cs
+++ b/src/Designer/backend/src/Designer/Services/Interfaces/IAppVersionService.cs
@@ -1,0 +1,9 @@
+using Altinn.Studio.Designer.Models;
+using NuGet.Versioning;
+
+namespace Altinn.Studio.Designer.Services.Interfaces;
+
+public interface IAppVersionService
+{
+    SemanticVersion GetAppLibVersion(AltinnRepoEditingContext altinnRepoEditingContext);
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added version control class

We only need to check the App.Lib version, since the core package is compiled with it. In practice, this means the core version in the app will always match the App.Lib version.

Note:
The helper currently only queries `PackageReference` elements, so a project using a `ProjectReference` (e.g. during active development) will silently return false for every .csproj, exhausting the loop and throwing `FileNotFoundException`.

<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added application library version retrieval so the system can extract and report version information from app dependencies.

* **Chores**
  * Registered a new backend service to enable the version retrieval capability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->