### PR TITLE
fix: normalize aksel icons lockfile selector

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4395,6 +4395,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@navikt/aksel-icons@npm:8.10.5, @navikt/aksel-icons@npm:^8.2.0, @navikt/aksel-icons@npm:^8.9.0":
+  version: 8.10.5
+  resolution: "@navikt/aksel-icons@npm:8.10.5"
+  checksum: 10/6a7b005e664c326e840111bba62845c8106d140030ceca2d400fca75aadd5e7e0fdf3e7f959cd233f0c93ff22ebeca78941b8a7f83d0e2cca0e47b5d75583261
+  languageName: node
+  linkType: hard
+
 "@navikt/aksel-icons@npm:8.10.6":
   version: 8.10.6
   resolution: "@navikt/aksel-icons@npm:8.10.6"
@@ -4413,13 +4420,6 @@ __metadata:
   version: 7.40.0
   resolution: "@navikt/aksel-icons@npm:7.40.0"
   checksum: 10/3aa95caee5484355b8e1bbe06fa3f4c1dd2f5db48c3c27e445f8ce53438e3571949f957178b2dbc81163c148f5c5c000222e67afe60556955419ad06ce505fab
-  languageName: node
-  linkType: hard
-
-"@navikt/aksel-icons@npm:^8.2.0, @navikt/aksel-icons@npm:^8.9.0":
-  version: 8.10.5
-  resolution: "@navikt/aksel-icons@npm:8.10.5"
-  checksum: 10/6a7b005e664c326e840111bba62845c8106d140030ceca2d400fca75aadd5e7e0fdf3e7f959cd233f0c93ff22ebeca78941b8a7f83d0e2cca0e47b5d75583261
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Normalizes the `@navikt/aksel-icons` `8.10.5` selector in `yarn.lock` so Yarn hardened mode does not try to rewrite the lockfile during CI installs.

This is a helper PR targeting #19198 because `martinothamar-agent` does not have permission to push directly to `Altinn/altinn-studio:ci/self-hosted-wave1`.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

Manual testing:

```sh
YARN_ENABLE_HARDENED_MODE=1 YARN_ENABLE_GLOBAL_CACHE=false YARN_NM_MODE=hardlinks-local HUSKY=0 yarn install --immutable --inline-builds
```

Result: passed locally after the lockfile normalization. Before the change, the same command reproduced the CI failure: `The lockfile would have been modified by this install, which is explicitly forbidden.`

CI on this helper PR is green, including Designer Frontend unit tests, Playwright, CodeQL, Lint PR, and `codecov/patch`.
