### PR TITLE
fix(admin): use latest StartsAt as the window end time

### DIFF
--- a/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Application/Alerts/HandleAlerts.cs
+++ b/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Application/Alerts/HandleAlerts.cs
@@ -102,7 +102,7 @@ internal static class HandleAlerts
         )
             ? interval
             : null;
-        var to = alertPayload.Alerts.Min(a => a.StartsAt);
+        var to = alertPayload.Alerts.Max(a => a.StartsAt);
         var from = intervalInMinutes.HasValue ? to.AddMinutes(-intervalInMinutes.Value) : to.AddMinutes(-5);
         var appNames = apps.Select(a => a.App).ToList();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix alert log window by using the latest StartsAt as the window end time

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the time window used when generating alert log links. This ensures the correct `from`/`to` range is queried for alert events, so users see the complete, relevant logs for troubleshooting and diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->