### PR TITLE
fix: gha runner trigger

### DIFF
--- a/src/github-runner/Dockerfile
+++ b/src/github-runner/Dockerfile
@@ -3,7 +3,10 @@ FROM ghcr.io/actions/actions-runner:2.330.0@sha256:ee54ad8776606f29434f159196529
 USER root
 
 COPY run.sh /usr/local/bin/altinn-github-runner
-RUN chmod +x /usr/local/bin/altinn-github-runner
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends make \
+    && rm -rf /var/lib/apt/lists/* \
+    && chmod +x /usr/local/bin/altinn-github-runner
 
 USER runner
 WORKDIR /home/runner

--- a/src/github-runner/infra/kustomize/base/scaledjob.yaml
+++ b/src/github-runner/infra/kustomize/base/scaledjob.yaml
@@ -49,8 +49,17 @@ spec:
                 fi
                 exec dockerd-entrypoint.sh --host=tcp://0.0.0.0:2376
             startupProbe:
-              tcpSocket:
-                port: 2376
+              exec:
+                command:
+                  - sh
+                  - -c
+                  - |
+                    docker --host=tcp://localhost:2376 \
+                      --tlsverify \
+                      --tlscacert=/certs/client/ca.pem \
+                      --tlscert=/certs/client/cert.pem \
+                      --tlskey=/certs/client/key.pem \
+                      info >/dev/null
               periodSeconds: 2
               failureThreshold: 45
             volumeMounts:
@@ -138,8 +147,8 @@ spec:
         runnerScope: repo
         repos: altinn-studio
         labels: self-hosted
-        noDefaultLabels: "false"
-        enableEtags: "true"
+        noDefaultLabels: "true"
+        enableEtags: "false"
         applicationIDFromEnv: APP_ID
         installationIDFromEnv: APP_INSTALLATION_ID
         targetWorkflowQueueLength: "1"


### PR DESCRIPTION
## Description

- needed make
- better startupprobe (saw some init failures)
- disable default labels, since this immediately spawned to 10 jobs due to unrelated queue

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimised Docker image build process by installing required build tooling and reducing image footprint through apt cache cleanup.
  * Implemented explicit TLS-authenticated readiness verification for GitHub runner container initialisation to strengthen health checks.
  * Adjusted GitHub runner controller configuration settings, including label handling and etag caching, to enhance system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->