### PR TITLE
ci: single runner scaling tweaks

### DIFF
--- a/src/github-runner/infra/kustomize/base/scaledjob-single.yaml
+++ b/src/github-runner/infra/kustomize/base/scaledjob-single.yaml
@@ -9,7 +9,7 @@ metadata:
     altinn.studio/image: altinntjenestercontainerregistry.azurecr.io/altinn-studio/github-runner:latest
     altinn.studio/image-tag: latest
 spec:
-  maxReplicaCount: 2
+  maxReplicaCount: 64
   minReplicaCount: 0
   pollingInterval: 30
   successfulJobsHistoryLimit: 5
@@ -83,9 +83,8 @@ spec:
                 memory: 8Gi
                 ephemeral-storage: 75Gi
               limits:
-                cpu: "4"
-                memory: 8Gi
-                ephemeral-storage: 85Gi
+                memory: 12Gi
+                ephemeral-storage: 100Gi
             volumeMounts:
               - name: runner-tmp
                 mountPath: /tmp


### PR DESCRIPTION
## Description

Increased the node size, should now be able to pack 8 jobs in 1 VM (reduce queueing is partly the point here..)

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded GitHub runner infrastructure scaling capacity, increasing the maximum concurrent instances from 2 to 64 to better handle increased workloads.
  * Enhanced per-instance resource allocation: memory limit increased to 12 GB and ephemeral storage expanded to 100 GB, enabling more resource-intensive operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->