### PR TITLE
fix: ci runner Init:Error

### DIFF
--- a/charts/gitea-org-runner/templates/scaledjob.yaml
+++ b/charts/gitea-org-runner/templates/scaledjob.yaml
@@ -70,6 +70,19 @@ spec:
                   mount /tmp/docker-disk.img /var/lib/docker
                 fi
                 exec dockerd-entrypoint.sh --host=tcp://0.0.0.0:2376
+            # Kata reports runtime SIGKILL as raw exit code 9, which makes a
+            # successful Job look like Init:Error after Kubernetes stops this
+            # restartable init sidecar. Start dockerd shutdown from inside the
+            # guest so it can exit cleanly before the runtime stop path runs.
+            lifecycle:
+              preStop:
+                exec:
+                  command:
+                    - sh
+                    - -c
+                    - |
+                      kill -TERM 1 2>/dev/null || true
+                      sleep 5
             startupProbe:
               tcpSocket:
                 port: 2376

--- a/src/github-runner/infra/kustomize/base/scaledjob-single.yaml
+++ b/src/github-runner/infra/kustomize/base/scaledjob-single.yaml
@@ -46,6 +46,19 @@ spec:
               privileged: true
               runAsUser: 0
               runAsGroup: 0
+            # Kata reports runtime SIGKILL as raw exit code 9. This runner
+            # starts dockerd inside the main container, so trigger the existing
+            # shell cleanup trap from inside the guest before the runtime stop
+            # path can force-kill the process.
+            lifecycle:
+              preStop:
+                exec:
+                  command:
+                    - sh
+                    - -c
+                    - |
+                      kill -TERM 1 2>/dev/null || true
+                      sleep 5
             env:
               - name: DOCKER_HOST
                 value: unix:///var/run/docker.sock

--- a/src/github-runner/infra/kustomize/base/scaledjob.yaml
+++ b/src/github-runner/infra/kustomize/base/scaledjob.yaml
@@ -59,6 +59,19 @@ spec:
                   mount /tmp/docker-disk.img /var/lib/docker
                 fi
                 exec dockerd-entrypoint.sh --host=tcp://0.0.0.0:2376 --registry-mirror="${DOCKER_REGISTRY_MIRROR}"
+            # Kata reports runtime SIGKILL as raw exit code 9, which makes a
+            # successful Job look like Init:Error after Kubernetes stops this
+            # restartable init sidecar. Start dockerd shutdown from inside the
+            # guest so it can exit cleanly before the runtime stop path runs.
+            lifecycle:
+              preStop:
+                exec:
+                  command:
+                    - sh
+                    - -c
+                    - |
+                      kill -TERM 1 2>/dev/null || true
+                      sleep 5
             startupProbe:
               exec:
                 command:


### PR DESCRIPTION
## Description

As commented, was able to repro with a tmp pod, so this essentially gives dockerd a little headstart for shutdown so we hopefully dont reach SIGKILL

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced graceful shutdown behaviour for all containerised runners and job configurations. Improved process termination procedures ensure clean container shutdowns and prevent false error status reporting when jobs complete successfully. This significantly increases the overall reliability of the runner infrastructure and helps reduce spurious job failure notifications that users may receive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->