### PR TITLE
fix: roll out apps after maskinporten rotations

### DIFF
--- a/src/Runtime/operator/api/v1alpha1/maskinportenclient_types.go
+++ b/src/Runtime/operator/api/v1alpha1/maskinportenclient_types.go
@@ -41,6 +41,14 @@ type MaskinportenClientStatus struct {
 	ClientId  string   `json:"clientId,omitempty"`
 	Authority string   `json:"authority,omitempty"`
 	KeyIds    []string `json:"keyIds,omitempty"`
+	// PendingSecretRotationFingerprint identifies a rotated Maskinporten secret that still needs an app rollout.
+	PendingSecretRotationFingerprint string `json:"pendingSecretRotationFingerprint,omitempty"`
+	// PendingSecretRotationDetectedAt is when the pending rotated secret was observed.
+	PendingSecretRotationDetectedAt *metav1.Time `json:"pendingSecretRotationDetectedAt,omitempty"`
+	// LastSecretRotationRestartedFingerprint identifies the latest rotated secret version that triggered an app rollout.
+	LastSecretRotationRestartedFingerprint string `json:"lastSecretRotationRestartedFingerprint,omitempty"`
+	// LastSecretRotationRestartedAt is when the latest Maskinporten compatibility rollout was triggered.
+	LastSecretRotationRestartedAt *metav1.Time `json:"lastSecretRotationRestartedAt,omitempty"`
 	// ActionHistory contains up to 10 recent actions, ordered oldest to newest
 	ActionHistory []ActionRecord `json:"actionHistory,omitempty"`
 	// Conditions represent the latest available observations of the resource's state

--- a/src/Runtime/operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/src/Runtime/operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -116,6 +116,14 @@ func (in *MaskinportenClientStatus) DeepCopyInto(out *MaskinportenClientStatus) 
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.PendingSecretRotationDetectedAt != nil {
+		in, out := &in.PendingSecretRotationDetectedAt, &out.PendingSecretRotationDetectedAt
+		*out = (*in).DeepCopy()
+	}
+	if in.LastSecretRotationRestartedAt != nil {
+		in, out := &in.LastSecretRotationRestartedAt, &out.LastSecretRotationRestartedAt
+		*out = (*in).DeepCopy()
+	}
 	if in.ActionHistory != nil {
 		in, out := &in.ActionHistory, &out.ActionHistory
 		*out = make([]ActionRecord, len(*in))

--- a/src/Runtime/operator/config/crd/bases/resources.altinn.studio_maskinportenclients.yaml
+++ b/src/Runtime/operator/config/crd/bases/resources.altinn.studio_maskinportenclients.yaml
@@ -153,6 +153,15 @@ spec:
                 items:
                   type: string
                 type: array
+              lastSecretRotationRestartedAt:
+                description: LastSecretRotationRestartedAt is when the latest Maskinporten
+                  compatibility rollout was triggered.
+                format: date-time
+                type: string
+              lastSecretRotationRestartedFingerprint:
+                description: LastSecretRotationRestartedFingerprint identifies the
+                  latest rotated secret version that triggered an app rollout.
+                type: string
               lastSynced:
                 description: LastSynced is the timestamp of the last successful sync
                   towards Maskinporten API
@@ -161,6 +170,15 @@ spec:
               observedGeneration:
                 format: int64
                 type: integer
+              pendingSecretRotationDetectedAt:
+                description: PendingSecretRotationDetectedAt is when the pending rotated
+                  secret was observed.
+                format: date-time
+                type: string
+              pendingSecretRotationFingerprint:
+                description: PendingSecretRotationFingerprint identifies a rotated
+                  Maskinporten secret that still needs an app rollout.
+                type: string
             type: object
         type: object
     served: true

--- a/src/Runtime/operator/config/rbac/role.yaml
+++ b/src/Runtime/operator/config/rbac/role.yaml
@@ -47,6 +47,7 @@ rules:
   verbs:
   - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:

--- a/src/Runtime/operator/internal/controller/maskinporten/controller.go
+++ b/src/Runtime/operator/internal/controller/maskinporten/controller.go
@@ -75,6 +75,7 @@ func NewReconciler(
 // +kubebuilder:rbac:groups=resources.altinn.studio,resources=maskinportenclients/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=resources.altinn.studio,resources=maskinportenclients/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -377,6 +378,7 @@ func (r *MaskinportenClientReconciler) updateStatus(
 			if result.Err == nil {
 				instance.Status.Authority = result.Authority
 				instance.Status.KeyIds = result.KeyIds
+				markRotationRestartPending(instance, result.RotationFingerprint, cmdResult.Timestamp.UTC())
 				apimeta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
 					Type:               maskinporten.ConditionTypeSecretSynced,
 					Status:             metav1.ConditionTrue,
@@ -430,6 +432,26 @@ func (r *MaskinportenClientReconciler) updateStatus(
 		return fmt.Errorf("update status: %w", err)
 	}
 	return nil
+}
+
+func markRotationRestartPending(
+	instance *resourcesv1alpha1.MaskinportenClient,
+	fingerprint string,
+	detectedAt time.Time,
+) {
+	if fingerprint == "" || fingerprint == instance.Status.LastSecretRotationRestartedFingerprint {
+		return
+	}
+	timestamp := metav1.NewTime(detectedAt.UTC())
+	instance.Status.PendingSecretRotationFingerprint = fingerprint
+	instance.Status.PendingSecretRotationDetectedAt = &timestamp
+	apimeta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+		Type:               maskinporten.ConditionTypeRotationRestart,
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: instance.GetGeneration(),
+		Reason:             "PendingCompatibilityRollout",
+		Message:            "Maskinporten secret rotation is pending an app Deployment rollout for compatibility",
+	})
 }
 
 func (r *MaskinportenClientReconciler) updateStatusWithError(
@@ -735,6 +757,7 @@ func shouldRequireClientIdentityForDeletion(instance *resourcesv1alpha1.Maskinpo
 	return condition != nil && condition.Status == metav1.ConditionTrue
 }
 
+//nolint:maintidx // Existing production reconciliation flow is intentionally kept together; this change only annotates one command path.
 func (r *MaskinportenClientReconciler) reconcile(
 	ctx context.Context,
 	configValue *config.Config,
@@ -824,6 +847,13 @@ func (r *MaskinportenClientReconciler) reconcile(
 				"Secret.Manifest must exist for UpdateSecretContentCommand",
 			)
 			err := r.updateSecretWithRetry(ctx, currentState.Secret.Manifest, func(s *corev1.Secret) error {
+				if data.RotationFingerprint != "" {
+					if s.Annotations == nil {
+						s.Annotations = map[string]string{}
+					}
+					s.Annotations[maskinporten.AnnotationSecretVersion] = data.RotationFingerprint
+					s.Annotations[maskinporten.AnnotationSecretRotatedAt] = clock.Now().UTC().Format(time.RFC3339)
+				}
 				return data.SecretContent.SerializeTo(s)
 			}, false)
 			if err != nil {
@@ -839,8 +869,9 @@ func (r *MaskinportenClientReconciler) reconcile(
 				}
 			}
 			builders[i].WithUpdateSecretContentResult(&maskinporten.UpdateSecretContentCommandResult{
-				Authority: data.SecretContent.Authority,
-				KeyIds:    keyIds,
+				Authority:           data.SecretContent.Authority,
+				KeyIds:              keyIds,
+				RotationFingerprint: data.RotationFingerprint,
 			})
 
 		case *maskinporten.DeleteClientInApiCommand:
@@ -958,6 +989,9 @@ func (r *MaskinportenClientReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		WithOptions(controller.Options{MaxConcurrentReconciles: goruntime.NumCPU() * 4}).
 		Complete(r); err != nil {
 		return fmt.Errorf("complete Maskinporten controller builder: %w", err)
+	}
+	if err := mgr.Add(newRotationRolloutProcessor(r)); err != nil {
+		return fmt.Errorf("add Maskinporten rotation rollout processor: %w", err)
 	}
 	return nil
 }

--- a/src/Runtime/operator/internal/controller/maskinporten/controller_unit_test.go
+++ b/src/Runtime/operator/internal/controller/maskinporten/controller_unit_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
+	nooptrace "go.opentelemetry.io/otel/trace/noop"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -490,7 +491,7 @@ func (r rotationRolloutTestRuntime) GetClock() opclock.Clock {
 }
 
 func (r rotationRolloutTestRuntime) Tracer() trace.Tracer {
-	return nil
+	return nooptrace.NewTracerProvider().Tracer("maskinporten-rotation-rollout-test")
 }
 
 func (r rotationRolloutTestRuntime) Meter() metric.Meter {

--- a/src/Runtime/operator/internal/controller/maskinporten/controller_unit_test.go
+++ b/src/Runtime/operator/internal/controller/maskinporten/controller_unit_test.go
@@ -7,16 +7,25 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	resourcesv1alpha1 "altinn.studio/operator/api/v1alpha1"
+	opclock "altinn.studio/operator/internal/clock"
 	"altinn.studio/operator/internal/config"
+	"altinn.studio/operator/internal/crypto"
 	mpdomain "altinn.studio/operator/internal/maskinporten"
+	"altinn.studio/operator/internal/operatorcontext"
 )
+
+const testRotationFingerprint = "rotation-fingerprint-1"
 
 func newFakeClientForSecretTests(t *testing.T) *MaskinportenClientReconciler {
 	t.Helper()
@@ -30,6 +39,29 @@ func newFakeClientForSecretTests(t *testing.T) *MaskinportenClientReconciler {
 			WithScheme(scheme).
 			Build(),
 		Scheme: scheme,
+	}
+}
+
+func newFakeReconcilerForRotationRollout(
+	t *testing.T,
+	objects ...client.Object,
+) *MaskinportenClientReconciler {
+	t.Helper()
+
+	scheme := k8sruntime.NewScheme()
+	g := NewWithT(t)
+	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(appsv1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(resourcesv1alpha1.AddToScheme(scheme)).To(Succeed())
+
+	return &MaskinportenClientReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(objects...).
+			WithStatusSubresource(&resourcesv1alpha1.MaskinportenClient{}).
+			Build(),
+		Scheme:  scheme,
+		runtime: rotationRolloutTestRuntime{serviceOwnerID: "ttd"},
 	}
 }
 
@@ -180,4 +212,287 @@ func TestRandomizeDuration_HandlesNilRandom(t *testing.T) {
 	g := NewWithT(t)
 	reconciler := &MaskinportenClientReconciler{}
 	g.Expect(reconciler.randomizeDuration(5*time.Second, 10.0)).To(Equal(5 * time.Second))
+}
+
+func TestMarkRotationRestartPending_TracksNewRotation(t *testing.T) {
+	g := NewWithT(t)
+	detectedAt := time.Date(2026, 6, 15, 1, 30, 0, 0, time.UTC)
+	instance := &resourcesv1alpha1.MaskinportenClient{}
+
+	markRotationRestartPending(instance, testRotationFingerprint, detectedAt)
+
+	g.Expect(instance.Status.PendingSecretRotationFingerprint).To(Equal(testRotationFingerprint))
+	g.Expect(instance.Status.PendingSecretRotationDetectedAt.Time).To(Equal(detectedAt))
+	g.Expect(instance.Status.Conditions).To(ContainElement(WithTransform(
+		func(condition metav1.Condition) string { return condition.Type + ":" + string(condition.Status) },
+		Equal(mpdomain.ConditionTypeRotationRestart+":"+string(metav1.ConditionTrue)),
+	)))
+}
+
+func TestMarkRotationRestartPending_IgnoresAlreadyRestartedRotation(t *testing.T) {
+	g := NewWithT(t)
+	instance := &resourcesv1alpha1.MaskinportenClient{
+		Status: resourcesv1alpha1.MaskinportenClientStatus{
+			LastSecretRotationRestartedFingerprint: testRotationFingerprint,
+		},
+	}
+
+	markRotationRestartPending(instance, testRotationFingerprint, time.Now())
+
+	g.Expect(instance.Status.PendingSecretRotationFingerprint).To(BeEmpty())
+}
+
+func TestProcessPendingMaskinportenRotationRollouts_PatchesDeploymentTemplateAndStatus(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	now := time.Date(2026, 6, 15, 2, 0, 0, 0, time.UTC)
+	fingerprint := testRotationFingerprint
+	instance := rotationRolloutClient("ttd-testapp", fingerprint)
+	deployment := rotationRolloutDeployment("ttd-testapp-deployment")
+	reconciler := newFakeReconcilerForRotationRollout(t, instance, deployment)
+
+	err := reconciler.processPendingMaskinportenRotationRollouts(ctx, now)
+
+	g.Expect(err).NotTo(HaveOccurred())
+
+	updatedDeployment := &appsv1.Deployment{}
+	g.Expect(reconciler.Get(ctx, client.ObjectKeyFromObject(deployment), updatedDeployment)).To(Succeed())
+	g.Expect(updatedDeployment.Spec.Template.Annotations).To(HaveKeyWithValue(
+		mpdomain.AnnotationSecretVersion,
+		fingerprint,
+	))
+	g.Expect(updatedDeployment.Spec.Template.Annotations).To(HaveKeyWithValue(
+		mpdomain.AnnotationSecretRotationRestartedAt,
+		now.Format(time.RFC3339),
+	))
+
+	updatedClient := &resourcesv1alpha1.MaskinportenClient{}
+	g.Expect(reconciler.Get(ctx, client.ObjectKeyFromObject(instance), updatedClient)).To(Succeed())
+	g.Expect(updatedClient.Status.PendingSecretRotationFingerprint).To(BeEmpty())
+	g.Expect(updatedClient.Status.LastSecretRotationRestartedFingerprint).To(Equal(fingerprint))
+	g.Expect(updatedClient.Status.LastSecretRotationRestartedAt.Time).To(BeTemporally("==", now))
+}
+
+func TestProcessPendingMaskinportenRotationRollouts_IsIdempotentForSameRotation(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	firstRun := time.Date(2026, 6, 15, 2, 0, 0, 0, time.UTC)
+	secondRun := firstRun.Add(24 * time.Hour)
+	fingerprint := testRotationFingerprint
+	instance := rotationRolloutClient("ttd-testapp", fingerprint)
+	deployment := rotationRolloutDeployment("ttd-testapp-deployment")
+	reconciler := newFakeReconcilerForRotationRollout(t, instance, deployment)
+
+	g.Expect(reconciler.processPendingMaskinportenRotationRollouts(ctx, firstRun)).To(Succeed())
+	g.Expect(reconciler.processPendingMaskinportenRotationRollouts(ctx, secondRun)).To(Succeed())
+
+	updatedDeployment := &appsv1.Deployment{}
+	g.Expect(reconciler.Get(ctx, client.ObjectKeyFromObject(deployment), updatedDeployment)).To(Succeed())
+	g.Expect(updatedDeployment.Spec.Template.Annotations).To(HaveKeyWithValue(
+		mpdomain.AnnotationSecretRotationRestartedAt,
+		firstRun.Format(time.RFC3339),
+	))
+}
+
+func TestProcessPendingMaskinportenRotationRollouts_OnlyPatchesPendingRotations(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	now := time.Date(2026, 6, 15, 2, 0, 0, 0, time.UTC)
+	pendingFingerprint := testRotationFingerprint
+	pendingClient := rotationRolloutClient("ttd-testapp", pendingFingerprint)
+	nonPendingClient := rotationRolloutClient("ttd-otherapp", "")
+	pendingDeployment := rotationRolloutDeployment("ttd-testapp-deployment")
+	nonPendingDeployment := rotationRolloutDeployment("ttd-otherapp-deployment")
+	reconciler := newFakeReconcilerForRotationRollout(
+		t,
+		pendingClient,
+		nonPendingClient,
+		pendingDeployment,
+		nonPendingDeployment,
+	)
+
+	err := reconciler.processPendingMaskinportenRotationRollouts(ctx, now)
+
+	g.Expect(err).NotTo(HaveOccurred())
+
+	updatedPendingDeployment := &appsv1.Deployment{}
+	g.Expect(reconciler.Get(ctx, client.ObjectKeyFromObject(pendingDeployment), updatedPendingDeployment)).To(Succeed())
+	g.Expect(updatedPendingDeployment.Spec.Template.Annotations).To(HaveKeyWithValue(
+		mpdomain.AnnotationSecretVersion,
+		pendingFingerprint,
+	))
+
+	updatedNonPendingDeployment := &appsv1.Deployment{}
+	g.Expect(reconciler.Get(ctx, client.ObjectKeyFromObject(nonPendingDeployment), updatedNonPendingDeployment)).
+		To(Succeed())
+	g.Expect(updatedNonPendingDeployment.Spec.Template.Annotations).NotTo(HaveKey(mpdomain.AnnotationSecretVersion))
+}
+
+func TestProcessPendingMaskinportenRotationRollouts_RecoversPendingRotationFromSecret(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	now := time.Date(2026, 6, 15, 2, 0, 0, 0, time.UTC)
+	instance := rotationRolloutClient("ttd-testapp", "")
+	deployment := rotationRolloutDeployment("ttd-testapp-deployment")
+	secret := rotationRolloutSecret("ttd-testapp-deployment", testRotationFingerprint)
+	reconciler := newFakeReconcilerForRotationRollout(t, instance, deployment, secret)
+
+	err := reconciler.processPendingMaskinportenRotationRollouts(ctx, now)
+
+	g.Expect(err).NotTo(HaveOccurred())
+
+	updatedDeployment := &appsv1.Deployment{}
+	g.Expect(reconciler.Get(ctx, client.ObjectKeyFromObject(deployment), updatedDeployment)).To(Succeed())
+	g.Expect(updatedDeployment.Spec.Template.Annotations).To(HaveKeyWithValue(
+		mpdomain.AnnotationSecretVersion,
+		testRotationFingerprint,
+	))
+
+	updatedClient := &resourcesv1alpha1.MaskinportenClient{}
+	g.Expect(reconciler.Get(ctx, client.ObjectKeyFromObject(instance), updatedClient)).To(Succeed())
+	g.Expect(updatedClient.Status.LastSecretRotationRestartedFingerprint).To(Equal(testRotationFingerprint))
+	g.Expect(updatedClient.Status.PendingSecretRotationFingerprint).To(BeEmpty())
+}
+
+func TestProcessPendingMaskinportenRotationRollouts_SkipsOtherServiceOwner(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	now := time.Date(2026, 6, 15, 2, 0, 0, 0, time.UTC)
+	instance := rotationRolloutClient("other-testapp", testRotationFingerprint)
+	deployment := rotationRolloutDeployment("other-testapp-deployment")
+	reconciler := newFakeReconcilerForRotationRollout(t, instance, deployment)
+	reconciler.runtime = rotationRolloutTestRuntime{serviceOwnerID: "ttd"}
+
+	err := reconciler.processPendingMaskinportenRotationRollouts(ctx, now)
+
+	g.Expect(err).NotTo(HaveOccurred())
+
+	updatedDeployment := &appsv1.Deployment{}
+	g.Expect(reconciler.Get(ctx, client.ObjectKeyFromObject(deployment), updatedDeployment)).To(Succeed())
+	g.Expect(updatedDeployment.Spec.Template.Annotations).NotTo(HaveKey(mpdomain.AnnotationSecretVersion))
+
+	updatedClient := &resourcesv1alpha1.MaskinportenClient{}
+	g.Expect(reconciler.Get(ctx, client.ObjectKeyFromObject(instance), updatedClient)).To(Succeed())
+	g.Expect(updatedClient.Status.PendingSecretRotationFingerprint).To(Equal(testRotationFingerprint))
+	g.Expect(updatedClient.Status.LastSecretRotationRestartedFingerprint).To(BeEmpty())
+}
+
+func TestProcessPendingMaskinportenRotationRollouts_MarksAlreadyAnnotatedDeploymentComplete(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	now := time.Date(2026, 6, 16, 2, 0, 0, 0, time.UTC)
+	restartedAt := time.Date(2026, 6, 15, 2, 0, 0, 0, time.UTC)
+	fingerprint := testRotationFingerprint
+	instance := rotationRolloutClient("ttd-testapp", fingerprint)
+	deployment := rotationRolloutDeployment("ttd-testapp-deployment")
+	deployment.Spec.Template.Annotations = map[string]string{
+		mpdomain.AnnotationSecretVersion:             fingerprint,
+		mpdomain.AnnotationSecretRotationRestartedAt: restartedAt.Format(time.RFC3339),
+	}
+	reconciler := newFakeReconcilerForRotationRollout(t, instance, deployment)
+
+	err := reconciler.processPendingMaskinportenRotationRollouts(ctx, now)
+
+	g.Expect(err).NotTo(HaveOccurred())
+
+	updatedDeployment := &appsv1.Deployment{}
+	g.Expect(reconciler.Get(ctx, client.ObjectKeyFromObject(deployment), updatedDeployment)).To(Succeed())
+	g.Expect(updatedDeployment.Spec.Template.Annotations).To(HaveKeyWithValue(
+		mpdomain.AnnotationSecretRotationRestartedAt,
+		restartedAt.Format(time.RFC3339),
+	))
+
+	updatedClient := &resourcesv1alpha1.MaskinportenClient{}
+	g.Expect(reconciler.Get(ctx, client.ObjectKeyFromObject(instance), updatedClient)).To(Succeed())
+	g.Expect(updatedClient.Status.PendingSecretRotationFingerprint).To(BeEmpty())
+	g.Expect(updatedClient.Status.LastSecretRotationRestartedFingerprint).To(Equal(fingerprint))
+	g.Expect(updatedClient.Status.LastSecretRotationRestartedAt.Time).To(BeTemporally("==", restartedAt))
+}
+
+func rotationRolloutClient(name string, pendingFingerprint string) *resourcesv1alpha1.MaskinportenClient {
+	pendingAt := metav1.NewTime(time.Date(2026, 6, 15, 1, 0, 0, 0, time.UTC))
+	instance := &resourcesv1alpha1.MaskinportenClient{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Status: resourcesv1alpha1.MaskinportenClientStatus{
+			PendingSecretRotationFingerprint: pendingFingerprint,
+		},
+	}
+	if pendingFingerprint != "" {
+		instance.Status.PendingSecretRotationDetectedAt = &pendingAt
+	}
+	return instance
+}
+
+func rotationRolloutDeployment(name string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+		},
+	}
+}
+
+func rotationRolloutSecret(appLabel string, fingerprint string) *corev1.Secret {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      appLabel + "-secrets",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app": appLabel,
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
+	if fingerprint != "" {
+		secret.Annotations = map[string]string{
+			mpdomain.AnnotationSecretVersion: fingerprint,
+		}
+	}
+	return secret
+}
+
+type rotationRolloutTestRuntime struct {
+	serviceOwnerID string
+}
+
+func (r rotationRolloutTestRuntime) GetConfigMonitor() *config.ConfigMonitor {
+	return nil
+}
+
+func (r rotationRolloutTestRuntime) GetOperatorContext() *operatorcontext.Context {
+	return &operatorcontext.Context{
+		ServiceOwner: operatorcontext.ServiceOwner{
+			Id: r.serviceOwnerID,
+		},
+	}
+}
+
+func (r rotationRolloutTestRuntime) GetCrypto() *crypto.CryptoService {
+	return nil
+}
+
+func (r rotationRolloutTestRuntime) GetMaskinportenApiClient() *mpdomain.HttpApiClient {
+	return nil
+}
+
+func (r rotationRolloutTestRuntime) GetClock() opclock.Clock {
+	return nil
+}
+
+func (r rotationRolloutTestRuntime) Tracer() trace.Tracer {
+	return nil
+}
+
+func (r rotationRolloutTestRuntime) Meter() metric.Meter {
+	return nil
 }

--- a/src/Runtime/operator/internal/controller/maskinporten/rotation_rollout.go
+++ b/src/Runtime/operator/internal/controller/maskinporten/rotation_rollout.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -90,16 +93,29 @@ func (r *MaskinportenClientReconciler) processPendingMaskinportenRotationRollout
 	ctx context.Context,
 	now time.Time,
 ) error {
+	ctx, span := r.runtime.Tracer().Start(
+		ctx,
+		"MaskinportenRotationRollout.processPending",
+		trace.WithAttributes(attribute.String("scheduled_at", now.UTC().Format(time.RFC3339))),
+	)
+	defer span.End()
+
 	logger := log.FromContext(ctx).WithName("maskinporten-rotation-rollout")
 	serviceOwnerID := r.serviceOwnerID()
+	span.SetAttributes(attribute.String("service_owner", serviceOwnerID))
 	if serviceOwnerID == "" {
+		span.SetStatus(codes.Error, "operator service owner scope is empty")
+		span.RecordError(errEmptyOperatorServiceOwnerScope)
 		return errEmptyOperatorServiceOwnerScope
 	}
 
 	list := &resourcesv1alpha1.MaskinportenClientList{}
 	if err := r.List(ctx, list); err != nil {
+		span.SetStatus(codes.Error, "list MaskinportenClients")
+		span.RecordError(err)
 		return fmt.Errorf("list MaskinportenClients: %w", err)
 	}
+	span.SetAttributes(attribute.Int("maskinporten_client_count", len(list.Items)))
 
 	var errs []error
 	for i := range list.Items {
@@ -120,20 +136,10 @@ func (r *MaskinportenClientReconciler) processPendingMaskinportenRotationRollout
 			continue
 		}
 
-		fingerprint, err := r.pendingRotationFingerprint(ctx, instance, deploymentName)
-		if err != nil {
-			errs = append(errs, err)
-			continue
-		}
-		if fingerprint == "" {
-			continue
-		}
-
-		if err := r.processPendingMaskinportenRotationRollout(
+		if err := r.processInScopeMaskinportenRotationRollout(
 			ctx,
 			instance,
 			deploymentName,
-			fingerprint,
 			now,
 		); err != nil {
 			logger.Error(
@@ -142,13 +148,58 @@ func (r *MaskinportenClientReconciler) processPendingMaskinportenRotationRollout
 				"maskinportenClient", instance.Name,
 				"namespace", instance.Namespace,
 				"deployment", deploymentName,
-				"fingerprint", fingerprint,
 			)
 			errs = append(errs, err)
 		}
 	}
 
-	return errors.Join(errs...)
+	if err := errors.Join(errs...); err != nil {
+		span.SetStatus(codes.Error, "one or more Maskinporten rotation rollouts failed")
+		span.RecordError(err)
+		return err
+	}
+
+	span.SetStatus(codes.Ok, "processed Maskinporten rotation rollouts")
+	return nil
+}
+
+func (r *MaskinportenClientReconciler) processInScopeMaskinportenRotationRollout(
+	ctx context.Context,
+	instance *resourcesv1alpha1.MaskinportenClient,
+	deploymentName string,
+	now time.Time,
+) error {
+	ctx, span := r.runtime.Tracer().Start(
+		ctx,
+		"MaskinportenRotationRollout.processItem",
+		trace.WithAttributes(
+			attribute.String("namespace", instance.Namespace),
+			attribute.String("maskinporten_client", instance.Name),
+			attribute.String("deployment", deploymentName),
+		),
+	)
+	defer span.End()
+
+	fingerprint, err := r.pendingRotationFingerprint(ctx, instance, deploymentName)
+	if err != nil {
+		span.SetStatus(codes.Error, "determine pending rotation fingerprint")
+		span.RecordError(err)
+		return err
+	}
+	if fingerprint == "" {
+		span.SetStatus(codes.Ok, "no pending rotation")
+		return nil
+	}
+	span.SetAttributes(attribute.String("fingerprint", fingerprint))
+
+	if err := r.processPendingMaskinportenRotationRollout(ctx, instance, deploymentName, fingerprint, now); err != nil {
+		span.SetStatus(codes.Error, "process pending rotation rollout")
+		span.RecordError(err)
+		return err
+	}
+
+	span.SetStatus(codes.Ok, "processed pending rotation rollout")
+	return nil
 }
 
 func (r *MaskinportenClientReconciler) processPendingMaskinportenRotationRollout(
@@ -220,7 +271,7 @@ func (r *MaskinportenClientReconciler) pendingRotationFingerprint(
 	if fromStatus := pendingRotationFingerprintFromStatus(instance); fromStatus != "" {
 		return fromStatus, nil
 	}
-	return r.pendingRotationFingerprintFromSecret(ctx, instance, deploymentName)
+	return r.pendingRotationFingerprintFromSecretRecovery(ctx, instance, deploymentName)
 }
 
 func pendingRotationFingerprintFromStatus(instance *resourcesv1alpha1.MaskinportenClient) string {
@@ -234,7 +285,10 @@ func pendingRotationFingerprintFromStatus(instance *resourcesv1alpha1.Maskinport
 	return pending
 }
 
-func (r *MaskinportenClientReconciler) pendingRotationFingerprintFromSecret(
+// pendingRotationFingerprintFromSecretRecovery is a crash-recovery fallback for the narrow case where
+// the app Secret was updated with rotated credentials but the MaskinportenClient status update did not persist.
+// MaskinportenClient status remains the primary source of truth for pending rollout state.
+func (r *MaskinportenClientReconciler) pendingRotationFingerprintFromSecretRecovery(
 	ctx context.Context,
 	instance *resourcesv1alpha1.MaskinportenClient,
 	deploymentName string,

--- a/src/Runtime/operator/internal/controller/maskinporten/rotation_rollout.go
+++ b/src/Runtime/operator/internal/controller/maskinporten/rotation_rollout.go
@@ -1,0 +1,339 @@
+package maskinporten
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	resourcesv1alpha1 "altinn.studio/operator/api/v1alpha1"
+	"altinn.studio/operator/internal/assert"
+	"altinn.studio/operator/internal/maskinporten"
+	"altinn.studio/operator/internal/resourcename"
+)
+
+const (
+	maskinportenRotationRolloutHourUTC = 2
+)
+
+var errEmptyOperatorServiceOwnerScope = errors.New("operator service owner scope is empty")
+
+type rotationRolloutProcessor struct {
+	reconciler *MaskinportenClientReconciler
+}
+
+func newRotationRolloutProcessor(reconciler *MaskinportenClientReconciler) *rotationRolloutProcessor {
+	return &rotationRolloutProcessor{reconciler: reconciler}
+}
+
+func (p *rotationRolloutProcessor) NeedLeaderElection() bool {
+	return true
+}
+
+func (p *rotationRolloutProcessor) Start(ctx context.Context) error {
+	assert.That(p.reconciler != nil, "rotationRolloutProcessor requires a reconciler")
+	assert.That(p.reconciler.runtime != nil, "rotationRolloutProcessor requires runtime")
+
+	clock := p.reconciler.runtime.GetClock()
+	logger := log.FromContext(ctx).WithName("maskinporten-rotation-rollout")
+	logger.Info(
+		"starting Maskinporten rotation rollout processor",
+		"hourUTC",
+		maskinportenRotationRolloutHourUTC,
+	)
+	defer logger.Info("exiting Maskinporten rotation rollout processor")
+
+	for {
+		now := clock.Now().UTC()
+		delay := durationUntilNextRotationRollout(now)
+		logger.Info("scheduled Maskinporten rotation rollout processing", "runAfter", delay)
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-clock.After(delay):
+		}
+
+		if err := p.reconciler.processPendingMaskinportenRotationRollouts(ctx, clock.Now().UTC()); err != nil {
+			logger.Error(err, "Maskinporten rotation rollout processing failed")
+		}
+	}
+}
+
+func durationUntilNextRotationRollout(now time.Time) time.Duration {
+	now = now.UTC()
+	next := time.Date(
+		now.Year(),
+		now.Month(),
+		now.Day(),
+		maskinportenRotationRolloutHourUTC,
+		0,
+		0,
+		0,
+		time.UTC,
+	)
+	if now.After(next) {
+		next = next.AddDate(0, 0, 1)
+	}
+	return next.Sub(now)
+}
+
+func (r *MaskinportenClientReconciler) processPendingMaskinportenRotationRollouts(
+	ctx context.Context,
+	now time.Time,
+) error {
+	logger := log.FromContext(ctx).WithName("maskinporten-rotation-rollout")
+	serviceOwnerID := r.serviceOwnerID()
+	if serviceOwnerID == "" {
+		return errEmptyOperatorServiceOwnerScope
+	}
+
+	list := &resourcesv1alpha1.MaskinportenClientList{}
+	if err := r.List(ctx, list); err != nil {
+		return fmt.Errorf("list MaskinportenClients: %w", err)
+	}
+
+	var errs []error
+	for i := range list.Items {
+		instance := &list.Items[i]
+
+		deploymentName, inScope, err := appDeploymentNameForMaskinportenClient(instance, serviceOwnerID)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if !inScope {
+			logger.Info(
+				"skipping MaskinportenClient outside operator service owner scope",
+				"maskinportenClient", instance.Name,
+				"namespace", instance.Namespace,
+				"serviceOwner", serviceOwnerID,
+			)
+			continue
+		}
+
+		fingerprint, err := r.pendingRotationFingerprint(ctx, instance, deploymentName)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if fingerprint == "" {
+			continue
+		}
+
+		if err := r.processPendingMaskinportenRotationRollout(
+			ctx,
+			instance,
+			deploymentName,
+			fingerprint,
+			now,
+		); err != nil {
+			logger.Error(
+				err,
+				"failed processing Maskinporten rotation rollout",
+				"maskinportenClient", instance.Name,
+				"namespace", instance.Namespace,
+				"deployment", deploymentName,
+				"fingerprint", fingerprint,
+			)
+			errs = append(errs, err)
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func (r *MaskinportenClientReconciler) processPendingMaskinportenRotationRollout(
+	ctx context.Context,
+	instance *resourcesv1alpha1.MaskinportenClient,
+	deploymentName string,
+	fingerprint string,
+	now time.Time,
+) error {
+	logger := log.FromContext(ctx).WithName("maskinporten-rotation-rollout")
+
+	deployment := &appsv1.Deployment{}
+	deploymentKey := client.ObjectKey{Namespace: instance.Namespace, Name: deploymentName}
+	if err := r.Get(ctx, deploymentKey, deployment); err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Info(
+				"app Deployment not found for pending Maskinporten rotation",
+				"maskinportenClient", instance.Name,
+				"namespace", instance.Namespace,
+				"deployment", deploymentName,
+				"fingerprint", fingerprint,
+			)
+		}
+		return fmt.Errorf("get app Deployment %s/%s: %w", instance.Namespace, deploymentName, err)
+	}
+
+	restartedAt := now.UTC().Format(time.RFC3339)
+	if deployment.Spec.Template.Annotations[maskinporten.AnnotationSecretVersion] == fingerprint {
+		if existing := deployment.Spec.Template.Annotations[maskinporten.AnnotationSecretRotationRestartedAt]; existing != "" {
+			restartedAt = existing
+		}
+		logger.Info(
+			"app Deployment already has Maskinporten rotation annotation, marking rotation rollout complete",
+			"maskinportenClient", instance.Name,
+			"namespace", instance.Namespace,
+			"deployment", deploymentName,
+			"fingerprint", fingerprint,
+		)
+		return r.markRotationRestarted(ctx, instance, fingerprint, restartedAt)
+	}
+
+	before := deployment.DeepCopy()
+	if deployment.Spec.Template.Annotations == nil {
+		deployment.Spec.Template.Annotations = map[string]string{}
+	}
+	deployment.Spec.Template.Annotations[maskinporten.AnnotationSecretVersion] = fingerprint
+	deployment.Spec.Template.Annotations[maskinporten.AnnotationSecretRotationRestartedAt] = restartedAt
+
+	if err := r.Patch(ctx, deployment, client.MergeFrom(before)); err != nil {
+		return fmt.Errorf("patch app Deployment pod template annotations: %w", err)
+	}
+
+	logger.Info(
+		"triggered app Deployment rollout for Maskinporten secret rotation compatibility",
+		"maskinportenClient", instance.Name,
+		"namespace", instance.Namespace,
+		"deployment", deploymentName,
+		"fingerprint", fingerprint,
+	)
+
+	return r.markRotationRestarted(ctx, instance, fingerprint, restartedAt)
+}
+
+func (r *MaskinportenClientReconciler) pendingRotationFingerprint(
+	ctx context.Context,
+	instance *resourcesv1alpha1.MaskinportenClient,
+	deploymentName string,
+) (string, error) {
+	if fromStatus := pendingRotationFingerprintFromStatus(instance); fromStatus != "" {
+		return fromStatus, nil
+	}
+	return r.pendingRotationFingerprintFromSecret(ctx, instance, deploymentName)
+}
+
+func pendingRotationFingerprintFromStatus(instance *resourcesv1alpha1.MaskinportenClient) string {
+	if instance == nil {
+		return ""
+	}
+	pending := instance.Status.PendingSecretRotationFingerprint
+	if pending == "" || pending == instance.Status.LastSecretRotationRestartedFingerprint {
+		return ""
+	}
+	return pending
+}
+
+func (r *MaskinportenClientReconciler) pendingRotationFingerprintFromSecret(
+	ctx context.Context,
+	instance *resourcesv1alpha1.MaskinportenClient,
+	deploymentName string,
+) (string, error) {
+	secrets := &corev1.SecretList{}
+	if err := r.List(
+		ctx,
+		secrets,
+		client.InNamespace(instance.Namespace),
+		client.MatchingLabels{"app": deploymentName},
+	); err != nil {
+		return "", fmt.Errorf("list app secrets for Maskinporten rotation recovery: %w", err)
+	}
+	if len(secrets.Items) == 0 {
+		return "", nil
+	}
+	if len(secrets.Items) > 1 {
+		return "", fmt.Errorf("%w for app label %q", errUnexpectedSecretCount, deploymentName)
+	}
+
+	fingerprint := secrets.Items[0].Annotations[maskinporten.AnnotationSecretVersion]
+	if fingerprint == "" || fingerprint == instance.Status.LastSecretRotationRestartedFingerprint {
+		return "", nil
+	}
+	return fingerprint, nil
+}
+
+func appDeploymentNameForMaskinportenClient(
+	instance *resourcesv1alpha1.MaskinportenClient,
+	serviceOwnerID string,
+) (string, bool, error) {
+	parsed, err := resourcename.ParseMaskinportenClientName(instance.Name)
+	if err != nil {
+		return "", false, fmt.Errorf("parse MaskinportenClient name %q: %w", instance.Name, err)
+	}
+	if serviceOwnerID != "" && parsed.ServiceOwnerId != serviceOwnerID {
+		return "", false, nil
+	}
+	return fmt.Sprintf("%s-%s-deployment", parsed.ServiceOwnerId, parsed.AppId), true, nil
+}
+
+func (r *MaskinportenClientReconciler) serviceOwnerID() string {
+	if r == nil || r.runtime == nil || r.runtime.GetOperatorContext() == nil {
+		return ""
+	}
+	return r.runtime.GetOperatorContext().ServiceOwner.Id
+}
+
+func (r *MaskinportenClientReconciler) markRotationRestarted(
+	ctx context.Context,
+	instance *resourcesv1alpha1.MaskinportenClient,
+	fingerprint string,
+	restartedAt string,
+) error {
+	timestamp, err := time.Parse(time.RFC3339, restartedAt)
+	if err != nil {
+		return fmt.Errorf("parse rotation rollout timestamp: %w", err)
+	}
+
+	current := &resourcesv1alpha1.MaskinportenClient{}
+	key := client.ObjectKeyFromObject(instance)
+	if err := r.Get(ctx, key, current); err != nil {
+		return fmt.Errorf("refresh MaskinportenClient before status patch: %w", err)
+	}
+
+	for attempt := range maxSecretUpdateRetries {
+		before := current.DeepCopy()
+		statusTime := metav1.NewTime(timestamp.UTC())
+		current.Status.LastSecretRotationRestartedFingerprint = fingerprint
+		current.Status.LastSecretRotationRestartedAt = &statusTime
+		if current.Status.PendingSecretRotationFingerprint == fingerprint {
+			current.Status.PendingSecretRotationFingerprint = ""
+			current.Status.PendingSecretRotationDetectedAt = nil
+		}
+		apimeta.SetStatusCondition(&current.Status.Conditions, metav1.Condition{
+			Type:               maskinporten.ConditionTypeRotationRestart,
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: current.GetGeneration(),
+			Reason:             "CompatibilityRolloutTriggered",
+			Message:            "App Deployment rollout was triggered for Maskinporten secret rotation compatibility",
+		})
+
+		err := r.Status().Patch(ctx, current, client.MergeFrom(before))
+		if err == nil {
+			return nil
+		}
+		if !apierrors.IsConflict(err) {
+			return fmt.Errorf("patch MaskinportenClient rotation restart status: %w", err)
+		}
+		if err := r.Get(ctx, key, current); err != nil {
+			return fmt.Errorf("refresh MaskinportenClient status after conflict: %w", err)
+		}
+		log.FromContext(ctx).Info(
+			"conflict patching MaskinportenClient rotation restart status, retrying",
+			"attempt", attempt+1,
+			"maskinportenClient", instance.Name,
+			"namespace", instance.Namespace,
+		)
+	}
+
+	return fmt.Errorf("patch MaskinportenClient rotation restart status: %w", errSecretUpdateRetryExhausted)
+}

--- a/src/Runtime/operator/internal/maskinporten/client_state.go
+++ b/src/Runtime/operator/internal/maskinporten/client_state.go
@@ -2,10 +2,13 @@
 package maskinporten
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 	"time"
 
@@ -26,6 +29,15 @@ const JsonFileName = "maskinporten-settings.json"
 // AnnotationRotateJwk is used to trigger manual JWK rotation (value must be "true").
 const AnnotationRotateJwk = "altinn.studio/maskinporten-rotate-jwk"
 
+// AnnotationSecretVersion identifies the Maskinporten secret content version used by an app Deployment rollout.
+const AnnotationSecretVersion = "altinn.studio/maskinporten-secret-version" // #nosec G101 -- annotation name, not a credential.
+
+// AnnotationSecretRotatedAt records when rotated Maskinporten secret content was written.
+const AnnotationSecretRotatedAt = "altinn.studio/maskinporten-secret-rotated-at" // #nosec G101 -- annotation name.
+
+// AnnotationSecretRotationRestartedAt records when an app Deployment rollout was triggered for a rotated secret.
+const AnnotationSecretRotationRestartedAt = "altinn.studio/maskinporten-secret-rotation-restarted-at" // #nosec G101 -- annotation name.
+
 // FinalizerName is used to ensure cleanup before deletion.
 const FinalizerName = "altinn.studio/maskinporten-finalizer"
 
@@ -34,6 +46,7 @@ const (
 	ConditionTypeReady            = "Ready"
 	ConditionTypeClientRegistered = "ClientRegistered"
 	ConditionTypeSecretSynced     = "SecretSynced"
+	ConditionTypeRotationRestart  = "MaskinportenSecretRotationRestart"
 	ConditionTypeDeleting         = "Deleting"
 )
 
@@ -92,6 +105,32 @@ type SecretStateContent struct {
 	Jwk       *crypto.Jwk  `json:"Jwk"`
 	ClientId  string       `json:"ClientId"`
 	Authority string       `json:"Authority"`
+}
+
+func (c *SecretStateContent) RotationFingerprint() string {
+	if c == nil {
+		return ""
+	}
+	keyIDs := make([]string, 0)
+	if c.Jwks != nil {
+		keyIDs = make([]string, 0, len(c.Jwks.Keys))
+		for _, key := range c.Jwks.Keys {
+			keyIDs = append(keyIDs, key.KeyID())
+		}
+		sort.Strings(keyIDs)
+	}
+
+	activeKeyID := ""
+	if c.Jwk != nil {
+		activeKeyID = c.Jwk.KeyID()
+	}
+
+	hasher := sha256.New()
+	_, _ = fmt.Fprintf(hasher, "clientId=%s\nauthority=%s\nactiveKeyId=%s\n", c.ClientId, c.Authority, activeKeyID)
+	for _, keyID := range keyIDs {
+		_, _ = fmt.Fprintf(hasher, "keyId=%s\n", keyID)
+	}
+	return hex.EncodeToString(hasher.Sum(nil))
 }
 
 func (c *SecretStateContent) SerializeTo(secret *corev1.Secret) error {
@@ -440,7 +479,11 @@ func (s *ClientState) Reconcile(
 					Jwks:      jwks,
 					Jwk:       jwks.Keys[0],
 				}
-				commands = append(commands, NewUpdateSecretContentCommand(secretStateContent))
+				if jwksRotated {
+					commands = append(commands, NewUpdateSecretContentCommandForRotation(secretStateContent))
+				} else {
+					commands = append(commands, NewUpdateSecretContentCommand(secretStateContent))
+				}
 			}
 
 			// Remove rotation annotation after successful forced rotation
@@ -554,7 +597,8 @@ type CreateClientInApiCommandResponse struct {
 	Resp *ClientResponse
 }
 type UpdateSecretContentCommand struct {
-	SecretContent *SecretStateContent
+	SecretContent       *SecretStateContent
+	RotationFingerprint string
 }
 type UpdateClientInApiCommand struct {
 	Api *ApiState
@@ -591,6 +635,19 @@ func NewUpdateSecretContentCommand(content *SecretStateContent) Command {
 	assert.That(content != nil, "UpdateSecretContentCommand requires non-nil SecretContent")
 	return Command{
 		Data:     &UpdateSecretContentCommand{SecretContent: content},
+		Callback: nil,
+	}
+}
+
+func NewUpdateSecretContentCommandForRotation(content *SecretStateContent) Command {
+	assert.That(content != nil, "UpdateSecretContentCommand requires non-nil SecretContent")
+	fingerprint := content.RotationFingerprint()
+	assert.That(fingerprint != "", "rotation secret content fingerprint must be non-empty")
+	return Command{
+		Data: &UpdateSecretContentCommand{
+			SecretContent:       content,
+			RotationFingerprint: fingerprint,
+		},
 		Callback: nil,
 	}
 }
@@ -650,9 +707,10 @@ type UpdateClientInApiCommandResult struct {
 }
 
 type UpdateSecretContentCommandResult struct {
-	Err       error
-	Authority string
-	KeyIds    []string
+	Err                 error
+	Authority           string
+	KeyIds              []string
+	RotationFingerprint string
 }
 
 type DeleteClientInApiCommandResult struct {

--- a/src/Runtime/operator/internal/maskinporten/client_state_test.go
+++ b/src/Runtime/operator/internal/maskinporten/client_state_test.go
@@ -770,6 +770,68 @@ func TestJwkRotation_TriggeredAtThreshold(t *testing.T) {
 	)
 }
 
+func TestJwkRotation_AddsSecretRotationFingerprint(t *testing.T) {
+	g := NewWithT(t)
+	deps := newFixture()
+	jwks, err := deps.crypto.CreateJwks(testCertSubj, deps.getNotAfter())
+	g.Expect(err).NotTo(HaveOccurred())
+	publicJwks, err := jwks.ToPublic()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	state, err := NewClientState(
+		createCrd(WithFinalizer()),
+		&ClientResponse{ClientId: testClientId, Scopes: testScopes},
+		publicJwks,
+		createSecret("ttd-"+testAppId),
+		&SecretStateContent{
+			ClientId:  testClientId,
+			Authority: testSecretStateContentAuthority,
+			Jwks:      jwks,
+			Jwk:       jwks.Keys[0],
+		},
+	)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	deps.clock.Advance(time.Hour * 24 * 24)
+	commands, err := state.Reconcile(deps.context, deps.config, deps.crypto, deps.clock)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	command := findUpdateSecretContentCommand(commands)
+	g.Expect(command).NotTo(BeNil())
+	g.Expect(command.RotationFingerprint).NotTo(BeEmpty())
+	g.Expect(command.RotationFingerprint).To(Equal(command.SecretContent.RotationFingerprint()))
+}
+
+func TestAuthorityOnlySecretUpdateDoesNotAddRotationFingerprint(t *testing.T) {
+	g := NewWithT(t)
+	deps := newFixture()
+	jwks, err := deps.crypto.CreateJwks(testCertSubj, deps.getNotAfter())
+	g.Expect(err).NotTo(HaveOccurred())
+	publicJwks, err := jwks.ToPublic()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	state, err := NewClientState(
+		createCrd(WithFinalizer()),
+		&ClientResponse{ClientId: testClientId, Scopes: testScopes},
+		publicJwks,
+		createSecret("ttd-"+testAppId),
+		&SecretStateContent{
+			ClientId:  testClientId,
+			Authority: "https://old.authority.no/",
+			Jwks:      jwks,
+			Jwk:       jwks.Keys[0],
+		},
+	)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	commands, err := state.Reconcile(deps.context, deps.config, deps.crypto, deps.clock)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	command := findUpdateSecretContentCommand(commands)
+	g.Expect(command).NotTo(BeNil())
+	g.Expect(command.RotationFingerprint).To(BeEmpty())
+}
+
 func TestJwkRotation_SecondRotation(t *testing.T) {
 	g := NewWithT(t)
 	deps := newFixture()
@@ -831,6 +893,15 @@ func TestForcedRotation_ViaAnnotation(t *testing.T) {
 		},
 		func(*fixture) {},
 	)
+}
+
+func findUpdateSecretContentCommand(commands CommandList) *UpdateSecretContentCommand {
+	for _, command := range commands {
+		if updateSecretCommand, ok := command.Data.(*UpdateSecretContentCommand); ok {
+			return updateSecretCommand
+		}
+	}
+	return nil
 }
 
 func TestForcedRotation_AnnotationValueNotTrue(t *testing.T) {

--- a/src/Runtime/operator/test/e2e/__snapshots__/step2b-jwk-rotated-client.snap
+++ b/src/Runtime/operator/test/e2e/__snapshots__/step2b-jwk-rotated-client.snap
@@ -98,6 +98,14 @@
     "reason": "Reconciled",
     "status": "True",
     "type": "Ready"
+   },
+   {
+    "lastTransitionTime": "2024-01-01T00:00:00Z",
+    "message": "Maskinporten secret rotation is pending an app Deployment rollout for compatibility",
+    "observedGeneration": 2,
+    "reason": "PendingCompatibilityRollout",
+    "status": "True",
+    "type": "MaskinportenSecretRotationRestart"
    }
   ],
   "keyIds": [
@@ -105,7 +113,9 @@
    "<key-uuid>.0"
   ],
   "lastSynced": "2024-01-01T00:00:00Z",
-  "observedGeneration": 2
+  "observedGeneration": 2,
+  "pendingSecretRotationDetectedAt": "2024-01-01T00:00:00Z",
+  "pendingSecretRotationFingerprint": "<sanitized-rotation-fingerprint>"
  }
 }
 ---

--- a/src/Runtime/operator/test/e2e/__snapshots__/step2b-jwk-rotated-secret.snap
+++ b/src/Runtime/operator/test/e2e/__snapshots__/step2b-jwk-rotated-secret.snap
@@ -109,6 +109,8 @@
  "kind": "Secret",
  "metadata": {
   "annotations": {
+   "altinn.studio/maskinporten-secret-rotated-at": "2024-01-01T00:00:00Z",
+   "altinn.studio/maskinporten-secret-version": "<sanitized-rotation-fingerprint>",
    "helm.sh/resource-policy": "keep",
    "meta.helm.sh/release-name": "ttd-localtestapp",
    "meta.helm.sh/release-namespace": "default"

--- a/src/Runtime/operator/test/e2e/__snapshots__/step2c-jwk-rotated-again-client.snap
+++ b/src/Runtime/operator/test/e2e/__snapshots__/step2c-jwk-rotated-again-client.snap
@@ -118,6 +118,14 @@
     "reason": "Reconciled",
     "status": "True",
     "type": "Ready"
+   },
+   {
+    "lastTransitionTime": "2024-01-01T00:00:00Z",
+    "message": "Maskinporten secret rotation is pending an app Deployment rollout for compatibility",
+    "observedGeneration": 2,
+    "reason": "PendingCompatibilityRollout",
+    "status": "True",
+    "type": "MaskinportenSecretRotationRestart"
    }
   ],
   "keyIds": [
@@ -125,7 +133,9 @@
    "<key-uuid>.1"
   ],
   "lastSynced": "2024-01-01T00:00:00Z",
-  "observedGeneration": 2
+  "observedGeneration": 2,
+  "pendingSecretRotationDetectedAt": "2024-01-01T00:00:00Z",
+  "pendingSecretRotationFingerprint": "<sanitized-rotation-fingerprint>"
  }
 }
 ---

--- a/src/Runtime/operator/test/e2e/__snapshots__/step2c-jwk-rotated-again-secret.snap
+++ b/src/Runtime/operator/test/e2e/__snapshots__/step2c-jwk-rotated-again-secret.snap
@@ -109,6 +109,8 @@
  "kind": "Secret",
  "metadata": {
   "annotations": {
+   "altinn.studio/maskinporten-secret-rotated-at": "2024-01-01T00:00:00Z",
+   "altinn.studio/maskinporten-secret-version": "<sanitized-rotation-fingerprint>",
    "helm.sh/resource-policy": "keep",
    "meta.helm.sh/release-name": "ttd-localtestapp",
    "meta.helm.sh/release-namespace": "default"

--- a/src/Runtime/operator/test/e2e/__snapshots__/step3-deleted-secret.snap
+++ b/src/Runtime/operator/test/e2e/__snapshots__/step3-deleted-secret.snap
@@ -36,6 +36,8 @@
  "kind": "Secret",
  "metadata": {
   "annotations": {
+   "altinn.studio/maskinporten-secret-rotated-at": "2024-01-01T00:00:00Z",
+   "altinn.studio/maskinporten-secret-version": "<sanitized-rotation-fingerprint>",
    "helm.sh/resource-policy": "keep",
    "meta.helm.sh/release-name": "ttd-localtestapp",
    "meta.helm.sh/release-namespace": "default"

--- a/src/Runtime/operator/test/e2e/snapshot_helpers.go
+++ b/src/Runtime/operator/test/e2e/snapshot_helpers.go
@@ -24,6 +24,7 @@ import (
 
 	resourcesv1alpha1 "altinn.studio/operator/api/v1alpha1"
 	"altinn.studio/operator/internal/fakes"
+	mpmaskinporten "altinn.studio/operator/internal/maskinporten"
 	"altinn.studio/operator/test/utils"
 )
 
@@ -234,6 +235,7 @@ func SanitizeMetadata(meta map[string]any) {
 
 const sanitizedClientId = "<sanitized-client-id>"
 const sanitizedTraceId = "<sanitized-trace-id>"
+const sanitizedRotationFingerprint = "<sanitized-rotation-fingerprint>"
 
 // SanitizeMaskinportenClientStatus sanitizes status timestamps and dynamic fields.
 func SanitizeMaskinportenClientStatus(status map[string]any) {
@@ -243,9 +245,25 @@ func SanitizeMaskinportenClientStatus(status map[string]any) {
 	if status["clientId"] != nil {
 		status["clientId"] = sanitizedClientId
 	}
+	sanitizeRotationRestartStatus(status)
 	sanitizeKeyIDs(status)
 	sanitizeActionHistory(status)
 	sanitizeConditions(status)
+}
+
+func sanitizeRotationRestartStatus(status map[string]any) {
+	if status["pendingSecretRotationDetectedAt"] != nil {
+		status["pendingSecretRotationDetectedAt"] = sanitizedTimestamp
+	}
+	if status["lastSecretRotationRestartedAt"] != nil {
+		status["lastSecretRotationRestartedAt"] = sanitizedTimestamp
+	}
+	if status["pendingSecretRotationFingerprint"] != nil {
+		status["pendingSecretRotationFingerprint"] = sanitizedRotationFingerprint
+	}
+	if status["lastSecretRotationRestartedFingerprint"] != nil {
+		status["lastSecretRotationRestartedFingerprint"] = sanitizedRotationFingerprint
+	}
 }
 
 func sanitizeKeyIDs(status map[string]any) {
@@ -479,6 +497,7 @@ func SnapshotSecret(secret *corev1.Secret, name string) {
 
 	if meta, ok := obj["metadata"].(map[string]any); ok {
 		SanitizeMetadata(meta)
+		sanitizeSecretRotationAnnotations(meta)
 	}
 
 	sanitizeSecretSnapshotData(obj)
@@ -487,6 +506,20 @@ func SnapshotSecret(secret *corev1.Secret, name string) {
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to marshal sanitized Secret")
 
 	snaps.WithConfig(snaps.Filename(name)).MatchJSON(ginkgo.GinkgoT(), sanitized)
+}
+
+func sanitizeSecretRotationAnnotations(meta map[string]any) {
+	annotations, ok := meta["annotations"].(map[string]any)
+	if !ok {
+		return
+	}
+
+	if annotations[mpmaskinporten.AnnotationSecretRotatedAt] != nil {
+		annotations[mpmaskinporten.AnnotationSecretRotatedAt] = sanitizedTimestamp
+	}
+	if annotations[mpmaskinporten.AnnotationSecretVersion] != nil {
+		annotations[mpmaskinporten.AnnotationSecretVersion] = sanitizedRotationFingerprint
+	}
 }
 
 func sanitizeSecretSnapshotData(obj map[string]any) {


### PR DESCRIPTION
## Description

Adds a targeted compatibility rollout path for apps affected by Maskinporten secret/JWK rotations.

- Tracks pending and completed rotation rollouts on `MaskinportenClient.status` using rotation fingerprints.
- Annotates rotated app Secrets with the Maskinporten secret version.
- Adds a leader-elected nightly processor that only handles MaskinportenClients with pending rotations.
- Triggers a normal app Deployment rollout by patching `spec.template.metadata.annotations`.
- Recovers from the case where the Secret update succeeded but the CR status update missed the pending marker.
- Enforces the same service-owner scope as the normal Maskinporten reconciler.
- Adds focused tests for idempotency, only-rotated-app behavior, Secret annotation recovery, service-owner scoping, and Deployment annotation patching.
- Updates e2e snapshot sanitization and Maskinporten rotation snapshots for the new rotation status and Secret annotations.

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

Commands run:

```sh
go test ./internal/maskinporten ./internal/controller/maskinporten -run 'Test(UpdateSecret|HasAuthoritative|ShouldRequire|GetMissing|Randomize|MarkRotation|ProcessPending|Duration|JwkRotation|AuthorityOnly)'
make lint
make test
make test-e2e
go test -tags=e2e ./test/e2e -run '^$'
git diff --check
```

Manual testing note: ran `make test-e2e` locally from a clean Kind/runtime fixture. This exercises the Maskinporten manual JWK rotation flow, verifies the new pending rollout status/Secret annotations in snapshots, and confirms the e2e suite passes with the updated goldens.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added automatic secret rotation tracking for Maskinporten clients with status fields recording pending and completed rotation states, including timestamps and fingerprints
- Enabled automatic deployment rollouts triggered when Maskinporten secrets are rotated, with deployment pod templates automatically updated

**Tests**
- Added comprehensive test coverage for secret rotation tracking and deployment rollout processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->