### PR TITLE
fix: added missing confirmation popover

### DIFF
--- a/app-libs/form-component/src/app-components/ConfirmPopover/ConfirmPopover.module.css
+++ b/app-libs/form-component/src/app-components/ConfirmPopover/ConfirmPopover.module.css
@@ -1,0 +1,8 @@
+.message {
+  margin-bottom: var(--ds-size-3);
+}
+
+.buttonContainer {
+  display: flex;
+  gap: var(--ds-size-2);
+}

--- a/app-libs/form-component/src/app-components/ConfirmPopover/ConfirmPopover.test.tsx
+++ b/app-libs/form-component/src/app-components/ConfirmPopover/ConfirmPopover.test.tsx
@@ -1,0 +1,65 @@
+import { Button } from '@digdir/designsystemet-react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ConfirmPopover, type ConfirmPopoverProps } from './ConfirmPopover';
+
+if (typeof document.getAnimations !== 'function') {
+  document.getAnimations = () => [];
+}
+
+const message = 'Are you sure?';
+const confirmText = 'Yes, delete';
+const cancelText = 'Cancel';
+
+function renderConfirmPopover(props: Partial<ConfirmPopoverProps> = {}) {
+  const mergedProps: ConfirmPopoverProps = {
+    message,
+    confirmText,
+    cancelText,
+    onConfirm: vi.fn(),
+    onCancel: vi.fn(),
+    children: <Button>Delete</Button>,
+    ...props,
+  };
+  render(<ConfirmPopover {...mergedProps} />);
+  return mergedProps;
+}
+
+describe(' ConfirmPopover', () => {
+  it('trigger the confirmation popover', () => {
+    renderConfirmPopover();
+    expect(screen.getByRole('button', { name: 'Delete' })).toHaveAttribute('popovertarget');
+    expect(screen.getByText(message)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: confirmText })).toBeInTheDocument();
+  });
+
+  it('calls onConfirm only after confirming', async () => {
+    const user = userEvent.setup();
+    const { onConfirm } = renderConfirmPopover();
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: confirmText }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCancel and does not confirm when cancelling', async () => {
+    const user = userEvent.setup();
+    const { onConfirm, onCancel } = renderConfirmPopover();
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('renders the provided cancel label', async () => {
+    const user = userEvent.setup();
+    renderConfirmPopover({ cancelText: 'No, keep it' });
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(screen.getByRole('button', { name: 'No, keep it' })).toBeInTheDocument();
+  });
+});

--- a/app-libs/form-component/src/app-components/ConfirmPopover/ConfirmPopover.tsx
+++ b/app-libs/form-component/src/app-components/ConfirmPopover/ConfirmPopover.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import type { ReactNode } from 'react';
+
+import { Button, Popover } from '@digdir/designsystemet-react';
+
+import classes from './ConfirmPopover.module.css';
+
+export interface ConfirmPopoverProps {
+  children: ReactNode;
+  message: ReactNode;
+  confirmText: ReactNode;
+  cancelText: ReactNode;
+  onConfirm: () => void;
+  onCancel?: () => void;
+  color?: 'warning' | 'danger';
+  placement?: 'top' | 'bottom' | 'left' | 'right';
+  popoverId?: string;
+}
+
+export function ConfirmPopover({
+  children,
+  message,
+  confirmText,
+  cancelText,
+  onConfirm,
+  onCancel,
+  color = 'warning',
+  placement = 'left',
+  popoverId,
+}: ConfirmPopoverProps) {
+  const [open, setOpen] = useState(false);
+
+  function handleConfirm() {
+    setOpen(false);
+    onConfirm();
+  }
+
+  function handleCancel() {
+    setOpen(false);
+    onCancel?.();
+  }
+
+  return (
+    <Popover.TriggerContext>
+      <Popover.Trigger asChild onClick={() => setOpen((prev) => !prev)}>
+        {children}
+      </Popover.Trigger>
+      <Popover
+        id={popoverId}
+        open={open}
+        onClose={handleCancel}
+        placement={placement}
+        data-color={color}
+      >
+        <div className={classes.message}>{message}</div>
+        <div className={classes.buttonContainer}>
+          <Button data-size='sm' color='danger' onClick={handleConfirm}>
+            {confirmText}
+          </Button>
+          <Button data-size='sm' variant='tertiary' color='second' onClick={handleCancel}>
+            {cancelText}
+          </Button>
+        </div>
+      </Popover>
+    </Popover.TriggerContext>
+  );
+}

--- a/app-libs/form-component/src/app-components/ConfirmPopover/index.ts
+++ b/app-libs/form-component/src/app-components/ConfirmPopover/index.ts
@@ -1,0 +1,2 @@
+export { ConfirmPopover } from './ConfirmPopover';
+export type { ConfirmPopoverProps } from './ConfirmPopover';

--- a/app-libs/form-component/src/app-components/Table/Table.tsx
+++ b/app-libs/form-component/src/app-components/Table/Table.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { type ReactNode } from 'react';
 
+import { ConfirmPopover } from '@app/form-component/app-components/ConfirmPopover';
 import { Spinner } from '@app/form-component/app-components/Spinner/Spinner';
 import { Button, Table } from '@digdir/designsystemet-react';
 import cn from 'classnames';
@@ -23,12 +24,19 @@ export interface Column<T> {
   enableInlineEditing?: boolean;
 }
 
+export interface TableActionButtonConfirm {
+  message: ReactNode;
+  confirmText: ReactNode;
+  cancelText: ReactNode;
+}
+
 export interface TableActionButton<T = unknown> {
   onClick: (rowIdx: number, rowData: T) => void;
   buttonText: React.ReactNode;
   icon: React.ReactNode;
   color?: 'first' | 'second' | 'success' | 'danger';
   variant?: 'tertiary' | 'primary' | 'secondary';
+  confirm?: TableActionButtonConfirm;
 }
 
 export interface AppTableProps<T> {
@@ -194,18 +202,38 @@ export function AppTable<T>({
               {actionButtons && actionButtons.length > 0 && (
                 <Table.Cell>
                   <div className={classes.buttonContainer}>
-                    {actionButtons.map((button, idx) => (
-                      <Button
-                        key={idx}
-                        onClick={() => button.onClick(rowIndex, rowData)}
-                        data-size='sm'
-                        variant={button.variant ? button.variant : defaultButtonVariant}
-                        color={button.color ? button.color : 'second'}
-                      >
-                        {button.buttonText}
-                        {button.icon}
-                      </Button>
-                    ))}
+                    {actionButtons.map((button, idx) => {
+                      const { confirm } = button;
+                      const handleAction = () => button.onClick(rowIndex, rowData);
+                      const buttonElement = (
+                        <Button
+                          key={idx}
+                          onClick={confirm ? undefined : handleAction}
+                          data-size='sm'
+                          variant={button.variant ?? defaultButtonVariant}
+                          color={button.color ?? 'second'}
+                        >
+                          {button.buttonText}
+                          {button.icon}
+                        </Button>
+                      );
+
+                      if (!confirm) {
+                        return buttonElement;
+                      }
+
+                      return (
+                        <ConfirmPopover
+                          key={idx}
+                          message={confirm.message}
+                          confirmText={confirm.confirmText}
+                          cancelText={confirm.cancelText}
+                          onConfirm={handleAction}
+                        >
+                          {buttonElement}
+                        </ConfirmPopover>
+                      );
+                    })}
                   </div>
                 </Table.Cell>
               )}

--- a/app-libs/form-component/src/app-components/index.ts
+++ b/app-libs/form-component/src/app-components/index.ts
@@ -2,6 +2,7 @@ export * from './AccordionItem';
 export * from './ConditionalWrapper';
 export * from './Button';
 export * from './Card';
+export * from './ConfirmPopover';
 export * from './Datepicker';
 export * from './DynamicForm';
 export * from './Dropzone';

--- a/src/App/frontend/src/layout/SimpleTable/SimpleTableComponent.tsx
+++ b/src/App/frontend/src/layout/SimpleTable/SimpleTableComponent.tsx
@@ -65,6 +65,11 @@ export function SimpleTableComponent({ baseComponentId, dataModelBindings }: Tab
       buttonText: <Lang id='general.delete' />,
       icon: <TrashIcon />,
       color: 'danger',
+      confirm: {
+        message: <Lang id='group.row_popover_delete_message' />,
+        confirmText: <Lang id='group.row_popover_delete_button_confirm' />,
+        cancelText: <Lang id='general.cancel' />,
+      },
     });
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description


CLOSES: #18944 

- Added a confirmation step before deleting a row in the `SimpleTable` component.
- Added a reusable `ConfirmPopover` in app-libs/form-component.
- Added test to `ConfirmPopover`
- Extended AppTable action buttons with an optional confirm config that shows the confirmation popover before running the action.
- Checked that voiceOver read the popover confirmation. 



https://github.com/user-attachments/assets/cf61d49f-78df-4a7d-a0ab-4da211e10572



## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new confirmation popover component for action confirmations
  * Table action buttons now support optional confirmation dialogs before execution
  * Delete action in simple table now requires user confirmation

* **Tests**
  * Added comprehensive unit test coverage for the confirmation popover component

<!-- end of auto-generated comment: release notes by coderabbit.ai -->