### PR TITLE
fix: send failed instance creation alerts

### DIFF
--- a/infra/runtime/grafana-manifests/alert-rules/altinn-apps.yaml
+++ b/infra/runtime/grafana-manifests/alert-rules/altinn-apps.yaml
@@ -132,8 +132,7 @@ spec:
                         or operation_Name == 'POST Instances/PostSimplified [app/org]'
                         or operation_Name == 'POST {org}/{app}/instances'
                         or operation_Name == 'POST {org}/{app}/instances/create'
-                    | extend instanceId = extract(@'/instances/\d+/([^/]+)', 1, url)
-                    | summarize count() by cloud_RoleName, instanceId
+                    | summarize count() by cloud_RoleName
                 resources:
                     - /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/monitor-${SERVICEOWNER_ID}-${ENVIRONMENT}-rg/providers/Microsoft.Insights/components/${SERVICEOWNER_ID}-${ENVIRONMENT}-ai
                 resultFormat: time_series

--- a/src/Designer/backend/tests/Designer.Tests/Services/AlertsServiceTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/AlertsServiceTests.cs
@@ -173,11 +173,32 @@ public class AlertsServiceTests
         );
     }
 
-    private static AlertApp BuildApp(string app, string status) =>
+    [Fact]
+    public async Task NotifyAlertsUpdatedAsync_WhenFiringAlertsWithEmptyInstanceId_ShouldCallNotifyInternal()
+    {
+        var service = CreateService();
+        var environment = AltinnEnvironment.FromName("tt02");
+        var alert = BuildAlert([BuildApp("app1", "firing", instanceId: string.Empty)]);
+
+        await service.NotifyAlertsUpdatedAsync("ttd", environment, alert, CancellationToken.None);
+
+        _notificationService.Verify(
+            s =>
+                s.NotifyInternalAsync(
+                    "ttd",
+                    environment,
+                    It.IsAny<NotificationPayload>(),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Once
+        );
+    }
+
+    private static AlertApp BuildApp(string app, string status, string instanceId = null) =>
         new()
         {
             App = app,
-            Instances = [new AlertInstance { Status = status, InstanceId = Guid.NewGuid().ToString() }],
+            Instances = [new AlertInstance { Status = status, InstanceId = instanceId ?? Guid.NewGuid().ToString() }],
         };
 
     private static Alert BuildAlert(IEnumerable<AlertApp> apps) =>

--- a/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Application/Alerts/HandleAlerts.cs
+++ b/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Application/Alerts/HandleAlerts.cs
@@ -87,7 +87,6 @@ internal static class HandleAlerts
                         Status = a.Status,
                         InstanceId = a.Labels.GetValueOrDefault("instanceId", string.Empty),
                     })
-                    .Where(i => !string.IsNullOrEmpty(i.InstanceId))
                     .ToList(),
             })
             .ToList();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Failed instance creation alerts were silently dropped because instance creation URLs have no instanceId to extract

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated alert rule aggregation to group failures by role name only, rather than by individual instance identifiers.
  * Adjusted alert handling so alerts with empty instance identifiers are no longer filtered out and are included in notifications.

* **Tests**
  * Added unit test coverage to ensure notifications are triggered correctly when a firing alert includes an empty instance identifier.
  * Enhanced the test helper to support specifying an optional instance identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->