### PR TITLE
ci: move first workflows to self-hosted

### DIFF
--- a/.github/workflows/app-backend-formatting.yml
+++ b/.github/workflows/app-backend-formatting.yml
@@ -15,7 +15,7 @@ jobs:
   verify-no-changes:
     if: |
       github.event.pull_request.user.login != 'renovate[bot]'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-single
     timeout-minutes: 5
     defaults:
       run:

--- a/.github/workflows/app-backend-tests.yml
+++ b/.github/workflows/app-backend-tests.yml
@@ -17,7 +17,7 @@ jobs:
   build-frontend:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-single
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: ./.github/actions/app-build-frontend
@@ -28,13 +28,16 @@ jobs:
       matrix:
         os:
           - id: ubuntu-latest
+            runner: self-hosted-single
             workingDir: src/App/backend/
           - id: macos-latest
+            runner: macos-latest
             workingDir: src/App/backend/
           - id: windows-latest
+            runner: windows-latest
             workingDir: src\App\backend\
     name: Build and test
-    runs-on: ${{ matrix.os.id }}
+    runs-on: ${{ matrix.os.runner }}
     timeout-minutes: 15
     env:
       DOTNET_HOSTBUILDER__RELOADCONFIGONCHANGE: false

--- a/.github/workflows/app-frontend-unit-tests.yml
+++ b/.github/workflows/app-frontend-unit-tests.yml
@@ -69,7 +69,7 @@ jobs:
         run: yarn lint
 
       - name: run tests
-        run: yarn test --coverage
+        run: yarn test --coverage --maxWorkers=2
         env:
           NODE_OPTIONS: --max-old-space-size=4096
 

--- a/.github/workflows/app-frontend-unit-tests.yml
+++ b/.github/workflows/app-frontend-unit-tests.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   unit-tests:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-single
     timeout-minutes: 30
     name: Type-checks, eslint, unit tests and SonarCloud
     defaults:
@@ -39,7 +39,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         id: yarn-cache

--- a/.github/workflows/app-frontend-unit-tests.yml
+++ b/.github/workflows/app-frontend-unit-tests.yml
@@ -70,6 +70,8 @@ jobs:
 
       - name: run tests
         run: yarn test --coverage
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
 
       # TODO: consider for removal?
       # - name: SonarCloud Scan

--- a/.github/workflows/cli-build-test.yaml
+++ b/.github/workflows/cli-build-test.yaml
@@ -17,7 +17,7 @@ jobs:
   detect-changelog-change:
     name: Detect changelog changes
     if: github.event_name == 'pull_request' && github.event.action != 'closed' && !github.event.pull_request.draft && !contains(github.event.pull_request.labels.*.name, 'skip-changelog')
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-single
     timeout-minutes: 30
     outputs:
       changed: ${{ steps.changes.outputs.changed }}
@@ -39,7 +39,7 @@ jobs:
     name: Validate changelog
     if: (github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft)) && needs.detect-changelog-change.outputs.changed == 'true'
     needs: detect-changelog-change
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-single
     timeout-minutes: 30
     steps:
       - name: Checkout repository
@@ -61,7 +61,7 @@ jobs:
   verify-release-artifacts:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Verify studioctl release artifacts
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-single
     timeout-minutes: 30
     steps:
       - name: Checkout repository
@@ -99,9 +99,15 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     strategy:
       matrix:
-        os: [macos-latest,windows-latest,ubuntu-latest]
+        include:
+          - os: macos-latest
+            runner: macos-latest
+          - os: windows-latest
+            runner: windows-latest
+          - os: ubuntu-latest
+            runner: self-hosted-single
     name: Build and test
-    runs-on: ${{ matrix.os}}
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     env:
       DOTNET_HOSTBUILDER__RELOADCONFIGONCHANGE: false

--- a/.github/workflows/designer-backend-dotnet-test.yaml
+++ b/.github/workflows/designer-backend-dotnet-test.yaml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [ubuntu-latest,windows-latest,macos-latest]
     name: Run dotnet build and test
-    runs-on: ${{ matrix.os}}
+    runs-on: ${{ matrix.os == 'ubuntu-latest' && 'self-hosted-single' || matrix.os }}
     timeout-minutes: 30
     env:
       DOTNET_HOSTBUILDER__RELOADCONFIGONCHANGE: false

--- a/.github/workflows/designer-frontend-unit-tests.yml
+++ b/.github/workflows/designer-frontend-unit-tests.yml
@@ -24,7 +24,7 @@ jobs:
   typecheck:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: 'Typechecking and linting'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-single
     timeout-minutes: 30
     permissions:
       actions: read
@@ -58,7 +58,7 @@ jobs:
   test:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: 'Testing'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-single
     timeout-minutes: 30
     steps:
       - name: 'Checking Out Code'

--- a/.github/workflows/libs-form-component-unit-tests.yml
+++ b/.github/workflows/libs-form-component-unit-tests.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   unit-tests:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-single
     timeout-minutes: 30
     name: Unit tests
     defaults:
@@ -38,7 +38,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         id: yarn-cache

--- a/.github/workflows/runtime-devenv-build.yml
+++ b/.github/workflows/runtime-devenv-build.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   lint:
     name: Check formatting and lint
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-single
     timeout-minutes: 30
     defaults:
       run:

--- a/.github/workflows/runtime-health-build.yml
+++ b/.github/workflows/runtime-health-build.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   lint:
     name: Check formatting and lint
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-single
     timeout-minutes: 30
     defaults:
       run:

--- a/.github/workflows/runtime-localtest-build.yml
+++ b/.github/workflows/runtime-localtest-build.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
+      - '.github/workflows/runtime-localtest-build.yml'
       - 'src/Runtime/localtest/**'
 
 concurrency:

--- a/.github/workflows/runtime-localtest-build.yml
+++ b/.github/workflows/runtime-localtest-build.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   build:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-single
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/runtime-workflow-engine-app-tests.yaml
+++ b/.github/workflows/runtime-workflow-engine-app-tests.yaml
@@ -25,7 +25,7 @@ jobs:
   build-and-test:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-single
     timeout-minutes: 30
     defaults:
       run:

--- a/.github/workflows/runtime-workflow-engine-tests.yaml
+++ b/.github/workflows/runtime-workflow-engine-tests.yaml
@@ -21,7 +21,7 @@ jobs:
   build-and-test:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-single
     timeout-minutes: 30
     defaults:
       run:


### PR DESCRIPTION
## Description

Generally a bit slower here, mostly due to fs 

| Workflow | Measured migrated job/leg | Current self-hosted run | Current exec | Previous branch/run | Previous exec | Delta |
|---|---|---:|---:|---:|---:|---:|
| App Backend - Build and test | Slowest migrated job: Ubuntu Build and test | [27657092517](https://github.com/Altinn/altinn-studio/actions/runs/27657092517) | 8m 05s | renovate/actions-checkout-digest / [27617358481](https://github.com/Altinn/altinn-studio/actions/runs/27617358481) | 6m 02s | +2m 03s (+34%) |
| App Backend - Verify formatting | verify-no-changes | [27657092471](https://github.com/Altinn/altinn-studio/actions/runs/27657092471) | 37s | feat/workflow-engine-integration / [27617645858](https://github.com/Altinn/altinn-studio/actions/runs/27617645858) | 29s | +8s (+28%) |
| App Frontend - Unit tests | Type-checks, eslint, unit tests and SonarCloud | [27650531105](https://github.com/Altinn/altinn-studio/actions/runs/27650531105) | 11m 51s | support-lists-in-expressions / [27650200237](https://github.com/Altinn/altinn-studio/actions/runs/27650200237) | 8m 36s | +3m 15s (+38%) |
| CLI - Build and test | Slowest migrated CLI job: Verify studioctl release artifacts | [27650531047](https://github.com/Altinn/altinn-studio/actions/runs/27650531047) | 5m 39s | renovate/actions-checkout-digest / [27617358325](https://github.com/Altinn/altinn-studio/actions/runs/27617358325) | 4m 26s | +1m 13s (+27%) |
| Designer Backend - Build and test | Ubuntu matrix leg only | [27650530965](https://github.com/Altinn/altinn-studio/actions/runs/27650530965) | 6m 07s | renovate/actions-checkout-digest / [27617357840](https://github.com/Altinn/altinn-studio/actions/runs/27617357840) | 4m 38s | +1m 29s (+32%) |
| Designer Frontend - Unit tests | Slowest migrated job: Testing | [27650531012](https://github.com/Altinn/altinn-studio/actions/runs/27650531012) | 16m 10s | renovate/node-24.x / [27646779758](https://github.com/Altinn/altinn-studio/actions/runs/27646779758) | 16m 30s | -20s (-2%) |
| Library Form Component - Unit tests | Unit tests | [27650531010](https://github.com/Altinn/altinn-studio/actions/runs/27650531010) | 6m 03s | renovate/typescript-6.x / [27644066101](https://github.com/Altinn/altinn-studio/actions/runs/27644066101) | 2m 46s | +3m 17s (+119%) |
| devenv - Lint | Check formatting and lint | [27650530985](https://github.com/Altinn/altinn-studio/actions/runs/27650530985) | 3m 17s | renovate/actions-checkout-digest / [27617358381](https://github.com/Altinn/altinn-studio/actions/runs/27617358381) | 3m 11s | +6s (+3%) |
| runtime-health - Lint | Check formatting and lint | [27650530945](https://github.com/Altinn/altinn-studio/actions/runs/27650530945) | 2m 12s | renovate/actions-checkout-digest / [27617357834](https://github.com/Altinn/altinn-studio/actions/runs/27617357834) | 2m 00s | +12s (+10%) |
| Localtest - Build | build | [27654304441](https://github.com/Altinn/altinn-studio/actions/runs/27654304441) | 47s | refactor/move-Input-to-layout-components / [26953843725](https://github.com/Altinn/altinn-studio/actions/runs/26953843725) | 39s | +8s (+21%) |
| Runtime Workflow Engine App - Build and test | Build and test | [27650531069](https://github.com/Altinn/altinn-studio/actions/runs/27650531069) | 2m 34s | renovate/actions-checkout-digest / [27617358390](https://github.com/Altinn/altinn-studio/actions/runs/27617358390) | 1m 39s | +55s (+56%) |
| Runtime Workflow Engine - Build and test | Build and test | [27650530980](https://github.com/Altinn/altinn-studio/actions/runs/27650530980) | 4m 11s | renovate/actions-checkout-digest / [27617358358](https://github.com/Altinn/altinn-studio/actions/runs/27617358358) | 2m 56s | +1m 15s (+43%) |

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflows to run build and unit-test validations on the `self-hosted-single` runner for more consistent automated checking.
  * Improved Yarn cache output handling to use the recommended `$GITHUB_OUTPUT` redirection format.
* **Tests**
  * Adjusted unit test execution to run with coverage enabled and controlled parallelism.
  * Increased Node.js memory for unit test runs to help prevent out-of-memory failures.
  * Typecheck and unit test jobs now follow the updated runner configuration across affected workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->