### PR TITLE
fix: resolve maskinporten rollout deployments by release label

### DIFF
--- a/src/Runtime/operator/internal/controller/maskinporten/controller_unit_test.go
+++ b/src/Runtime/operator/internal/controller/maskinporten/controller_unit_test.go
@@ -249,7 +249,7 @@ func TestProcessPendingMaskinportenRotationRollouts_PatchesDeploymentTemplateAnd
 	now := time.Date(2026, 6, 15, 2, 0, 0, 0, time.UTC)
 	fingerprint := testRotationFingerprint
 	instance := rotationRolloutClient("ttd-testapp", fingerprint)
-	deployment := rotationRolloutDeployment("ttd-testapp-deployment")
+	deployment := rotationRolloutDeployment("ttd-testapp-deployment", "ttd-testapp")
 	reconciler := newFakeReconcilerForRotationRollout(t, instance, deployment)
 
 	err := reconciler.processPendingMaskinportenRotationRollouts(ctx, now)
@@ -274,6 +274,27 @@ func TestProcessPendingMaskinportenRotationRollouts_PatchesDeploymentTemplateAnd
 	g.Expect(updatedClient.Status.LastSecretRotationRestartedAt.Time).To(BeTemporally("==", now))
 }
 
+func TestProcessPendingMaskinportenRotationRollouts_FindsV2DeploymentByReleaseLabel(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	now := time.Date(2026, 6, 15, 2, 0, 0, 0, time.UTC)
+	fingerprint := testRotationFingerprint
+	instance := rotationRolloutClient("ttd-testapp", fingerprint)
+	deployment := rotationRolloutDeployment("ttd-testapp-deployment-v2", "ttd-testapp")
+	reconciler := newFakeReconcilerForRotationRollout(t, instance, deployment)
+
+	err := reconciler.processPendingMaskinportenRotationRollouts(ctx, now)
+
+	g.Expect(err).NotTo(HaveOccurred())
+
+	updatedDeployment := &appsv1.Deployment{}
+	g.Expect(reconciler.Get(ctx, client.ObjectKeyFromObject(deployment), updatedDeployment)).To(Succeed())
+	g.Expect(updatedDeployment.Spec.Template.Annotations).To(HaveKeyWithValue(
+		mpdomain.AnnotationSecretVersion,
+		fingerprint,
+	))
+}
+
 func TestProcessPendingMaskinportenRotationRollouts_IsIdempotentForSameRotation(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
@@ -281,7 +302,7 @@ func TestProcessPendingMaskinportenRotationRollouts_IsIdempotentForSameRotation(
 	secondRun := firstRun.Add(24 * time.Hour)
 	fingerprint := testRotationFingerprint
 	instance := rotationRolloutClient("ttd-testapp", fingerprint)
-	deployment := rotationRolloutDeployment("ttd-testapp-deployment")
+	deployment := rotationRolloutDeployment("ttd-testapp-deployment", "ttd-testapp")
 	reconciler := newFakeReconcilerForRotationRollout(t, instance, deployment)
 
 	g.Expect(reconciler.processPendingMaskinportenRotationRollouts(ctx, firstRun)).To(Succeed())
@@ -302,8 +323,8 @@ func TestProcessPendingMaskinportenRotationRollouts_OnlyPatchesPendingRotations(
 	pendingFingerprint := testRotationFingerprint
 	pendingClient := rotationRolloutClient("ttd-testapp", pendingFingerprint)
 	nonPendingClient := rotationRolloutClient("ttd-otherapp", "")
-	pendingDeployment := rotationRolloutDeployment("ttd-testapp-deployment")
-	nonPendingDeployment := rotationRolloutDeployment("ttd-otherapp-deployment")
+	pendingDeployment := rotationRolloutDeployment("ttd-testapp-deployment", "ttd-testapp")
+	nonPendingDeployment := rotationRolloutDeployment("ttd-otherapp-deployment", "ttd-otherapp")
 	reconciler := newFakeReconcilerForRotationRollout(
 		t,
 		pendingClient,
@@ -334,7 +355,7 @@ func TestProcessPendingMaskinportenRotationRollouts_RecoversPendingRotationFromS
 	ctx := context.Background()
 	now := time.Date(2026, 6, 15, 2, 0, 0, 0, time.UTC)
 	instance := rotationRolloutClient("ttd-testapp", "")
-	deployment := rotationRolloutDeployment("ttd-testapp-deployment")
+	deployment := rotationRolloutDeployment("ttd-testapp-deployment", "ttd-testapp")
 	secret := rotationRolloutSecret("ttd-testapp-deployment", testRotationFingerprint)
 	reconciler := newFakeReconcilerForRotationRollout(t, instance, deployment, secret)
 
@@ -360,7 +381,7 @@ func TestProcessPendingMaskinportenRotationRollouts_SkipsOtherServiceOwner(t *te
 	ctx := context.Background()
 	now := time.Date(2026, 6, 15, 2, 0, 0, 0, time.UTC)
 	instance := rotationRolloutClient("other-testapp", testRotationFingerprint)
-	deployment := rotationRolloutDeployment("other-testapp-deployment")
+	deployment := rotationRolloutDeployment("other-testapp-deployment", "other-testapp")
 	reconciler := newFakeReconcilerForRotationRollout(t, instance, deployment)
 	reconciler.runtime = rotationRolloutTestRuntime{serviceOwnerID: "ttd"}
 
@@ -385,7 +406,7 @@ func TestProcessPendingMaskinportenRotationRollouts_MarksAlreadyAnnotatedDeploym
 	restartedAt := time.Date(2026, 6, 15, 2, 0, 0, 0, time.UTC)
 	fingerprint := testRotationFingerprint
 	instance := rotationRolloutClient("ttd-testapp", fingerprint)
-	deployment := rotationRolloutDeployment("ttd-testapp-deployment")
+	deployment := rotationRolloutDeployment("ttd-testapp-deployment", "ttd-testapp")
 	deployment.Spec.Template.Annotations = map[string]string{
 		mpdomain.AnnotationSecretVersion:             fingerprint,
 		mpdomain.AnnotationSecretRotationRestartedAt: restartedAt.Format(time.RFC3339),
@@ -427,11 +448,14 @@ func rotationRolloutClient(name string, pendingFingerprint string) *resourcesv1a
 	return instance
 }
 
-func rotationRolloutDeployment(name string) *appsv1.Deployment {
+func rotationRolloutDeployment(name string, releaseName string) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: "default",
+			Labels: map[string]string{
+				appReleaseLabelKey: releaseName,
+			},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Template: corev1.PodTemplateSpec{

--- a/src/Runtime/operator/internal/controller/maskinporten/rotation_rollout.go
+++ b/src/Runtime/operator/internal/controller/maskinporten/rotation_rollout.go
@@ -25,9 +25,12 @@ import (
 
 const (
 	maskinportenRotationRolloutHourUTC = 2
+	appReleaseLabelKey                 = "release"
 )
 
 var errEmptyOperatorServiceOwnerScope = errors.New("operator service owner scope is empty")
+var errAppDeploymentNotFound = errors.New("app Deployment not found")
+var errUnexpectedAppDeploymentCount = errors.New("unexpected number of app Deployments")
 
 type rotationRolloutProcessor struct {
 	reconciler *MaskinportenClientReconciler
@@ -121,7 +124,7 @@ func (r *MaskinportenClientReconciler) processPendingMaskinportenRotationRollout
 	for i := range list.Items {
 		instance := &list.Items[i]
 
-		deploymentName, inScope, err := appDeploymentNameForMaskinportenClient(instance, serviceOwnerID)
+		releaseName, inScope, err := appReleaseNameForMaskinportenClient(instance, serviceOwnerID)
 		if err != nil {
 			errs = append(errs, err)
 			continue
@@ -135,11 +138,16 @@ func (r *MaskinportenClientReconciler) processPendingMaskinportenRotationRollout
 			)
 			continue
 		}
+		secretAppLabel := instance.GetLabels()["app"]
+		if secretAppLabel == "" {
+			secretAppLabel = releaseName + "-deployment"
+		}
 
 		if err := r.processInScopeMaskinportenRotationRollout(
 			ctx,
 			instance,
-			deploymentName,
+			releaseName,
+			secretAppLabel,
 			now,
 		); err != nil {
 			logger.Error(
@@ -147,7 +155,7 @@ func (r *MaskinportenClientReconciler) processPendingMaskinportenRotationRollout
 				"failed processing Maskinporten rotation rollout",
 				"maskinportenClient", instance.Name,
 				"namespace", instance.Namespace,
-				"deployment", deploymentName,
+				"release", releaseName,
 			)
 			errs = append(errs, err)
 		}
@@ -166,7 +174,8 @@ func (r *MaskinportenClientReconciler) processPendingMaskinportenRotationRollout
 func (r *MaskinportenClientReconciler) processInScopeMaskinportenRotationRollout(
 	ctx context.Context,
 	instance *resourcesv1alpha1.MaskinportenClient,
-	deploymentName string,
+	releaseName string,
+	secretAppLabel string,
 	now time.Time,
 ) error {
 	ctx, span := r.runtime.Tracer().Start(
@@ -175,12 +184,13 @@ func (r *MaskinportenClientReconciler) processInScopeMaskinportenRotationRollout
 		trace.WithAttributes(
 			attribute.String("namespace", instance.Namespace),
 			attribute.String("maskinporten_client", instance.Name),
-			attribute.String("deployment", deploymentName),
+			attribute.String("release", releaseName),
+			attribute.String("app_label", secretAppLabel),
 		),
 	)
 	defer span.End()
 
-	fingerprint, err := r.pendingRotationFingerprint(ctx, instance, deploymentName)
+	fingerprint, err := r.pendingRotationFingerprint(ctx, instance, secretAppLabel)
 	if err != nil {
 		span.SetStatus(codes.Error, "determine pending rotation fingerprint")
 		span.RecordError(err)
@@ -192,7 +202,7 @@ func (r *MaskinportenClientReconciler) processInScopeMaskinportenRotationRollout
 	}
 	span.SetAttributes(attribute.String("fingerprint", fingerprint))
 
-	if err := r.processPendingMaskinportenRotationRollout(ctx, instance, deploymentName, fingerprint, now); err != nil {
+	if err := r.processPendingMaskinportenRotationRollout(ctx, instance, releaseName, fingerprint, now); err != nil {
 		span.SetStatus(codes.Error, "process pending rotation rollout")
 		span.RecordError(err)
 		return err
@@ -205,26 +215,26 @@ func (r *MaskinportenClientReconciler) processInScopeMaskinportenRotationRollout
 func (r *MaskinportenClientReconciler) processPendingMaskinportenRotationRollout(
 	ctx context.Context,
 	instance *resourcesv1alpha1.MaskinportenClient,
-	deploymentName string,
+	releaseName string,
 	fingerprint string,
 	now time.Time,
 ) error {
 	logger := log.FromContext(ctx).WithName("maskinporten-rotation-rollout")
 
-	deployment := &appsv1.Deployment{}
-	deploymentKey := client.ObjectKey{Namespace: instance.Namespace, Name: deploymentName}
-	if err := r.Get(ctx, deploymentKey, deployment); err != nil {
-		if apierrors.IsNotFound(err) {
+	deployment, err := r.appDeploymentByReleaseLabel(ctx, instance.Namespace, releaseName)
+	if err != nil {
+		if errors.Is(err, errAppDeploymentNotFound) {
 			logger.Info(
 				"app Deployment not found for pending Maskinporten rotation",
 				"maskinportenClient", instance.Name,
 				"namespace", instance.Namespace,
-				"deployment", deploymentName,
+				"release", releaseName,
 				"fingerprint", fingerprint,
 			)
 		}
-		return fmt.Errorf("get app Deployment %s/%s: %w", instance.Namespace, deploymentName, err)
+		return err
 	}
+	deploymentName := deployment.Name
 
 	restartedAt := now.UTC().Format(time.RFC3339)
 	if deployment.Spec.Template.Annotations[maskinporten.AnnotationSecretVersion] == fingerprint {
@@ -263,15 +273,43 @@ func (r *MaskinportenClientReconciler) processPendingMaskinportenRotationRollout
 	return r.markRotationRestarted(ctx, instance, fingerprint, restartedAt)
 }
 
+func (r *MaskinportenClientReconciler) appDeploymentByReleaseLabel(
+	ctx context.Context,
+	namespace string,
+	releaseName string,
+) (*appsv1.Deployment, error) {
+	deployments := &appsv1.DeploymentList{}
+	if err := r.List(
+		ctx,
+		deployments,
+		client.InNamespace(namespace),
+		client.MatchingLabels{appReleaseLabelKey: releaseName},
+	); err != nil {
+		return nil, fmt.Errorf("list app Deployments for release %q: %w", releaseName, err)
+	}
+	if len(deployments.Items) == 0 {
+		return nil, fmt.Errorf("%w for release %q", errAppDeploymentNotFound, releaseName)
+	}
+	if len(deployments.Items) > 1 {
+		return nil, fmt.Errorf(
+			"%w for release %q: %d",
+			errUnexpectedAppDeploymentCount,
+			releaseName,
+			len(deployments.Items),
+		)
+	}
+	return &deployments.Items[0], nil
+}
+
 func (r *MaskinportenClientReconciler) pendingRotationFingerprint(
 	ctx context.Context,
 	instance *resourcesv1alpha1.MaskinportenClient,
-	deploymentName string,
+	secretAppLabel string,
 ) (string, error) {
 	if fromStatus := pendingRotationFingerprintFromStatus(instance); fromStatus != "" {
 		return fromStatus, nil
 	}
-	return r.pendingRotationFingerprintFromSecretRecovery(ctx, instance, deploymentName)
+	return r.pendingRotationFingerprintFromSecretRecovery(ctx, instance, secretAppLabel)
 }
 
 func pendingRotationFingerprintFromStatus(instance *resourcesv1alpha1.MaskinportenClient) string {
@@ -291,14 +329,14 @@ func pendingRotationFingerprintFromStatus(instance *resourcesv1alpha1.Maskinport
 func (r *MaskinportenClientReconciler) pendingRotationFingerprintFromSecretRecovery(
 	ctx context.Context,
 	instance *resourcesv1alpha1.MaskinportenClient,
-	deploymentName string,
+	secretAppLabel string,
 ) (string, error) {
 	secrets := &corev1.SecretList{}
 	if err := r.List(
 		ctx,
 		secrets,
 		client.InNamespace(instance.Namespace),
-		client.MatchingLabels{"app": deploymentName},
+		client.MatchingLabels{"app": secretAppLabel},
 	); err != nil {
 		return "", fmt.Errorf("list app secrets for Maskinporten rotation recovery: %w", err)
 	}
@@ -306,7 +344,7 @@ func (r *MaskinportenClientReconciler) pendingRotationFingerprintFromSecretRecov
 		return "", nil
 	}
 	if len(secrets.Items) > 1 {
-		return "", fmt.Errorf("%w for app label %q", errUnexpectedSecretCount, deploymentName)
+		return "", fmt.Errorf("%w for app label %q", errUnexpectedSecretCount, secretAppLabel)
 	}
 
 	fingerprint := secrets.Items[0].Annotations[maskinporten.AnnotationSecretVersion]
@@ -316,7 +354,7 @@ func (r *MaskinportenClientReconciler) pendingRotationFingerprintFromSecretRecov
 	return fingerprint, nil
 }
 
-func appDeploymentNameForMaskinportenClient(
+func appReleaseNameForMaskinportenClient(
 	instance *resourcesv1alpha1.MaskinportenClient,
 	serviceOwnerID string,
 ) (string, bool, error) {
@@ -327,7 +365,7 @@ func appDeploymentNameForMaskinportenClient(
 	if serviceOwnerID != "" && parsed.ServiceOwnerId != serviceOwnerID {
 		return "", false, nil
 	}
-	return fmt.Sprintf("%s-%s-deployment", parsed.ServiceOwnerId, parsed.AppId), true, nil
+	return fmt.Sprintf("%s-%s", parsed.ServiceOwnerId, parsed.AppId), true, nil
 }
 
 func (r *MaskinportenClientReconciler) serviceOwnerID() string {


### PR DESCRIPTION
## Description

Fixes the Maskinporten rotation rollout processor to resolve app Deployments by the Helm release label instead of constructing the old Deployment name.

In TT02, the processor found the pending rotation for `ttd-martinotest`, but tried to patch `default/ttd-martinotest-deployment`. Current app chart Deployments are named like `ttd-martinotest-deployment-v2`, while they carry `release=ttd-martinotest`. This follows the same Deployment identity convention used by the inactivity scaler.

The existing `app` label path for app Secret lookup/recovery is unchanged.

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

Observed in TT02 logs before the fix:

```text
app Deployment not found for pending Maskinporten rotation {"maskinportenClient":"ttd-martinotest","namespace":"default","deployment":"ttd-martinotest-deployment"}
```

Verified TT02 Deployment label selector:

```text
kubectl get deploy -l release=ttd-martinotest -o jsonpath='{range .items[*]}{.metadata.name}{" release="}{.metadata.labels.release}{"\n"}{end}'
ttd-martinotest-deployment-v2 release=ttd-martinotest
```

Commands run locally:

```sh
go test ./internal/controller/maskinporten -run 'TestProcessPendingMaskinportenRotationRollouts'
make lint
git diff --check
```
