### PR TITLE
ci: move first workflows to self-hosted

### DIFF
--- a/.github/workflows/app-frontend-unit-tests.yml
+++ b/.github/workflows/app-frontend-unit-tests.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   unit-tests:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-single
     timeout-minutes: 30
     name: Type-checks, eslint, unit tests and SonarCloud
     defaults:
@@ -39,7 +39,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         id: yarn-cache
@@ -69,7 +69,9 @@ jobs:
         run: yarn lint
 
       - name: run tests
-        run: yarn test --coverage
+        run: yarn test --coverage --maxWorkers=2
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
 
       # TODO: consider for removal?
       # - name: SonarCloud Scan

--- a/.github/workflows/cli-build-test.yaml
+++ b/.github/workflows/cli-build-test.yaml
@@ -17,7 +17,7 @@ jobs:
   detect-changelog-change:
     name: Detect changelog changes
     if: github.event_name == 'pull_request' && github.event.action != 'closed' && !github.event.pull_request.draft && !contains(github.event.pull_request.labels.*.name, 'skip-changelog')
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-single
     timeout-minutes: 30
     outputs:
       changed: ${{ steps.changes.outputs.changed }}
@@ -39,7 +39,7 @@ jobs:
     name: Validate changelog
     if: (github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft)) && needs.detect-changelog-change.outputs.changed == 'true'
     needs: detect-changelog-change
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-single
     timeout-minutes: 30
     steps:
       - name: Checkout repository
@@ -61,7 +61,7 @@ jobs:
   verify-release-artifacts:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Verify studioctl release artifacts
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-single
     timeout-minutes: 30
     steps:
       - name: Checkout repository
@@ -99,9 +99,15 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     strategy:
       matrix:
-        os: [macos-latest,windows-latest,ubuntu-latest]
+        include:
+          - os: macos-latest
+            runner: macos-latest
+          - os: windows-latest
+            runner: windows-latest
+          - os: ubuntu-latest
+            runner: self-hosted-single
     name: Build and test
-    runs-on: ${{ matrix.os}}
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     env:
       DOTNET_HOSTBUILDER__RELOADCONFIGONCHANGE: false

--- a/.github/workflows/designer-frontend-unit-tests.yml
+++ b/.github/workflows/designer-frontend-unit-tests.yml
@@ -24,7 +24,7 @@ jobs:
   typecheck:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: 'Typechecking and linting'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-single
     timeout-minutes: 30
     permissions:
       actions: read
@@ -58,7 +58,7 @@ jobs:
   test:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: 'Testing'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-single
     timeout-minutes: 30
     steps:
       - name: 'Checking Out Code'

--- a/.github/workflows/libs-form-component-unit-tests.yml
+++ b/.github/workflows/libs-form-component-unit-tests.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   unit-tests:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-single
     timeout-minutes: 30
     name: Unit tests
     defaults:
@@ -38,7 +38,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         id: yarn-cache


### PR DESCRIPTION
## Description

Moves the first CI workflows from `ubuntu-latest` to the `self-hosted-single` runner:

- App frontend unit tests
- Designer frontend unit tests
- Form component unit tests
- Ubuntu leg of the CLI build/test matrix

This is a clean replacement for the current `ci/self-hosted-wave1` branch state. It intentionally leaves `yarn.lock` unchanged from `main`, because the stale lockfile selector from #19209 is now what makes the rebased branch fail hardened-mode installs.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

Manual verification:

- `git diff --cached --check`
- `git diff --name-status upstream/main...HEAD`
- Confirmed the PR branch only changes four workflow files and does not modify `yarn.lock`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimised testing infrastructure configuration, including improved resource allocation and environment settings for more reliable and efficient test execution across workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->