### PR TITLE
ci: prewarm github runner tools

### DIFF
--- a/.github/workflows/deploy-github-runners.yaml
+++ b/.github/workflows/deploy-github-runners.yaml
@@ -4,6 +4,7 @@ on:
     branches: [main]
     paths:
       - 'src/github-runner/**'
+      - 'src/tools/releaser/go.mod'
       - '.github/workflows/deploy-github-runners.yaml'
 
   workflow_dispatch:
@@ -36,9 +37,11 @@ jobs:
         id: vars
         run: |
           SHA="${GITHUB_SHA::10}"
-          echo "short-sha=$SHA" >> "$GITHUB_OUTPUT"
-          echo "image-repo=altinntjenestercontainerregistry.azurecr.io/altinn-studio/github-runner:${SHA}" >> "$GITHUB_OUTPUT"
-          echo "config-repo=altinntjenestercontainerregistry.azurecr.io/altinn-studio/configs/github-runners-repo:${SHA}" >> "$GITHUB_OUTPUT"
+          {
+            echo "short-sha=$SHA"
+            echo "image-repo=altinntjenestercontainerregistry.azurecr.io/altinn-studio/github-runner:${SHA}"
+            echo "config-repo=altinntjenestercontainerregistry.azurecr.io/altinn-studio/configs/github-runners-repo:${SHA}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: az login
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
@@ -53,8 +56,15 @@ jobs:
       - name: flux install
         uses: fluxcd/flux2/action@bfa461ed2153ae5e0cca6bce08e0845268fb3088 # v2.8.2
 
+      - name: Resolve Go version
+        id: go-version
+        run: |
+          GO_VERSION="$(awk '$1 == "go" { print $2; exit }' ../tools/releaser/go.mod)"
+          test -n "${GO_VERSION}"
+          echo "version=${GO_VERSION}" >> "$GITHUB_OUTPUT"
+
       - name: docker build
-        run: docker build -t ${{ steps.vars.outputs.image-repo }} -f Dockerfile .
+        run: docker build --build-arg GO_VERSION=${{ steps.go-version.outputs.version }} -t ${{ steps.vars.outputs.image-repo }} -f Dockerfile .
 
       - name: push image
         run: docker push ${{ steps.vars.outputs.image-repo }}

--- a/.github/workflows/github-runner-parity.yaml
+++ b/.github/workflows/github-runner-parity.yaml
@@ -11,15 +11,32 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Collect pre-setup diagnostics
+        shell: bash
+        run: bash .github/workflows/scripts/github-runner-parity.sh pre-setup
+
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: src/tools/releaser/go.mod
           cache-dependency-path: src/tools/releaser/go.sum
 
-      - name: Collect diagnostics
+      - name: Setup Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: '22'
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
+
+      - name: Collect post-setup diagnostics
         shell: bash
-        run: bash .github/workflows/scripts/github-runner-parity.sh
+        run: bash .github/workflows/scripts/github-runner-parity.sh post-setup
 
   self-hosted:
     name: Self-hosted runner
@@ -28,12 +45,29 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Collect pre-setup diagnostics
+        shell: bash
+        run: bash .github/workflows/scripts/github-runner-parity.sh pre-setup
+
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: src/tools/releaser/go.mod
           cache-dependency-path: src/tools/releaser/go.sum
 
-      - name: Collect diagnostics
+      - name: Setup Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: '22'
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
+
+      - name: Collect post-setup diagnostics
         shell: bash
-        run: bash .github/workflows/scripts/github-runner-parity.sh
+        run: bash .github/workflows/scripts/github-runner-parity.sh post-setup

--- a/.github/workflows/scripts/github-runner-parity.sh
+++ b/.github/workflows/scripts/github-runner-parity.sh
@@ -5,10 +5,64 @@ section() {
   printf '\n## %s\n' "$1"
 }
 
+phase="${1:-diagnostics}"
+
 run_optional() {
   printf '\n$ %s\n' "$*"
   "$@" || true
 }
+
+tool_version() {
+  local tool="$1"
+  printf '\n### %s\n' "${tool}"
+  if ! command -v "${tool}" >/dev/null 2>&1; then
+    echo "not found"
+    return
+  fi
+
+  command -v "${tool}"
+  case "${tool}" in
+    go)
+      "${tool}" version 2>&1 || true
+      ;;
+    dotnet)
+      "${tool}" --info 2>&1 | head -n 30 || true
+      ;;
+    node)
+      "${tool}" --version 2>&1 || true
+      ;;
+    yarn)
+      "${tool}" --version 2>&1 || true
+      ;;
+    *)
+      "${tool}" --version 2>&1 | head -n 5 || true
+      ;;
+  esac
+}
+
+benchmark_small_files() {
+  local base="$1"
+  if [[ ! -d "${base}" || ! -w "${base}" ]]; then
+    printf '\n### %s\nnot writable or not found\n' "${base}"
+    return
+  fi
+
+  local dir start end elapsed
+  dir="$(mktemp -d "${base%/}/parity-small-files.XXXXXX")"
+  start="$(date +%s%N)"
+  for i in $(seq 1 1000); do
+    printf 'file %s\n' "${i}" >"${dir}/file-${i}.txt"
+  done
+  sync "${dir}" 2>/dev/null || true
+  end="$(date +%s%N)"
+  elapsed="$(((end - start) / 1000000))"
+  rm -rf "${dir}"
+
+  printf '\n### %s\n1000 small files: %sms\n' "${base}" "${elapsed}"
+}
+
+section "Phase"
+echo "${phase}"
 
 section "Identity"
 run_optional uname -a
@@ -20,13 +74,7 @@ env | sort
 
 section "Tool Versions"
 for tool in bash git make gcc g++ pkg-config go dotnet node yarn docker jq curl unzip tar; do
-  printf '\n### %s\n' "${tool}"
-  if command -v "${tool}" >/dev/null 2>&1; then
-    command -v "${tool}"
-    "${tool}" --version 2>&1 | head -n 5 || true
-  else
-    echo "not found"
-  fi
+  tool_version "${tool}"
 done
 
 section "Go Environment"
@@ -37,13 +85,21 @@ for path in \
   "${HOME}/.cache" \
   "${HOME}/.cache/go-build" \
   "${HOME}/.cache/yarn" \
+  "${HOME}/.npm" \
   "${HOME}/.nuget/packages" \
   "${HOME}/go/pkg/mod" \
   "${HOME}/_work/_tool" \
+  "/opt/tools" \
+  "/usr/share/dotnet" \
   "${RUNNER_TOOL_CACHE:-${RUNNER_WORKSPACE:-${HOME}/_work}/_tool}"; do
   printf '\n### %s\n' "${path}"
   run_optional stat "${path}"
 done
+
+section "Small File Write Benchmark"
+benchmark_small_files "${RUNNER_TEMP:-${HOME}/_work/_temp}"
+benchmark_small_files "${TMPDIR:-/tmp}"
+benchmark_small_files "${GITHUB_WORKSPACE:-$(pwd)}"
 
 section "Disk"
 run_optional df -h

--- a/src/github-runner/Dockerfile
+++ b/src/github-runner/Dockerfile
@@ -1,4 +1,11 @@
-FROM ghcr.io/actions/actions-runner:2.330.0@sha256:ee54ad8776606f29434f159196529b7b9c83c0cb9195c1ff5a7817e7e570dcfe
+FROM ghcr.io/actions/actions-runner:2.335.1@sha256:08c30b0a7105f64bddfc485d2487a22aa03932a791402393352fdf674bda2c29
+
+ARG GO_VERSION=1.26.1
+ARG NODE_CHANNEL=22
+ARG YARN_CHANNEL=stable
+ARG DOTNET_CHANNELS="8.0 9.0 10.0"
+ARG DOTNET_INSTALL_SCRIPT_COMMIT=6f559c420847ded38591392dafe785ad511f39f5
+ARG DOTNET_INSTALL_SCRIPT_SHA256=082f7685e156738a1b2e2ed8381a621870d4ce8e8c59278034556f05c186eb2e
 
 USER root
 
@@ -10,22 +17,70 @@ RUN apt-get update \
       curl \
       git \
       jq \
+      libicu74 \
       make \
       pkg-config \
       tar \
       unzip \
+      xz-utils \
+      zstd \
     && rm -rf /var/lib/apt/lists/* \
     && chmod +x /usr/local/bin/altinn-github-runner \
     && mkdir -p \
       /home/runner/.cache/go-build \
+      /home/runner/.npm \
       /home/runner/.cache/yarn \
       /home/runner/.nuget/packages \
       /home/runner/go/pkg/mod \
-      /home/runner/_work/_tool \
-    && chown -R runner:runner /home/runner/.cache /home/runner/.nuget /home/runner/go /home/runner/_work
+      /home/runner/_work/_temp \
+      /usr/share/dotnet \
+      /opt/corepack \
+    && test -n "${GO_VERSION}" \
+    && GO_SHA256="$(curl -fsSL "https://go.dev/dl/?mode=json&include=all" \
+      | jq -r --arg version "go${GO_VERSION}" --arg filename "go${GO_VERSION}.linux-amd64.tar.gz" '.[] | select(.version == $version) | .files[] | select(.filename == $filename) | .sha256')" \
+    && test -n "${GO_SHA256}" \
+    && test "${GO_SHA256}" != "null" \
+    && curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o /tmp/go.tar.gz \
+    && echo "${GO_SHA256}  /tmp/go.tar.gz" | sha256sum -c - \
+    && mkdir -p "/opt/tools/go/${GO_VERSION}/x64" \
+    && tar -xzf /tmp/go.tar.gz --strip-components=1 -C "/opt/tools/go/${GO_VERSION}/x64" \
+    && rm -f /tmp/go.tar.gz \
+    && touch "/opt/tools/go/${GO_VERSION}/x64.complete" \
+    && ln -s "/opt/tools/go/${GO_VERSION}/x64" /opt/tools/go/current \
+    && NODE_VERSION="$(curl -fsSL "https://nodejs.org/dist/index.json" \
+      | jq -r --arg channel "v${NODE_CHANNEL}." '[.[] | select(.version | startswith($channel))][0].version | sub("^v"; "")')" \
+    && test -n "${NODE_VERSION}" \
+    && test "${NODE_VERSION}" != "null" \
+    && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt" -o /tmp/node-shasums.txt \
+    && NODE_SHA256="$(grep " node-v${NODE_VERSION}-linux-x64.tar.xz\$" /tmp/node-shasums.txt | awk '{ print $1 }')" \
+    && test -n "${NODE_SHA256}" \
+    && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" -o /tmp/node.tar.xz \
+    && echo "${NODE_SHA256}  /tmp/node.tar.xz" | sha256sum -c - \
+    && mkdir -p "/opt/tools/node/${NODE_VERSION}/x64" \
+    && tar -xJf /tmp/node.tar.xz --strip-components=1 -C "/opt/tools/node/${NODE_VERSION}/x64" \
+    && rm -f /tmp/node.tar.xz /tmp/node-shasums.txt \
+    && touch "/opt/tools/node/${NODE_VERSION}/x64.complete" \
+    && ln -s "/opt/tools/node/${NODE_VERSION}/x64" /opt/tools/node/current \
+    && curl -fsSL "https://raw.githubusercontent.com/dotnet/install-scripts/${DOTNET_INSTALL_SCRIPT_COMMIT}/src/dotnet-install.sh" -o /tmp/dotnet-install.sh \
+    && echo "${DOTNET_INSTALL_SCRIPT_SHA256}  /tmp/dotnet-install.sh" | sha256sum -c - \
+    && chmod +x /tmp/dotnet-install.sh \
+    && for channel in ${DOTNET_CHANNELS}; do \
+      /tmp/dotnet-install.sh --install-dir /usr/share/dotnet --channel "${channel}" --quality GA; \
+    done \
+    && rm -f /tmp/dotnet-install.sh \
+    && PATH="/opt/tools/node/current/bin:${PATH}" COREPACK_HOME=/opt/corepack corepack enable \
+    && PATH="/opt/tools/node/current/bin:${PATH}" COREPACK_HOME=/opt/corepack corepack prepare "yarn@${YARN_CHANNEL}" --activate \
+    && chown -R runner:runner /home/runner/.cache /home/runner/.npm /home/runner/.nuget /home/runner/go /home/runner/_work /opt/tools /opt/corepack
 
 ENV CGO_ENABLED=1
-ENV RUNNER_TOOL_CACHE=/home/runner/_work/_tool
+ENV DOTNET_ROOT=/usr/share/dotnet
+ENV DOTNET_INSTALL_DIR=/usr/share/dotnet
+ENV COREPACK_HOME=/opt/corepack
+ENV RUNNER_TOOL_CACHE=/opt/tools
+ENV TMPDIR=/tmp
+ENV TMP=/tmp
+ENV TEMP=/tmp
+ENV PATH=/opt/tools/go/current/bin:/opt/tools/node/current/bin:/usr/share/dotnet:${PATH}
 
 USER runner
 WORKDIR /home/runner

--- a/src/github-runner/infra/kustomize/base/scaledjob.yaml
+++ b/src/github-runner/infra/kustomize/base/scaledjob.yaml
@@ -126,12 +126,24 @@ spec:
                 readOnly: true
               - name: runner-work
                 mountPath: /home/runner/_work
+              - name: runner-temp
+                mountPath: /home/runner/_work/_temp
+              - name: runner-tmp
+                mountPath: /tmp
         volumes:
           - name: docker-certs
             emptyDir: {}
           - name: runner-work
             emptyDir:
               sizeLimit: 20Gi
+          - name: runner-temp
+            emptyDir:
+              medium: Memory
+              sizeLimit: 2Gi
+          - name: runner-tmp
+            emptyDir:
+              medium: Memory
+              sizeLimit: 2Gi
         nodeSelector:
           purpose: github-runner
         tolerations:

--- a/src/github-runner/run.sh
+++ b/src/github-runner/run.sh
@@ -108,8 +108,9 @@ trap cleanup EXIT INT TERM
 
 mkdir -p \
   "${RUNNER_WORKDIR}" \
-  "${RUNNER_WORKDIR}/_tool" \
+  "${RUNNER_WORKDIR}/_temp" \
   "${RUNNER_HOME}/.cache/go-build" \
+  "${RUNNER_HOME}/.npm" \
   "${RUNNER_HOME}/.cache/yarn" \
   "${RUNNER_HOME}/.nuget/packages" \
   "${RUNNER_HOME}/go/pkg/mod"


### PR DESCRIPTION
## Summary
- bump the self-hosted runner image to actions-runner 2.335.1 and preinstall runner tools
- preinstall Go as an exact patch version passed from src/tools/releaser/go.mod during deployment, while still exposing it through /opt/tools/go/current so PATH is not duplicated
- preinstall latest stable tools from configured channels for Node 22.x, Yarn stable, and .NET SDK channels 8.0/9.0/10.0
- verify Go and Node archives against publisher SHA256 checksums before extracting, and pin/hash-verify dotnet-install.sh before executing it
- expose Go/Node through RUNNER_TOOL_CACHE=/opt/tools with setup-action-compatible version directories plus stable current symlinks used by PATH
- keep .NET under /usr/share/dotnet, set DOTNET_INSTALL_DIR/DOTNET_ROOT, and set TMPDIR/TMP/TEMP=/tmp
- mount /home/runner/_work/_temp and /tmp as memory-backed emptyDirs, and expand the parity workflow with setup-node/setup-dotnet plus small-file benchmarks

## Verification
- bash -n src/github-runner/run.sh
- bash -n .github/workflows/scripts/github-runner-parity.sh
- actionlint .github/workflows/deploy-github-runners.yaml .github/workflows/github-runner-parity.yaml
- git diff --check
- docker build --check src/github-runner
- docker build --build-arg GO_VERSION=1.26.1 -t altinn-github-runner-tools-check src/github-runner
  - confirmed checksum output for /tmp/go.tar.gz, /tmp/node.tar.xz, and /tmp/dotnet-install.sh
- docker run probe confirmed Go 1.26.1, Node 22.22.3, Yarn 4.16.0, .NET SDKs 8.0.422/9.0.315/10.0.301, and setup-action-compatible /opt/tools markers

After merge/deploy, rerun the GitHub runner parity workflow on main to verify setup-go/setup-node/setup-dotnet cache hits and compare tmpfs small-file timings.