### PR TITLE
fix: assign fake ansattporten dependency updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -95,6 +95,8 @@ src/cli/**/dockerfile*                                          @altinn/team-alt
 src/cli/**/global.json                                          @altinn/team-altinn-studio-kjoring
 src/cli/**/go.mod                                               @altinn/team-altinn-studio-kjoring
 src/cli/**/go.sum                                               @altinn/team-altinn-studio-kjoring
+src/Designer/development/fake-ansattporten/**/Dockerfile*       @altinn/team-altinn-studio-kjoring
+src/Designer/development/fake-ansattporten/**/go.mod            @altinn/team-altinn-studio-kjoring
 src/gitea-proxy/**/docker-compose.*.yml                         @altinn/team-altinn-studio-kjoring
 src/gitea-proxy/**/Dockerfile*                                  @altinn/team-altinn-studio-kjoring
 src/gitea-runner/**/Dockerfile*                                 @altinn/team-altinn-studio-kjoring

--- a/.github/scripts/codeowners-generate.mjs
+++ b/.github/scripts/codeowners-generate.mjs
@@ -88,6 +88,7 @@ const GROUPS = [
       'src/Runtime/pdf3',
       'src/Runtime/gateway',
       'src/Runtime/devenv',
+      'src/Designer/development/fake-ansattporten',
       'src/test/K6',
       'src/tools/health',
       'src/tools/releaser',


### PR DESCRIPTION
## Description

Adds `src/Designer/development/fake-ansattporten` to the Squad Kjøring roots in `.github/scripts/codeowners-generate.mjs` and regenerates `.github/CODEOWNERS`.

This makes Renovate changes to the fake Ansattporten Dockerfile and Go module request review from `@altinn/team-altinn-studio-kjoring`.

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

Manual verification:

```sh
node .github/scripts/codeowners-generate.mjs --check
git diff --check
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership configuration for development infrastructure components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->