### PR TITLE
ci: run runtime gateway tests on self-hosted runners

### DIFF
--- a/.github/workflows/runtime-gateway-tests.yaml
+++ b/.github/workflows/runtime-gateway-tests.yaml
@@ -18,7 +18,7 @@ jobs:
   build-and-test:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Build and test
-    runs-on: [self-hosted, Linux]
+    runs-on: self-hosted
     timeout-minutes: 30
     defaults:
       run:

--- a/.github/workflows/runtime-gateway-tests.yaml
+++ b/.github/workflows/runtime-gateway-tests.yaml
@@ -18,7 +18,7 @@ jobs:
   build-and-test:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux]
     timeout-minutes: 30
     defaults:
       run:
@@ -26,8 +26,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5


### PR DESCRIPTION
## Summary
- move Runtime Gateway build/test workflow to Linux self-hosted runners
- remove full-history checkout so the job uses the default shallow checkout

## Why
This is the first workload migration after the runner parity work. The GitHub runner UI already shows the default labels self-hosted, Linux, and X64, so the workflow can target Linux explicitly without additional runner-label changes.

The workflow Makefile does not depend on Git history; it only runs git diff after formatting, so fetch-depth: 0 is unnecessary and expensive on the Kata workspace.

## Verification
- actionlint .github/workflows/runtime-gateway-tests.yaml
- git diff --check