### PR TITLE
fix: Add property menu closes without adding when an item is clicked

### DIFF
--- a/src/Designer/frontend/packages/schema-editor/src/components/SchemaTree/SchemaNode/SchemaNode.module.css
+++ b/src/Designer/frontend/packages/schema-editor/src/components/SchemaTree/SchemaNode/SchemaNode.module.css
@@ -18,7 +18,8 @@
 }
 
 .schemaNodeLabel:hover .actionButtons,
-.schemaNodeLabel:focus-within .actionButtons {
+.schemaNodeLabel:focus-within .actionButtons,
+.actionButtons:has([aria-expanded='true']) {
   visibility: visible;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The v1 StudioDropdown renders its menu inline, so it inherited the visibility: hidden from .actionButtons once hover was lost, making items unclickable. Keep the buttons visible while the menu is open via .actionButtons:has([aria-expanded='true']).


https://digdir-samarbeid.slack.com/archives/C02EJ9HKQA3/p1781596252440539

Now it works.

https://github.com/user-attachments/assets/67c09a0a-0538-430a-a5c1-898857be446a


<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved action button visibility in the schema editor. Action buttons now display when hovering over elements, when an area receives keyboard focus, or when schema nodes are in an expanded state. This enhancement increases overall accessibility and improves the user experience when navigating schema structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->