### PR TITLE
fix: preserve Maskinporten scope selections

### DIFF
--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.test.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.test.tsx
@@ -247,6 +247,20 @@ describe('ScopeList', () => {
     expect(selectedDefaultScopeCheckbox).toBeChecked();
   });
 
+  it('should show the select all checkbox as partially checked when some scopes are selected', async () => {
+    const user = userEvent.setup();
+    renderScopeList();
+
+    await openAddScopeDialog(user);
+    const dialog = getDialog();
+
+    expect(
+      within(dialog).getByRole('checkbox', {
+        name: textMock('app_settings.maskinporten_select_all_scopes'),
+      }),
+    ).toBePartiallyChecked();
+  });
+
   it('should sort serviceowner scopes first in selected scopes and dialog scopes', async () => {
     const user = userEvent.setup();
     renderScopeList();
@@ -327,6 +341,43 @@ describe('ScopeList', () => {
 
     const updatedScopes: MaskinportenScopes = {
       scopes: [scopeMock4, scopeMock3, scopeMock1],
+    };
+
+    expect(queriesMock.updateSelectedMaskinportenScopes).toHaveBeenCalledTimes(1);
+    expect(queriesMock.updateSelectedMaskinportenScopes).toHaveBeenCalledWith(
+      org,
+      app,
+      updatedScopes,
+    );
+  });
+
+  it('should use updated selected scopes when completing the dialog after selected scopes change', async () => {
+    const user = userEvent.setup();
+    const { renderResult } = renderScopeList({
+      componentProps: {
+        maskinPortenScopes: [scopeMock1, scopeMock2, scopeMock3],
+        selectedScopes: [scopeMock3, scopeMock4],
+      },
+    });
+
+    renderResult.rerender(
+      <ScopeList
+        {...defaultProps}
+        maskinPortenScopes={[scopeMock1, scopeMock2, scopeMock3]}
+        selectedScopes={[scopeMock4]}
+      />,
+    );
+
+    await openAddScopeDialog(user);
+    const dialog = getDialog();
+    await user.click(
+      within(dialog).getByRole('button', {
+        name: textMock('app_settings.maskinporten_add_scope_dialog_done'),
+      }),
+    );
+
+    const updatedScopes: MaskinportenScopes = {
+      scopes: [scopeMock4],
     };
 
     expect(queriesMock.updateSelectedMaskinportenScopes).toHaveBeenCalledTimes(1);

--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.test.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.test.tsx
@@ -370,6 +370,65 @@ describe('ScopeList', () => {
     );
   });
 
+  it('should call updateSelectedMaskinportenScopes without unchecked scopes when completing the dialog', async () => {
+    const user = userEvent.setup();
+    renderScopeList();
+
+    await openAddScopeDialog(user);
+    const dialog = getDialog();
+    await user.click(within(dialog).getByRole('checkbox', { name: scopeMock3.scope }));
+    await user.click(
+      within(dialog).getByRole('button', {
+        name: textMock('app_settings.maskinporten_add_scope_dialog_done'),
+      }),
+    );
+
+    const updatedScopes: MaskinportenScopes = {
+      scopes: [scopeMock4],
+    };
+
+    expect(queriesMock.updateSelectedMaskinportenScopes).toHaveBeenCalledTimes(1);
+    expect(queriesMock.updateSelectedMaskinportenScopes).toHaveBeenCalledWith(
+      org,
+      app,
+      updatedScopes,
+    );
+  });
+
+  it('should select and deselect filtered scopes with the select all checkbox', async () => {
+    const user = userEvent.setup();
+    renderScopeList();
+
+    await openAddScopeDialog(user);
+    const dialog = getDialog();
+    const selectAllCheckbox = within(dialog).getByRole('checkbox', {
+      name: textMock('app_settings.maskinporten_select_all_scopes'),
+    });
+
+    await user.click(selectAllCheckbox);
+
+    expect(within(dialog).getByRole('checkbox', { name: scopeMock1.scope })).toBeChecked();
+    expect(within(dialog).getByRole('checkbox', { name: scopeMock2.scope })).toBeChecked();
+
+    await user.click(selectAllCheckbox);
+    await user.click(
+      within(dialog).getByRole('button', {
+        name: textMock('app_settings.maskinporten_add_scope_dialog_done'),
+      }),
+    );
+
+    const updatedScopes: MaskinportenScopes = {
+      scopes: [scopeMock4],
+    };
+
+    expect(queriesMock.updateSelectedMaskinportenScopes).toHaveBeenCalledTimes(1);
+    expect(queriesMock.updateSelectedMaskinportenScopes).toHaveBeenCalledWith(
+      org,
+      app,
+      updatedScopes,
+    );
+  });
+
   it('should use updated selected scopes when completing the dialog after selected scopes change', async () => {
     const user = userEvent.setup();
     const { renderResult } = renderScopeList({

--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.test.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.test.tsx
@@ -32,9 +32,18 @@ const scopeMock5: MaskinportenScope = {
   scope: 'altinn:serviceowner',
   description: 'description5',
 };
+const dataAltinnNoScope: MaskinportenScope = {
+  scope: 'altinn:dataaltinnno',
+  description: 'Data Altinn scope',
+};
+const correspondenceWriteScope: MaskinportenScope = {
+  scope: 'altinn:correspondence.write',
+  description: 'Correspondence write scope',
+};
 
 const maskinportenScopesMock: MaskinportenScope[] = [scopeMock1, scopeMock2];
 const selectedScopesMock: MaskinportenScope[] = [scopeMock3, scopeMock4];
+const selectedDefaultScopesMock: MaskinportenScope[] = [scopeMock5, scopeMock4, scopeMock2];
 
 describe('ScopeList', () => {
   afterEach(jest.clearAllMocks);
@@ -318,6 +327,46 @@ describe('ScopeList', () => {
 
     const updatedScopes: MaskinportenScopes = {
       scopes: [scopeMock4, scopeMock3, scopeMock1],
+    };
+
+    expect(queriesMock.updateSelectedMaskinportenScopes).toHaveBeenCalledTimes(1);
+    expect(queriesMock.updateSelectedMaskinportenScopes).toHaveBeenCalledWith(
+      org,
+      app,
+      updatedScopes,
+    );
+  });
+
+  it('should preserve previously selected scopes when adding scopes through filtered search results', async () => {
+    const user = userEvent.setup();
+    renderScopeList({
+      componentProps: {
+        maskinPortenScopes: [dataAltinnNoScope, correspondenceWriteScope],
+        selectedScopes: selectedDefaultScopesMock,
+      },
+    });
+
+    await openAddScopeDialog(user);
+    const dialog = getDialog();
+    const searchField = within(dialog).getByRole('searchbox', {
+      name: textMock('app_settings.maskinporten_scope_search_label'),
+    });
+
+    await user.type(searchField, dataAltinnNoScope.scope);
+    await user.click(within(dialog).getByRole('checkbox', { name: dataAltinnNoScope.scope }));
+    await user.clear(searchField);
+    await user.type(searchField, correspondenceWriteScope.scope);
+    await user.click(
+      within(dialog).getByRole('checkbox', { name: correspondenceWriteScope.scope }),
+    );
+    await user.click(
+      within(dialog).getByRole('button', {
+        name: textMock('app_settings.maskinporten_add_scope_dialog_done'),
+      }),
+    );
+
+    const updatedScopes: MaskinportenScopes = {
+      scopes: [scopeMock5, scopeMock4, scopeMock2, correspondenceWriteScope, dataAltinnNoScope],
     };
 
     expect(queriesMock.updateSelectedMaskinportenScopes).toHaveBeenCalledTimes(1);

--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.test.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.test.tsx
@@ -261,6 +261,25 @@ describe('ScopeList', () => {
     ).toBePartiallyChecked();
   });
 
+  it('should not check select all when filtered scopes only contain selected default scopes', async () => {
+    const user = userEvent.setup();
+    renderScopeList();
+
+    await openAddScopeDialog(user);
+    const dialog = getDialog();
+    const searchField = within(dialog).getByRole('searchbox', {
+      name: textMock('app_settings.maskinporten_scope_search_label'),
+    });
+
+    await user.type(searchField, scopeMock4.scope);
+
+    const selectAllCheckbox = within(dialog).getByRole('checkbox', {
+      name: textMock('app_settings.maskinporten_select_all_scopes'),
+    });
+    expect(selectAllCheckbox).not.toBeChecked();
+    expect(selectAllCheckbox).not.toBePartiallyChecked();
+  });
+
   it('should sort serviceowner scopes first in selected scopes and dialog scopes', async () => {
     const user = userEvent.setup();
     renderScopeList();

--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.tsx
@@ -310,10 +310,12 @@ function AddScopesDialog({
     [filteredScopeNames, selectedDefaultScopeNames],
   );
   const allFilteredScopesSelected: boolean =
-    filteredScopeNames.length > 0 &&
-    filteredScopeNames.every((scopeName: string) => selectedScopeNames.includes(scopeName));
-  const someFilteredScopesSelected: boolean = filteredScopeNames.some((scopeName: string) =>
-    selectedScopeNames.includes(scopeName),
+    selectableFilteredScopeNames.length > 0 &&
+    selectableFilteredScopeNames.every((scopeName: string) =>
+      selectedScopeNames.includes(scopeName),
+    );
+  const someFilteredScopesSelected: boolean = selectableFilteredScopeNames.some(
+    (scopeName: string) => selectedScopeNames.includes(scopeName),
   );
 
   const handleSearchChange = (event: ChangeEvent<HTMLInputElement>): void => {

--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import type { ChangeEvent, ReactElement } from 'react';
 import classes from './ScopeList.module.css';
 import {
   StudioAlert,
   StudioButton,
-  StudioCheckboxTable,
+  StudioCheckbox,
   StudioDeleteButton,
   StudioDialog,
   StudioFormActions,
@@ -13,7 +13,6 @@ import {
   StudioParagraph,
   StudioSearch,
   StudioTable,
-  useStudioCheckboxTable,
 } from '@studio/components';
 import { Trans, useTranslation } from 'react-i18next';
 import { LoggedInTitle } from '../LoggedInTitle';
@@ -279,20 +278,13 @@ function AddScopesDialog({
   const { t } = useTranslation();
   const title: string = t('app_settings.maskinporten_select_all_scopes');
   const keepSelectionOnCloseRef = useRef<boolean>(false);
+  const [selectedScopeNames, setSelectedScopeNames] = useState<string[]>(initialValues);
   const { saveScopes, isSaving } = useSaveScopes(allAvailableScopes);
 
-  const { getCheckboxProps, selectedValues, setSelectedValues } = useStudioCheckboxTable(
-    initialValues,
-    title,
-  );
   const selectedDefaultScopeNames = useMemo(
     () => initialValues.filter(isDefaultMaskinportenScope),
     [initialValues],
   );
-
-  useEffect(() => {
-    setSelectedValues(initialValues);
-  }, [initialValues, setSelectedValues]);
 
   const filteredScopes = useMemo(() => {
     const searchTerm = searchValue.trim().toLowerCase();
@@ -304,6 +296,23 @@ function AddScopesDialog({
       );
     });
   }, [allAvailableScopes, searchValue]);
+  const filteredScopeNames = useMemo(
+    () => filteredScopes.map((scope: MaskinportenScope) => scope.scope),
+    [filteredScopes],
+  );
+  const selectableFilteredScopeNames = useMemo(
+    () =>
+      filteredScopeNames.filter(
+        (scopeName: string) => !selectedDefaultScopeNames.includes(scopeName),
+      ),
+    [filteredScopeNames, selectedDefaultScopeNames],
+  );
+  const allFilteredScopesSelected: boolean =
+    filteredScopeNames.length > 0 &&
+    filteredScopeNames.every((scopeName: string) => selectedScopeNames.includes(scopeName));
+  const someFilteredScopesSelected: boolean = filteredScopeNames.some((scopeName: string) =>
+    selectedScopeNames.includes(scopeName),
+  );
 
   const handleSearchChange = (event: ChangeEvent<HTMLInputElement>): void => {
     setSearchValue(event.target.value);
@@ -311,7 +320,7 @@ function AddScopesDialog({
 
   const handleDialogClose = (): void => {
     if (!keepSelectionOnCloseRef.current) {
-      setSelectedValues(initialValues);
+      setSelectedScopeNames(initialValues);
     }
 
     keepSelectionOnCloseRef.current = false;
@@ -323,12 +332,42 @@ function AddScopesDialog({
   };
 
   const saveSelectedScopes = (): void => {
-    const valuesToSave = Array.from(new Set([...selectedValues, ...selectedDefaultScopeNames]));
+    const valuesToSave = Array.from(new Set([...selectedScopeNames, ...selectedDefaultScopeNames]));
 
     saveScopes(valuesToSave, () => {
       keepSelectionOnCloseRef.current = true;
       closeDialog();
     });
+  };
+
+  const setScopeSelected = (scopeName: string, checked: boolean): void => {
+    setSelectedScopeNames((currentSelectedScopeNames: string[]) => {
+      if (checked) {
+        return Array.from(new Set([...currentSelectedScopeNames, scopeName]));
+      }
+
+      return currentSelectedScopeNames.filter(
+        (currentScopeName: string) => currentScopeName !== scopeName,
+      );
+    });
+  };
+
+  const setFilteredScopesSelected = (checked: boolean): void => {
+    setSelectedScopeNames((currentSelectedScopeNames: string[]) => {
+      if (checked) {
+        return Array.from(new Set([...currentSelectedScopeNames, ...selectableFilteredScopeNames]));
+      }
+
+      return currentSelectedScopeNames.filter(
+        (currentScopeName: string) => !selectableFilteredScopeNames.includes(currentScopeName),
+      );
+    });
+  };
+
+  const setSelectAllCheckboxRef = (checkbox: HTMLInputElement | null): void => {
+    if (checkbox) {
+      checkbox.indeterminate = !allFilteredScopesSelected && someFilteredScopesSelected;
+    }
   };
 
   return (
@@ -355,37 +394,52 @@ function AddScopesDialog({
           clearButtonLabel={t('general.search_clear_button_title')}
         />
         <div className={classes.dialogTableWrapper}>
-          <StudioCheckboxTable data-size='sm'>
-            <StudioCheckboxTable.Head
-              title={title}
-              descriptionCellTitle={t('app_settings.maskinporten_select_all_scopes_description')}
-              getCheckboxProps={{
-                ...getCheckboxProps({
-                  allowIndeterminate: true,
-                  value: 'all',
-                }),
-              }}
-            />
-            <StudioCheckboxTable.Body>
+          <StudioTable data-size='sm'>
+            <StudioTable.Head>
+              <StudioTable.Row>
+                <StudioTable.HeaderCell>
+                  <StudioCheckbox
+                    ref={setSelectAllCheckboxRef}
+                    aria-label={title}
+                    name={title}
+                    value='all'
+                    checked={allFilteredScopesSelected}
+                    onChange={(event: ChangeEvent<HTMLInputElement>) => {
+                      setFilteredScopesSelected(event.currentTarget.checked);
+                    }}
+                  />
+                </StudioTable.HeaderCell>
+                <StudioTable.HeaderCell aria-hidden>{title}</StudioTable.HeaderCell>
+                <StudioTable.HeaderCell>
+                  {t('app_settings.maskinporten_select_all_scopes_description')}
+                </StudioTable.HeaderCell>
+              </StudioTable.Row>
+            </StudioTable.Head>
+            <StudioTable.Body>
               {filteredScopes.map((scope: MaskinportenScope) => {
                 const isSelectedDefaultScope = selectedDefaultScopeNames.includes(scope.scope);
 
                 return (
-                  <StudioCheckboxTable.Row
-                    key={scope.scope}
-                    label={scope.scope}
-                    description={scope.description}
-                    getCheckboxProps={{
-                      ...getCheckboxProps({
-                        value: scope.scope,
-                      }),
-                      disabled: isSelectedDefaultScope,
-                    }}
-                  />
+                  <StudioTable.Row key={scope.scope}>
+                    <StudioTable.Cell>
+                      <StudioCheckbox
+                        aria-label={scope.scope}
+                        name={title}
+                        value={scope.scope}
+                        checked={selectedScopeNames.includes(scope.scope)}
+                        disabled={isSelectedDefaultScope}
+                        onChange={(event: ChangeEvent<HTMLInputElement>) => {
+                          setScopeSelected(scope.scope, event.currentTarget.checked);
+                        }}
+                      />
+                    </StudioTable.Cell>
+                    <StudioTable.Cell aria-hidden>{scope.scope}</StudioTable.Cell>
+                    <StudioTable.Cell>{scope.description}</StudioTable.Cell>
+                  </StudioTable.Row>
                 );
               })}
-            </StudioCheckboxTable.Body>
-          </StudioCheckboxTable>
+            </StudioTable.Body>
+          </StudioTable>
           {filteredScopes.length === 0 && (
             <StudioParagraph className={classes.emptyState}>
               {t('app_settings.maskinporten_no_scopes_search_match')}

--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.tsx
@@ -82,6 +82,7 @@ export function ScopeList({
     () => mapMaskinPortenScopesToScopeList(sortedSelectedScopes),
     [sortedSelectedScopes],
   );
+  const addScopesDialogKey = initialValues.join('\u001f');
   const contactByEmail = new GetInTouchWith(new EmailContactProvider());
 
   const openDialog = (): void => {
@@ -128,6 +129,7 @@ export function ScopeList({
       />
       {canManageScopes && (
         <AddScopesDialog
+          key={addScopesDialogKey}
           dialogRef={dialogRef}
           searchValue={searchValue}
           setSearchValue={setSearchValue}
@@ -401,6 +403,9 @@ function AddScopesDialog({
                   <StudioCheckbox
                     ref={setSelectAllCheckboxRef}
                     aria-label={title}
+                    aria-checked={
+                      !allFilteredScopesSelected && someFilteredScopesSelected ? 'mixed' : undefined
+                    }
                     name={title}
                     value='all'
                     checked={allFilteredScopesSelected}


### PR DESCRIPTION
## Description

Fixes the Maskinporten add-scopes dialog so selections are preserved when the user filters the table between selections.

The dialog now keeps selected scope names in component state instead of relying on the checkbox-table hook state, which lost checked values when filtered rows unmounted. This also keeps default service-owner scopes selected and disabled.

![Maskinporten scope selection](https://raw.githubusercontent.com/martinothamar-agent/altinn-studio/pr-assets/maskinporten-scope-selection/pr-assets/maskinporten-scope-selection.png)

## Verification

- [x] Related issues are connected (if applicable): no related issue known
- [ ] **Your** code builds clean without any errors or warnings: full Docker frontend image build was blocked by registry timeouts in local Docker; focused frontend checks passed
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

Manual test:

- Started Studio locally with compose services for DB/Gitea/load balancer and source backend/frontend.
- Created `ttd/maskinporten-scope-test` locally.
- Opened `app-settings?currentTab=maskinporten`.
- Selected `altinn:dataaltinnno`, changed the search filter, selected `altinn:correspondence.write`, and clicked `Fullfør`.
- Verified the PUT payload contained both scopes plus the default service-owner scopes.

Automated checks:

- `yarn test ScopeList.test.tsx`
- `yarn typecheck`
- `yarn prettier --check app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.tsx app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.test.tsx`
- `yarn eslint app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.tsx app-development/features/appSettings/components/TabsContent/Tabs/MaskinportenTab/ScopeListContainer/ScopeList/ScopeList.test.tsx` (only existing Browserslist stale-data warning)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Maskinporten “Add scopes” so previously selected scopes stay selected when using search and filtering, and when adding additional scopes.
  * Updated the “select all” checkbox in the add-scopes dialog to correctly reflect partial selections (indeterminate state) and remain fully unchecked when appropriate.

* **Tests**
  * Expanded Maskinporten add-scopes dialog coverage with new fixtures and assertions for search-filtered selection, re-render updates, and correct save payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->