### PR TITLE
test: add studioctl server test project

### DIFF
--- a/src/cli/Directory.Packages.props
+++ b/src/cli/Directory.Packages.props
@@ -8,10 +8,12 @@
     <PackageVersion Include="AngleSharp" Version="1.4.0" />
     <PackageVersion Include="Jint" Version="4.6.4" />
     <PackageVersion Include="LibGit2Sharp" Version="0.31.0" />
+    <PackageVersion Include="coverlet.collector" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.11.2" />
     <PackageVersion Include="Microsoft.Build" Version="18.4.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="MinVer" Version="6.1.0" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="CSharpier.MsBuild" Version="1.2.6" />
@@ -21,5 +23,8 @@
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="18.4.0" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.4.0" />
     <PackageVersion Include="Microsoft.NET.StringTools" Version="18.4.0" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 </Project>

--- a/src/cli/studioctl-server.Tests/Upgrade/FakeAppProject.cs
+++ b/src/cli/studioctl-server.Tests/Upgrade/FakeAppProject.cs
@@ -1,0 +1,12 @@
+namespace Altinn.Studio.StudioctlServer.Tests.Upgrade;
+
+internal sealed record FakeAppProject(
+    string RootDirectory,
+    string AppDirectory,
+    string ProjectFile,
+    string ProgramFile,
+    string ProcessFile,
+    string ApplicationMetadataFile,
+    string UiDirectory,
+    string TextsDirectory
+);

--- a/src/cli/studioctl-server.Tests/Upgrade/FakeAppProjectFixture.cs
+++ b/src/cli/studioctl-server.Tests/Upgrade/FakeAppProjectFixture.cs
@@ -1,0 +1,205 @@
+using System.Globalization;
+
+namespace Altinn.Studio.StudioctlServer.Tests.Upgrade;
+
+internal sealed class FakeAppProjectFixture : IDisposable
+{
+    private readonly List<string> _rootDirectories = [];
+
+    public FakeAppProject Create(FakeAppSourceVersion sourceVersion, string? programCs = null)
+    {
+        var rootDirectory = Path.Combine(
+            Path.GetTempPath(),
+            "studioctl-server-test-app-" + Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture)
+        );
+        var appDirectory = Path.Combine(rootDirectory, "App");
+        var configDirectory = Path.Combine(appDirectory, "config");
+        var processDirectory = Path.Combine(configDirectory, "process");
+        var textsDirectory = Path.Combine(configDirectory, "texts");
+        var uiDirectory = Path.Combine(appDirectory, "ui");
+        var layoutDirectory = Path.Combine(uiDirectory, "form", "layouts");
+        var viewsDirectory = Path.Combine(appDirectory, "views", "Home");
+        var propertiesDirectory = Path.Combine(appDirectory, "Properties");
+
+        Directory.CreateDirectory(processDirectory);
+        Directory.CreateDirectory(textsDirectory);
+        Directory.CreateDirectory(layoutDirectory);
+        Directory.CreateDirectory(viewsDirectory);
+        Directory.CreateDirectory(propertiesDirectory);
+
+        var projectFile = Path.Combine(appDirectory, "App.csproj");
+        var programFile = Path.Combine(appDirectory, "Program.cs");
+        var processFile = Path.Combine(processDirectory, "process.bpmn");
+        var applicationMetadataFile = Path.Combine(configDirectory, "applicationmetadata.json");
+
+        File.WriteAllText(projectFile, CreateProjectFile(sourceVersion));
+        File.WriteAllText(programFile, programCs ?? CreateProgramCs());
+        File.WriteAllText(Path.Combine(appDirectory, "appsettings.json"), "{}" + Environment.NewLine);
+        File.WriteAllText(Path.Combine(propertiesDirectory, "launchSettings.json"), CreateLaunchSettings());
+        File.WriteAllText(applicationMetadataFile, CreateApplicationMetadata());
+        File.WriteAllText(processFile, CreateProcessFile());
+        File.WriteAllText(Path.Combine(textsDirectory, "resource.nb.json"), "[]" + Environment.NewLine);
+        File.WriteAllText(Path.Combine(uiDirectory, "layout-sets.json"), CreateLayoutSets());
+        File.WriteAllText(Path.Combine(layoutDirectory, "form.json"), CreateLayout());
+        File.WriteAllText(
+            Path.Combine(viewsDirectory, "Index.cshtml"),
+            "<div id=\"root\"></div>" + Environment.NewLine
+        );
+        File.WriteAllText(Path.Combine(rootDirectory, "Dockerfile"), CreateDockerfile(sourceVersion));
+
+        _rootDirectories.Add(rootDirectory);
+
+        return new FakeAppProject(
+            rootDirectory,
+            appDirectory,
+            projectFile,
+            programFile,
+            processFile,
+            applicationMetadataFile,
+            uiDirectory,
+            textsDirectory
+        );
+    }
+
+    public void Dispose()
+    {
+        foreach (var rootDirectory in _rootDirectories)
+        {
+            if (Directory.Exists(rootDirectory))
+            {
+                Directory.Delete(rootDirectory, recursive: true);
+            }
+        }
+    }
+
+    private static string CreateProjectFile(FakeAppSourceVersion sourceVersion)
+    {
+        var packageVersion = sourceVersion switch
+        {
+            FakeAppSourceVersion.V7 => "7.0.0",
+            FakeAppSourceVersion.V8 => "8.0.0",
+            _ => throw new ArgumentOutOfRangeException(nameof(sourceVersion), sourceVersion, null),
+        };
+        var targetFramework = sourceVersion switch
+        {
+            FakeAppSourceVersion.V7 => "net6.0",
+            FakeAppSourceVersion.V8 => "net8.0",
+            _ => throw new ArgumentOutOfRangeException(nameof(sourceVersion), sourceVersion, null),
+        };
+
+        return $$"""
+            <Project Sdk="Microsoft.NET.Sdk.Web">
+              <PropertyGroup>
+                <TargetFramework>{{targetFramework}}</TargetFramework>
+                <RootNamespace>Altinn.App</RootNamespace>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Altinn.App.Api" Version="{{packageVersion}}" />
+                <PackageReference Include="Altinn.App.Core" Version="{{packageVersion}}" />
+              </ItemGroup>
+            </Project>
+            """;
+    }
+
+    private static string CreateDockerfile(FakeAppSourceVersion sourceVersion)
+    {
+        var targetFramework = sourceVersion switch
+        {
+            FakeAppSourceVersion.V7 => "net6.0",
+            FakeAppSourceVersion.V8 => "net8.0",
+            _ => throw new ArgumentOutOfRangeException(nameof(sourceVersion), sourceVersion, null),
+        };
+
+        return $$"""
+            FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+            WORKDIR /app
+
+            FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+            WORKDIR /src
+            COPY App/App.csproj App/
+            RUN dotnet restore "App/App.csproj"
+            COPY . .
+            RUN dotnet publish "App/App.csproj" -c Release -f {{targetFramework}} -o /app/publish
+            """;
+    }
+
+    private static string CreateProgramCs() =>
+        """
+            namespace Altinn.App;
+
+            internal static class Program
+            {
+                private static void Main()
+                {
+                }
+            }
+            """;
+
+    private static string CreateLaunchSettings() =>
+        """
+            {
+              "profiles": {
+                "App": {
+                  "commandName": "Project"
+                }
+              }
+            }
+            """ + Environment.NewLine;
+
+    private static string CreateApplicationMetadata() =>
+        """
+            {
+              "id": "ttd/test-app",
+              "org": "ttd",
+              "title": {
+                "nb": "Test app"
+              },
+              "dataTypes": [
+                {
+                  "id": "default",
+                  "taskId": "Task_1",
+                  "appLogic": {
+                    "classRef": "Altinn.App.Models.Model"
+                  }
+                }
+              ]
+            }
+            """;
+
+    private static string CreateProcessFile() =>
+        """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL">
+              <bpmn:process id="Process_1">
+                <bpmn:startEvent id="StartEvent_1" />
+                <bpmn:task id="Task_1" />
+                <bpmn:endEvent id="EndEvent_1" />
+              </bpmn:process>
+            </bpmn:definitions>
+            """;
+
+    private static string CreateLayoutSets() =>
+        """
+            {
+              "sets": [
+                {
+                  "id": "form",
+                  "dataType": "default",
+                  "tasks": [
+                    "Task_1"
+                  ]
+                }
+              ]
+            }
+            """;
+
+    private static string CreateLayout() =>
+        """
+            {
+              "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+              "data": {
+                "layout": []
+              }
+            }
+            """;
+}

--- a/src/cli/studioctl-server.Tests/Upgrade/FakeAppProjectFixtureTests.cs
+++ b/src/cli/studioctl-server.Tests/Upgrade/FakeAppProjectFixtureTests.cs
@@ -1,0 +1,43 @@
+namespace Altinn.Studio.StudioctlServer.Tests.Upgrade;
+
+public sealed class FakeAppProjectFixtureTests
+{
+    [Fact]
+    public void Create_WritesV8AppProjectLayout()
+    {
+        using var fixture = new FakeAppProjectFixture();
+
+        var app = fixture.Create(FakeAppSourceVersion.V8);
+
+        Assert.True(Directory.Exists(app.RootDirectory));
+        Assert.True(File.Exists(app.ProjectFile));
+        Assert.True(File.Exists(app.ProgramFile));
+        Assert.True(File.Exists(app.ProcessFile));
+        Assert.True(File.Exists(app.ApplicationMetadataFile));
+        Assert.True(Directory.Exists(app.UiDirectory));
+        Assert.True(Directory.Exists(app.TextsDirectory));
+        Assert.Contains("Version=\"8.0.0\"", File.ReadAllText(app.ProjectFile));
+        Assert.Contains("<TargetFramework>net8.0</TargetFramework>", File.ReadAllText(app.ProjectFile));
+    }
+
+    [Fact]
+    public void Create_WritesV7AppProjectLayout()
+    {
+        using var fixture = new FakeAppProjectFixture();
+
+        var app = fixture.Create(FakeAppSourceVersion.V7);
+
+        Assert.Contains("Version=\"7.0.0\"", File.ReadAllText(app.ProjectFile));
+        Assert.Contains("<TargetFramework>net6.0</TargetFramework>", File.ReadAllText(app.ProjectFile));
+    }
+
+    [Fact]
+    public void Create_WritesCustomProgramCs()
+    {
+        using var fixture = new FakeAppProjectFixture();
+
+        var app = fixture.Create(FakeAppSourceVersion.V8, "using Microsoft.OpenApi.Models;" + Environment.NewLine);
+
+        Assert.Equal("using Microsoft.OpenApi.Models;" + Environment.NewLine, File.ReadAllText(app.ProgramFile));
+    }
+}

--- a/src/cli/studioctl-server.Tests/Upgrade/FakeAppSourceVersion.cs
+++ b/src/cli/studioctl-server.Tests/Upgrade/FakeAppSourceVersion.cs
@@ -1,0 +1,7 @@
+namespace Altinn.Studio.StudioctlServer.Tests.Upgrade;
+
+internal enum FakeAppSourceVersion
+{
+    V7,
+    V8,
+}

--- a/src/cli/studioctl-server.Tests/studioctl-server.Tests.csproj
+++ b/src/cli/studioctl-server.Tests/studioctl-server.Tests.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <AssemblyName>studioctl-server.Tests</AssemblyName>
+    <RootNamespace>Altinn.Studio.StudioctlServer.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.StringTools" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\studioctl-server\studioctl-server.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/cli/studioctl-server/Properties/AssemblyInfo.cs
+++ b/src/cli/studioctl-server/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("studioctl-server.Tests")]

--- a/src/cli/studioctl.slnx
+++ b/src/cli/studioctl.slnx
@@ -1,3 +1,4 @@
 <Solution>
   <Project Path="studioctl-server/studioctl-server.csproj" />
+  <Project Path="studioctl-server.Tests/studioctl-server.Tests.csproj" />
 </Solution>


### PR DESCRIPTION
## Description

Adds a C# test project for `studioctl-server` and includes it in `src/cli/studioctl.slnx`.

The new test project includes an upgrade test fixture that creates a fake Altinn app project layout from a source version (`V7` or `V8`). The fixture writes the files the upgrade flows expect, including `App/App.csproj`, `Program.cs`, appsettings, launch settings, process, application metadata, UI layout files, texts, Index.cshtml, and Dockerfile.

This is intended as a base for adding focused tests for the v8-to-v9 OpenAPI namespace migration in #19192 and future upgrade migrations.

Also adds `InternalsVisibleTo` for the test assembly and central package versions needed by the test project. `System.Security.Cryptography.Xml` is centrally pinned to `10.0.9` to avoid a vulnerable transitive `10.0.1` pulled in by MSBuild packages.

## Verification

- [x] Related issues are connected (if applicable)
  - Follow-up requested in #19192.
- [x] **Your** code builds clean without any errors or warnings
  - `make build` in `src/cli/studioctl-server`: passed with `0 Warning(s), 0 Error(s)`.
  - `CI=true dotnet test studioctl.slnx -c Release` in `src/cli`: passed with `0 Warning(s), 0 Error(s)`.
- [x] Manual testing done (required)
  - Verified the fake app fixture creates V7 and V8 app layouts, including custom `Program.cs` content, through the new test project.
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
  - Added `FakeAppProjectFixtureTests` with three fixture coverage tests.

Also ran:

```bash
dotnet list studioctl-server.Tests/studioctl-server.Tests.csproj package --vulnerable --include-transitive
git diff --check
```

The vulnerable package check reports no vulnerable packages for the test project, and `git diff --check` passed.
