### PR TITLE
test: run app integration localtest in dev mode

### DIFF
--- a/src/App/backend/test/Altinn.App.Integration.Tests/ModuleInitializer.cs
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/ModuleInitializer.cs
@@ -8,6 +8,7 @@ internal static class ModuleInitializer
     [ModuleInitializer]
     public static void Init()
     {
+        Environment.SetEnvironmentVariable("STUDIOCTL_INTERNAL_DEV", "true");
         Verifier.DerivePathInfo(
             (file, _, type, method) => new(Path.Join(Path.GetDirectoryName(file), "_snapshots"), type.Name, method.Name)
         );

--- a/src/App/backend/test/Altinn.App.Integration.Tests/README.md
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/README.md
@@ -7,7 +7,7 @@ This project contains scenario-based integration tests for Altinn apps. The test
 - `studioctl` installed and available on `PATH`
 - A local container runtime usable by `studioctl env up`
 
-The harness starts localtest with `studioctl env up --detach` if no environment is running. If localtest was already running, the harness reuses it and does not stop it during cleanup.
+The harness starts localtest with `studioctl env up --detach` if no environment is running. It always sets `STUDIOCTL_INTERNAL_DEV=true` on its `studioctl` subprocesses so localtest uses images built from the current monorepo checkout when available. If localtest was already running, the harness reuses it and does not stop it during cleanup.
 
 ## Architecture
 


### PR DESCRIPTION
## Description

Ensure App backend integration tests run `studioctl` with `STUDIOCTL_INTERNAL_DEV=true` by setting it during the test assembly module initialization.

This makes locally-started `studioctl env up` use dev-mode localtest images from the current monorepo checkout, including workflow-engine, instead of depending on published images.

Updated the integration test README to document the behavior.

## Verification

- [x] Related issues are connected (if applicable) - not applicable
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out) - covered by existing integration fixture path

Commands run:

```bash
dotnet build test/Altinn.App.Integration.Tests/Altinn.App.Integration.Tests.csproj -v m
SKIP_FRONTEND_BUILD=true dotnet test test/Altinn.App.Integration.Tests/Altinn.App.Integration.Tests.csproj -v m --filter "FullyQualifiedName~BasicAppTests.AppConnectivity_Localtest" --logger "console;verbosity=detailed"
git diff --check
```

Observed during the selected integration test:

```text
Building and starting localtest environment (dev mode)...
localtest-workflow-engine: building
Passed Altinn.App.Integration.Tests.Basic.BasicAppTests.AppConnectivity_Localtest
```
