### PR TITLE
ci: improve GitHub runner environment parity

### DIFF
--- a/.github/workflows/github-runner-parity.yaml
+++ b/.github/workflows/github-runner-parity.yaml
@@ -1,0 +1,39 @@
+name: GitHub Runner - Parity Diagnostics
+
+on:
+  workflow_dispatch:
+
+jobs:
+  github-hosted:
+    name: GitHub-hosted Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: src/tools/releaser/go.mod
+          cache-dependency-path: src/tools/releaser/go.sum
+
+      - name: Collect diagnostics
+        shell: bash
+        run: bash .github/workflows/scripts/github-runner-parity.sh
+
+  self-hosted:
+    name: Self-hosted runner
+    runs-on: self-hosted
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: src/tools/releaser/go.mod
+          cache-dependency-path: src/tools/releaser/go.sum
+
+      - name: Collect diagnostics
+        shell: bash
+        run: bash .github/workflows/scripts/github-runner-parity.sh

--- a/.github/workflows/scripts/github-runner-parity.sh
+++ b/.github/workflows/scripts/github-runner-parity.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+section() {
+  printf '\n## %s\n' "$1"
+}
+
+run_optional() {
+  printf '\n$ %s\n' "$*"
+  "$@" || true
+}
+
+section "Identity"
+run_optional uname -a
+run_optional id
+run_optional pwd
+
+section "Environment"
+env | sort
+
+section "Tool Versions"
+for tool in bash git make gcc g++ pkg-config go dotnet node yarn docker jq curl unzip tar; do
+  printf '\n### %s\n' "${tool}"
+  if command -v "${tool}" >/dev/null 2>&1; then
+    command -v "${tool}"
+    "${tool}" --version 2>&1 | head -n 5 || true
+  else
+    echo "not found"
+  fi
+done
+
+section "Go Environment"
+run_optional go env CGO_ENABLED CC CXX GOCACHE GOMODCACHE GOROOT GOPATH GOTOOLCHAIN GOOS GOARCH
+
+section "Cache Directories"
+for path in \
+  "${HOME}/.cache" \
+  "${HOME}/.cache/go-build" \
+  "${HOME}/.cache/yarn" \
+  "${HOME}/.nuget/packages" \
+  "${HOME}/go/pkg/mod" \
+  "${HOME}/_work/_tool" \
+  "${RUNNER_TOOL_CACHE:-${RUNNER_WORKSPACE:-${HOME}/_work}/_tool}"; do
+  printf '\n### %s\n' "${path}"
+  run_optional stat "${path}"
+done
+
+section "Disk"
+run_optional df -h
+
+section "Mounts"
+run_optional mount

--- a/src/github-runner/Dockerfile
+++ b/src/github-runner/Dockerfile
@@ -4,9 +4,28 @@ USER root
 
 COPY run.sh /usr/local/bin/altinn-github-runner
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends make \
+    && apt-get install -y --no-install-recommends \
+      build-essential \
+      ca-certificates \
+      curl \
+      git \
+      jq \
+      make \
+      pkg-config \
+      tar \
+      unzip \
     && rm -rf /var/lib/apt/lists/* \
-    && chmod +x /usr/local/bin/altinn-github-runner
+    && chmod +x /usr/local/bin/altinn-github-runner \
+    && mkdir -p \
+      /home/runner/.cache/go-build \
+      /home/runner/.cache/yarn \
+      /home/runner/.nuget/packages \
+      /home/runner/go/pkg/mod \
+      /home/runner/_work/_tool \
+    && chown -R runner:runner /home/runner/.cache /home/runner/.nuget /home/runner/go /home/runner/_work
+
+ENV CGO_ENABLED=1
+ENV RUNNER_TOOL_CACHE=/home/runner/_work/_tool
 
 USER runner
 WORKDIR /home/runner

--- a/src/github-runner/run.sh
+++ b/src/github-runner/run.sh
@@ -100,13 +100,19 @@ cleanup() {
   if [[ -f "${RUNNER_HOME}/.runner" ]]; then
     echo "Removing GitHub runner registration"
     remove_token="$(request_token "${remove_url}")"
-  "${RUNNER_HOME}/config.sh" remove --token "${remove_token}" || true
+    "${RUNNER_HOME}/config.sh" remove --token "${remove_token}" || true
   fi
 }
 
 trap cleanup EXIT INT TERM
 
-mkdir -p "${RUNNER_WORKDIR}"
+mkdir -p \
+  "${RUNNER_WORKDIR}" \
+  "${RUNNER_WORKDIR}/_tool" \
+  "${RUNNER_HOME}/.cache/go-build" \
+  "${RUNNER_HOME}/.cache/yarn" \
+  "${RUNNER_HOME}/.nuget/packages" \
+  "${RUNNER_HOME}/go/pkg/mod"
 cd "${RUNNER_HOME}"
 
 registration_token="$(request_token "${registration_url}")"


### PR DESCRIPTION
## Summary
- install native build tooling in the custom GitHub runner image
- set CGO_ENABLED=1 and RUNNER_TOOL_CACHE for closer GitHub-hosted Ubuntu parity
- create runner-owned cache directories at image build and startup
- add a manual parity diagnostics workflow comparing ubuntu-latest with self-hosted

## Verification
- bash -n src/github-runner/run.sh
- bash -n .github/workflows/scripts/github-runner-parity.sh
- actionlint .github/workflows/github-runner-parity.yaml
- git diff --cached --check
- docker build -t altinn-github-runner-check src/github-runner
- docker build --check src/github-runner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced automated build infrastructure with improved diagnostic capabilities for runner compatibility testing.
  * Expanded build environment dependencies to support a wider range of compilation and runtime requirements.
  * Optimised cache and dependency management for faster and more reliable automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->