### PR TITLE
ci: prewarm runner yarn versions

### DIFF
--- a/.github/workflows/deploy-github-runners.yaml
+++ b/.github/workflows/deploy-github-runners.yaml
@@ -5,6 +5,9 @@ on:
     paths:
       - 'src/github-runner/**'
       - 'src/tools/releaser/go.mod'
+      - 'package.json'
+      - 'src/App/frontend/package.json'
+      - 'src/test/K6/package.json'
       - '.github/workflows/deploy-github-runners.yaml'
 
   workflow_dispatch:
@@ -63,8 +66,39 @@ jobs:
           test -n "${GO_VERSION}"
           echo "version=${GO_VERSION}" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve Yarn versions
+        id: yarn-versions
+        run: |
+          PACKAGE_MANIFESTS=(
+            ../../package.json
+            ../App/frontend/package.json
+            ../test/K6/package.json
+          )
+
+          YARN_VERSION="$(jq -r '.packageManager // empty' ../../package.json | sed -n 's/^yarn@//p')"
+          test -n "${YARN_VERSION}"
+
+          readarray -t YARN_VERSIONS < <(
+            jq -r '.packageManager // empty' "${PACKAGE_MANIFESTS[@]}" \
+              | sed -n 's/^yarn@//p' \
+              | sort -Vu
+          )
+          test "${#YARN_VERSIONS[@]}" -gt 0
+
+          YARN_EXTRA_VERSIONS="$(printf '%s\n' "${YARN_VERSIONS[@]}" | awk -v version="${YARN_VERSION}" '$0 != version' | paste -sd ' ' -)"
+          {
+            echo "version=${YARN_VERSION}"
+            echo "extra-versions=${YARN_EXTRA_VERSIONS}"
+          } >> "$GITHUB_OUTPUT"
+
       - name: docker build
-        run: docker build --build-arg GO_VERSION=${{ steps.go-version.outputs.version }} -t ${{ steps.vars.outputs.image-repo }} -f Dockerfile .
+        run: |
+          docker build \
+            --build-arg GO_VERSION=${{ steps.go-version.outputs.version }} \
+            --build-arg YARN_VERSION=${{ steps.yarn-versions.outputs.version }} \
+            --build-arg YARN_EXTRA_VERSIONS="${{ steps.yarn-versions.outputs.extra-versions }}" \
+            -t ${{ steps.vars.outputs.image-repo }} \
+            -f Dockerfile .
 
       - name: push image
         run: docker push ${{ steps.vars.outputs.image-repo }}

--- a/src/github-runner/Dockerfile
+++ b/src/github-runner/Dockerfile
@@ -2,7 +2,8 @@ FROM ghcr.io/actions/actions-runner:2.335.1@sha256:08c30b0a7105f64bddfc485d2487a
 
 ARG GO_VERSION=1.26.1
 ARG NODE_CHANNEL=22
-ARG YARN_CHANNEL=stable
+ARG YARN_VERSION=4.12.0
+ARG YARN_EXTRA_VERSIONS="4.5.0 4.14.1"
 ARG DOTNET_CHANNELS="8.0 9.0 10.0"
 ARG DOTNET_INSTALL_SCRIPT_COMMIT=6f559c420847ded38591392dafe785ad511f39f5
 ARG DOTNET_INSTALL_SCRIPT_SHA256=082f7685e156738a1b2e2ed8381a621870d4ce8e8c59278034556f05c186eb2e
@@ -69,7 +70,9 @@ RUN apt-get update \
     done \
     && rm -f /tmp/dotnet-install.sh \
     && PATH="/opt/tools/node/current/bin:${PATH}" COREPACK_HOME=/opt/corepack corepack enable \
-    && PATH="/opt/tools/node/current/bin:${PATH}" COREPACK_HOME=/opt/corepack corepack prepare "yarn@${YARN_CHANNEL}" --activate \
+    && for yarn_version in ${YARN_EXTRA_VERSIONS} ${YARN_VERSION}; do \
+      PATH="/opt/tools/node/current/bin:${PATH}" COREPACK_HOME=/opt/corepack corepack prepare "yarn@${yarn_version}" --activate; \
+    done \
     && chown -R runner:runner /home/runner/.cache /home/runner/.npm /home/runner/.nuget /home/runner/go /home/runner/_work /opt/tools /opt/corepack
 
 ENV CGO_ENABLED=1


### PR DESCRIPTION
## Summary
- prewarm the exact Yarn versions pinned by current packageManager fields in the GitHub runner image
- derive the root Yarn version and extra pinned versions in the runner deploy workflow
- keep the root Yarn version active as the default Corepack version

## Verification
- actionlint .github/workflows/deploy-github-runners.yaml
- docker build --check src/github-runner
- docker build --build-arg GO_VERSION=1.26.1 --build-arg YARN_VERSION=4.12.0 --build-arg YARN_EXTRA_VERSIONS="4.5.0 4.14.1" -t altinn-github-runner-yarn-check -f src/github-runner/Dockerfile src/github-runner
- docker run --rm --network none --entrypoint bash altinn-github-runner-yarn-check -lc '... yarn --version for 4.12.0, 4.14.1, 4.5.0 ...'

Offline Corepack probe output:
```
4.12.0
4.12.0
4.14.1
4.5.0
```

Local image size from Docker:
```
CONTENT SIZE 1.44GB
DISK USAGE   5.64GB
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced GitHub runner Docker image to support multiple Yarn versions, improving build environment compatibility and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->