### PR TITLE
refactor: add current language support to LanguageTranslatorProvider

### DIFF
--- a/app-libs/form-component/src/LanguageTranslatorProvider.tsx
+++ b/app-libs/form-component/src/LanguageTranslatorProvider.tsx
@@ -10,11 +10,16 @@ type LangAsStringFn = (key: LanguageKey | undefined, params?: LangParams) => str
 type LanguageTranslatorContextProps = {
   lang: LangFn;
   langAsString: LangAsStringFn;
+  /**
+   * The currently active language code (e.g. `nb`, `nn`, `en`)
+   */
+  currentLanguage: string;
 };
 
 const contextNoTranslate: LanguageTranslatorContextProps = {
   lang: (key) => key ?? null,
   langAsString: (key) => key ?? '',
+  currentLanguage: 'nb',
 };
 
 const LanguageTranslatorContext = createContext<LanguageTranslatorContextProps>(contextNoTranslate);
@@ -22,10 +27,11 @@ const LanguageTranslatorContext = createContext<LanguageTranslatorContextProps>(
 export function LanguageTranslatorProvider({
   lang,
   langAsString,
+  currentLanguage,
   children,
 }: PropsWithChildren<LanguageTranslatorContextProps>) {
   return (
-    <LanguageTranslatorContext.Provider value={{ lang, langAsString }}>
+    <LanguageTranslatorContext.Provider value={{ lang, langAsString, currentLanguage }}>
       {children}
     </LanguageTranslatorContext.Provider>
   );
@@ -33,4 +39,8 @@ export function LanguageTranslatorProvider({
 
 export function useTranslation(): LanguageTranslatorContextProps {
   return useContext(LanguageTranslatorContext);
+}
+
+export function useCurrentLanguage(): string {
+  return useContext(LanguageTranslatorContext).currentLanguage;
 }

--- a/app-libs/form-component/src/layout-components/DemoLayoutComponent/DemoLayoutComponent.test.tsx
+++ b/app-libs/form-component/src/layout-components/DemoLayoutComponent/DemoLayoutComponent.test.tsx
@@ -11,6 +11,7 @@ describe('DemoLayoutComponent', () => {
     expect(
       screen.getByText(/The static text with key helptext\.button_title is translated as: Help/),
     ).toBeInTheDocument();
+    expect(screen.getByText(/The current language is: en/)).toBeInTheDocument();
   });
 
   it('uses the translations for the given language', () => {
@@ -20,6 +21,7 @@ describe('DemoLayoutComponent', () => {
     expect(
       screen.getByText(/The static text with key helptext\.button_title is translated as: Hjelp/),
     ).toBeInTheDocument();
+    expect(screen.getByText(/The current language is: nb/)).toBeInTheDocument();
   });
 
   it('renders HTML content as parsed React nodes', () => {

--- a/app-libs/form-component/src/layout-components/DemoLayoutComponent/DemoLayoutComponent.tsx
+++ b/app-libs/form-component/src/layout-components/DemoLayoutComponent/DemoLayoutComponent.tsx
@@ -1,10 +1,11 @@
-import { useTranslation } from '@app/form-component/LanguageTranslatorProvider';
+import { useCurrentLanguage, useTranslation } from '@app/form-component/LanguageTranslatorProvider';
 
 export interface DemoLayoutComponentProps {
   content: string;
 }
 export function DemoLayoutComponent({ content }: DemoLayoutComponentProps) {
   const { langAsString, lang } = useTranslation();
+  const currentLanguage = useCurrentLanguage();
 
   return (
     <>
@@ -13,7 +14,11 @@ export function DemoLayoutComponent({ content }: DemoLayoutComponentProps) {
         The static text with key helptext.button_title is translated as:{' '}
         {langAsString('helptext.button_title')}
       </p>
-      <p>Below is content set with props a text, but can be html or mark down</p>
+      <p>The current language is: {currentLanguage}</p>
+      <p>
+        Below is the content. It is a property of type text, but the text can be html or markdown
+        and will be parsed accordingly.
+      </p>
       <div>{lang(content)}</div>
     </>
   );

--- a/app-libs/form-component/src/test/StaticLanguageTranslatorProvider.tsx
+++ b/app-libs/form-component/src/test/StaticLanguageTranslatorProvider.tsx
@@ -54,6 +54,7 @@ export function StaticLanguageTranslatorProvider({
     <LanguageTranslatorProvider
       lang={(key, params) => parseAndCleanText(translateKey(key, params))}
       langAsString={translateKey}
+      currentLanguage={language}
     >
       {children}
     </LanguageTranslatorProvider>

--- a/src/App/frontend/src/AppLanguageTranslatorProvider.tsx
+++ b/src/App/frontend/src/AppLanguageTranslatorProvider.tsx
@@ -3,15 +3,18 @@ import type { PropsWithChildren } from 'react';
 
 import { LanguageTranslatorProvider } from '@app/form-component';
 
+import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useLanguage } from 'src/features/language/useLanguage';
 
 export function AppLanguageTranslatorProvider({ children }: PropsWithChildren) {
   const { lang, langAsString } = useLanguage();
+  const currentLanguage = useCurrentLanguage();
 
   return (
     <LanguageTranslatorProvider
       lang={lang}
       langAsString={langAsString}
+      currentLanguage={currentLanguage}
     >
       {children}
     </LanguageTranslatorProvider>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This change makes it possible for layout components in form-component library to the the current language by using the hook useCurrentLanguage()

We can the specify what language to use in storybook and unit tests.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
