### PR TITLE
fix: update Dockerfile to .NET 10 during v8->v9 app upgrade

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -8,6 +8,10 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+### Fixed
+
+- Update `studioctl app upgrade v9` to rewrite the app `Dockerfile` .NET base images to match the upgraded target framework (`net10.0`), so v9 apps build and publish on the correct .NET SDK/runtime images.
+
 ## [0.1.0-preview.14] - 2026-06-08
 
 ### Changed

--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -10,7 +10,7 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ### Fixed
 
-- Update `studioctl app upgrade v9` to rewrite the app `Dockerfile` .NET base images to match the upgraded target framework (`net10.0`), so v9 apps build and publish on the correct .NET SDK/runtime images.
+- Update `studioctl app upgrade v9` to rewrite the app `Dockerfile` .NET base images to match the upgraded target framework (`net10.0`).
 
 ## [0.1.0-preview.14] - 2026-06-08
 

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/DockerfileMigration.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/DockerfileMigration.cs
@@ -55,7 +55,7 @@ internal static class DockerfileMigration
     }
 
     /// <summary>
-    /// Derives the .NET image tag from the target framework, e.g. "net10.0" =&gt; "10.0-alpine".
+    /// Derives the .NET image tag from the target framework, e.g. "net10.0" => "10.0-alpine".
     /// </summary>
     private static string GetImageTag(string targetFramework)
     {

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/DockerfileMigration.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/DockerfileMigration.cs
@@ -1,0 +1,77 @@
+using System.Text.RegularExpressions;
+
+namespace Altinn.Studio.Cli.Upgrade.v8Tov9;
+
+/// <summary>
+/// Updates the .NET base image tags in the app Dockerfile to match the target framework
+/// of the upgraded project. Without this, a v9 app left targeting net10.0 would still be
+/// built and published with the .NET 8 SDK/runtime images and fail to build.
+/// </summary>
+internal static class DockerfileMigration
+{
+    // Matches "FROM mcr.microsoft.com/dotnet/{sdk|aspnet}:<tag>[ AS <stage>]" and rewrites
+    // the image tag.
+    private static readonly Regex _sdkImagePattern = new(
+        @"(^FROM mcr\.microsoft\.com/dotnet/sdk):(.+?)( AS .*)?$",
+        RegexOptions.None,
+        TimeSpan.FromSeconds(1)
+    );
+
+    private static readonly Regex _aspNetImagePattern = new(
+        @"(^FROM mcr\.microsoft\.com/dotnet/aspnet):(.+?)( AS .*)?$",
+        RegexOptions.None,
+        TimeSpan.FromSeconds(1)
+    );
+
+    internal static async Task Migrate(string projectFolder, string targetFramework)
+    {
+        var dockerfilePath = Path.Combine(projectFolder, "Dockerfile");
+        if (!File.Exists(dockerfilePath))
+        {
+            await UpgradeConsole.Out.WriteLineAsync("No Dockerfile found, skipping Dockerfile migration");
+            return;
+        }
+
+        var imageTag = GetImageTag(targetFramework);
+        var lines = await File.ReadAllLinesAsync(dockerfilePath);
+        var updated = Array.ConvertAll(lines, line => ReplaceImageTag(line, imageTag));
+
+        if (!lines.SequenceEqual(updated))
+        {
+            await File.WriteAllLinesAsync(dockerfilePath, updated);
+            await UpgradeConsole.Out.WriteLineAsync($"Dockerfile updated to .NET image tag '{imageTag}'");
+            return;
+        }
+
+        if (lines.Any(IsDotnetBaseImage))
+        {
+            await UpgradeConsole.Out.WriteLineAsync($"Dockerfile already targets .NET image tag '{imageTag}'");
+            return;
+        }
+
+        await UpgradeConsole.Error.WriteLineAsync(
+            "Warning: No .NET base image found in Dockerfile. Update the .NET version manually to match the app."
+        );
+    }
+
+    /// <summary>
+    /// Derives the .NET image tag from the target framework, e.g. "net10.0" =&gt; "10.0-alpine".
+    /// </summary>
+    private static string GetImageTag(string targetFramework)
+    {
+        var version = targetFramework.StartsWith("net", StringComparison.OrdinalIgnoreCase)
+            ? targetFramework["net".Length..]
+            : targetFramework;
+        return $"{version}-alpine";
+    }
+
+    private static bool IsDotnetBaseImage(string line) =>
+        _sdkImagePattern.IsMatch(line) || _aspNetImagePattern.IsMatch(line);
+
+    private static string ReplaceImageTag(string line, string imageTag)
+    {
+        line = _sdkImagePattern.Replace(line, $"$1:{imageTag}$3");
+        line = _aspNetImagePattern.Replace(line, $"$1:{imageTag}$3");
+        return line;
+    }
+}

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/DockerfileMigration.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/DockerfileMigration.cs
@@ -4,13 +4,11 @@ namespace Altinn.Studio.Cli.Upgrade.v8Tov9;
 
 /// <summary>
 /// Updates the .NET base image tags in the app Dockerfile to match the target framework
-/// of the upgraded project. Without this, a v9 app left targeting net10.0 would still be
-/// built and published with the .NET 8 SDK/runtime images and fail to build.
+/// of the upgraded project.
 /// </summary>
 internal static class DockerfileMigration
 {
-    // Matches "FROM mcr.microsoft.com/dotnet/{sdk|aspnet}:<tag>[ AS <stage>]" and rewrites
-    // the image tag.
+    // Matches "FROM mcr.microsoft.com/dotnet/{sdk|aspnet}:<tag>[ AS <stage>]"
     private static readonly Regex _sdkImagePattern = new(
         @"(^FROM mcr\.microsoft\.com/dotnet/sdk):(.+?)( AS .*)?$",
         RegexOptions.None,

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/V8Tov9Upgrade.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/V8Tov9Upgrade.cs
@@ -69,6 +69,9 @@ internal static class V8Tov9Upgrade
                 );
                 returnCode = await UpgradeProjectFile(projectFile, targetVersion, options.TargetFramework);
             }
+
+            if (returnCode == 0)
+                returnCode = await MigrateDockerfile(projectFolder, options.TargetFramework);
         }
 
         options.CancellationToken.ThrowIfCancellationRequested();
@@ -118,6 +121,20 @@ internal static class V8Tov9Upgrade
         catch (Exception ex)
         {
             await UpgradeConsole.Error.WriteLineAsync($"Error upgrading project file: {ex.Message}");
+            return 1;
+        }
+    }
+
+    static async Task<int> MigrateDockerfile(string projectFolder, string targetFramework)
+    {
+        try
+        {
+            await DockerfileMigration.Migrate(projectFolder, targetFramework);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            await UpgradeConsole.Error.WriteLineAsync($"Error migrating Dockerfile: {ex.Message}");
             return 1;
         }
     }


### PR DESCRIPTION
## Description

The `studioctl app upgrade v9` flow bumps `App/App.csproj` `<TargetFramework>` to `net10.0` (and the Altinn.App packages to the latest v9), but it never updated the app `Dockerfile`. The Dockerfile was left on the .NET 8 base images:

```
FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine ...
FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine ...
```

A `net10.0` project cannot be built/published by the .NET 8 SDK image, so an "upgraded to .NET 10" app fails to build in its container (`studioctl app build` / deploy). The .NET 10 migration was therefore incomplete.

This PR adds a Dockerfile migration step to the v8→v9 upgrade (`DockerfileMigration`) that rewrites the `dotnet/sdk` and `dotnet/aspnet` base-image tags to match the upgraded target framework (`net10.0` → `10.0-alpine`), discarding any stale `@sha256:<digest>` pin. The step:

- runs only when the csproj framework was actually bumped,
- is idempotent (no-op when already on the target tag),
- skips gracefully when the app has no `Dockerfile`,
- warns (instead of silently reporting success) when a customized Dockerfile contains no recognizable .NET base image.

The image tag is derived from the same `TargetFramework` already threaded through the upgrade, so the csproj and Dockerfile stay in sync.

Addresses #19169 (sub-issue of #19167). Note: the "point to latest v9 from NuGet + update `App.csproj`" part of #19169/#19168 was already fixed in #19063 — confirmed not reproducible against a real app; this PR completes the remaining .NET 10 (Dockerfile) gap.

## Verification

Reproduced against a real app with the released `studioctl` (preview.14, which already contains #19063):

```
$ studioctl app clone --env prod Jondyr/dev
$ studioctl app upgrade           # defaults to v9
...
# App/App.csproj: net8.0 -> net10.0, Altinn.App.* 8.3.5 -> 9.0.0-preview.1  (correct)
# Dockerfile: UNCHANGED, still dotnet/sdk:8.0-alpine + dotnet/aspnet:8.0-alpine  (the bug)
```

Verified the fix by running the actual upgrade source (including the new `DockerfileMigration`) against the real app's Dockerfile and the digest-pinned app template:

```
[net8 -> needs change]      Dockerfile updated to .NET image tag '10.0-alpine'
                            FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
                            FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS final   (sha256 pin dropped)
[already net10]             Dockerfile already targets .NET image tag '10.0-alpine'      (no-op)
[custom, no dotnet image]   Warning: No .NET base image found in Dockerfile. ...         (no false success)
[missing dockerfile]        No Dockerfile found, skipping Dockerfile migration
```

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings (`dotnet build` + `csharpier check`)
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out) — studioctl-server has no C# test project; verified via manual reproduction instead


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `studioctl app upgrade v9` to rewrite .NET base image tags in an app’s Dockerfile to match the upgraded target framework (for example, net10.0 → 10.0-alpine), improving build and publish compatibility. If no matching tags are found, a warning is shown for manual updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->