### PR TITLE
ci: test new runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - self-hosted-single

--- a/.github/workflows/deploy-github-runners.yaml
+++ b/.github/workflows/deploy-github-runners.yaml
@@ -74,8 +74,10 @@ jobs:
         run: |
           export IMAGE="${{ steps.vars.outputs.image-repo }}"
           export IMAGE_TAG="${{ steps.vars.outputs.short-sha }}"
-          yq -i '.metadata.annotations["altinn.studio/image"] = env(IMAGE)' scaledjob.yaml
-          yq -i '.metadata.annotations["altinn.studio/image-tag"] = env(IMAGE_TAG)' scaledjob.yaml
+          for file in scaledjob.yaml scaledjob-single.yaml; do
+            yq -i '.metadata.annotations["altinn.studio/image"] = env(IMAGE)' "$file"
+            yq -i '.metadata.annotations["altinn.studio/image-tag"] = env(IMAGE_TAG)' "$file"
+          done
 
       - name: push artifact
         working-directory: src/github-runner/infra/kustomize

--- a/.github/workflows/github-runner-parity.yaml
+++ b/.github/workflows/github-runner-parity.yaml
@@ -71,3 +71,37 @@ jobs:
       - name: Collect post-setup diagnostics
         shell: bash
         run: bash .github/workflows/scripts/github-runner-parity.sh post-setup
+
+  self-hosted-single:
+    name: Self-hosted single-container runner
+    runs-on: [self-hosted, self-hosted-single]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Collect pre-setup diagnostics
+        shell: bash
+        run: bash .github/workflows/scripts/github-runner-parity.sh pre-setup
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: src/tools/releaser/go.mod
+          cache-dependency-path: src/tools/releaser/go.sum
+
+      - name: Setup Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: '22'
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
+
+      - name: Collect post-setup diagnostics
+        shell: bash
+        run: bash .github/workflows/scripts/github-runner-parity.sh post-setup

--- a/.github/workflows/scripts/github-runner-parity.sh
+++ b/.github/workflows/scripts/github-runner-parity.sh
@@ -103,6 +103,10 @@ benchmark_small_files "${GITHUB_WORKSPACE:-$(pwd)}"
 
 section "Disk"
 run_optional df -h
+run_optional df -PT / "${HOME}/_work" /var/lib/docker /tmp
 
 section "Mounts"
 run_optional mount
+
+section "Docker"
+run_optional docker info

--- a/src/github-runner/Dockerfile
+++ b/src/github-runner/Dockerfile
@@ -10,22 +10,29 @@ ARG DOTNET_INSTALL_SCRIPT_SHA256=082f7685e156738a1b2e2ed8381a621870d4ce8e8c59278
 USER root
 
 COPY run.sh /usr/local/bin/altinn-github-runner
+COPY run-with-dockerd.sh /usr/local/bin/altinn-github-runner-dind
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
       build-essential \
       ca-certificates \
       curl \
+      docker.io \
+      e2fsprogs \
       git \
+      iproute2 \
+      iptables \
       jq \
       libicu74 \
       make \
       pkg-config \
       tar \
       unzip \
+      util-linux \
       xz-utils \
       zstd \
     && rm -rf /var/lib/apt/lists/* \
     && chmod +x /usr/local/bin/altinn-github-runner \
+    && chmod +x /usr/local/bin/altinn-github-runner-dind \
     && mkdir -p \
       /home/runner/.cache/go-build \
       /home/runner/.npm \
@@ -72,6 +79,7 @@ RUN apt-get update \
     && PATH="/opt/tools/node/current/bin:${PATH}" COREPACK_HOME=/opt/corepack corepack prepare "yarn@${YARN_CHANNEL}" --activate \
     && git config --system checkout.workers 4 \
     && git config --system checkout.thresholdForParallelism 100 \
+    && usermod -aG docker runner \
     && chown -R runner:runner /home/runner/.cache /home/runner/.npm /home/runner/.nuget /home/runner/go /home/runner/_work /opt/tools /opt/corepack
 
 ENV CGO_ENABLED=1

--- a/src/github-runner/infra/kustomize/base/kustomization.yaml
+++ b/src/github-runner/infra/kustomize/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - scaledjob.yaml
+  - scaledjob-single.yaml
   - triggerauthentication.yaml
 replacements:
   - source:
@@ -12,5 +13,10 @@ replacements:
       - select:
           kind: ScaledJob
           name: github-runners
+        fieldPaths:
+          - spec.jobTargetRef.template.spec.containers.[name=github-runner].image
+      - select:
+          kind: ScaledJob
+          name: github-runners-single
         fieldPaths:
           - spec.jobTargetRef.template.spec.containers.[name=github-runner].image

--- a/src/github-runner/infra/kustomize/base/scaledjob-single.yaml
+++ b/src/github-runner/infra/kustomize/base/scaledjob-single.yaml
@@ -1,0 +1,118 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledJob
+metadata:
+  name: github-runners-single
+  labels:
+    app.kubernetes.io/name: github-runner
+    app.kubernetes.io/component: runner-single
+  annotations:
+    altinn.studio/image: altinntjenestercontainerregistry.azurecr.io/altinn-studio/github-runner:latest
+    altinn.studio/image-tag: latest
+spec:
+  maxReplicaCount: 2
+  minReplicaCount: 0
+  pollingInterval: 30
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 5
+  jobTargetRef:
+    backoffLimit: 0
+    ttlSecondsAfterFinished: 300
+    activeDeadlineSeconds: 7200
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/name: github-runner
+          app.kubernetes.io/component: runner-single
+      spec:
+        runtimeClassName: kata-vm-isolation
+        restartPolicy: Never
+        securityContext:
+          fsGroup: 1001
+        containers:
+          - name: github-runner
+            image: altinntjenestercontainerregistry.azurecr.io/altinn-studio/github-runner:latest
+            imagePullPolicy: Always
+            command: ["/usr/local/bin/altinn-github-runner-dind"]
+            securityContext:
+              privileged: true
+              runAsUser: 0
+              runAsGroup: 0
+            env:
+              - name: DOCKER_HOST
+                value: unix:///var/run/docker.sock
+              - name: GITHUB_API_URL
+                value: https://api.github.com
+              - name: GITHUB_HOST
+                value: github.com
+              - name: GITHUB_SERVER_URL
+                value: https://github.com
+              - name: GITHUB_OWNER
+                value: Altinn
+              - name: GITHUB_REPOSITORY
+                value: altinn-studio
+              - name: RUNNER_SCOPE
+                value: repo
+              - name: RUNNER_LABELS
+                value: self-hosted,self-hosted-single
+              - name: RUNNER_GROUP
+                value: Default
+              - name: RUNNER_WORKDIR
+                value: /home/runner/_work
+              - name: RUNNER_WORK_DISK_SIZE
+                value: 20G
+              - name: DOCKER_DISK_SIZE
+                value: 30G
+              - name: APP_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: github-runner-auth
+                    key: appId
+              - name: APP_INSTALLATION_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: github-runner-auth
+                    key: installationId
+              - name: APP_PRIVATE_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: github-runner-auth
+                    key: appPrivateKey
+            resources:
+              requests:
+                cpu: "4"
+                memory: 8Gi
+                ephemeral-storage: 60Gi
+              limits:
+                cpu: "4"
+                memory: 8Gi
+                ephemeral-storage: 70Gi
+            volumeMounts:
+              - name: runner-tmp
+                mountPath: /tmp
+        volumes:
+          - name: runner-tmp
+            emptyDir:
+              medium: Memory
+              sizeLimit: 2Gi
+        nodeSelector:
+          purpose: github-runner
+        tolerations:
+          - key: purpose
+            operator: Equal
+            value: github-runner
+            effect: NoSchedule
+  triggers:
+    - type: github-runner
+      metadata:
+        githubApiURL: https://api.github.com
+        owner: Altinn
+        runnerScope: repo
+        repos: altinn-studio
+        labels: self-hosted,self-hosted-single
+        noDefaultLabels: "true"
+        enableEtags: "false"
+        applicationIDFromEnv: APP_ID
+        installationIDFromEnv: APP_INSTALLATION_ID
+        targetWorkflowQueueLength: "1"
+      authenticationRef:
+        name: github-runner-auth

--- a/src/github-runner/run-with-dockerd.sh
+++ b/src/github-runner/run-with-dockerd.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  printf '[runner-dind] %s\n' "$*" >&2
+}
+
+fs_type() {
+  df -PT "$1" | awk 'NR == 2 { print $2 }'
+}
+
+mount_ext4_image() {
+  local image="$1"
+  local size="$2"
+  local mountpoint="$3"
+
+  if mountpoint -q "${mountpoint}"; then
+    log "${mountpoint} is already a mountpoint"
+    return
+  fi
+
+  log "mounting ${size} ext4 image at ${mountpoint}"
+  mkdir -p "$(dirname "${image}")" "${mountpoint}"
+  truncate -s "${size}" "${image}"
+  mkfs.ext4 -F -q "${image}"
+  mount -o loop,noatime "${image}" "${mountpoint}"
+}
+
+maybe_mount_ext4_image() {
+  local image="$1"
+  local size="$2"
+  local mountpoint="$3"
+  local type
+
+  mkdir -p "${mountpoint}"
+  type="$(fs_type "${mountpoint}")"
+
+  if [[ "${type}" != "virtiofs" ]]; then
+    log "${mountpoint} is ${type}; keeping existing filesystem"
+    return
+  fi
+
+  mount_ext4_image "${image}" "${size}" "${mountpoint}"
+}
+
+wait_for_docker() {
+  local attempt
+
+  for attempt in $(seq 1 60); do
+    if docker info >/dev/null 2>&1; then
+      return
+    fi
+    sleep 1
+  done
+
+  log "dockerd did not become ready"
+  docker info || true
+  return 1
+}
+
+stop_dockerd() {
+  local pid="$1"
+
+  if [[ -z "${pid}" ]] || ! kill -0 "${pid}" 2>/dev/null; then
+    return
+  fi
+
+  log "stopping dockerd"
+  kill "${pid}" 2>/dev/null || true
+  wait "${pid}" 2>/dev/null || true
+}
+
+terminate_runner() {
+  local pid="$1"
+
+  if [[ -z "${pid}" ]] || ! kill -0 "${pid}" 2>/dev/null; then
+    return
+  fi
+
+  log "terminating runner"
+  kill "${pid}" 2>/dev/null || true
+  wait "${pid}" 2>/dev/null || true
+}
+
+RUNNER_HOME="${RUNNER_HOME:-/home/runner}"
+export RUNNER_WORKDIR="${RUNNER_WORKDIR:-${RUNNER_HOME}/_work}"
+export DOCKER_HOST="${DOCKER_HOST:-unix:///var/run/docker.sock}"
+export HOME="${RUNNER_HOME}"
+export USER=runner
+export LOGNAME=runner
+
+RUNNER_WORK_DISK_SIZE="${RUNNER_WORK_DISK_SIZE:-20G}"
+DOCKER_DISK_SIZE="${DOCKER_DISK_SIZE:-30G}"
+RUNNER_DIND_DISK_DIR="${RUNNER_DIND_DISK_DIR:-/var/lib/github-runner-disks}"
+runner_pid=""
+
+mkdir -p "${RUNNER_HOME}" "${RUNNER_WORKDIR}" /var/lib/docker /var/run "${RUNNER_DIND_DISK_DIR}"
+
+maybe_mount_ext4_image "${RUNNER_DIND_DISK_DIR}/runner-work.img" "${RUNNER_WORK_DISK_SIZE}" "${RUNNER_WORKDIR}"
+maybe_mount_ext4_image "${RUNNER_DIND_DISK_DIR}/docker.img" "${DOCKER_DISK_SIZE}" /var/lib/docker
+
+mkdir -p \
+  "${RUNNER_WORKDIR}/_temp" \
+  "${RUNNER_HOME}/.cache/go-build" \
+  "${RUNNER_HOME}/.cache/yarn" \
+  "${RUNNER_HOME}/.npm" \
+  "${RUNNER_HOME}/.nuget/packages" \
+  "${RUNNER_HOME}/go/pkg/mod"
+chown -R runner:runner \
+  "${RUNNER_WORKDIR}" \
+  "${RUNNER_HOME}/.cache" \
+  "${RUNNER_HOME}/.npm" \
+  "${RUNNER_HOME}/.nuget" \
+  "${RUNNER_HOME}/go"
+
+log "filesystem layout before dockerd startup"
+df -PT / "${RUNNER_WORKDIR}" /var/lib/docker /tmp || true
+
+dockerd --host="${DOCKER_HOST}" --ip6tables=false &
+dockerd_pid="$!"
+
+cleanup() {
+  terminate_runner "${runner_pid:-}"
+  stop_dockerd "${dockerd_pid:-}"
+}
+trap cleanup EXIT INT TERM
+
+wait_for_docker
+chgrp docker /var/run/docker.sock 2>/dev/null || true
+chmod 660 /var/run/docker.sock 2>/dev/null || true
+
+log "docker is ready"
+docker info || true
+
+set +e
+runuser --preserve-environment -u runner -- /usr/local/bin/altinn-github-runner &
+runner_pid="$!"
+wait "${runner_pid}"
+runner_status="$?"
+set -e
+runner_pid=""
+
+exit "${runner_status}"


### PR DESCRIPTION
## Description

The current runner setup was significantly slower than the GH managed one, in large part due to fs.
Fs is particularly slow since we need shared fs between the 2 pod containers.
This PR combines them (since runner<->dind container is not a security boundary anyway) to see if it yields better perf

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Docker-in-Docker support for self-hosted GitHub runners, enabling advanced containerised workflows.
  * Introduced single-replica runner configuration for scaled job deployments.
  * Enhanced diagnostic reporting for infrastructure verification.

* **Infrastructure**
  * Updated deployment workflows to support multi-configuration runner setups.
  * Configured validation for self-hosted runner environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->