### PR TITLE
ci: gh runner gcr mirror

### DIFF
--- a/src/github-runner/infra/kustomize/base/scaledjob-single.yaml
+++ b/src/github-runner/infra/kustomize/base/scaledjob-single.yaml
@@ -71,6 +71,8 @@ spec:
                 value: 40G
               - name: DOCKER_DISK_SIZE
                 value: 30G
+              - name: DOCKER_REGISTRY_MIRROR
+                value: https://mirror.gcr.io
               - name: APP_ID
                 valueFrom:
                   secretKeyRef:

--- a/src/github-runner/infra/kustomize/base/scaledjob.yaml
+++ b/src/github-runner/infra/kustomize/base/scaledjob.yaml
@@ -47,6 +47,8 @@ spec:
             env:
               - name: DOCKER_TLS_CERTDIR
                 value: /certs
+              - name: DOCKER_REGISTRY_MIRROR
+                value: https://mirror.gcr.io
             command: ["sh", "-c"]
             args:
               - |
@@ -56,7 +58,7 @@ spec:
                   mkfs.ext4 -F /tmp/docker-disk.img &&
                   mount /tmp/docker-disk.img /var/lib/docker
                 fi
-                exec dockerd-entrypoint.sh --host=tcp://0.0.0.0:2376
+                exec dockerd-entrypoint.sh --host=tcp://0.0.0.0:2376 --registry-mirror="${DOCKER_REGISTRY_MIRROR}"
             startupProbe:
               exec:
                 command:

--- a/src/github-runner/run-with-dockerd.sh
+++ b/src/github-runner/run-with-dockerd.sh
@@ -178,6 +178,7 @@ export LOGNAME=runner
 
 RUNNER_HOME_DISK_SIZE="${RUNNER_HOME_DISK_SIZE:-40G}"
 DOCKER_DISK_SIZE="${DOCKER_DISK_SIZE:-30G}"
+DOCKER_REGISTRY_MIRROR="${DOCKER_REGISTRY_MIRROR:-https://mirror.gcr.io}"
 RUNNER_DIND_DISK_DIR="${RUNNER_DIND_DISK_DIR:-/var/lib/github-runner-disks}"
 export GOPATH="${GOPATH:-${RUNNER_HOME}/go}"
 export GOCACHE="${GOCACHE:-${RUNNER_HOME}/.cache/go-build}"
@@ -210,7 +211,15 @@ chown -R runner:runner \
 log "filesystem layout before dockerd startup"
 df -PT / "${RUNNER_HOME}" "${RUNNER_WORKDIR}" /var/lib/docker /tmp || true
 
-dockerd --host="${DOCKER_HOST}" --ip6tables=false &
+dockerd_args=(
+  --host="${DOCKER_HOST}"
+  --ip6tables=false
+)
+if [[ "${DOCKER_REGISTRY_MIRROR}" != "" ]]; then
+  dockerd_args+=(--registry-mirror="${DOCKER_REGISTRY_MIRROR}")
+fi
+
+dockerd "${dockerd_args[@]}" &
 dockerd_pid="$!"
 
 cleanup() {


### PR DESCRIPTION
## Description

tested with a tmp pod with matching config
re: rate limits

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured Docker registry mirror support for the GitHub runner infrastructure, setting `https://mirror.gcr.io` as the default mirror for container image pulling operations throughout all runner environments.
  * Updated runner startup and initialisation processes across all deployment configurations to support configurable registry mirror settings for Docker image operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->