### PR TITLE
ci: gh runner - prevent workflow interruption

### DIFF
--- a/src/github-runner/infra/kustomize/base/scaledjob-single.yaml
+++ b/src/github-runner/infra/kustomize/base/scaledjob-single.yaml
@@ -12,6 +12,11 @@ spec:
   maxReplicaCount: 64
   minReplicaCount: 0
   pollingInterval: 30
+  # Keep in-flight CI jobs running when the runner image/spec changes
+  # default strategy cancels running job on updates
+  # (this lets us deploy runner changes without interrupting active workflows)
+  rollout:
+    strategy: gradual
   successfulJobsHistoryLimit: 5
   failedJobsHistoryLimit: 5
   jobTargetRef:
@@ -20,6 +25,10 @@ spec:
     activeDeadlineSeconds: 7200
     template:
       metadata:
+        annotations:
+          # Same as above, we want to leave time for nodes to complete all jobs
+          # before letting the cluster-autoscaler shutdown/drain nodes for scaledown
+          cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
         labels:
           app.kubernetes.io/name: github-runner
           app.kubernetes.io/component: runner-single

--- a/src/github-runner/infra/kustomize/base/scaledjob.yaml
+++ b/src/github-runner/infra/kustomize/base/scaledjob.yaml
@@ -12,6 +12,11 @@ spec:
   maxReplicaCount: 16
   minReplicaCount: 0
   pollingInterval: 30
+  # Keep in-flight CI jobs running when the runner image/spec changes
+  # default strategy cancels running job on updates
+  # (this lets us deploy runner changes without interrupting active workflows)
+  rollout:
+    strategy: gradual
   successfulJobsHistoryLimit: 5
   failedJobsHistoryLimit: 5
   jobTargetRef:
@@ -20,6 +25,10 @@ spec:
     activeDeadlineSeconds: 7200
     template:
       metadata:
+        annotations:
+          # Same as above, we want to leave time for nodes to complete all jobs
+          # before letting the cluster-autoscaler shutdown/drain nodes for scaledown
+          cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
         labels:
           app.kubernetes.io/name: github-runner
           app.kubernetes.io/component: runner


### PR DESCRIPTION
## Description

as described in comments, tweaks some defaults so that we leave running workflows complete
- dont let cluster-autoscaler evict active workflows during scaledown
- dont let KEDA cancel active workflows (`Job`s) when spec `ScaledJob` changes

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced GitHub runner deployment configuration to preserve active CI jobs during updates and prevent nodes from shutting down whilst jobs are in progress, ensuring improved reliability and job continuity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->