### PR TITLE
ci: migrate designer playwright to self-hosted

### DIFF
--- a/.github/workflows/designer-frontend-playwright-staging.yml
+++ b/.github/workflows/designer-frontend-playwright-staging.yml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   playwright-run:
     name: 'Playwright Tests'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-single
     timeout-minutes: 30
 
     steps:
@@ -53,9 +53,7 @@ jobs:
           GITEA_ACCESS_TOKEN: ${{ secrets.AUTO_TEST_USER_TOKEN_STAGING }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          yarn
           yarn install --immutable --inline-builds
-          yarn playwright install --with-deps
           yarn playwright:test:all
 
       - name: Store artifacts

--- a/.github/workflows/designer-frontend-run-playwright-on-pr.yaml
+++ b/.github/workflows/designer-frontend-run-playwright-on-pr.yaml
@@ -28,7 +28,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Playwright (${{ matrix.studio-oidc-mode && 'StudioOidc' || 'GiteaOidc' }})
     timeout-minutes: 25
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-single
     strategy:
       fail-fast: false
       matrix:
@@ -83,7 +83,7 @@ jobs:
         env:
           environment: local
         run: |
-          yarn setup:playwright
+          yarn setup:local:env
           yarn playwright:test:all
 
       - name: Store artifacts

--- a/src/Designer/frontend/testing/playwright/playwright.config.ts
+++ b/src/Designer/frontend/testing/playwright/playwright.config.ts
@@ -13,6 +13,7 @@ export default defineConfig<ExtendedTestOptions>({
     trace: 'on-first-retry',
     baseURL: process.env.PLAYWRIGHT_TEST_BASE_URL,
     screenshot: 'only-on-failure',
+    channel: 'chrome',
   },
   fullyParallel: false,
   forbidOnly: !!process.env.CI,


### PR DESCRIPTION
## Description

moves designer playwright tests to self hosted runner

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Playwright CI workflows to run on a self-hosted runner and adjusted setup/install steps for more consistent staging and pull-request test execution.
  * Updated Playwright test configuration to use the Chrome browser channel for consistent browser behaviour during runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->