### PR TITLE
fix(admin): replace `intervalInMinutes` with `startsAt` for log query window

### DIFF
--- a/infra/runtime/grafana-manifests/alert-rules/altinn-apps.yaml
+++ b/infra/runtime/grafana-manifests/alert-rules/altinn-apps.yaml
@@ -102,7 +102,6 @@ spec:
         __dashboardUid__: AltinnApps
         __panelId__: "14"
         ruleId: failed_process_next_requests
-        intervalInMinutes: "5"
       labels:
         Type: Altinn
         # Org and Env are included to ensure each deployment generates a unique fingerprint,
@@ -203,7 +202,6 @@ spec:
         __dashboardUid__: AltinnApps
         __panelId__: "14"
         ruleId: failed_instance_creation_requests
-        intervalInMinutes: "5"
       labels:
         Type: Altinn
         # Org and Env are included to ensure each deployment generates a unique fingerprint,

--- a/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Application/Alerts/HandleAlerts.cs
+++ b/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Application/Alerts/HandleAlerts.cs
@@ -96,14 +96,8 @@ internal static class HandleAlerts
             return Results.BadRequest();
         }
 
-        int? intervalInMinutes = int.TryParse(
-            alertPayload.CommonAnnotations.GetValueOrDefault("intervalInMinutes"),
-            out var interval
-        )
-            ? interval
-            : null;
         var to = DateTimeOffset.UtcNow;
-        var from = intervalInMinutes.HasValue ? to.AddMinutes(-intervalInMinutes.Value) : to.AddMinutes(-5);
+        var from = alertPayload.Alerts.Min(a => a.StartsAt);
         var appNames = apps.Select(a => a.App).ToList();
 
         var logsUrl = metricsClient.GetLogsUrl(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`StartsAt` from the Grafana payload reflects when the condition was first met, making the window reliable regardless of delivery delay between grafana and gateway.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alert monitoring accuracy by updating query time window calculations to dynamically use actual alert start times instead of pre-configured fixed intervals, resulting in more precise log retrieval for alert investigations.

* **Chores**
  * Simplified alert rule configuration by removing unnecessary interval settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->