### PR TITLE
fix: usecase prod logformat parameter

### DIFF
--- a/src/test/K6/use-cases-prod.yaml
+++ b/src/test/K6/use-cases-prod.yaml
@@ -36,7 +36,7 @@ steps:
 - script: |
    echo k6 version:`k6 version`
 
-   k6 run --quiet --logformat raw --console-output=$(Build.SourcesDirectory)/result.txt $(Build.SourcesDirectory)/src/test/K6/src/availability.js -e env=$(environment)
+   k6 run --quiet --log-format raw --console-output=$(Build.SourcesDirectory)/result.txt $(Build.SourcesDirectory)/src/test/K6/src/availability.js -e env=$(environment)
 
    cat result.txt
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- `use-cases-prod.yaml` missing the log-format parameter fix after k6/ubuntu altinn-vmss-testagent update

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Corrected the K6 availability test invocation flag format to use the standard hyphenated syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->