### PR TITLE
fix(admin): revert `intervalInMinutes` and use `startsAt` as end time instead

### DIFF
--- a/infra/runtime/grafana-manifests/alert-rules/altinn-apps.yaml
+++ b/infra/runtime/grafana-manifests/alert-rules/altinn-apps.yaml
@@ -102,6 +102,7 @@ spec:
         __dashboardUid__: AltinnApps
         __panelId__: "14"
         ruleId: failed_process_next_requests
+        intervalInMinutes: "5"
       labels:
         Type: Altinn
         # Org and Env are included to ensure each deployment generates a unique fingerprint,
@@ -202,6 +203,7 @@ spec:
         __dashboardUid__: AltinnApps
         __panelId__: "14"
         ruleId: failed_instance_creation_requests
+        intervalInMinutes: "5"
       labels:
         Type: Altinn
         # Org and Env are included to ensure each deployment generates a unique fingerprint,

--- a/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Application/Alerts/HandleAlerts.cs
+++ b/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Application/Alerts/HandleAlerts.cs
@@ -96,8 +96,14 @@ internal static class HandleAlerts
             return Results.BadRequest();
         }
 
-        var to = DateTimeOffset.UtcNow;
-        var from = alertPayload.Alerts.Min(a => a.StartsAt);
+        int? intervalInMinutes = int.TryParse(
+            alertPayload.CommonAnnotations.GetValueOrDefault("intervalInMinutes"),
+            out var interval
+        )
+            ? interval
+            : null;
+        var to = alertPayload.Alerts.Min(a => a.StartsAt);
+        var from = intervalInMinutes.HasValue ? to.AddMinutes(-intervalInMinutes.Value) : to.AddMinutes(-5);
         var appNames = apps.Select(a => a.App).ToList();
 
         var logsUrl = metricsClient.GetLogsUrl(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Revert `intervalInMinutes` and use `startsAt` as end time instead

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Set Grafana alert rule evaluation intervals to 5 minutes for more consistent monitoring cadence.

* **Bug Fixes**
  * Improved alert log retrieval by basing the query time window on the alerts’ actual start times, and using the provided interval when available (defaulting to 5 minutes otherwise).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->