### PR TITLE
ci: add Linux label to GitHub runners

### DIFF
--- a/src/github-runner/infra/kustomize/base/scaledjob.yaml
+++ b/src/github-runner/infra/kustomize/base/scaledjob.yaml
@@ -91,7 +91,7 @@ spec:
               - name: RUNNER_SCOPE
                 value: repo
               - name: RUNNER_LABELS
-                value: self-hosted
+                value: self-hosted,Linux
               - name: RUNNER_GROUP
                 value: Default
               - name: RUNNER_WORKDIR
@@ -158,7 +158,7 @@ spec:
         owner: Altinn
         runnerScope: repo
         repos: altinn-studio
-        labels: self-hosted
+        labels: self-hosted,Linux
         noDefaultLabels: "true"
         enableEtags: "false"
         applicationIDFromEnv: APP_ID


### PR DESCRIPTION
## Summary
- register self-hosted runners with both self-hosted and Linux labels
- update the KEDA GitHub runner scaler to watch the same label set

## Why
Workflows should target the OS explicitly with runs-on: [self-hosted, Linux]. Since runner default labels are disabled, the label must exist on runner registration before workloads can depend on it.

## Verification
- git diff --check
- parsed src/github-runner/infra/kustomize/base/scaledjob.yaml as YAML

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated runner label configuration to include explicit Linux designation alongside self-hosted labels, improving runner identification and enabling better selection of appropriate runners in automated workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->