### PR TITLE
chore: Enable selection of language in storybook for form-component lib

### DIFF
--- a/app-libs/form-component/.storybook/preview.tsx
+++ b/app-libs/form-component/.storybook/preview.tsx
@@ -1,7 +1,10 @@
 import '@digdir/designsystemet-css';
 import '@digdir/designsystemet-css/theme';
 
-import { StaticLanguageTranslatorProvider } from '@app/form-component/test/StaticLanguageTranslatorProvider';
+import {
+  type StaticLanguageCode,
+  StaticLanguageTranslatorProvider,
+} from '@app/form-component/test/StaticLanguageTranslatorProvider';
 import type { Preview } from '@storybook/react-vite';
 
 import '@app/form-component/styles/global.css';
@@ -11,10 +14,29 @@ const preview: Preview = {
     layout: 'centered',
   },
   tags: ['autodocs'],
+  initialGlobals: {
+    locale: 'en' satisfies StaticLanguageCode,
+  },
+  globalTypes: {
+    locale: {
+      description:
+        'Select language used for built-in application text — example texts passed to components in stories are not translated',
+      toolbar: {
+        title: 'Language',
+        icon: 'globe',
+        items: [
+          { value: 'en', title: 'English' },
+          { value: 'nb', title: 'Norsk (nb)' },
+          { value: 'nn', title: 'Norsk (nn)' },
+        ] satisfies { value: StaticLanguageCode; title: string }[],
+        dynamicTitle: true,
+      },
+    },
+  },
   decorators: [
     // Provide the real translations from @app/language so components using useTranslation() render translated text.
-    (Story) => (
-      <StaticLanguageTranslatorProvider>
+    (Story, context) => (
+      <StaticLanguageTranslatorProvider language={context.globals.locale as StaticLanguageCode}>
         <Story />
       </StaticLanguageTranslatorProvider>
     ),


### PR DESCRIPTION
Made it possible to select language in stroybook. This affects how static text defined inside the app are translated. 

## Description

In the images below, we se how the static text "helptext.button_title" is translated based on the selected language

<img width="1062" height="396" alt="image" src="https://github.com/user-attachments/assets/ea1c44be-bb07-43d6-a68f-c094c408f989" />
<img width="998" height="269" alt="image" src="https://github.com/user-attachments/assets/ebf4da2e-7cb6-4639-8ffe-0a91db150b6e" />


## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced Storybook configuration for form components to support language selection across English, Norwegian Bokmål, and Norwegian Nynorsk for development and testing purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->