### PR TITLE
ci: enable parallel git checkout on runners

### DIFF
--- a/src/github-runner/Dockerfile
+++ b/src/github-runner/Dockerfile
@@ -70,6 +70,8 @@ RUN apt-get update \
     && rm -f /tmp/dotnet-install.sh \
     && PATH="/opt/tools/node/current/bin:${PATH}" COREPACK_HOME=/opt/corepack corepack enable \
     && PATH="/opt/tools/node/current/bin:${PATH}" COREPACK_HOME=/opt/corepack corepack prepare "yarn@${YARN_CHANNEL}" --activate \
+    && git config --system checkout.workers 4 \
+    && git config --system checkout.thresholdForParallelism 100 \
     && chown -R runner:runner /home/runner/.cache /home/runner/.npm /home/runner/.nuget /home/runner/go /home/runner/_work /opt/tools /opt/corepack
 
 ENV CGO_ENABLED=1


### PR DESCRIPTION
## Summary
- configure Git system checkout parallelism in the self-hosted runner image
- set checkout.workers to 4 to match the current runner CPU limit
- set checkout.thresholdForParallelism explicitly to 100 so the behavior is visible/tunable

## Context
The parity run showed self-hosted checkout was mostly slow during worktree materialization, not fetch:
- self-hosted fetch: ~6.2s
- self-hosted checkout files: ~16.4s for 17,177 files
- hosted fetch: ~2.7s
- hosted checkout files: ~1.0s

Since /home/runner/_work is on Kata virtiofs and cannot be fully memory-backed, parallel checkout is a low-risk way to reduce the small-file checkout penalty.

## Verification
- git diff --check
- docker build --check src/github-runner
- docker build --build-arg GO_VERSION=1.26.1 -t altinn-github-runner-parallel-checkout -f src/github-runner/Dockerfile src/github-runner
- docker run --rm --entrypoint git altinn-github-runner-parallel-checkout config --system --get-regexp '^checkout\.'

Docker image config output:
```
checkout.workers 4
checkout.thresholdforparallelism 100
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Git settings in the build configuration to adjust parallel checkout parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->