### PR TITLE
fix: migrate openapi namespace during v9 upgrade

### DIFF
--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/UsingNamespaceMigration.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/UsingNamespaceMigration.cs
@@ -1,0 +1,144 @@
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Altinn.Studio.Cli.Upgrade.v8Tov9;
+
+internal sealed class UsingNamespaceMigration
+{
+    private readonly string _projectFile;
+
+    public UsingNamespaceMigration(string projectFile)
+    {
+        _projectFile = projectFile;
+    }
+
+    public bool Migrate(string oldNamespace, string newNamespace, Regex pathMatcher)
+    {
+        var csharpFiles = GetMatchingCSharpFiles(pathMatcher).ToArray();
+        if (csharpFiles.Length == 0)
+        {
+            UpgradeConsole.WriteLine($"Namespace migration skipped; no C# files matched {pathMatcher}");
+            return false;
+        }
+
+        var migratedAnyFile = false;
+        foreach (var csharpFile in csharpFiles)
+        {
+            migratedAnyFile |= MigrateFile(csharpFile, oldNamespace, newNamespace);
+        }
+
+        if (!migratedAnyFile)
+        {
+            UpgradeConsole.WriteLine(
+                $"Namespace migration skipped; old namespace '{oldNamespace}' not found in matching files"
+            );
+        }
+
+        return migratedAnyFile;
+    }
+
+    private IEnumerable<string> GetMatchingCSharpFiles(Regex pathMatcher)
+    {
+        var projectDirectory = Path.GetDirectoryName(_projectFile);
+        if (projectDirectory is null || !Directory.Exists(projectDirectory))
+        {
+            yield break;
+        }
+
+        foreach (var csharpFile in Directory.EnumerateFiles(projectDirectory, "*.cs", SearchOption.AllDirectories))
+        {
+            var relativePath = Path.GetRelativePath(projectDirectory, csharpFile);
+            if (pathMatcher.IsMatch(relativePath))
+            {
+                yield return csharpFile;
+            }
+        }
+    }
+
+    private static bool MigrateFile(string csharpFile, string oldNamespace, string newNamespace)
+    {
+        var content = File.ReadAllText(csharpFile);
+        var root = CSharpSyntaxTree.ParseText(content).GetCompilationUnitRoot();
+        var oldUsings = root.DescendantNodes().OfType<UsingDirectiveSyntax>().Where(IsOldUsing).ToArray();
+        if (oldUsings.Length == 0)
+        {
+            return false;
+        }
+
+        var scopesWithNewUsing = root.DescendantNodes()
+            .OfType<UsingDirectiveSyntax>()
+            .Where(IsNewUsing)
+            .Select(static usingDirective => usingDirective.Parent)
+            .OfType<SyntaxNode>()
+            .ToHashSet();
+        var updatedRoot = UpdateUsings(root, oldUsings, newNamespace, scopesWithNewUsing);
+
+        File.WriteAllText(csharpFile, updatedRoot.ToFullString());
+        UpgradeConsole.WriteLine($"Namespace migrated in {csharpFile}: {oldNamespace} -> {newNamespace}");
+        return true;
+
+        bool IsOldUsing(UsingDirectiveSyntax usingDirective) =>
+            usingDirective.Alias is null && usingDirective.Name?.ToString() == oldNamespace;
+
+        bool IsNewUsing(UsingDirectiveSyntax usingDirective) =>
+            usingDirective.Alias is null && usingDirective.Name?.ToString() == newNamespace;
+    }
+
+    private static CompilationUnitSyntax UpdateUsings(
+        CompilationUnitSyntax root,
+        UsingDirectiveSyntax[] oldUsings,
+        string newNamespace,
+        HashSet<SyntaxNode> scopesWithNewUsing
+    )
+    {
+        var trackedRoot = root.TrackNodes(oldUsings);
+        foreach (var oldUsingsInScope in oldUsings.GroupBy(static usingDirective => usingDirective.Parent))
+        {
+            var oldUsingsToRemove = oldUsingsInScope.AsEnumerable();
+            if (oldUsingsInScope.Key is not null && !scopesWithNewUsing.Contains(oldUsingsInScope.Key))
+            {
+                var firstOldUsing = trackedRoot.GetCurrentNode(oldUsingsInScope.First());
+                if (firstOldUsing is null)
+                {
+                    throw new InvalidOperationException("Failed to update using directive");
+                }
+
+                trackedRoot = ReplaceUsing(trackedRoot, firstOldUsing, newNamespace);
+                oldUsingsToRemove = oldUsingsInScope.Skip(1);
+            }
+
+            foreach (var oldUsing in oldUsingsToRemove)
+            {
+                var currentOldUsing = trackedRoot.GetCurrentNode(oldUsing);
+                if (currentOldUsing is not null)
+                {
+                    trackedRoot =
+                        trackedRoot.RemoveNode(currentOldUsing, SyntaxRemoveOptions.KeepNoTrivia)
+                        ?? throw new InvalidOperationException("Failed to remove using directive");
+                }
+            }
+        }
+
+        return trackedRoot;
+    }
+
+    private static CompilationUnitSyntax ReplaceUsing(
+        CompilationUnitSyntax root,
+        UsingDirectiveSyntax oldUsing,
+        string newNamespace
+    )
+    {
+        var oldName = oldUsing.Name;
+        if (oldName is null)
+        {
+            throw new InvalidOperationException("Using directive has no namespace");
+        }
+
+        return root.ReplaceNode(
+            oldUsing,
+            oldUsing.WithName(SyntaxFactory.ParseName(newNamespace).WithTriviaFrom(oldName))
+        );
+    }
+}

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/V8Tov9Upgrade.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/V8Tov9Upgrade.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
 using Altinn.Studio.Cli.Upgrade.ProjectFile;
 using Altinn.Studio.Cli.Upgrade.v8Tov9.IndexMigration;
 using Altinn.Studio.Cli.Upgrade.v8Tov9.LayoutSetsMigration;
@@ -23,6 +24,11 @@ internal sealed record V8Tov9UpgradeOptions(
 
 internal static class V8Tov9Upgrade
 {
+    private static readonly Regex _programCsPathMatcher = new(
+        @"^Program\.cs$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant
+    );
+
     internal static async Task<int> RunAsync(V8Tov9UpgradeOptions options)
     {
         using var outputScope = UpgradeConsole.Use(options.Output, options.Error);
@@ -77,6 +83,10 @@ internal static class V8Tov9Upgrade
 
         options.CancellationToken.ThrowIfCancellationRequested();
         if (returnCode == 0)
+            returnCode = await MigrateOpenApiNamespace(projectFile);
+
+        options.CancellationToken.ThrowIfCancellationRequested();
+        if (returnCode == 0)
             returnCode = await MigrateLaunchSettings(projectFile);
 
         options.CancellationToken.ThrowIfCancellationRequested();
@@ -128,6 +138,21 @@ internal static class V8Tov9Upgrade
         await rewriter.RemovePackageReference("Swashbuckle.AspNetCore");
         await UpgradeConsole.Out.WriteLineAsync("Swashbuckle.AspNetCore package reference removed");
         return 0;
+    }
+
+    static async Task<int> MigrateOpenApiNamespace(string projectFile)
+    {
+        try
+        {
+            var migration = new UsingNamespaceMigration(projectFile);
+            migration.Migrate("Microsoft.OpenApi.Models", "Microsoft.OpenApi", _programCsPathMatcher);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            await UpgradeConsole.Error.WriteLineAsync($"Error migrating OpenAPI namespace in Program.cs: {ex.Message}");
+            return 1;
+        }
     }
 
     static async Task<int> MigrateLaunchSettings(string projectFile)


### PR DESCRIPTION
## Description

Adds a v8-to-v9 upgrade migration for app `Program.cs` files after the Microsoft.OpenApi update.

The migration resolves `Program.cs` from the app project file being upgraded and rewrites actual C# using directives from `Microsoft.OpenApi.Models` to `Microsoft.OpenApi`. If the new namespace is already present, stale old namespace usings are removed.

## Verification

- [x] Related issues are connected (if applicable)
  - Not applicable; requested directly by @martinothamar.
- [x] **Your** code builds clean without any errors or warnings
  - `make build` in `src/cli/studioctl-server`: passed with `0 Warning(s), 0 Error(s)`.
- [x] Manual testing done (required)
  - Ran a reflection-based smoke test against the built `studioctl-server.dll` on a temp app project. It verified duplicate `using Microsoft.OpenApi.Models;` directives are removed and `using Microsoft.OpenApi;` remains.
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
  - Not added; there are currently no C# test projects for `studioctl-server` upgrade helpers in this tree.

Also ran:

```bash
git diff --check
```

which passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the v8-to-v9 upgrade to automatically migrate OpenAPI namespace references in project source files, reducing the need for manual changes.
* **Bug Fixes**
  * Improved upgrade cancellation responsiveness to stop work promptly when cancellation is requested.
* **Tests**
  * Added/updated coverage for the OpenAPI namespace migration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->