### PR TITLE
ci: gh runner preinstall chrome for testing

### DIFF
--- a/.github/workflows/app-frontend-cypress.yml
+++ b/.github/workflows/app-frontend-cypress.yml
@@ -25,9 +25,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true
 
-env:
-  CYPRESS_BROWSER_IMAGE: cypress/browsers:node-22.13.1-chrome-133.0.6943.53-1-ff-135.0-edge-132.0.2957.140-1@sha256:914c9814a9567f32660203db7ecd610b8f8fede6e9103885728b3bd3f6dca4ff
-
 jobs:
   build-frontend:
     if: |
@@ -203,31 +200,23 @@ jobs:
           PERCY_TARGET_BRANCH: ${{ github.base_ref || 'main' }}
           IS_PR_DRAFT: ${{ github.event.pull_request.draft }}
         run: |
-          base_command='npx cypress run --record --parallel --group altinn-app-frontend --tag altinn-app-frontend --browser chrome --ci-build-id "${{ github.run_id }}-${{ github.run_attempt }}" --spec test/e2e/integration --env environment=localtest'
+          cypress_args=(
+            run
+            --record
+            --parallel
+            --group altinn-app-frontend
+            --tag altinn-app-frontend
+            --browser "${CHROME_PATH:-chrome}"
+            --ci-build-id "${{ github.run_id }}-${{ github.run_attempt }}"
+            --spec test/e2e/integration
+            --env environment=localtest
+          )
 
           if [ "${ENABLE_PERCY:-false}" = "true" ]; then
-            container_command="npx percy exec --parallel -- ${base_command}"
+            npx percy exec --parallel -- npx cypress "${cypress_args[@]}"
           else
-            container_command="${base_command}"
+            npx cypress "${cypress_args[@]}"
           fi
-
-          docker run --rm --network host \
-            --user "$(id -u):$(id -g)" \
-            -e HOME=/tmp \
-            -e CI=1 \
-            -e CYPRESS_CACHE_FOLDER \
-            -e CYPRESS_PROJECT_ID \
-            -e CYPRESS_RECORD_KEY \
-            -e GITHUB_TOKEN \
-            -e PERCY_TOKEN \
-            -e PERCY_PARALLEL_TOTAL \
-            -e PERCY_PARALLEL_NONCE \
-            -e PERCY_BRANCH \
-            -e PERCY_TARGET_BRANCH \
-            -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" \
-            -w "${GITHUB_WORKSPACE}/src/App/frontend" \
-            "${CYPRESS_BROWSER_IMAGE}" \
-            bash -lc "${container_command}"
 
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         if: failure()
@@ -295,16 +284,7 @@ jobs:
         shell: bash
         env:
           CYPRESS_CACHE_FOLDER: ${{ github.workspace }}/.cache/Cypress
-        run: |
-          docker run --rm --network host \
-            --user "$(id -u):$(id -g)" \
-            -e HOME=/tmp \
-            -e CI=1 \
-            -e CYPRESS_CACHE_FOLDER \
-            -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" \
-            -w "${GITHUB_WORKSPACE}/src/App/frontend" \
-            "${CYPRESS_BROWSER_IMAGE}" \
-            bash -lc 'npx cypress run --browser chrome --spec test/e2e/integration --env environment=localtest'
+        run: npx cypress run --browser chrome --spec test/e2e/integration --env environment=localtest
 
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         if: failure()

--- a/src/App/frontend/lighthouserc.js
+++ b/src/App/frontend/lighthouserc.js
@@ -3,6 +3,9 @@
 // Configuration
 const { BASE_URL, APP_PATH } = require('./scripts/lighthouse/lighthouse-config-constants');
 
+const chromePath =
+  process.env.CHROME_PATH || process.env.PUPPETEER_EXECUTABLE_PATH || require('puppeteer').executablePath();
+
 /**
  * Lighthouse CI configuration object
  * https://github.com/GoogleChrome/lighthouse-ci
@@ -20,7 +23,7 @@ module.exports = {
         args: ['--disable-features=HttpsFirstBalancedModeAutoEnable', '--no-sandbox', '--disable-setuid-sandbox'],
       },
 
-      chromePath: require('puppeteer').executablePath(),
+      chromePath,
     },
     upload: {
       target: process.env.LHCI_SERVER_URL ? 'lhci' : 'temporary-public-storage',

--- a/src/github-runner/Dockerfile
+++ b/src/github-runner/Dockerfile
@@ -32,10 +32,12 @@ RUN apt-get update \
       libdbus-1-3 \
       libexpat1 \
       libfontconfig1 \
+      libgbm-dev \
       libgbm1 \
       libglib2.0-0 \
       libgtk-3-0 \
       libicu74 \
+      libnotify-dev \
       libnspr4 \
       libnss3 \
       libpango-1.0-0 \
@@ -60,8 +62,10 @@ RUN apt-get update \
       unzip \
       util-linux \
       wget \
+      xauth \
       xdg-utils \
       xz-utils \
+      xvfb \
       zstd \
     && CHROME_FOR_TESTING_URL="$(curl -fsSL "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json" \
       | jq -r --arg channel "${CHROME_FOR_TESTING_CHANNEL}" '.channels[$channel].downloads.chrome[] | select(.platform == "linux64") | .url')" \

--- a/src/github-runner/Dockerfile
+++ b/src/github-runner/Dockerfile
@@ -4,6 +4,7 @@ ARG GO_VERSION=1.26.1
 ARG NODE_CHANNEL=22
 ARG YARN_CHANNEL=stable
 ARG DOTNET_CHANNELS="8.0 9.0 10.0"
+ARG CHROME_FOR_TESTING_CHANNEL=Stable
 ARG DOTNET_INSTALL_SCRIPT_COMMIT=6f559c420847ded38591392dafe785ad511f39f5
 ARG DOTNET_INSTALL_SCRIPT_SHA256=082f7685e156738a1b2e2ed8381a621870d4ce8e8c59278034556f05c186eb2e
 
@@ -62,6 +63,18 @@ RUN apt-get update \
       xdg-utils \
       xz-utils \
       zstd \
+    && CHROME_FOR_TESTING_URL="$(curl -fsSL "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json" \
+      | jq -r --arg channel "${CHROME_FOR_TESTING_CHANNEL}" '.channels[$channel].downloads.chrome[] | select(.platform == "linux64") | .url')" \
+    && test -n "${CHROME_FOR_TESTING_URL}" \
+    && test "${CHROME_FOR_TESTING_URL}" != "null" \
+    && curl -fsSL "${CHROME_FOR_TESTING_URL}" -o /tmp/chrome-for-testing.zip \
+    && mkdir -p /opt/chrome-for-testing \
+    && unzip -q /tmp/chrome-for-testing.zip -d /opt/chrome-for-testing \
+    && rm -f /tmp/chrome-for-testing.zip \
+    && mkdir -p /opt/google/chrome \
+    && ln -s /opt/chrome-for-testing/chrome-linux64/chrome /opt/google/chrome/chrome \
+    && ln -s /opt/chrome-for-testing/chrome-linux64/chrome /usr/bin/google-chrome \
+    && ln -s /opt/chrome-for-testing/chrome-linux64/chrome /usr/bin/chrome \
     && rm -rf /var/lib/apt/lists/* \
     && chmod +x /usr/local/bin/altinn-github-runner \
     && chmod +x /usr/local/bin/altinn-github-runner-dind \
@@ -119,6 +132,8 @@ ENV DOTNET_ROOT=/usr/share/dotnet
 ENV DOTNET_INSTALL_DIR=/usr/share/dotnet
 ENV COREPACK_HOME=/opt/corepack
 ENV RUNNER_TOOL_CACHE=/opt/tools
+ENV CHROME_PATH=/opt/chrome-for-testing/chrome-linux64/chrome
+ENV PUPPETEER_EXECUTABLE_PATH=/opt/chrome-for-testing/chrome-linux64/chrome
 ENV TMPDIR=/tmp
 ENV TMP=/tmp
 ENV TEMP=/tmp


### PR DESCRIPTION

## Description

recent yarn disables postbuild scripts by default, but preinstalling this instead makes us not have to get browser through yarn/npm postbuild scripts. Tested with local docker build, image is 1.6~ GB

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Streamlined continuous integration by switching end-to-end testing from containerised Docker-based runs to direct execution on the runner.
  * Improved browser selection for automated audits by resolving the Chrome location from environment variables with sensible fallbacks.
  * Updated the test browser setup to install “Chrome for Testing” and expose consistent Chrome paths for automation tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->