### PR TITLE
ci: gh runner add chrome deps

### DIFF
--- a/src/github-runner/Dockerfile
+++ b/src/github-runner/Dockerfile
@@ -18,17 +18,48 @@ RUN apt-get update \
       curl \
       docker.io \
       e2fsprogs \
+      fonts-liberation \
       git \
       iproute2 \
       iptables \
       jq \
+      libasound2t64 \
+      libatk-bridge2.0-0 \
+      libatk1.0-0 \
+      libcairo2 \
+      libcups2 \
+      libdbus-1-3 \
+      libexpat1 \
+      libfontconfig1 \
+      libgbm1 \
+      libglib2.0-0 \
+      libgtk-3-0 \
       libicu74 \
+      libnspr4 \
+      libnss3 \
+      libpango-1.0-0 \
+      libpangocairo-1.0-0 \
+      libx11-6 \
+      libx11-xcb1 \
+      libxcb1 \
+      libxcomposite1 \
+      libxcursor1 \
+      libxdamage1 \
+      libxext6 \
+      libxfixes3 \
+      libxi6 \
+      libxrandr2 \
+      libxrender1 \
+      libxss1 \
+      libxtst6 \
+      lsb-release \
       make \
       pkg-config \
       tar \
       unzip \
       util-linux \
       wget \
+      xdg-utils \
       xz-utils \
       zstd \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
## Description

so we can look into cypres/playwright runs and whatnot requiring chromium

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
