### PR TITLE
fix 'branch not created' bug in sync script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,12 +144,18 @@ create-pr:
 		echo "Install GitHub CLI to enable automatic PR creation: https://cli.github.com/"; \
 	fi
 
-# Generate individual sync targets dynamically
-$(foreach subtree,$(SUBTREES), \
-	$(eval sync-$(word 1,$(subst |, ,$(subtree))): ; \
-		$$(call create-sync-branch,$(word 1,$(subst |, ,$(subtree)))) \
-		$$(call pull-subtree,$(word 1,$(subst |, ,$(subtree))),$(word 2,$(subst |, ,$(subtree))),$(word 3,$(subst |, ,$(subtree))),$(word 4,$(subst |, ,$(subtree)))) \
-		@$$(MAKE) create-pr SUBTREE_NAME=$(word 1,$(subst |, ,$(subtree)))))
+# Generate individual sync targets dynamically.
+# Each macro must live on its own recipe line (like sync-test-apps below); joining
+# them with backslash continuations collapses them into a single shell command,
+# which breaks command separation and the @-silenced recursive make call.
+define sync-target-template
+sync-$(word 1,$(subst |, ,$(1))):
+	$$(call create-sync-branch,$(word 1,$(subst |, ,$(1))))
+	$$(call pull-subtree,$(word 1,$(subst |, ,$(1))),$(word 2,$(subst |, ,$(1))),$(word 3,$(subst |, ,$(1))),$(word 4,$(subst |, ,$(1))))
+	@$$(MAKE) create-pr SUBTREE_NAME=$(word 1,$(subst |, ,$(1)))
+endef
+
+$(foreach subtree,$(SUBTREES),$(eval $(call sync-target-template,$(subtree))))
 
 # Sync all test apps
 sync-test-apps: ## Sync all test app subtrees


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Branch creation failed with
'fatal: empty string is not a valid pathspec. please use . instead if you meant to match all paths'

Root cause: In Makefile, the dynamically-generated sync-* targets (e.g. sync-frontend) joined the create-sync-branch, pull-subtree, and $(MAKE) create-pr macros with \ line-continuations, collapsing them into a single shell command line. create-sync-branch ends with git checkout -b … origin/main and no separator, so the next macro's echo "" was passed to git as a pathspec argument — and the empty "" produced fatal: empty string is not a valid pathspec.

Fix: Replaced the inline '$(eval … : ; … \ … \ …)' generation with a define sync-target-template whose recipe lines are each on their own TAB-indented line — exactly how the working sync-test-apps / sync-all targets are structured. Each macro now runs as a separate command, and the recursive @$(MAKE) is a proper standalone recipe line.

This also fixes a nastier latent footgun: because the git operations were on the same shell line as $(MAKE), GNU make force-executed them even under make -n. That's why a diagnostic dry-run actually started a real subtree merge. Now the git steps are print-only under -n.

<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal build system efficiency through streamlined configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->