### PR TITLE
feat: Add defaultDataType in settings for v9

### DIFF
--- a/src/Designer/backend/src/Designer/Controllers/AppDevelopmentController.cs
+++ b/src/Designer/backend/src/Designer/Controllers/AppDevelopmentController.cs
@@ -1170,16 +1170,21 @@ public class AppDevelopmentController : Controller
     }
 
     [HttpGet("app-version")]
-    public VersionResponse GetAppVersion(string org, string app)
+    public ActionResult<VersionResponse> GetAppVersion(string org, string app)
     {
         string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
         var editingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(org, app, developer);
 
         var backendVersion = _appVersionService.GetAppLibVersion(editingContext);
+        if (backendVersion is null)
+        {
+            return NotFound();
+        }
+
         string frontendVersion;
 
         // For v9 apps and onwards, Index.cshtml no longer exists and frontend major version aligns with backend major version.
-        if (backendVersion?.Major >= 9)
+        if (backendVersion.Major >= 9)
         {
             frontendVersion = backendVersion.Major.ToString();
         }
@@ -1188,6 +1193,6 @@ public class AppDevelopmentController : Controller
             _appDevelopmentService.TryGetFrontendVersion(editingContext, out frontendVersion);
         }
 
-        return new VersionResponse { BackendVersion = backendVersion, FrontendVersion = frontendVersion };
+        return Ok(new VersionResponse { BackendVersion = backendVersion, FrontendVersion = frontendVersion });
     }
 }

--- a/src/Designer/backend/src/Designer/Controllers/AppDevelopmentController.cs
+++ b/src/Designer/backend/src/Designer/Controllers/AppDevelopmentController.cs
@@ -18,6 +18,7 @@ using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using NuGet.Versioning;
 using IRepository = Altinn.Studio.Designer.Services.Interfaces.IRepository;
 
 namespace Altinn.Studio.Designer.Controllers;
@@ -1175,7 +1176,7 @@ public class AppDevelopmentController : Controller
         string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
         var editingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(org, app, developer);
 
-        var backendVersion = _appVersionService.GetAppLibVersion(editingContext);
+        SemanticVersion backendVersion = _appVersionService.GetAppLibVersion(editingContext);
         if (backendVersion is null)
         {
             return NotFound();

--- a/src/Designer/backend/src/Designer/EventHandlers/ProcessDataTypesChanged/ProcessDataTypesChangedLayoutSetsHandler.cs
+++ b/src/Designer/backend/src/Designer/EventHandlers/ProcessDataTypesChanged/ProcessDataTypesChangedLayoutSetsHandler.cs
@@ -42,7 +42,10 @@ public class ProcessDataTypesChangedLayoutSetsHandler : INotificationHandler<Pro
                     notification.EditingContext.Developer
                 );
 
-                if (!repository.AppUsesLayoutSets() || _appVersionService.GetAppLibVersion(notification.EditingContext).Major >= 9)
+                if (
+                    !repository.AppUsesLayoutSets()
+                    || _appVersionService.GetAppLibVersion(notification.EditingContext).Major >= 9
+                )
                 {
                     return hasChanges;
                 }

--- a/src/Designer/backend/src/Designer/EventHandlers/ProcessDataTypesChanged/ProcessDataTypesChangedLayoutSetsHandler.cs
+++ b/src/Designer/backend/src/Designer/EventHandlers/ProcessDataTypesChanged/ProcessDataTypesChangedLayoutSetsHandler.cs
@@ -7,6 +7,7 @@ using Altinn.Studio.Designer.Hubs.Sync;
 using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Services.Interfaces;
 using MediatR;
+using NuGet.Versioning;
 
 namespace Altinn.Studio.Designer.EventHandlers.ProcessDataTypeChanged;
 
@@ -42,10 +43,8 @@ public class ProcessDataTypesChangedLayoutSetsHandler : INotificationHandler<Pro
                     notification.EditingContext.Developer
                 );
 
-                if (
-                    !repository.AppUsesLayoutSets()
-                    || _appVersionService.GetAppLibVersion(notification.EditingContext).Major >= 9
-                )
+                SemanticVersion version = _appVersionService.GetAppLibVersion(notification.EditingContext);
+                if (!repository.AppUsesLayoutSets() || version != null && version.Major >= 9)
                 {
                     return hasChanges;
                 }

--- a/src/Designer/backend/src/Designer/EventHandlers/ProcessDataTypesChanged/ProcessDataTypesChangedLayoutSettingsHandler.cs
+++ b/src/Designer/backend/src/Designer/EventHandlers/ProcessDataTypesChanged/ProcessDataTypesChangedLayoutSettingsHandler.cs
@@ -1,10 +1,10 @@
 #nullable disable
 using System.Linq;
 using System.Threading;
-using Altinn.Studio.Designer.Infrastructure.GitRepository;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Events;
 using Altinn.Studio.Designer.Hubs.Sync;
+using Altinn.Studio.Designer.Infrastructure.GitRepository;
 using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Services.Interfaces;
 using MediatR;

--- a/src/Designer/backend/src/Designer/EventHandlers/ProcessDataTypesChanged/ProcessDataTypesChangedLayoutSettingsHandler.cs
+++ b/src/Designer/backend/src/Designer/EventHandlers/ProcessDataTypesChanged/ProcessDataTypesChangedLayoutSettingsHandler.cs
@@ -8,6 +8,7 @@ using Altinn.Studio.Designer.Infrastructure.GitRepository;
 using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Services.Interfaces;
 using MediatR;
+using NuGet.Versioning;
 
 namespace Altinn.Studio.Designer.EventHandlers.ProcessDataTypeChanged;
 
@@ -36,7 +37,8 @@ public class ProcessDataTypesChangedLayoutSettingsHandler : INotificationHandler
             $"App/ui/{notification.ConnectedTaskId}/Settings.json",
             async () =>
             {
-                if (_appVersionService.GetAppLibVersion(notification.EditingContext).Major < 9)
+                SemanticVersion version = _appVersionService.GetAppLibVersion(notification.EditingContext);
+                if (version is null || version.Major < 9)
                 {
                     return false;
                 }

--- a/src/Designer/backend/src/Designer/EventHandlers/ProcessDataTypesChanged/ProcessDataTypesChangedLayoutSettingsHandler.cs
+++ b/src/Designer/backend/src/Designer/EventHandlers/ProcessDataTypesChanged/ProcessDataTypesChangedLayoutSettingsHandler.cs
@@ -1,6 +1,7 @@
 #nullable disable
-using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
+using Altinn.Studio.Designer.Infrastructure.GitRepository;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Events;
 using Altinn.Studio.Designer.Hubs.Sync;
@@ -10,13 +11,13 @@ using MediatR;
 
 namespace Altinn.Studio.Designer.EventHandlers.ProcessDataTypeChanged;
 
-public class ProcessDataTypesChangedLayoutSetsHandler : INotificationHandler<ProcessDataTypesChangedEvent>
+public class ProcessDataTypesChangedLayoutSettingsHandler : INotificationHandler<ProcessDataTypesChangedEvent>
 {
     private readonly IAltinnGitRepositoryFactory _altinnGitRepositoryFactory;
     private readonly IFileSyncHandlerExecutor _fileSyncHandlerExecutor;
     private readonly IAppVersionService _appVersionService;
 
-    public ProcessDataTypesChangedLayoutSetsHandler(
+    public ProcessDataTypesChangedLayoutSettingsHandler(
         IAltinnGitRepositoryFactory altinnGitRepositoryFactory,
         IFileSyncHandlerExecutor fileSyncHandlerExecutor,
         IAppVersionService appVersionService
@@ -29,46 +30,38 @@ public class ProcessDataTypesChangedLayoutSetsHandler : INotificationHandler<Pro
 
     public async Task Handle(ProcessDataTypesChangedEvent notification, CancellationToken cancellationToken)
     {
-        bool hasChanges = false;
         await _fileSyncHandlerExecutor.ExecuteWithExceptionHandlingAndConditionalNotification(
             notification.EditingContext,
-            SyncErrorCodes.LayoutSetsDataTypeSyncError,
-            "App/ui/layout-sets.json",
+            SyncErrorCodes.LayoutSettingsDataTypeSyncError,
+            $"App/ui/{notification.ConnectedTaskId}/Settings.json",
             async () =>
             {
-                var repository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(
+                if (_appVersionService.GetAppLibVersion(notification.EditingContext).Major < 9)
+                {
+                    return false;
+                }
+
+                AltinnAppGitRepository repository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(
                     notification.EditingContext.Org,
                     notification.EditingContext.Repo,
                     notification.EditingContext.Developer
                 );
 
-                if (!repository.AppUsesLayoutSets() || _appVersionService.GetAppLibVersion(notification.EditingContext).Major >= 9)
+                LayoutSettings layoutSettings = await repository.GetLayoutSettings(
+                    notification.ConnectedTaskId,
+                    cancellationToken
+                );
+
+                string newDataType = notification.NewDataTypes.FirstOrDefault();
+                if (layoutSettings.DefaultDataType == newDataType)
                 {
-                    return hasChanges;
+                    return false;
                 }
 
-                var layoutSets = await repository.GetLayoutSetsFile(cancellationToken);
-                if (TryChangeDataTypes(layoutSets, notification.NewDataTypes, notification.ConnectedTaskId))
-                {
-                    await repository.SaveLayoutSets(layoutSets);
-                    hasChanges = true;
-                }
-
-                return hasChanges;
+                layoutSettings.DefaultDataType = newDataType;
+                await repository.SaveLayoutSettings(notification.ConnectedTaskId, layoutSettings);
+                return true;
             }
         );
-    }
-
-    private static bool TryChangeDataTypes(LayoutSets layoutSets, List<string> newDataTypes, string connectedTaskId)
-    {
-        bool hasChanges = false;
-        var layoutSet = layoutSets.Sets?.Find(layoutSet => layoutSet.Tasks?[0] == connectedTaskId);
-        if (layoutSet is not null && !newDataTypes.Contains(layoutSet.DataType))
-        {
-            layoutSet.DataType = newDataTypes[0];
-            hasChanges = true;
-        }
-
-        return hasChanges;
     }
 }

--- a/src/Designer/backend/src/Designer/Hubs/Sync/SyncErrorCodes.cs
+++ b/src/Designer/backend/src/Designer/Hubs/Sync/SyncErrorCodes.cs
@@ -9,6 +9,7 @@ public static class SyncErrorCodes
     public const string PolicyFileTaskIdSyncError = nameof(PolicyFileTaskIdSyncError);
     public const string ApplicationMetadataDataTypeSyncError = nameof(ApplicationMetadataDataTypeSyncError);
     public const string LayoutSetsDataTypeSyncError = nameof(LayoutSetsDataTypeSyncError);
+    public const string LayoutSettingsDataTypeSyncError = nameof(LayoutSettingsDataTypeSyncError);
     public const string LayoutSetComponentIdSyncError = nameof(LayoutSetComponentIdSyncError);
     public const string LayoutSetDeletedLayoutsSyncError = nameof(LayoutSetDeletedLayoutsSyncError);
     public const string LayoutSetIdChangedLayoutsSyncError = nameof(LayoutSetIdChangedLayoutsSyncError);

--- a/src/Designer/backend/src/Designer/Models/LayoutSettings.cs
+++ b/src/Designer/backend/src/Designer/Models/LayoutSettings.cs
@@ -12,7 +12,7 @@ public class LayoutSettings
     public Pages? Pages { get; set; }
 
     [JsonPropertyName("defaultDataType")]
-    public string? DataType { get; set; }
+    public string? DefaultDataType { get; set; }
 
     [JsonPropertyName("type")]
     public string? Type { get; set; }

--- a/src/Designer/backend/src/Designer/Services/Implementation/AppDevelopmentService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/AppDevelopmentService.cs
@@ -294,10 +294,10 @@ public class AppDevelopmentService : IAppDevelopmentService
     )
     {
         AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(
-                altinnRepoEditingContext.Org,
-                altinnRepoEditingContext.Repo,
-                altinnRepoEditingContext.Developer
-            );
+            altinnRepoEditingContext.Org,
+            altinnRepoEditingContext.Repo,
+            altinnRepoEditingContext.Developer
+        );
 
         if (string.IsNullOrEmpty(layoutSetName))
         {
@@ -315,8 +315,10 @@ public class AppDevelopmentService : IAppDevelopmentService
 
         if (_appVersionService.GetAppLibVersion(altinnRepoEditingContext).Major >= 9)
         {
-            Designer.Models.LayoutSettings layoutSettings =
-                await altinnAppGitRepository.GetLayoutSettings(layoutSetName, cancellationToken);
+            Designer.Models.LayoutSettings layoutSettings = await altinnAppGitRepository.GetLayoutSettings(
+                layoutSetName,
+                cancellationToken
+            );
             return layoutSettings.DefaultDataType ?? string.Empty;
         }
 

--- a/src/Designer/backend/src/Designer/Services/Implementation/AppDevelopmentService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/AppDevelopmentService.cs
@@ -28,6 +28,7 @@ public class AppDevelopmentService : IAppDevelopmentService
 {
     private readonly IAltinnGitRepositoryFactory _altinnGitRepositoryFactory;
     private readonly ISchemaModelService _schemaModelService;
+    private readonly IAppVersionService _appVersionService;
     private readonly string _layoutSetNameRegEx = @"^[a-zA-Z0-9_\-]{2,28}$";
 
     /// <summary>
@@ -35,13 +36,16 @@ public class AppDevelopmentService : IAppDevelopmentService
     /// </summary>
     /// <param name="altinnGitRepositoryFactory">IAltinnGitRepository</param>
     /// <param name="schemaModelService">ISchemaModelService</param>
+    /// <param name="appVersionService">IAppVersionService</param>
     public AppDevelopmentService(
         IAltinnGitRepositoryFactory altinnGitRepositoryFactory,
-        ISchemaModelService schemaModelService
+        ISchemaModelService schemaModelService,
+        IAppVersionService appVersionService
     )
     {
         _altinnGitRepositoryFactory = altinnGitRepositoryFactory;
         _schemaModelService = schemaModelService;
+        _appVersionService = appVersionService;
     }
 
     /// <inheritdoc />
@@ -289,14 +293,15 @@ public class AppDevelopmentService : IAppDevelopmentService
         CancellationToken cancellationToken = default
     )
     {
-        if (string.IsNullOrEmpty(layoutSetName))
-        {
-            // Fallback to first model in app metadata if no layout set is provided
-            AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(
+        AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(
                 altinnRepoEditingContext.Org,
                 altinnRepoEditingContext.Repo,
                 altinnRepoEditingContext.Developer
             );
+
+        if (string.IsNullOrEmpty(layoutSetName))
+        {
+            // Fallback to first model in app metadata if no layout set is provided
             ApplicationMetadata applicationMetadata = await altinnAppGitRepository.GetApplicationMetadata(
                 cancellationToken
             );
@@ -308,8 +313,15 @@ public class AppDevelopmentService : IAppDevelopmentService
                 ?? string.Empty;
         }
 
+        if (_appVersionService.GetAppLibVersion(altinnRepoEditingContext).Major >= 9)
+        {
+            Designer.Models.LayoutSettings layoutSettings =
+                await altinnAppGitRepository.GetLayoutSettings(layoutSetName, cancellationToken);
+            return layoutSettings.DefaultDataType ?? string.Empty;
+        }
+
         LayoutSets layoutSets = await GetLayoutSets(altinnRepoEditingContext, cancellationToken);
-        var foundLayoutSet = layoutSets.Sets.Find(set => set.Id == layoutSetName);
+        LayoutSetConfig foundLayoutSet = layoutSets.Sets.Find(set => set.Id == layoutSetName);
 
         return foundLayoutSet.DataType;
     }

--- a/src/Designer/backend/src/Designer/Services/Implementation/AppDevelopmentService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/AppDevelopmentService.cs
@@ -313,7 +313,7 @@ public class AppDevelopmentService : IAppDevelopmentService
                 ?? string.Empty;
         }
 
-        if (_appVersionService.GetAppLibVersion(altinnRepoEditingContext).Major >= 9)
+        if (_appVersionService.GetAppLibVersion(altinnRepoEditingContext)?.Major >= 9 == true)
         {
             Designer.Models.LayoutSettings layoutSettings = await altinnAppGitRepository.GetLayoutSettings(
                 layoutSetName,

--- a/src/Designer/backend/src/Designer/Services/Implementation/AppVersionService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/AppVersionService.cs
@@ -1,3 +1,4 @@
+#nullable disable
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -28,11 +29,10 @@ public class AppVersionService : IAppVersionService
             altinnRepoEditingContext.Developer
         );
 
-        return FindVersion(repository.FindFiles(["*.csproj"]))
-            ?? throw new FileNotFoundException("Unable to extract the version of the app-lib from csproj files.");
+        return FindVersion(repository.FindFiles(["*.csproj"]));
     }
 
-    private static SemanticVersion? FindVersion(IEnumerable<string> csprojFiles) =>
+    private static SemanticVersion FindVersion(IEnumerable<string> csprojFiles) =>
         csprojFiles
             .Select(file =>
                 PackageVersionHelper.TryGetPackageVersionFromCsprojFile(

--- a/src/Designer/backend/src/Designer/Services/Implementation/AppVersionService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/AppVersionService.cs
@@ -1,6 +1,5 @@
 #nullable disable
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using Altinn.Studio.Designer.Helpers;
 using Altinn.Studio.Designer.Infrastructure.GitRepository;

--- a/src/Designer/backend/src/Designer/Services/Implementation/SchemaModelService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/SchemaModelService.cs
@@ -366,7 +366,11 @@ public class SchemaModelService : ISchemaModelService
             var schemaFileName = altinnAppGitRepository.GetSchemaName(relativeFilePath);
 
             bool isV9OrNewer = _appVersionService.GetAppLibVersion(altinnRepoEditingContext).Major >= 9;
-            await DeleteDatatypeFromApplicationMetadataAndLayoutSets(altinnAppGitRepository, schemaFileName, isV9OrNewer);
+            await DeleteDatatypeFromApplicationMetadataAndLayoutSets(
+                altinnAppGitRepository,
+                schemaFileName,
+                isV9OrNewer
+            );
             DeleteRelatedSchemaFiles(altinnAppGitRepository, schemaFileName, altinnCoreFile.Directory);
         }
         else
@@ -590,7 +594,6 @@ public class SchemaModelService : ISchemaModelService
             await altinnAppGitRepository.SaveLayoutSettings(layoutSetName, layoutSettings);
         }
     }
-
 
     private string GetFullTypeName(ApplicationMetadata application, string csharpModelName)
     {

--- a/src/Designer/backend/src/Designer/Services/Implementation/SchemaModelService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/SchemaModelService.cs
@@ -365,7 +365,7 @@ public class SchemaModelService : ISchemaModelService
             var altinnCoreFile = altinnAppGitRepository.GetAltinnCoreFileByRelativePath(relativeFilePath);
             var schemaFileName = altinnAppGitRepository.GetSchemaName(relativeFilePath);
 
-            bool isV9OrNewer = _appVersionService.GetAppLibVersion(altinnRepoEditingContext).Major >= 9;
+            bool isV9OrNewer = _appVersionService.GetAppLibVersion(altinnRepoEditingContext)?.Major >= 9 == true;
             await DeleteDatatypeFromApplicationMetadataAndLayoutSets(
                 altinnAppGitRepository,
                 schemaFileName,

--- a/src/Designer/backend/src/Designer/Services/Implementation/SchemaModelService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/SchemaModelService.cs
@@ -42,6 +42,7 @@ public class SchemaModelService : ISchemaModelService
     private readonly IJsonSchemaToXmlSchemaConverter _jsonSchemaToXmlSchemaConverter;
     private readonly IModelMetadataToCsharpConverter _modelMetadataToCsharpConverter;
     private readonly IApplicationMetadataService _applicationMetadataService;
+    private readonly IAppVersionService _appVersionService;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SchemaModelService"/> class.
@@ -62,6 +63,7 @@ public class SchemaModelService : ISchemaModelService
     /// Class for converting Json schemas to Xml schemas.</param>
     /// <param name="modelMetadataToCsharpConverter">C# model generator</param>
     /// <param name="applicationMetadataService"></param>
+    /// <param name="appVersionService"></param>
     public SchemaModelService(
         IAltinnGitRepositoryFactory altinnGitRepositoryFactory,
         ILoggerFactory loggerFactory,
@@ -69,7 +71,8 @@ public class SchemaModelService : ISchemaModelService
         IXmlSchemaToJsonSchemaConverter xmlSchemaToJsonSchemaConverter,
         IJsonSchemaToXmlSchemaConverter jsonSchemaToXmlSchemaConverter,
         IModelMetadataToCsharpConverter modelMetadataToCsharpConverter,
-        IApplicationMetadataService applicationMetadataService
+        IApplicationMetadataService applicationMetadataService,
+        IAppVersionService appVersionService
     )
     {
         _altinnGitRepositoryFactory = altinnGitRepositoryFactory;
@@ -79,6 +82,7 @@ public class SchemaModelService : ISchemaModelService
         _jsonSchemaToXmlSchemaConverter = jsonSchemaToXmlSchemaConverter;
         _modelMetadataToCsharpConverter = modelMetadataToCsharpConverter;
         _applicationMetadataService = applicationMetadataService;
+        _appVersionService = appVersionService;
     }
 
     /// <inheritdoc/>
@@ -361,7 +365,8 @@ public class SchemaModelService : ISchemaModelService
             var altinnCoreFile = altinnAppGitRepository.GetAltinnCoreFileByRelativePath(relativeFilePath);
             var schemaFileName = altinnAppGitRepository.GetSchemaName(relativeFilePath);
 
-            await DeleteDatatypeFromApplicationMetadataAndLayoutSets(altinnAppGitRepository, schemaFileName);
+            bool isV9OrNewer = _appVersionService.GetAppLibVersion(altinnRepoEditingContext).Major >= 9;
+            await DeleteDatatypeFromApplicationMetadataAndLayoutSets(altinnAppGitRepository, schemaFileName, isV9OrNewer);
             DeleteRelatedSchemaFiles(altinnAppGitRepository, schemaFileName, altinnCoreFile.Directory);
         }
         else
@@ -529,7 +534,8 @@ public class SchemaModelService : ISchemaModelService
 
     private static async Task DeleteDatatypeFromApplicationMetadataAndLayoutSets(
         AltinnAppGitRepository altinnAppGitRepository,
-        string id
+        string id,
+        bool isV9OrNewer
     )
     {
         var applicationMetadata = await altinnAppGitRepository.GetApplicationMetadata();
@@ -537,22 +543,54 @@ public class SchemaModelService : ISchemaModelService
         if (applicationMetadata.DataTypes != null)
         {
             DataType dataTypeToDelete = applicationMetadata.DataTypes.Find(m => m.Id == id);
-            if (altinnAppGitRepository.AppUsesLayoutSets())
+            if (isV9OrNewer)
             {
-                var layoutSets = await altinnAppGitRepository.GetLayoutSetsFile();
-                List<LayoutSetConfig> layoutSetsWithDataTypeToDelete = layoutSets.Sets.FindAll(set =>
-                    set.DataType == id
-                );
-                foreach (LayoutSetConfig layoutSet in layoutSetsWithDataTypeToDelete)
-                {
-                    layoutSet.DataType = null;
-                }
-                await altinnAppGitRepository.SaveLayoutSets(layoutSets);
+                await ClearDefaultDataTypeFromLayoutSettings(altinnAppGitRepository, id);
+            }
+            else if (altinnAppGitRepository.AppUsesLayoutSets())
+            {
+                await ClearDataTypeFromLayoutSets(altinnAppGitRepository, id);
             }
             applicationMetadata.DataTypes.Remove(dataTypeToDelete);
             await altinnAppGitRepository.SaveApplicationMetadata(applicationMetadata);
         }
     }
+
+    private static async Task ClearDataTypeFromLayoutSets(AltinnAppGitRepository altinnAppGitRepository, string id)
+    {
+        LayoutSets layoutSets = await altinnAppGitRepository.GetLayoutSetsFile();
+        layoutSets.Sets.FindAll(set => set.DataType == id).ForEach(set => set.DataType = null);
+        await altinnAppGitRepository.SaveLayoutSets(layoutSets);
+    }
+
+    private static async Task ClearDefaultDataTypeFromLayoutSettings(
+        AltinnAppGitRepository altinnAppGitRepository,
+        string id
+    )
+    {
+        IEnumerable<string> uiFolders = await altinnAppGitRepository.GetUiFolders();
+        foreach (string layoutSetName in uiFolders)
+        {
+            LayoutSettings layoutSettings;
+            try
+            {
+                layoutSettings = await altinnAppGitRepository.GetLayoutSettings(layoutSetName);
+            }
+            catch (Exception e) when (e is FileNotFoundException or JsonException)
+            {
+                continue;
+            }
+
+            if (layoutSettings.DefaultDataType != id)
+            {
+                continue;
+            }
+
+            layoutSettings.DefaultDataType = null;
+            await altinnAppGitRepository.SaveLayoutSettings(layoutSetName, layoutSettings);
+        }
+    }
+
 
     private string GetFullTypeName(ApplicationMetadata application, string csharpModelName)
     {

--- a/src/Designer/backend/src/Designer/Services/Implementation/UiFoldersService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/UiFoldersService.cs
@@ -97,7 +97,7 @@ public class UiFoldersService : IUiFoldersService
         new()
         {
             Id = info.LayoutSetName,
-            DataType = info.LayoutSettings.DataType,
+            DataType = info.LayoutSettings.DefaultDataType,
             Type = info.LayoutSettings.Type,
             Task = info.TaskType != null ? new TaskModel { Type = info.TaskType } : null,
         };

--- a/src/Designer/backend/src/Designer/Services/Implementation/UiFoldersService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/UiFoldersService.cs
@@ -249,7 +249,7 @@ public class UiFoldersService : IUiFoldersService
 
         string? dataType = (
             await TryGetLayoutSettings(altinnAppGitRepository, layoutSetToDeleteId, cancellationToken)
-        )?.DataType;
+        )?.DefaultDataType;
         if (!string.IsNullOrEmpty(dataType))
         {
             await DeleteTaskRefInApplicationMetadata(altinnAppGitRepository, dataType);

--- a/src/Designer/backend/src/Designer/Services/Interfaces/IAppVersionService.cs
+++ b/src/Designer/backend/src/Designer/Services/Interfaces/IAppVersionService.cs
@@ -5,5 +5,10 @@ namespace Altinn.Studio.Designer.Services.Interfaces;
 
 public interface IAppVersionService
 {
+    /// <summary>
+    /// Returns the app-lib version of the given app, or <c>null</c> if no .csproj file is found
+    /// (e.g. when the app uses a project reference instead of a package reference).
+    /// Callers must guard against a null return value.
+    /// </summary>
     SemanticVersion GetAppLibVersion(AltinnRepoEditingContext altinnRepoEditingContext);
 }

--- a/src/Designer/backend/src/Designer/Services/Interfaces/IAppVersionService.cs
+++ b/src/Designer/backend/src/Designer/Services/Interfaces/IAppVersionService.cs
@@ -6,7 +6,7 @@ namespace Altinn.Studio.Designer.Services.Interfaces;
 public interface IAppVersionService
 {
     /// <summary>
-    /// Returns the app-lib version of the given app, or <c>null</c> if no .csproj file is found
+    /// Returns the app-lib version of the given app, or <c>null</c> if no version is found
     /// (e.g. when the app uses a project reference instead of a package reference).
     /// Callers must guard against a null return value.
     /// </summary>

--- a/src/Designer/backend/tests/Designer.Tests/Services/AppDevelopmentServiceTest.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/AppDevelopmentServiceTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json.Nodes;
+using System.Threading;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Exceptions.AppDevelopment;
 using Altinn.Studio.Designer.Factories;
@@ -10,6 +11,7 @@ using Altinn.Studio.Designer.Services.Implementation;
 using Altinn.Studio.Designer.Services.Interfaces;
 using Designer.Tests.Utils;
 using Moq;
+using NuGet.Versioning;
 using Xunit;
 
 namespace Designer.Tests.Services;
@@ -28,6 +30,9 @@ public class AppDevelopmentServiceTest : IDisposable
     {
         _schemaModelServiceMock = new Mock<ISchemaModelService>();
         _appVersionServiceMock = new Mock<IAppVersionService>();
+        _appVersionServiceMock
+            .Setup(s => s.GetAppLibVersion(It.IsAny<AltinnRepoEditingContext>()))
+            .Returns(new SemanticVersion(8, 0, 0));
         _altinnGitRepositoryFactory = new(TestDataHelper.GetTestDataRepositoriesRootDirectory());
         _appDevelopmentService = new AppDevelopmentService(
             _altinnGitRepositoryFactory,
@@ -304,6 +309,43 @@ public class AppDevelopmentServiceTest : IDisposable
 
         // Assert
         await Assert.ThrowsAsync<NoLayoutSetsFileFoundException>(act);
+    }
+
+    [Fact]
+    public async Task GetModelMetadata_WhenV9App_ShouldReadDefaultDataTypeFromSettings()
+    {
+        // Arrange
+        string layoutSetName = "layoutSet1";
+        string targetRepository = TestDataHelper.GenerateTestRepoName();
+        AltinnRepoEditingContext editingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(
+            _org,
+            targetRepository,
+            _developer
+        );
+        _appVersionServiceMock
+            .Setup(s => s.GetAppLibVersion(It.IsAny<AltinnRepoEditingContext>()))
+            .Returns(new SemanticVersion(9, 0, 0));
+
+        CreatedTestRepoPath = await TestDataHelper.CopyRepositoryForTest(
+            _org,
+            _repository,
+            _developer,
+            targetRepository
+        );
+
+        // Act
+        await _appDevelopmentService.GetModelMetadata(editingContext, layoutSetName, null);
+
+        // Assert: v9 reads defaultDataType from Settings.json
+        _schemaModelServiceMock.Verify(
+            s =>
+                s.GenerateModelMetadataFromJsonSchema(
+                    editingContext,
+                    "App/models/datamodel.schema.json",
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Once
+        );
     }
 
     private List<string> GetFileNamesInLayoutSet(string layoutSetName)

--- a/src/Designer/backend/tests/Designer.Tests/Services/AppDevelopmentServiceTest.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/AppDevelopmentServiceTest.cs
@@ -17,6 +17,7 @@ namespace Designer.Tests.Services;
 public class AppDevelopmentServiceTest : IDisposable
 {
     private readonly Mock<ISchemaModelService> _schemaModelServiceMock;
+    private readonly Mock<IAppVersionService> _appVersionServiceMock;
     private readonly IAppDevelopmentService _appDevelopmentService;
     private readonly AltinnGitRepositoryFactory _altinnGitRepositoryFactory;
     private readonly string _org = "ttd";
@@ -26,8 +27,13 @@ public class AppDevelopmentServiceTest : IDisposable
     public AppDevelopmentServiceTest()
     {
         _schemaModelServiceMock = new Mock<ISchemaModelService>();
+        _appVersionServiceMock = new Mock<IAppVersionService>();
         _altinnGitRepositoryFactory = new(TestDataHelper.GetTestDataRepositoriesRootDirectory());
-        _appDevelopmentService = new AppDevelopmentService(_altinnGitRepositoryFactory, _schemaModelServiceMock.Object);
+        _appDevelopmentService = new AppDevelopmentService(
+            _altinnGitRepositoryFactory,
+            _schemaModelServiceMock.Object,
+            _appVersionServiceMock.Object
+        );
     }
 
     public string CreatedTestRepoPath { get; set; }

--- a/src/Designer/backend/tests/Designer.Tests/Services/OptionListReferenceServiceTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/OptionListReferenceServiceTests.cs
@@ -125,8 +125,11 @@ public class OptionListReferenceServiceTests
         AltinnGitRepositoryFactory altinnGitRepositoryFactory = new(
             TestDataHelper.GetTestDataRepositoriesRootDirectory()
         );
-        var schemaModelServiceMock = new Mock<ISchemaModelService>().Object;
-        AppDevelopmentService appDevelopmentService = new(altinnGitRepositoryFactory, schemaModelServiceMock);
+        AppDevelopmentService appDevelopmentService = new(
+            altinnGitRepositoryFactory,
+            new Mock<ISchemaModelService>().Object,
+            new Mock<IAppVersionService>().Object
+        );
         OptionListReferenceService optionListReferenceService = new(altinnGitRepositoryFactory, appDevelopmentService);
 
         return optionListReferenceService;

--- a/src/Designer/backend/tests/Designer.Tests/Services/ProcessModelingServiceTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/ProcessModelingServiceTests.cs
@@ -6,6 +6,7 @@ using Altinn.Studio.Designer.Services.Implementation.ProcessModeling;
 using Altinn.Studio.Designer.Services.Interfaces;
 using Designer.Tests.Utils;
 using Moq;
+using NuGet.Versioning;
 using SharedResources.Tests;
 using Xunit;
 
@@ -23,6 +24,9 @@ public class ProcessModelingServiceTests : FluentTestsBase<ProcessModelingServic
     {
         _schemaModelServiceMock = new Mock<ISchemaModelService>();
         _appVersionServiceMock = new Mock<IAppVersionService>();
+        _appVersionServiceMock
+            .Setup(s => s.GetAppLibVersion(It.IsAny<AltinnRepoEditingContext>()))
+            .Returns(new SemanticVersion(8, 0, 0));
         _altinnGitRepositoryFactory = new AltinnGitRepositoryFactory(
             TestDataHelper.GetTestDataRepositoriesRootDirectory()
         );

--- a/src/Designer/backend/tests/Designer.Tests/Services/ProcessModelingServiceTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/ProcessModelingServiceTests.cs
@@ -13,17 +13,24 @@ namespace Designer.Tests.Services;
 
 public class ProcessModelingServiceTests : FluentTestsBase<ProcessModelingServiceTests>
 {
+    private readonly Mock<ISchemaModelService> _schemaModelServiceMock;
+    private readonly Mock<IAppVersionService> _appVersionServiceMock;
     private readonly AltinnGitRepositoryFactory _altinnGitRepositoryFactory;
     private readonly IAppDevelopmentService _appDevelopmentService;
     public string CreatedTestRepoPath { get; set; }
 
     public ProcessModelingServiceTests()
     {
-        var schemaModelServiceMock = new Mock<ISchemaModelService>();
+        _schemaModelServiceMock = new Mock<ISchemaModelService>();
+        _appVersionServiceMock = new Mock<IAppVersionService>();
         _altinnGitRepositoryFactory = new AltinnGitRepositoryFactory(
             TestDataHelper.GetTestDataRepositoriesRootDirectory()
         );
-        _appDevelopmentService = new AppDevelopmentService(_altinnGitRepositoryFactory, schemaModelServiceMock.Object);
+        _appDevelopmentService = new AppDevelopmentService(
+            _altinnGitRepositoryFactory,
+            _schemaModelServiceMock.Object,
+            _appVersionServiceMock.Object
+        );
     }
 
     [Theory]

--- a/src/Designer/backend/tests/Designer.Tests/Services/SchemaModelServiceTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/SchemaModelServiceTests.cs
@@ -22,12 +22,14 @@ namespace Designer.Tests.Services;
 public class SchemaModelServiceTests
 {
     private readonly Mock<IApplicationMetadataService> _applicationMetadataService;
+    private readonly Mock<IAppVersionService> _appVersionServiceMock;
     private readonly AltinnGitRepositoryFactory _altinnGitRepositoryFactory;
     private readonly ISchemaModelService _schemaModelService;
 
     public SchemaModelServiceTests()
     {
         _applicationMetadataService = new Mock<IApplicationMetadataService>();
+        _appVersionServiceMock = new Mock<IAppVersionService>();
         _altinnGitRepositoryFactory = new AltinnGitRepositoryFactory(
             TestDataHelper.GetTestDataRepositoriesRootDirectory()
         );
@@ -38,7 +40,8 @@ public class SchemaModelServiceTests
             TestDataHelper.XmlSchemaToJsonSchemaConverter,
             TestDataHelper.JsonSchemaToXmlSchemaConverter,
             TestDataHelper.ModelMetadataToCsharpConverter,
-            _applicationMetadataService.Object
+            _applicationMetadataService.Object,
+            _appVersionServiceMock.Object
         );
     }
 

--- a/src/Designer/backend/tests/Designer.Tests/Services/SchemaModelServiceTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/SchemaModelServiceTests.cs
@@ -14,6 +14,7 @@ using Altinn.Studio.Designer.Services.Implementation;
 using Altinn.Studio.Designer.Services.Interfaces;
 using Designer.Tests.Utils;
 using Moq;
+using NuGet.Versioning;
 using SharedResources.Tests;
 using Xunit;
 
@@ -30,6 +31,9 @@ public class SchemaModelServiceTests
     {
         _applicationMetadataService = new Mock<IApplicationMetadataService>();
         _appVersionServiceMock = new Mock<IAppVersionService>();
+        _appVersionServiceMock
+            .Setup(s => s.GetAppLibVersion(It.IsAny<AltinnRepoEditingContext>()))
+            .Returns(new SemanticVersion(8, 0, 0));
         _altinnGitRepositoryFactory = new AltinnGitRepositoryFactory(
             TestDataHelper.GetTestDataRepositoriesRootDirectory()
         );

--- a/src/Designer/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-layoutsets/App/ui/layoutSet1/Settings.json
+++ b/src/Designer/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-layoutsets/App/ui/layoutSet1/Settings.json
@@ -1,9 +1,7 @@
 {
     "$schema": "https://altinncdn.no/schemas/json/layout/layoutSettings.schema.v1.json",
     "pages": {
-        "order": [
-            "layoutFile1InSet1",
-            "layoutFile2InSet1"
-        ]
-    }
+        "order": ["layoutFile1InSet1", "layoutFile2InSet1"]
+    },
+    "defaultDataType": "datamodel"
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The C# property `dataType `has been renamed to match the JSON key.

Full CRUD support for defaultDataType:
* `ProcessDataTypesChangedLayoutSettingsHandler` keeps `defaultDataType `in sync when process data types change.
* `SchemaModelService.DeleteSchema` clears (nulls) `defaultDataType `in `Settings.json` when a data model is deleted.
* `AppDevelopmentService.GetModelName` retrieves the data type from `Settings.json` for v9

App version control:

Previously, the `GetAppLibVersion `method threw a `FileNotFoundException `when no` .csproj` file was found (e.g., when using a project reference). It now returns null, and all call sites explicitly handle this case. **Open to thoughts if you see a better way.** 

Additionally, a comment has been added to indicate that `IAppVersionService.GetAppLibVersion` may return null, and that callers are responsible for handling it, since `#nullable disable` is used across the entire codebase.

The return type of `GetAppVersion `has been changed from `IActionResult` to `ActionResult<VersionResponse>` so that the endpoint can return both a typed response and a 404 status code.

Test files:
* Added an `IAppVersionService `mock to the constructors of `AppDevelopmentServiceTest`, `SchemaModelServiceTests`, and `ProcessModelingServiceTests `(missing from appVersionService implementation).
* Set `SemanticVersion(8, 0, 0)` explicitly as the default to make tests deterministic and consistent across version branches. **Open to thoughts if you see a better way.** 
* Added a new test in `AppDevelopmentServiceTest `to verify that v9 apps read the data type from `Settings.json `(defaultDataType) instead of `layout-sets.json`.


<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conditional automatic synchronisation for layout settings and layout sets, skipping sync based on app library major version.
  * API now returns 404 when backend library version cannot be resolved.
  * Added a new synchronisation error identifier for layout‑settings datatype issues.

* **Refactors**
  * Version‑aware data‑type handling for pre‑v9 and v9+ apps; layout settings naming aligned across services.

* **Chores**
  * Updated tests and service wiring to support version‑aware behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->