### PR TITLE
feat: Remove Admin feature flag

### DIFF
--- a/src/Designer/frontend/app-development/contexts/PageHeaderContext/PageHeaderContext.test.tsx
+++ b/src/Designer/frontend/app-development/contexts/PageHeaderContext/PageHeaderContext.test.tsx
@@ -2,13 +2,6 @@ import { render, screen } from '@testing-library/react';
 import { PageHeaderContextProvider, usePageHeaderContext } from './PageHeaderContext';
 import { renderWithProviders } from 'app-development/test/mocks';
 import { textMock } from '@studio/testing/mocks/i18nMock';
-import { FeatureFlag } from '@studio/feature-flags';
-
-const mockEnvironment = { environment: null, isLoading: false, error: null };
-
-jest.mock('app-shared/contexts/EnvironmentConfigContext', () => ({
-  useEnvironmentConfig: () => mockEnvironment,
-}));
 
 const SettingsLinkConsumer = () => {
   const { profileMenuGroups } = usePageHeaderContext();
@@ -18,15 +11,8 @@ const SettingsLinkConsumer = () => {
   return <div data-testid='settings-href'>{href ?? 'none'}</div>;
 };
 
-const renderPageHeaderContext = (featureFlags: FeatureFlag[] = []) =>
-  renderWithProviders(
-    {},
-    undefined,
-    {},
-    undefined,
-    undefined,
-    featureFlags,
-  )(
+const renderPageHeaderContext = () =>
+  renderWithProviders()(
     <PageHeaderContextProvider>
       <SettingsLinkConsumer />
     </PageHeaderContextProvider>,
@@ -69,27 +55,9 @@ describe('PageHeaderContext', () => {
     );
   });
 
-  it('should include user settings link in profile menu when studioOidc feature flag is enabled', () => {
-    mockEnvironment.environment = { featureFlags: { studioOidc: true } };
-
+  it('should include user settings link in profile menu', () => {
     renderPageHeaderContext();
 
     expect(screen.getByTestId('settings-href')).not.toHaveTextContent('none');
-  });
-
-  it('should include user settings link in profile menu when Admin feature flag is enabled', () => {
-    mockEnvironment.environment = { featureFlags: { studioOidc: false } };
-
-    renderPageHeaderContext([FeatureFlag.Admin]);
-
-    expect(screen.getByTestId('settings-href')).not.toHaveTextContent('none');
-  });
-
-  it('should not include user settings link in profile menu when neither studioOidc nor Admin flag is enabled', () => {
-    mockEnvironment.environment = { featureFlags: { studioOidc: false } };
-
-    renderPageHeaderContext();
-
-    expect(screen.getByTestId('settings-href')).toHaveTextContent('none');
   });
 });

--- a/src/Designer/frontend/app-development/contexts/PageHeaderContext/PageHeaderContext.tsx
+++ b/src/Designer/frontend/app-development/contexts/PageHeaderContext/PageHeaderContext.tsx
@@ -14,8 +14,7 @@ import { useTranslation } from 'react-i18next';
 import { altinnDocsUrl } from 'app-shared/ext-urls';
 import { useLogoutMutation } from 'app-shared/hooks/mutations/useLogoutMutation';
 import { useSearchParams } from 'react-router-dom';
-import { FeatureFlag, useFeatureFlagsContext } from '@studio/feature-flags';
-import { useEnvironmentConfig } from 'app-shared/contexts/EnvironmentConfigContext';
+import { useFeatureFlagsContext } from '@studio/feature-flags';
 import { SETTINGS_BASENAME } from 'app-shared/constants';
 
 export type PageHeaderContextProps = {
@@ -46,8 +45,6 @@ export const PageHeaderContextProvider = ({
   const [searchParams] = useSearchParams();
   const returnTo = searchParams.get('returnTo');
 
-  const { environment } = useEnvironmentConfig();
-
   const repoType = getRepositoryType(org, app);
   const menuItems = getTopBarMenuItems(repoType, repoOwnerIsOrg, flags);
 
@@ -70,17 +67,13 @@ export const PageHeaderContextProvider = ({
     itemName: t('shared.header_logout'),
   };
 
-  const studioOidc = environment?.featureFlags?.studioOidc;
-  const isAdminEnabled = flags.includes(FeatureFlag.Admin);
-  const showSettingsLink = studioOidc || isAdminEnabled;
-
   const profileMenuItems: StudioProfileMenuItem[] = [
-    ...(showSettingsLink ? [settingsMenuItem] : []),
+    settingsMenuItem,
     docsMenuItem,
     logOutMenuItem,
   ];
   const profileMenuGroups: StudioProfileMenuGroup[] = [
-    ...(showSettingsLink ? [{ items: [settingsMenuItem] }] : []),
+    { items: [settingsMenuItem] },
     { items: [docsMenuItem] },
     { items: [logOutMenuItem] },
   ];

--- a/src/Designer/frontend/app-preview/src/components/UserProfileMenu/UserProfileMenu.test.tsx
+++ b/src/Designer/frontend/app-preview/src/components/UserProfileMenu/UserProfileMenu.test.tsx
@@ -8,15 +8,6 @@ import { app, org } from '@studio/testing/testids';
 import { repository } from 'app-shared/mocks/mocks';
 import { renderWithProviders } from '../../../test/mocks';
 import { StudioPageHeaderContextProvider } from '@studio/components/src/components/StudioPageHeader/context';
-import { FeatureFlag, FeatureFlagsContextProvider } from '@studio/feature-flags';
-
-const mockEnvironment: { environment: { featureFlags: { studioOidc: boolean } } | null } = {
-  environment: null,
-};
-
-jest.mock('app-shared/contexts/EnvironmentConfigContext', () => ({
-  useEnvironmentConfig: () => mockEnvironment,
-}));
 
 jest.mock('@studio/components-legacy/src/hooks/useMediaQuery');
 
@@ -49,10 +40,6 @@ const defaultProps: UserProfileMenuProps = {
 };
 
 describe('UserProfileMenu', () => {
-  beforeEach(() => {
-    mockEnvironment.environment = null;
-  });
-
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -87,51 +74,25 @@ describe('UserProfileMenu', () => {
     expect(screen.getByAltText(textMock('general.profile_icon'))).toBeInTheDocument();
   });
 
-  it('should include user settings link in profile menu when studioOidc is enabled', async () => {
+  it('should include user settings link in profile menu', async () => {
     const user = userEvent.setup();
-    mockEnvironment.environment = { featureFlags: { studioOidc: true } };
 
     renderUserProfileMenu();
 
     await user.click(screen.getByRole('button'));
 
     expect(screen.getByRole('menuitem', { name: textMock('settings') })).toBeInTheDocument();
-  });
-
-  it('should include user settings link in profile menu when Admin feature flag is enabled', async () => {
-    const user = userEvent.setup();
-    mockEnvironment.environment = { featureFlags: { studioOidc: false } };
-
-    renderUserProfileMenu({ flags: [FeatureFlag.Admin] });
-
-    await user.click(screen.getByRole('button'));
-
-    expect(screen.getByRole('menuitem', { name: textMock('settings') })).toBeInTheDocument();
-  });
-
-  it('should not include user settings link in profile menu when neither studioOidc nor Admin flag is enabled', async () => {
-    const user = userEvent.setup();
-    mockEnvironment.environment = { featureFlags: { studioOidc: false } };
-
-    renderUserProfileMenu();
-
-    await user.click(screen.getByRole('button'));
-
-    expect(screen.queryByRole('menuitem', { name: textMock('settings') })).not.toBeInTheDocument();
   });
 });
 
 type RenderOptions = {
   props?: Partial<UserProfileMenuProps>;
-  flags?: FeatureFlag[];
 };
 
-const renderUserProfileMenu = ({ props, flags = [] }: RenderOptions = {}) => {
+const renderUserProfileMenu = ({ props }: RenderOptions = {}) => {
   return renderWithProviders()(
-    <FeatureFlagsContextProvider value={{ flags }}>
-      <StudioPageHeaderContextProvider variant='preview'>
-        <UserProfileMenu {...defaultProps} {...props} />
-      </StudioPageHeaderContextProvider>
-    </FeatureFlagsContextProvider>,
+    <StudioPageHeaderContextProvider variant='preview'>
+      <UserProfileMenu {...defaultProps} {...props} />
+    </StudioPageHeaderContextProvider>,
   );
 };

--- a/src/Designer/frontend/app-preview/src/components/UserProfileMenu/UserProfileMenu.tsx
+++ b/src/Designer/frontend/app-preview/src/components/UserProfileMenu/UserProfileMenu.tsx
@@ -13,8 +13,6 @@ import {
 import { MEDIA_QUERY_MAX_WIDTH, SETTINGS_BASENAME } from 'app-shared/constants';
 import { useLogoutMutation } from 'app-shared/hooks/mutations/useLogoutMutation';
 import { altinnDocsUrl } from 'app-shared/ext-urls';
-import { useEnvironmentConfig } from 'app-shared/contexts/EnvironmentConfigContext';
-import { FeatureFlag, useFeatureFlag } from '@studio/feature-flags';
 
 export type UserProfileMenuProps = {
   user: User;
@@ -27,10 +25,6 @@ export const UserProfileMenu = ({ user, repository }: UserProfileMenuProps): Rea
   const userNameAndOrg = useUserNameAndOrg(user, org, repository);
   const shouldDisplayText = !useMediaQuery(MEDIA_QUERY_MAX_WIDTH);
   const { mutate: logout } = useLogoutMutation();
-  const { environment } = useEnvironmentConfig();
-  const studioOidc = environment?.featureFlags?.studioOidc;
-  const isAdminEnabled = useFeatureFlag(FeatureFlag.Admin);
-  const showSettingsLink = studioOidc || isAdminEnabled;
 
   const docsMenuItem: StudioProfileMenuItem = {
     action: { type: 'link', href: altinnDocsUrl() },
@@ -52,7 +46,7 @@ export const UserProfileMenu = ({ user, repository }: UserProfileMenuProps): Rea
   };
 
   const profileMenuGroups: StudioProfileMenuGroup[] = [
-    ...(showSettingsLink ? [{ items: [settingsMenuItem] }] : []),
+    { items: [settingsMenuItem] },
     { items: [docsMenuItem] },
     { items: [logOutMenuItem] },
   ];

--- a/src/Designer/frontend/dashboard/context/HeaderContext/HeaderContext.test.tsx
+++ b/src/Designer/frontend/dashboard/context/HeaderContext/HeaderContext.test.tsx
@@ -2,13 +2,6 @@ import { render, screen } from '@testing-library/react';
 import { HeaderContextProvider, useHeaderContext } from './HeaderContext';
 import { renderWithProviders } from '../../testing/mocks';
 import { textMock } from '@studio/testing/mocks/i18nMock';
-import { FeatureFlag } from '@studio/feature-flags';
-
-const mockEnvironment = { environment: null, isLoading: false, error: null };
-
-jest.mock('app-shared/contexts/EnvironmentConfigContext', () => ({
-  useEnvironmentConfig: () => mockEnvironment,
-}));
 
 const SettingsLinkConsumer = () => {
   const { profileMenuGroups } = useHeaderContext();
@@ -63,27 +56,9 @@ describe('HeaderContext', () => {
     );
   });
 
-  it('should include user settings link in profile menu when studioOidc feature flag is enabled', () => {
-    mockEnvironment.environment = { featureFlags: { studioOidc: true } };
-
+  it('should include user settings link in profile menu', () => {
     renderHeaderContext();
 
     expect(screen.getByTestId('settings-href')).not.toHaveTextContent(/^none$/);
-  });
-
-  it('should include user settings link in profile menu when Admin feature flag is enabled', () => {
-    mockEnvironment.environment = { featureFlags: { studioOidc: false } };
-
-    renderHeaderContext({ featureFlags: [FeatureFlag.Admin] });
-
-    expect(screen.getByTestId('settings-href')).not.toHaveTextContent(/^none$/);
-  });
-
-  it('should not include user settings link in profile menu when neither studioOidc nor Admin flag is enabled', () => {
-    mockEnvironment.environment = { featureFlags: { studioOidc: false } };
-
-    renderHeaderContext();
-
-    expect(screen.getByTestId('settings-href')).toHaveTextContent(/^none$/);
   });
 });

--- a/src/Designer/frontend/dashboard/context/HeaderContext/HeaderContext.tsx
+++ b/src/Designer/frontend/dashboard/context/HeaderContext/HeaderContext.tsx
@@ -6,7 +6,7 @@ import { type Organization } from 'app-shared/types/Organization';
 import { type User } from 'app-shared/types/Repository';
 import { useLogoutMutation } from 'app-shared/hooks/mutations/useLogoutMutation';
 import { dashboardHeaderMenuItems } from '../../utils/headerUtils/headerUtils';
-import { useFeatureFlagsContext, FeatureFlag, useFeatureFlag } from '@studio/feature-flags';
+import { useFeatureFlagsContext } from '@studio/feature-flags';
 import { useSelectedContext } from '../../hooks/useSelectedContext';
 import { useRepoPath } from '../../hooks/useRepoPath';
 import { useSubroute } from '../../hooks/useSubRoute';
@@ -14,7 +14,6 @@ import { type NavigationMenuItem } from '../../types/NavigationMenuItem';
 import { type NavigationMenuGroup } from '../../types/NavigationMenuGroup';
 import type { HeaderMenuItem } from '../../types/HeaderMenuItem';
 import { SelectedContextType } from '../../enums/SelectedContextType';
-import { useEnvironmentConfig } from 'app-shared/contexts/EnvironmentConfigContext';
 import { SETTINGS_BASENAME } from 'app-shared/constants';
 import { isOrg } from 'dashboard/utils/orgUtils/orgUtils';
 
@@ -45,7 +44,6 @@ export const HeaderContextProvider = ({
   const repoPath = useRepoPath(user, selectableOrgs);
   const subroute = useSubroute();
 
-  const { environment } = useEnvironmentConfig();
   const { flags } = useFeatureFlagsContext();
 
   const handleSetSelectedContext = (context: string | SelectedContextType) => {
@@ -90,24 +88,16 @@ export const HeaderContextProvider = ({
     itemName: t('shared.header_logout'),
   };
 
-  const studioOidc = environment?.featureFlags?.studioOidc;
-  const isAdminEnabled = useFeatureFlag(FeatureFlag.Admin);
-  const showSettingsLink = studioOidc || isAdminEnabled;
-
   const selectableOrgMenuGroup: NavigationMenuGroup = {
     name: t('top_bar.group_organizations'),
     showName: true,
     items: [allMenuItem, ...selectableOrgMenuItems, selfMenuItem],
   };
-  const profileMenuItems: NavigationMenuItem[] = [
-    ...(showSettingsLink ? [settingsMenuItem] : []),
-    giteaMenuItem,
-    logOutMenuItem,
-  ];
+  const profileMenuItems: NavigationMenuItem[] = [settingsMenuItem, giteaMenuItem, logOutMenuItem];
 
   const profileMenuGroups: NavigationMenuGroup[] = [
     selectableOrgMenuGroup,
-    ...(showSettingsLink ? [{ items: [settingsMenuItem] }] : []),
+    { items: [settingsMenuItem] },
     { items: [giteaMenuItem] },
     { items: [logOutMenuItem] },
   ];

--- a/src/Designer/frontend/dashboard/utils/headerUtils/headerUtils.ts
+++ b/src/Designer/frontend/dashboard/utils/headerUtils/headerUtils.ts
@@ -6,7 +6,6 @@ import type { HeaderMenuGroup } from '../../types/HeaderMenuGroup';
 import { isOrg } from '../orgUtils/orgUtils';
 import type { NavigationMenuGroup } from '../../types/NavigationMenuGroup';
 import { type StudioProfileMenuGroup } from '@studio/components';
-import { FeatureFlag } from '@studio/feature-flags';
 import { ADMIN_BASENAME, DASHBOARD_BASENAME } from 'app-shared/constants';
 
 export const dashboardHeaderMenuItems: HeaderMenuItem[] = [
@@ -22,7 +21,6 @@ export const dashboardHeaderMenuItems: HeaderMenuItem[] = [
       `${ADMIN_BASENAME}/${isOrg(selectedContext) ? selectedContext : ''}`,
     name: 'admin.apps.title',
     group: HeaderMenuGroupKey.Tools,
-    featureFlag: FeatureFlag.Admin,
     isExternalLink: true,
     isBeta: true,
   },

--- a/src/Designer/frontend/libs/studio-feature-flags/src/FeatureFlag.ts
+++ b/src/Designer/frontend/libs/studio-feature-flags/src/FeatureFlag.ts
@@ -1,6 +1,5 @@
 export enum FeatureFlag {
   AddComponentModal = 'addComponentModal',
-  Admin = 'admin',
   AiAssistant = 'aiAssistant',
   ComponentConfigBeta = 'componentConfigBeta',
   CustomTemplates = 'customTemplates',

--- a/src/Designer/frontend/libs/studio-feature-flags/src/useFeatureFlag.test.tsx
+++ b/src/Designer/frontend/libs/studio-feature-flags/src/useFeatureFlag.test.tsx
@@ -6,7 +6,7 @@ import type { FeatureFlagsContextValue } from './FeatureFlagsContext';
 import { useFeatureFlag } from './useFeatureFlag';
 
 // Test data:
-const enabledFlag = FeatureFlag.Admin;
+const enabledFlag = FeatureFlag.AiAssistant;
 const disabledFlag = FeatureFlag.NewCodeLists;
 const flags = [enabledFlag];
 const contextValue: FeatureFlagsContextValue = { flags };

--- a/src/Designer/frontend/libs/studio-feature-flags/src/useFeatureToggle.test.tsx
+++ b/src/Designer/frontend/libs/studio-feature-flags/src/useFeatureToggle.test.tsx
@@ -7,7 +7,7 @@ import { FeatureFlagsContextProvider } from './FeatureFlagsContext';
 import { FeatureFlagMutationContextProvider } from './FeatureFlagMutationContext';
 
 // Test data:
-const enabledFlag = FeatureFlag.Admin;
+const enabledFlag = FeatureFlag.AiAssistant;
 const disabledFlag = FeatureFlag.NewCodeLists;
 const flags = [enabledFlag];
 const addFlag = jest.fn();

--- a/src/Designer/frontend/packages/shared/src/components/PageHeader/PageHeader.test.tsx
+++ b/src/Designer/frontend/packages/shared/src/components/PageHeader/PageHeader.test.tsx
@@ -4,8 +4,6 @@ import { MemoryRouter } from 'react-router-dom';
 import { textMock } from '@studio/testing/mocks/i18nMock';
 import { PageHeader } from './PageHeader';
 import { useMediaQuery } from '@studio/hooks';
-import type { AltinnStudioEnvironment } from 'app-shared/utils/altinnStudioEnv';
-import { FeatureFlag, FeatureFlagsProvider } from '@studio/feature-flags';
 import {
   ADMIN_BASENAME,
   APP_DASHBOARD_BASENAME,
@@ -14,11 +12,6 @@ import {
   ORG_LIBRARY_BASENAME,
 } from 'app-shared/constants';
 
-const mockEnvironment: {
-  environment: AltinnStudioEnvironment | null;
-  isLoading: boolean;
-  error: null;
-} = { environment: null, isLoading: false, error: null };
 const mockLogout = jest.fn();
 const mockOrgSelect = jest.fn();
 const mockUserSelect = jest.fn();
@@ -42,16 +35,6 @@ jest.mock('@studio/hooks', () => ({
   useMediaQuery: jest.fn(),
 }));
 
-const mockUseFeatureFlag = jest.fn();
-jest.mock('@studio/feature-flags', () => ({
-  ...jest.requireActual('@studio/feature-flags'),
-  useFeatureFlag: (...args: unknown[]) => mockUseFeatureFlag(...args),
-}));
-
-jest.mock('app-shared/contexts/EnvironmentConfigContext', () => ({
-  useEnvironmentConfig: () => mockEnvironment,
-}));
-
 jest.mock('app-shared/hooks/mutations/useLogoutMutation', () => ({
   useLogoutMutation: () => ({ mutate: mockLogout }),
 }));
@@ -70,7 +53,6 @@ const triggerButtonName = textMock('shared.header_user_for_org', {
 describe('PageHeader', () => {
   beforeEach(() => {
     (useMediaQuery as jest.Mock).mockReturnValue(false);
-    mockEnvironment.environment = null;
   });
 
   afterEach(() => {
@@ -82,9 +64,8 @@ describe('PageHeader', () => {
     expect(screen.getByText(DISPLAY_NAME)).toBeInTheDocument();
   });
 
-  it('includes the user settings link in the profile menu when studioOidc is enabled', async () => {
+  it('includes the user settings link in the profile menu', async () => {
     const user = userEvent.setup();
-    mockEnvironment.environment = { featureFlags: { studioOidc: true } };
 
     renderPageHeader();
 
@@ -96,17 +77,6 @@ describe('PageHeader', () => {
     expect(
       screen.getByRole('menuitemradio', { name: textMock('shared.header_logout') }),
     ).toBeInTheDocument();
-  });
-
-  it('does not include the user settings link in the profile menu when studioOidc is disabled', async () => {
-    const user = userEvent.setup();
-    mockEnvironment.environment = { featureFlags: { studioOidc: false } };
-
-    renderPageHeader();
-
-    await user.click(screen.getByRole('button', { name: triggerButtonName }));
-
-    expect(screen.queryByRole('menuitem', { name: textMock('settings') })).not.toBeInTheDocument();
   });
 
   it('renders org menu items in the profile menu', async () => {
@@ -160,10 +130,12 @@ describe('PageHeader', () => {
     ).toHaveAttribute('href', '/dashboard/org-library/ttd');
   });
 
-  it('does not render the admin link when the admin feature flag is disabled', () => {
-    mockUseFeatureFlag.mockReturnValue(false);
+  it('renders the admin nav link with correct href', () => {
     renderPageHeader();
-    expect(screen.queryByText(textMock('admin.apps.title'))).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: textMock('admin.apps.title') })).toHaveAttribute(
+      'href',
+      '/admin/ttd',
+    );
   });
 
   describe('dashboard link active state', () => {
@@ -207,10 +179,6 @@ describe('PageHeader', () => {
   });
 
   describe('admin link active state', () => {
-    beforeEach(() => {
-      mockUseFeatureFlag.mockImplementation((flag: FeatureFlag) => flag === FeatureFlag.Admin);
-    });
-
     it.each([
       [ADMIN_BASENAME, true],
       [`${ADMIN_BASENAME}/ttd`, true],
@@ -240,9 +208,7 @@ const renderPageHeader = (initialEntries?: string[]) => {
   }
   return render(
     <MemoryRouter initialEntries={initialEntries}>
-      <FeatureFlagsProvider>
-        <PageHeader owner='ttd' onOrgSelect={mockOrgSelect} onUserSelect={mockUserSelect} />
-      </FeatureFlagsProvider>
+      <PageHeader owner='ttd' onOrgSelect={mockOrgSelect} onUserSelect={mockUserSelect} />
     </MemoryRouter>,
   );
 };

--- a/src/Designer/frontend/packages/shared/src/components/PageHeader/PageHeader.test.tsx
+++ b/src/Designer/frontend/packages/shared/src/components/PageHeader/PageHeader.test.tsx
@@ -138,6 +138,24 @@ describe('PageHeader', () => {
     );
   });
 
+  it('renders nav links without owner segment when owner is undefined', () => {
+    render(
+      <MemoryRouter>
+        <PageHeader owner={undefined} onOrgSelect={mockOrgSelect} onUserSelect={mockUserSelect} />
+      </MemoryRouter>,
+    );
+    expect(
+      screen.getByRole('link', { name: textMock('dashboard.header_item_dashboard') }),
+    ).toHaveAttribute('href', `/dashboard/app-dashboard/`);
+    expect(
+      screen.getByRole('link', { name: textMock('dashboard.header_item_library') }),
+    ).toHaveAttribute('href', `/dashboard/org-library/`);
+    expect(screen.getByRole('link', { name: textMock('admin.apps.title') })).toHaveAttribute(
+      'href',
+      '/admin/',
+    );
+  });
+
   describe('dashboard link active state', () => {
     const appDashboardBasePath = `${DASHBOARD_BASENAME}/${APP_DASHBOARD_BASENAME}`;
 

--- a/src/Designer/frontend/packages/shared/src/components/PageHeader/PageHeader.tsx
+++ b/src/Designer/frontend/packages/shared/src/components/PageHeader/PageHeader.tsx
@@ -13,7 +13,6 @@ import type { Organization } from 'app-shared/types/Organization';
 import type { User } from 'app-shared/types/Repository';
 import { NavigationMenu } from './NavigationMenu/NavigationMenu';
 import type { NavigationMenuItem } from './NavigationMenu/NavigationMenuItem';
-import { FeatureFlag, useFeatureFlag } from '@studio/feature-flags';
 import { ProfileMenu } from './ProfileMenu/ProfileMenu';
 
 const isPathActive = (pathname: string, basePath: string): boolean =>
@@ -28,7 +27,6 @@ type PageHeaderProps = {
 export const PageHeader = ({ owner, onOrgSelect, onUserSelect }: PageHeaderProps): ReactElement => {
   const shouldDisplayDesktopMenu = !useMediaQuery(MEDIA_QUERY_MAX_WIDTH);
 
-  const adminEnabled = useFeatureFlag(FeatureFlag.Admin);
   const appDashboardBasePath = `${DASHBOARD_BASENAME}/${APP_DASHBOARD_BASENAME}`;
   const orgLibraryBasePath = `${DASHBOARD_BASENAME}/${ORG_LIBRARY_BASENAME}`;
   const { pathname } = window.location;
@@ -38,16 +36,12 @@ export const PageHeader = ({ owner, onOrgSelect, onUserSelect }: PageHeaderProps
       textKey: 'dashboard.header_item_dashboard',
       isActive: isPathActive(pathname, appDashboardBasePath),
     },
-    ...(adminEnabled
-      ? [
-          {
-            href: `${ADMIN_BASENAME}/${owner ?? ''}`,
-            textKey: 'admin.apps.title',
-            isActive: isPathActive(pathname, ADMIN_BASENAME),
-            isBeta: true,
-          },
-        ]
-      : []),
+    {
+      href: `${ADMIN_BASENAME}/${owner ?? ''}`,
+      textKey: 'admin.apps.title',
+      isActive: isPathActive(pathname, ADMIN_BASENAME),
+      isBeta: true,
+    },
     {
       href: `${orgLibraryBasePath}/${owner ?? ''}`,
       textKey: 'dashboard.header_item_library',

--- a/src/Designer/frontend/packages/shared/src/components/PageHeader/ProfileMenu/ProfileMenu.test.tsx
+++ b/src/Designer/frontend/packages/shared/src/components/PageHeader/ProfileMenu/ProfileMenu.test.tsx
@@ -2,16 +2,13 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { textMock } from '@studio/testing/mocks/i18nMock';
-import type { AltinnStudioEnvironment } from 'app-shared/utils/altinnStudioEnv';
 import type { Organization } from 'app-shared/types/Organization';
 import type { User } from 'app-shared/types/Repository';
 import { ProfileMenu } from './ProfileMenu';
-import { FeatureFlag, FeatureFlagsContextProvider } from '@studio/feature-flags';
 
 const mockLogout = jest.fn();
 const mockOnOrgSelect = jest.fn();
 const mockOnUserSelect = jest.fn();
-const mockEnvironment: { environment: AltinnStudioEnvironment | null } = { environment: null };
 
 const mockUseUserQuery = jest.fn();
 const mockUseOrganizationsQuery = jest.fn();
@@ -24,10 +21,6 @@ jest.mock('app-shared/hooks/queries', () => ({
 
 jest.mock('app-shared/hooks/mutations/useLogoutMutation', () => ({
   useLogoutMutation: () => ({ mutate: mockLogout }),
-}));
-
-jest.mock('app-shared/contexts/EnvironmentConfigContext', () => ({
-  useEnvironmentConfig: () => mockEnvironment,
 }));
 
 const userWithFullName: User = {
@@ -64,7 +57,6 @@ type RenderOptions = {
   user?: User | null;
   organizations?: Organization[];
   shouldDisplayDesktopMenu?: boolean;
-  featureFlags?: FeatureFlag[];
 };
 
 const renderProfileMenu = ({
@@ -72,22 +64,19 @@ const renderProfileMenu = ({
   user = userWithFullName,
   organizations = [],
   shouldDisplayDesktopMenu = false,
-  featureFlags = [],
 }: RenderOptions = {}) => {
   mockUseUserQuery.mockReturnValue({ data: user ?? undefined });
   mockUseOrganizationsQuery.mockReturnValue({ data: organizations });
   return render(
-    <FeatureFlagsContextProvider value={{ flags: featureFlags }}>
-      <MemoryRouter>
-        <ProfileMenu
-          owner={owner}
-          navigationMenuItems={[]}
-          shouldDisplayDesktopMenu={shouldDisplayDesktopMenu}
-          onOrgSelect={mockOnOrgSelect}
-          onUserSelect={mockOnUserSelect}
-        />
-      </MemoryRouter>
-    </FeatureFlagsContextProvider>,
+    <MemoryRouter>
+      <ProfileMenu
+        owner={owner}
+        navigationMenuItems={[]}
+        shouldDisplayDesktopMenu={shouldDisplayDesktopMenu}
+        onOrgSelect={mockOnOrgSelect}
+        onUserSelect={mockOnUserSelect}
+      />
+    </MemoryRouter>,
   );
 };
 
@@ -163,41 +152,14 @@ describe('ProfileMenu', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('should include settings link when studioOidc is enabled', async () => {
+  it('should include settings link', async () => {
     const user = userEvent.setup();
-    mockEnvironment.environment = { featureFlags: { studioOidc: true } } as AltinnStudioEnvironment;
 
     renderProfileMenu();
 
     await user.click(getTriggerButton());
 
     expect(screen.getByRole('menuitem', { name: textMock('settings') })).toBeInTheDocument();
-  });
-
-  it('should include settings link when Admin feature flag is enabled', async () => {
-    const user = userEvent.setup();
-    mockEnvironment.environment = {
-      featureFlags: { studioOidc: false },
-    } as AltinnStudioEnvironment;
-
-    renderProfileMenu({ featureFlags: [FeatureFlag.Admin] });
-
-    await user.click(getTriggerButton());
-
-    expect(screen.getByRole('menuitem', { name: textMock('settings') })).toBeInTheDocument();
-  });
-
-  it('should not include settings link when neither studioOidc nor Admin flag is enabled', async () => {
-    const user = userEvent.setup();
-    mockEnvironment.environment = {
-      featureFlags: { studioOidc: false },
-    } as AltinnStudioEnvironment;
-
-    renderProfileMenu();
-
-    await user.click(getTriggerButton());
-
-    expect(screen.queryByRole('menuitem', { name: textMock('settings') })).not.toBeInTheDocument();
   });
 
   it('renders no org items when organizations data is unavailable', async () => {
@@ -205,17 +167,15 @@ describe('ProfileMenu', () => {
     mockUseOrganizationsQuery.mockReturnValue({ data: undefined });
     const user = userEvent.setup();
     render(
-      <FeatureFlagsContextProvider value={{ flags: [] }}>
-        <MemoryRouter>
-          <ProfileMenu
-            owner='testuser'
-            navigationMenuItems={[]}
-            shouldDisplayDesktopMenu={false}
-            onOrgSelect={mockOnOrgSelect}
-            onUserSelect={mockOnUserSelect}
-          />
-        </MemoryRouter>
-      </FeatureFlagsContextProvider>,
+      <MemoryRouter>
+        <ProfileMenu
+          owner='testuser'
+          navigationMenuItems={[]}
+          shouldDisplayDesktopMenu={false}
+          onOrgSelect={mockOnOrgSelect}
+          onUserSelect={mockOnUserSelect}
+        />
+      </MemoryRouter>,
     );
     await user.click(getTriggerButton());
     expect(

--- a/src/Designer/frontend/packages/shared/src/components/PageHeader/ProfileMenu/ProfileMenu.tsx
+++ b/src/Designer/frontend/packages/shared/src/components/PageHeader/ProfileMenu/ProfileMenu.tsx
@@ -2,9 +2,7 @@ import type { ReactElement } from 'react';
 import type { StudioProfileMenuGroup } from '@studio/components';
 import { useTranslation } from 'react-i18next';
 import { repositoryOwnerPath } from 'app-shared/api/paths';
-import { useEnvironmentConfig } from 'app-shared/contexts/EnvironmentConfigContext';
 import { useLogoutMutation } from 'app-shared/hooks/mutations/useLogoutMutation';
-import { FeatureFlag, useFeatureFlag } from '@studio/feature-flags';
 import { useOrganizationsQuery, useUserQuery } from 'app-shared/hooks/queries';
 import { SETTINGS_BASENAME } from 'app-shared/constants';
 import type { Organization } from 'app-shared/types/Organization';
@@ -32,10 +30,6 @@ export const ProfileMenu = ({
   const { data: user } = useUserQuery();
   const { data: organizations } = useOrganizationsQuery();
   const { mutate: logout } = useLogoutMutation();
-  const { environment } = useEnvironmentConfig();
-  const studioOidc = environment?.featureFlags?.studioOidc;
-  const isAdminEnabled = useFeatureFlag(FeatureFlag.Admin);
-  const showSettingsLink = studioOidc || isAdminEnabled;
 
   if (!owner || !user) {
     return null;
@@ -97,7 +91,7 @@ export const ProfileMenu = ({
       ? []
       : [{ name: t('top_bar.group_tools'), items: [...navigationItems] }]),
     { name: t('top_bar.group_organizations'), items: [...orgMenuItems, userMenuItem] },
-    ...(showSettingsLink ? [{ items: [settingsMenuItem] }] : []),
+    { items: [settingsMenuItem] },
     { items: [giteaMenuItem] },
     { items: [logOutMenuItem] },
   ];

--- a/src/Designer/frontend/resourceadm/components/ResourceAdmHeader/ResourceAdmHeader.test.tsx
+++ b/src/Designer/frontend/resourceadm/components/ResourceAdmHeader/ResourceAdmHeader.test.tsx
@@ -6,7 +6,6 @@ import { queriesMock } from 'app-shared/mocks/queriesMock';
 import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
 import { ServicesContextProvider } from 'app-shared/contexts/ServicesContext';
 import { ResourceAdmHeader } from './ResourceAdmHeader';
-import { FeatureFlag, FeatureFlagsContextProvider } from '@studio/feature-flags';
 
 const mainOrganization = {
   avatar_url: '',
@@ -33,14 +32,6 @@ const testUser = {
 
 const resourceId = 'res-id';
 
-const mockEnvironment: { environment: { featureFlags: { studioOidc: boolean } } | null } = {
-  environment: null,
-};
-
-jest.mock('app-shared/contexts/EnvironmentConfigContext', () => ({
-  useEnvironmentConfig: () => mockEnvironment,
-}));
-
 const navigateMock = jest.fn();
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -52,10 +43,6 @@ jest.mock('react-router-dom', () => ({
 }));
 
 describe('ResourceAdmHeader', () => {
-  beforeEach(() => {
-    mockEnvironment.environment = null;
-  });
-
   afterEach(jest.clearAllMocks);
 
   it('should show org name and resource id in header', () => {
@@ -84,9 +71,8 @@ describe('ResourceAdmHeader', () => {
     expect(navigateMock).toHaveBeenCalled();
   });
 
-  it('should include user settings link in profile menu when studioOidc is enabled', async () => {
+  it('should include user settings link in profile menu', async () => {
     const user = userEvent.setup();
-    mockEnvironment.environment = { featureFlags: { studioOidc: true } };
 
     renderResourceAdmHeader();
 
@@ -100,57 +86,15 @@ describe('ResourceAdmHeader', () => {
     );
 
     expect(screen.getByRole('menuitem', { name: textMock('settings') })).toBeInTheDocument();
-  });
-
-  it('should include user settings link in profile menu when Admin feature flag is enabled', async () => {
-    const user = userEvent.setup();
-    mockEnvironment.environment = { featureFlags: { studioOidc: false } };
-
-    renderResourceAdmHeader({ featureFlags: [FeatureFlag.Admin] });
-
-    await user.click(
-      screen.getByRole('button', {
-        name: textMock('shared.header_user_for_org', {
-          user: testUser.full_name,
-          org: mainOrganization.full_name,
-        }),
-      }),
-    );
-
-    expect(screen.getByRole('menuitem', { name: textMock('settings') })).toBeInTheDocument();
-  });
-
-  it('should not include user settings link in profile menu when neither studioOidc nor Admin flag is enabled', async () => {
-    const user = userEvent.setup();
-    mockEnvironment.environment = { featureFlags: { studioOidc: false } };
-
-    renderResourceAdmHeader();
-
-    await user.click(
-      screen.getByRole('button', {
-        name: textMock('shared.header_user_for_org', {
-          user: testUser.full_name,
-          org: mainOrganization.full_name,
-        }),
-      }),
-    );
-
-    expect(screen.queryByRole('menuitem', { name: textMock('settings') })).not.toBeInTheDocument();
   });
 });
 
-type RenderOptions = {
-  featureFlags?: FeatureFlag[];
-};
-
-const renderResourceAdmHeader = ({ featureFlags = [] }: RenderOptions = {}) => {
+const renderResourceAdmHeader = () => {
   return render(
     <MemoryRouter>
-      <FeatureFlagsContextProvider value={{ flags: featureFlags }}>
-        <ServicesContextProvider {...queriesMock} client={createQueryClientMock()}>
-          <ResourceAdmHeader organizations={organizations} user={testUser} />
-        </ServicesContextProvider>
-      </FeatureFlagsContextProvider>
+      <ServicesContextProvider {...queriesMock} client={createQueryClientMock()}>
+        <ResourceAdmHeader organizations={organizations} user={testUser} />
+      </ServicesContextProvider>
     </MemoryRouter>,
   );
 };

--- a/src/Designer/frontend/resourceadm/components/ResourceAdmHeader/ResourceAdmHeader.tsx
+++ b/src/Designer/frontend/resourceadm/components/ResourceAdmHeader/ResourceAdmHeader.tsx
@@ -16,8 +16,6 @@ import type { User } from 'app-shared/types/Repository';
 import { useUrlParams } from '../../hooks/useUrlParams';
 import { getAppName } from '../../utils/stringUtils';
 import { GiteaHeader } from 'app-shared/components/GiteaHeader';
-import { useEnvironmentConfig } from 'app-shared/contexts/EnvironmentConfigContext';
-import { FeatureFlag, useFeatureFlag } from '@studio/feature-flags';
 
 interface ResourceAdmHeaderProps {
   organizations: Organization[];
@@ -59,10 +57,6 @@ const DashboardHeaderMenu = ({ organizations, user }: ResourceAdmHeaderProps) =>
   const { mutate: logout } = useLogoutMutation();
   const navigate = useNavigate();
   const selectableOrgs = organizations;
-  const { environment } = useEnvironmentConfig();
-  const studioOidc = environment?.featureFlags?.studioOidc;
-  const isAdminEnabled = useFeatureFlag(FeatureFlag.Admin);
-  const showSettingsLink = studioOidc || isAdminEnabled;
 
   const triggerButtonText = t('shared.header_user_for_org', {
     user: user?.full_name || user?.login,
@@ -103,7 +97,7 @@ const DashboardHeaderMenu = ({ organizations, user }: ResourceAdmHeaderProps) =>
 
   const profileMenuGroups: StudioProfileMenuGroup[] = [
     { items: selectableOrgMenuItems },
-    ...(showSettingsLink ? [{ items: [settingsMenuItem] }] : []),
+    { items: [settingsMenuItem] },
     { items: [giteaMenuItem] },
     { items: [logOutMenuItem] },
   ];

--- a/src/Designer/frontend/settings/components/OwnerIndexRedirect/OwnerIndexRedirect.test.tsx
+++ b/src/Designer/frontend/settings/components/OwnerIndexRedirect/OwnerIndexRedirect.test.tsx
@@ -2,11 +2,11 @@ import { screen } from '@testing-library/react';
 import { Route, Routes } from 'react-router-dom';
 import { OwnerIndexRedirect } from './OwnerIndexRedirect';
 import { renderWithProviders } from '../../testing/mocks';
-import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
-import { QueryKey } from 'app-shared/types/QueryKey';
 import { user as userMock } from 'app-shared/mocks/mocks';
+import { textMock } from '@studio/testing/mocks/i18nMock';
 import { RoutePaths as UserRoutePaths } from '../../features/user/routes/RoutePaths';
 import { RoutePaths as OrgRoutePaths } from '../../features/orgs/routes/RoutePaths';
+
 const userWithLogin = { ...userMock, login: 'testuser' };
 
 const mockEnvironment: { environment: { featureFlags: { studioOidc: boolean } } | null } = {
@@ -17,6 +17,12 @@ jest.mock('app-shared/contexts/EnvironmentConfigContext', () => ({
 }));
 jest.mock('../NoOrgSelected/NoOrgSelected', () => ({
   NoOrgSelected: () => <div data-testid='no-org-selected' />,
+}));
+
+const mockUseUserQuery = jest.fn();
+jest.mock('app-shared/hooks/queries', () => ({
+  ...jest.requireActual('app-shared/hooks/queries'),
+  useUserQuery: () => mockUseUserQuery(),
 }));
 
 const RoutedOwnerIndexRedirect = () => (
@@ -31,20 +37,13 @@ const RoutedOwnerIndexRedirect = () => (
   </Routes>
 );
 
-const renderOwnerIndexRedirect = (initialPath: string, seedUser = true) => {
-  const queryClient = createQueryClientMock();
-  if (seedUser) {
-    queryClient.setQueryData([QueryKey.CurrentUser], userWithLogin);
-  }
-  return renderWithProviders(<RoutedOwnerIndexRedirect />, {
-    queryClient,
-    initialEntries: [initialPath],
-  });
-};
+const renderOwnerIndexRedirect = (initialPath: string) =>
+  renderWithProviders(<RoutedOwnerIndexRedirect />, { initialEntries: [initialPath] });
 
 describe('OwnerIndexRedirect', () => {
   beforeEach(() => {
     mockEnvironment.environment = { featureFlags: { studioOidc: true } };
+    mockUseUserQuery.mockReturnValue({ isPending: false, isError: false, data: userWithLogin });
   });
 
   afterEach(() => jest.clearAllMocks());
@@ -77,10 +76,17 @@ describe('OwnerIndexRedirect', () => {
   });
 
   it('renders nothing when user data is not yet available', () => {
-    renderOwnerIndexRedirect('/ttd', false);
+    mockUseUserQuery.mockReturnValue({ isPending: true, isError: false, data: undefined });
+    renderOwnerIndexRedirect('/ttd');
     expect(screen.queryByText('User page')).not.toBeInTheDocument();
     expect(screen.queryByText('Bot accounts page')).not.toBeInTheDocument();
     expect(screen.queryByText('Contact points page')).not.toBeInTheDocument();
     expect(screen.queryByTestId('no-org-selected')).not.toBeInTheDocument();
+  });
+
+  it('renders an error page when the user query fails', () => {
+    mockUseUserQuery.mockReturnValue({ isPending: false, isError: true, data: undefined });
+    renderOwnerIndexRedirect('/ttd');
+    expect(screen.getByText(textMock('general.page_error_title'))).toBeInTheDocument();
   });
 });

--- a/src/Designer/frontend/settings/components/OwnerIndexRedirect/OwnerIndexRedirect.test.tsx
+++ b/src/Designer/frontend/settings/components/OwnerIndexRedirect/OwnerIndexRedirect.test.tsx
@@ -18,15 +18,6 @@ jest.mock('app-shared/contexts/EnvironmentConfigContext', () => ({
 jest.mock('../NoOrgSelected/NoOrgSelected', () => ({
   NoOrgSelected: () => <div data-testid='no-org-selected' />,
 }));
-jest.mock('../NotFound/NotFound', () => ({
-  NotFound: () => <div data-testid='not-found' />,
-}));
-
-const mockUseFeatureFlag = jest.fn();
-jest.mock('@studio/feature-flags', () => ({
-  ...jest.requireActual('@studio/feature-flags'),
-  useFeatureFlag: () => mockUseFeatureFlag(),
-}));
 
 const RoutedOwnerIndexRedirect = () => (
   <Routes>
@@ -54,7 +45,6 @@ const renderOwnerIndexRedirect = (initialPath: string, seedUser = true) => {
 describe('OwnerIndexRedirect', () => {
   beforeEach(() => {
     mockEnvironment.environment = { featureFlags: { studioOidc: true } };
-    mockUseFeatureFlag.mockReturnValue(false);
   });
 
   afterEach(() => jest.clearAllMocks());
@@ -71,7 +61,6 @@ describe('OwnerIndexRedirect', () => {
 
   it('renders the no-org-selected message when owner matches the logged-in user and studioOidc is disabled', () => {
     mockEnvironment.environment = { featureFlags: { studioOidc: false } };
-    mockUseFeatureFlag.mockReturnValue(true);
     renderOwnerIndexRedirect('/testuser');
     expect(screen.getByTestId('no-org-selected')).toBeInTheDocument();
   });
@@ -83,16 +72,8 @@ describe('OwnerIndexRedirect', () => {
 
   it('redirects to the contact-points page when owner is an org and studioOidc is disabled', () => {
     mockEnvironment.environment = { featureFlags: { studioOidc: false } };
-    mockUseFeatureFlag.mockReturnValue(true);
     renderOwnerIndexRedirect('/ttd');
     expect(screen.getByText('Contact points page')).toBeInTheDocument();
-  });
-
-  it('renders a not-found page when neither studioOidc nor Admin flag is enabled', () => {
-    mockEnvironment.environment = { featureFlags: { studioOidc: false } };
-    mockUseFeatureFlag.mockReturnValue(false);
-    renderOwnerIndexRedirect('/ttd');
-    expect(screen.getByTestId('not-found')).toBeInTheDocument();
   });
 
   it('renders nothing when user data is not yet available', () => {
@@ -101,6 +82,5 @@ describe('OwnerIndexRedirect', () => {
     expect(screen.queryByText('Bot accounts page')).not.toBeInTheDocument();
     expect(screen.queryByText('Contact points page')).not.toBeInTheDocument();
     expect(screen.queryByTestId('no-org-selected')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('not-found')).not.toBeInTheDocument();
   });
 });

--- a/src/Designer/frontend/settings/components/OwnerIndexRedirect/OwnerIndexRedirect.tsx
+++ b/src/Designer/frontend/settings/components/OwnerIndexRedirect/OwnerIndexRedirect.tsx
@@ -5,8 +5,6 @@ import { RoutePaths as OrgRoutePaths } from '../../features/orgs/routes/RoutePat
 import { useRequiredRoutePathsParams } from 'settings/hooks/useRequiredRoutePathsParams';
 import { useEnvironmentConfig } from 'app-shared/contexts/EnvironmentConfigContext';
 import { NoOrgSelected } from '../NoOrgSelected/NoOrgSelected';
-import { NotFound } from '../NotFound/NotFound';
-import { FeatureFlag, useFeatureFlag } from '@studio/feature-flags';
 import { StudioCenter, StudioPageSpinner } from '@studio/components';
 import { StudioPageError } from 'app-shared/components';
 import { useTranslation } from 'react-i18next';
@@ -18,7 +16,6 @@ export const OwnerIndexRedirect = () => {
   const { data: user, isPending: isUserPending, isError: isUserError } = useUserQuery();
   const { environment, isPending: isEnvironmentPending } = useEnvironmentConfig();
   const studioOidc = environment?.featureFlags?.studioOidc;
-  const isAdminEnabled = useFeatureFlag(FeatureFlag.Admin);
 
   if (isUserPending || isEnvironmentPending) {
     return (
@@ -32,9 +29,6 @@ export const OwnerIndexRedirect = () => {
     return <StudioPageError />;
   }
 
-  if (!studioOidc && !isAdminEnabled) {
-    return <NotFound />;
-  }
   if (StringUtils.areCaseInsensitiveEqual(owner, user.login)) {
     return studioOidc ? <Navigate to={UserRoutePaths.ApiKeys} replace /> : <NoOrgSelected />;
   }

--- a/src/Designer/frontend/settings/features/orgs/components/Menu/Menu.test.tsx
+++ b/src/Designer/frontend/settings/features/orgs/components/Menu/Menu.test.tsx
@@ -2,19 +2,12 @@ import { screen } from '@testing-library/react';
 import { Menu } from './Menu';
 import { renderWithProviders } from '../../../../testing/mocks';
 import { textMock } from '@studio/testing/mocks/i18nMock';
-import { FeatureFlag } from '@studio/feature-flags';
 
 const mockNavigate = jest.fn();
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useNavigate: () => mockNavigate,
-}));
-
-const mockUseFeatureFlag = jest.fn();
-jest.mock('@studio/feature-flags', () => ({
-  ...jest.requireActual('@studio/feature-flags'),
-  useFeatureFlag: (flag: FeatureFlag) => mockUseFeatureFlag(flag),
 }));
 
 const mockEnvironment: { environment: { featureFlags: { studioOidc: boolean } } | null } = {
@@ -45,14 +38,12 @@ describe('Menu', () => {
   afterEach(() => jest.clearAllMocks());
 
   it('renders the bot accounts tab when studioOidc is enabled', () => {
-    mockUseFeatureFlag.mockReturnValue(false);
     mockEnvironment.environment = { featureFlags: { studioOidc: true } };
     renderMenu();
     expect(getBotAccountsTab()).toBeInTheDocument();
   });
 
   it('does not render the bot accounts tab when studioOidc is disabled', () => {
-    mockUseFeatureFlag.mockReturnValue(false);
     mockEnvironment.environment = { featureFlags: { studioOidc: false } };
     renderMenu();
     expect(
@@ -62,19 +53,7 @@ describe('Menu', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('does not render the contact points tab when Admin is disabled', () => {
-    mockUseFeatureFlag.mockReturnValue(false);
-    mockEnvironment.environment = { featureFlags: { studioOidc: true } };
-    renderMenu();
-    expect(
-      screen.queryByRole('tab', {
-        name: textMock('settings.orgs.contact_points.menu.contact_points'),
-      }),
-    ).not.toBeInTheDocument();
-  });
-
-  it('renders the contact points tab when Admin is enabled', () => {
-    mockUseFeatureFlag.mockImplementation((flag: FeatureFlag) => flag === FeatureFlag.Admin);
+  it('renders the contact points tab', () => {
     mockEnvironment.environment = { featureFlags: { studioOidc: false } };
     renderMenu();
     expect(getContactPointsTab()).toBeInTheDocument();

--- a/src/Designer/frontend/settings/features/orgs/components/Menu/Menu.test.tsx
+++ b/src/Designer/frontend/settings/features/orgs/components/Menu/Menu.test.tsx
@@ -1,4 +1,5 @@
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Menu } from './Menu';
 import { renderWithProviders } from '../../../../testing/mocks';
 import { textMock } from '@studio/testing/mocks/i18nMock';
@@ -57,5 +58,13 @@ describe('Menu', () => {
     mockEnvironment.environment = { featureFlags: { studioOidc: false } };
     renderMenu();
     expect(getContactPointsTab()).toBeInTheDocument();
+  });
+
+  it('navigates when a tab is clicked', async () => {
+    const user = userEvent.setup();
+    mockEnvironment.environment = { featureFlags: { studioOidc: false } };
+    renderMenu();
+    await user.click(getContactPointsTab());
+    expect(mockNavigate).toHaveBeenCalledWith({ pathname: 'contact-points' });
   });
 });

--- a/src/Designer/frontend/settings/features/orgs/components/Menu/Menu.tsx
+++ b/src/Designer/frontend/settings/features/orgs/components/Menu/Menu.tsx
@@ -4,7 +4,6 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { RobotSmileIcon, BellIcon } from '@studio/icons';
 import { useTranslation } from 'react-i18next';
 import { RoutePaths } from '../../routes/RoutePaths';
-import { FeatureFlag, useFeatureFlag } from '@studio/feature-flags';
 import { useEnvironmentConfig } from 'app-shared/contexts/EnvironmentConfigContext';
 
 export function Menu(): ReactElement {
@@ -12,7 +11,6 @@ export function Menu(): ReactElement {
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const selectedTabId = pathname.split('/').at(-1);
-  const adminEnabled = useFeatureFlag(FeatureFlag.Admin);
   const { environment } = useEnvironmentConfig();
   const studioOidc = environment?.featureFlags?.studioOidc;
   const menuTabs = [
@@ -25,15 +23,11 @@ export function Menu(): ReactElement {
           },
         ]
       : []),
-    ...(adminEnabled
-      ? [
-          {
-            tabId: RoutePaths.ContactPoints,
-            tabName: t('settings.orgs.contact_points.menu.contact_points'),
-            icon: <BellIcon />,
-          },
-        ]
-      : []),
+    {
+      tabId: RoutePaths.ContactPoints,
+      tabName: t('settings.orgs.contact_points.menu.contact_points'),
+      icon: <BellIcon />,
+    },
   ];
   return (
     <StudioContentMenu

--- a/src/Designer/frontend/settings/layouts/OrgPageLayout/OrgPageLayout.test.tsx
+++ b/src/Designer/frontend/settings/layouts/OrgPageLayout/OrgPageLayout.test.tsx
@@ -12,19 +12,6 @@ jest.mock('../../features/orgs/layout/PageLayout', () => ({
   PageLayout: () => <div>PageLayout</div>,
 }));
 
-const mockEnvironment: { environment: { featureFlags: { studioOidc: boolean } } | null } = {
-  environment: { featureFlags: { studioOidc: true } },
-};
-jest.mock('app-shared/contexts/EnvironmentConfigContext', () => ({
-  useEnvironmentConfig: () => mockEnvironment,
-}));
-
-const mockUseFeatureFlag = jest.fn();
-jest.mock('@studio/feature-flags', () => ({
-  ...jest.requireActual('@studio/feature-flags'),
-  useFeatureFlag: () => mockUseFeatureFlag(),
-}));
-
 const orgUser = { ...userMock, login: 'testuser' };
 
 const RoutedOrgPageLayout = () => (
@@ -54,13 +41,6 @@ const renderOrgPageLayout = ({
 };
 
 describe('OrgPageLayout', () => {
-  beforeEach(() => {
-    mockEnvironment.environment = { featureFlags: { studioOidc: true } };
-    mockUseFeatureFlag.mockReturnValue(false);
-  });
-
-  afterEach(() => jest.clearAllMocks());
-
   it('renders PageLayout when owner is an org (not the logged-in user)', () => {
     renderOrgPageLayout({ initialEntries: ['/ttd/bot-accounts'] });
     expect(screen.getByText('PageLayout')).toBeInTheDocument();
@@ -101,21 +81,5 @@ describe('OrgPageLayout', () => {
       seedCurrentUser: false,
     });
     await screen.findByRole('heading', { name: textMock('general.page_error_title') });
-  });
-
-  it('renders a not-found page when neither studioOidc nor Admin flag is enabled', () => {
-    mockEnvironment.environment = { featureFlags: { studioOidc: false } };
-    mockUseFeatureFlag.mockReturnValue(false);
-    renderOrgPageLayout();
-    expect(
-      screen.getByRole('heading', { name: textMock('not_found_page.heading') }),
-    ).toBeInTheDocument();
-  });
-
-  it('renders PageLayout when only Admin flag is enabled', () => {
-    mockEnvironment.environment = { featureFlags: { studioOidc: false } };
-    mockUseFeatureFlag.mockReturnValue(true);
-    renderOrgPageLayout();
-    expect(screen.getByText('PageLayout')).toBeInTheDocument();
   });
 });

--- a/src/Designer/frontend/settings/layouts/OrgPageLayout/OrgPageLayout.tsx
+++ b/src/Designer/frontend/settings/layouts/OrgPageLayout/OrgPageLayout.tsx
@@ -5,19 +5,14 @@ import { StudioCenter, StudioPageSpinner } from '@studio/components';
 import { StudioPageError } from 'app-shared/components';
 import { useTranslation } from 'react-i18next';
 import { useRequiredRoutePathsParams } from 'settings/hooks/useRequiredRoutePathsParams';
-import { useEnvironmentConfig } from 'app-shared/contexts/EnvironmentConfigContext';
-import { FeatureFlag, useFeatureFlag } from '@studio/feature-flags';
 import { StringUtils } from '@studio/pure-functions';
 
 export const OrgPageLayout = () => {
   const { t } = useTranslation();
   const { owner: org } = useRequiredRoutePathsParams(['owner']);
   const { data: user, isPending: isUserPending, isError: isUserError } = useUserQuery();
-  const { environment, isPending: isEnvironmentPending } = useEnvironmentConfig();
-  const studioOidc = environment?.featureFlags?.studioOidc;
-  const isAdminEnabled = useFeatureFlag(FeatureFlag.Admin);
 
-  if (isUserPending || isEnvironmentPending) {
+  if (isUserPending) {
     return (
       <StudioCenter>
         <StudioPageSpinner spinnerTitle={t('general.loading')} />
@@ -30,10 +25,6 @@ export const OrgPageLayout = () => {
   }
 
   if (StringUtils.areCaseInsensitiveEqual(org, user?.login ?? '')) {
-    return <NotFound />;
-  }
-
-  if (!studioOidc && !isAdminEnabled) {
     return <NotFound />;
   }
 

--- a/src/Designer/frontend/settings/layouts/UserPageLayout/UserPageLayout.test.tsx
+++ b/src/Designer/frontend/settings/layouts/UserPageLayout/UserPageLayout.test.tsx
@@ -12,19 +12,6 @@ jest.mock('../../features/user/layout/PageLayout', () => ({
   PageLayout: () => <div>PageLayout</div>,
 }));
 
-const mockEnvironment: { environment: { featureFlags: { studioOidc: boolean } } | null } = {
-  environment: { featureFlags: { studioOidc: true } },
-};
-jest.mock('app-shared/contexts/EnvironmentConfigContext', () => ({
-  useEnvironmentConfig: () => mockEnvironment,
-}));
-
-const mockUseFeatureFlag = jest.fn();
-jest.mock('@studio/feature-flags', () => ({
-  ...jest.requireActual('@studio/feature-flags'),
-  useFeatureFlag: () => mockUseFeatureFlag(),
-}));
-
 const loggedInUser = { ...userMock, login: 'testuser' };
 
 const RoutedUserPageLayout = () => (
@@ -54,13 +41,6 @@ const renderUserPageLayout = ({
 };
 
 describe('UserPageLayout', () => {
-  beforeEach(() => {
-    mockEnvironment.environment = { featureFlags: { studioOidc: true } };
-    mockUseFeatureFlag.mockReturnValue(false);
-  });
-
-  afterEach(() => jest.clearAllMocks());
-
   it('renders PageLayout when owner matches the logged-in user', () => {
     renderUserPageLayout({ initialEntries: ['/testuser/profile'] });
     expect(screen.getByText('PageLayout')).toBeInTheDocument();
@@ -101,21 +81,5 @@ describe('UserPageLayout', () => {
       seedCurrentUser: false,
     });
     await screen.findByRole('heading', { name: textMock('general.page_error_title') });
-  });
-
-  it('renders a not-found page when neither studioOidc nor Admin flag is enabled', () => {
-    mockEnvironment.environment = { featureFlags: { studioOidc: false } };
-    mockUseFeatureFlag.mockReturnValue(false);
-    renderUserPageLayout();
-    expect(
-      screen.getByRole('heading', { name: textMock('not_found_page.heading') }),
-    ).toBeInTheDocument();
-  });
-
-  it('renders PageLayout when studioOidc is disabled but Admin flag is enabled', () => {
-    mockEnvironment.environment = { featureFlags: { studioOidc: false } };
-    mockUseFeatureFlag.mockReturnValue(true);
-    renderUserPageLayout();
-    expect(screen.getByText('PageLayout')).toBeInTheDocument();
   });
 });

--- a/src/Designer/frontend/settings/layouts/UserPageLayout/UserPageLayout.tsx
+++ b/src/Designer/frontend/settings/layouts/UserPageLayout/UserPageLayout.tsx
@@ -5,19 +5,14 @@ import { StudioCenter, StudioPageSpinner } from '@studio/components';
 import { StudioPageError } from 'app-shared/components';
 import { useTranslation } from 'react-i18next';
 import { useRequiredRoutePathsParams } from 'settings/hooks/useRequiredRoutePathsParams';
-import { useEnvironmentConfig } from 'app-shared/contexts/EnvironmentConfigContext';
-import { FeatureFlag, useFeatureFlag } from '@studio/feature-flags';
 import { StringUtils } from '@studio/pure-functions';
 
 export const UserPageLayout = () => {
   const { t } = useTranslation();
   const { owner } = useRequiredRoutePathsParams(['owner']);
   const { data: user, isPending: isUserPending, isError: isUserError } = useUserQuery();
-  const { environment, isPending: isEnvironmentPending } = useEnvironmentConfig();
-  const studioOidc = environment?.featureFlags?.studioOidc;
-  const isAdminEnabled = useFeatureFlag(FeatureFlag.Admin);
 
-  if (isUserPending || isEnvironmentPending) {
+  if (isUserPending) {
     return (
       <StudioCenter>
         <StudioPageSpinner spinnerTitle={t('general.loading')} />
@@ -30,10 +25,6 @@ export const UserPageLayout = () => {
   }
 
   if (!StringUtils.areCaseInsensitiveEqual(owner, user?.login ?? '')) {
-    return <NotFound />;
-  }
-
-  if (!studioOidc && !isAdminEnabled) {
     return <NotFound />;
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Remove Admin feature flag
- Add some test coverage

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * User settings is now always shown in profile menus across the application.
  * Admin navigation items are consistently displayed and no longer hidden behind feature flags.
  * Contact Points is now always available in organisation settings.
  * Routing and loading behaviour no longer depends on the removed Admin feature flag; loading indicators now rely on user data readiness, with Not Found driven by owner/user login matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->