### PR TITLE
refactor: introduce LabelComponent and  and useLabelData to enable moving more code to form-component

### DIFF
--- a/app-libs/form-component/src/app-components/Label/Label.tsx
+++ b/app-libs/form-component/src/app-components/Label/Label.tsx
@@ -1,4 +1,4 @@
-import type { JSX, PropsWithChildren, ReactElement, Ref } from 'react';
+import type { JSX, PropsWithChildren, ReactElement, ReactNode, Ref } from 'react';
 
 import { Flex } from '@app/form-component/app-components/Flex/Flex';
 import { Label as DesignsystemetLabel } from '@digdir/designsystemet-react';
@@ -10,7 +10,7 @@ import classes from './Label.module.css';
 
 export type LabelProps = {
   id?: string;
-  label: string | ReactElement | undefined;
+  label: ReactNode;
   htmlFor?: DesignsystemetLabelProps['htmlFor'];
   required?: boolean;
   requiredIndicator?: JSX.Element;

--- a/app-libs/form-component/src/index.ts
+++ b/app-libs/form-component/src/index.ts
@@ -16,6 +16,7 @@ export type { ParserReplace } from './text/parseAndCleanText';
 export * from './app-components';
 export * from './layout-components';
 export * from './layout-components/common/HelpTextContainer';
+export * from './layout-components/common/LabelComponent';
 export * from './layout-components/common/Description';
 export * from './layout-components/common/OptionalIndicator';
 export * from './layout-components/common/RequiredIndicator';

--- a/app-libs/form-component/src/layout-components/common/LabelComponent/LabelComponent.stories.tsx
+++ b/app-libs/form-component/src/layout-components/common/LabelComponent/LabelComponent.stories.tsx
@@ -1,0 +1,49 @@
+import { StaticLanguageTranslatorProvider } from '@app/form-component/test/StaticLanguageTranslatorProvider';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { LabelComponent } from './LabelComponent';
+
+const meta = {
+  title: 'LayoutComponents/Common/LabelComponent',
+  component: LabelComponent,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story) => (
+      <StaticLanguageTranslatorProvider>
+        <Story />
+      </StaticLanguageTranslatorProvider>
+    ),
+  ],
+  args: {
+    htmlFor: 'example',
+    componentId: 'example',
+    title: 'First name',
+  },
+} satisfies Meta<typeof LabelComponent>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Preview: Story = {};
+
+export const Required: Story = {
+  args: {
+    required: true,
+  },
+};
+
+export const Optional: Story = {
+  args: {
+    showOptionalMarking: true,
+  },
+};
+
+export const WithHelpAndDescription: Story = {
+  args: {
+    help: 'Enter the name exactly as written in your passport.',
+    description: 'We use this to address you.',
+  },
+};

--- a/app-libs/form-component/src/layout-components/common/LabelComponent/LabelComponent.test.tsx
+++ b/app-libs/form-component/src/layout-components/common/LabelComponent/LabelComponent.test.tsx
@@ -1,0 +1,48 @@
+import { renderWithTranslations } from '@app/form-component/test/renderWithTranslations';
+import { screen } from '@testing-library/react';
+
+import { LabelComponent } from './LabelComponent';
+import type { ILabelComponentProps } from './LabelComponent';
+
+const overrides = {
+  'my.title': 'First name',
+  'my.help': 'Helpful explanation',
+  'my.description': 'A short description',
+};
+
+describe('LabelComponent', () => {
+  const render = (props?: Partial<ILabelComponentProps>) =>
+    renderWithTranslations(
+      <LabelComponent htmlFor='example' componentId='example' title='my.title' {...props}>
+        <input id='example' />
+      </LabelComponent>,
+      { overrides },
+    );
+
+  it('renders the translated label text', () => {
+    render();
+    expect(screen.getByText('First name')).toBeInTheDocument();
+  });
+
+  it('renders only the children when no title is given', () => {
+    render({ title: undefined });
+    expect(screen.queryByText('First name')).not.toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('shows the optional marking when enabled and not required', () => {
+    render({ showOptionalMarking: true });
+    expect(screen.getByText(/\(optional\)/i)).toBeInTheDocument();
+  });
+
+  it('does not show the optional marking when required', () => {
+    render({ required: true, showOptionalMarking: true });
+    expect(screen.queryByText(/\(optional\)/i)).not.toBeInTheDocument();
+  });
+
+  it('renders the help text button and description when given', () => {
+    render({ help: 'my.help', description: 'my.description' });
+    expect(screen.getByRole('button', { name: /Helptext for First name/i })).toBeInTheDocument();
+    expect(screen.getByText('A short description')).toBeInTheDocument();
+  });
+});

--- a/app-libs/form-component/src/layout-components/common/LabelComponent/LabelComponent.tsx
+++ b/app-libs/form-component/src/layout-components/common/LabelComponent/LabelComponent.tsx
@@ -1,0 +1,76 @@
+import { type PropsWithChildren } from 'react';
+
+import { Label } from '@app/form-component/app-components/Label';
+import { useTranslation } from '@app/form-component/LanguageTranslatorProvider';
+import { Description } from '@app/form-component/layout-components/common/Description';
+import { HelpTextContainer } from '@app/form-component/layout-components/common/HelpTextContainer';
+import { OptionalIndicator } from '@app/form-component/layout-components/common/OptionalIndicator';
+import { RequiredIndicator } from '@app/form-component/layout-components/common/RequiredIndicator';
+import type { IGridStyling } from '@app/form-component/app-components/Flex/Flex';
+
+export interface ILabelComponentProps {
+  /** Id for the rendered label element. */
+  id?: string;
+  /** Id of the form element this label belongs to. Sets the label's `htmlFor`. */
+  htmlFor?: string;
+  /** Id of the component, used to build the description element id. */
+  componentId?: string;
+  /** Text-resource key for the label text. When undefined, only the children are rendered. */
+  title?: string;
+  /** Text-resource key for the help text. */
+  help?: string;
+  /** Text-resource key for the description. */
+  description?: string;
+  required?: boolean;
+  readOnly?: boolean;
+  showOptionalMarking?: boolean;
+  grid?: IGridStyling;
+}
+
+/**
+ * Smart label wrapper for form components. Takes only primitive props (text-resource keys + booleans),
+ * translates them and builds the help text, description and required/optional indicators internally,
+ * then delegates to the dumb {@link Label} app-component. Conceptually parallel to how
+ * `HelpTextContainer` wraps `HelpText`.
+ */
+export function LabelComponent({
+  id,
+  htmlFor,
+  componentId,
+  title,
+  help,
+  description,
+  required,
+  readOnly,
+  showOptionalMarking,
+  grid,
+  children,
+}: PropsWithChildren<ILabelComponentProps>) {
+  const { lang } = useTranslation();
+
+  return (
+    <Label
+      id={id}
+      htmlFor={htmlFor}
+      label={title ? lang(title) : undefined}
+      grid={grid}
+      required={required}
+      requiredIndicator={<RequiredIndicator required={required} />}
+      optionalIndicator={
+        <OptionalIndicator
+          readOnly={readOnly}
+          required={required}
+          showOptionalMarking={showOptionalMarking}
+        />
+      }
+      help={help ? <HelpTextContainer title={title} helpText={lang(help)} /> : undefined}
+      description={
+        description ? (
+          <Description componentId={componentId} description={lang(description)} />
+        ) : undefined
+      }
+    >
+      {children}
+    </Label>
+  );
+}

--- a/app-libs/form-component/src/layout-components/common/LabelComponent/index.ts
+++ b/app-libs/form-component/src/layout-components/common/LabelComponent/index.ts
@@ -1,0 +1,2 @@
+export { LabelComponent } from './LabelComponent';
+export type { ILabelComponentProps } from './LabelComponent';

--- a/src/App/frontend/src/layout/Datepicker/DatepickerComponent.tsx
+++ b/src/App/frontend/src/layout/Datepicker/DatepickerComponent.tsx
@@ -6,7 +6,7 @@ import {
   Flex,
   getDateConstraint,
   getDateFormat,
-  Label,
+  LabelComponent,
 } from '@app/form-component';
 
 import { useDataModelBindings } from 'src/features/formData/useDataModelBindings';
@@ -14,7 +14,7 @@ import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import { getDatepickerFormat } from 'src/utils/dateUtils';
-import { useLabel } from 'src/utils/layout/useLabel';
+import { useLabelData } from 'src/utils/layout/useLabelData';
 import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
@@ -45,19 +45,13 @@ export function DatepickerComponent({ baseComponentId, overrideDisplay }: PropsF
     setValue('simpleBinding', isoDateString);
   };
 
-  const { labelText, getRequiredComponent, getOptionalComponent, getHelpTextComponent, getDescriptionComponent } =
-    useLabel({ baseComponentId, overrideDisplay });
+  const labelData = useLabelData({ baseComponentId, overrideDisplay });
 
   return (
-    <Label
+    <LabelComponent
       htmlFor={id}
-      label={labelText}
       grid={grid?.labelGrid}
-      required={required}
-      requiredIndicator={getRequiredComponent()}
-      optionalIndicator={getOptionalComponent()}
-      help={getHelpTextComponent()}
-      description={getDescriptionComponent()}
+      {...labelData}
     >
       <ComponentStructureWrapper baseComponentId={baseComponentId}>
         <Flex
@@ -89,6 +83,6 @@ export function DatepickerComponent({ baseComponentId, overrideDisplay }: PropsF
           />
         </Flex>
       </ComponentStructureWrapper>
-    </Label>
+    </LabelComponent>
   );
 }

--- a/src/App/frontend/src/utils/layout/useLabelData.ts
+++ b/src/App/frontend/src/utils/layout/useLabelData.ts
@@ -1,0 +1,40 @@
+import { useIndexedId } from 'src/utils/layout/DataModelLocation';
+import { useItemFor } from 'src/utils/layout/useNodeItem';
+import type { GenericComponentOverrideDisplay } from 'src/layout/FormComponentContext';
+
+/**
+ * Returns the primitive data (text-resource keys + booleans) needed to render a label, ready to be
+ * spread into the `LabelComponent` from `@app/form-component`. Replaces {@link useLabel}, which
+ * returned ready-made JSX. The `LabelComponent` is responsible for translating the keys and building
+ * the help text, description and indicators.
+ */
+export function useLabelData({
+  baseComponentId,
+  overrideDisplay,
+}: {
+  baseComponentId: string;
+  overrideDisplay: GenericComponentOverrideDisplay | undefined;
+}) {
+  const item = useItemFor(baseComponentId);
+  const componentId = useIndexedId(baseComponentId);
+
+  const readOnly = item['readOnly'];
+  const required = item['required'];
+  const showOptionalMarking = !!item['labelSettings']?.['optionalIndicator'];
+  const title = item.textResourceBindings?.['title'];
+  const help = item.textResourceBindings?.['help'];
+  const description = item.textResourceBindings?.['description'];
+
+  const shouldShowLabel =
+    (overrideDisplay?.renderLabel ?? true) && overrideDisplay?.renderedInTable !== true && !!title;
+
+  return {
+    componentId,
+    title: shouldShowLabel ? title : undefined,
+    help,
+    description,
+    required,
+    readOnly,
+    showOptionalMarking,
+  };
+}

--- a/src/App/frontend/src/utils/layout/useLabelData.ts
+++ b/src/App/frontend/src/utils/layout/useLabelData.ts
@@ -2,11 +2,18 @@ import { useIndexedId } from 'src/utils/layout/DataModelLocation';
 import { useItemFor } from 'src/utils/layout/useNodeItem';
 import type { GenericComponentOverrideDisplay } from 'src/layout/FormComponentContext';
 
+export interface LabelData {
+  componentId: string;
+  title: string | undefined;
+  help: string | undefined;
+  description: string | undefined;
+  required: boolean | undefined;
+  readOnly: boolean | undefined;
+  showOptionalMarking: boolean;
+}
+
 /**
- * Returns the primitive data (text-resource keys + booleans) needed to render a label, ready to be
- * spread into the `LabelComponent` from `@app/form-component`. Replaces {@link useLabel}, which
- * returned ready-made JSX. The `LabelComponent` is responsible for translating the keys and building
- * the help text, description and indicators.
+ * Returns the primitive data (text-resource keys + booleans) needed to render a label
  */
 export function useLabelData({
   baseComponentId,
@@ -14,16 +21,22 @@ export function useLabelData({
 }: {
   baseComponentId: string;
   overrideDisplay: GenericComponentOverrideDisplay | undefined;
-}) {
+}): LabelData {
   const item = useItemFor(baseComponentId);
   const componentId = useIndexedId(baseComponentId);
 
-  const readOnly = item['readOnly'];
-  const required = item['required'];
-  const showOptionalMarking = !!item['labelSettings']?.['optionalIndicator'];
-  const title = item.textResourceBindings?.['title'];
-  const help = item.textResourceBindings?.['help'];
-  const description = item.textResourceBindings?.['description'];
+  const readOnly = 'readOnly' in item ? item.readOnly : undefined;
+  const required = 'required' in item ? item.required : undefined;
+  const showOptionalMarking = 'labelSettings' in item && !!item.labelSettings?.optionalIndicator;
+
+  const trb = item.textResourceBindings;
+  const { title, help, description } = trb
+    ? {
+        title: 'title' in trb ? trb.title : undefined,
+        help: 'help' in trb ? trb.help : undefined,
+        description: 'description' in trb ? trb.description : undefined,
+      }
+    : { title: undefined, help: undefined, description: undefined };
 
   const shouldShowLabel =
     (overrideDisplay?.renderLabel ?? true) && overrideDisplay?.renderedInTable !== true && !!title;


### PR DESCRIPTION
The motivation behind this refac is to make it easier to move layout components (such as DatePickerComponent) to form-component lib. These components use Label internally

## Description

- Create a LabelComponent which accept props similar to the ones a user would configure in stuido. It translate texts and uses the existing Label component from app-components
- Created a new useLabelData hook. Its similar to existing useLabel, but it only returns config values instead of React-components

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced label component to accept a wider range of content types for increased flexibility in form layouts.
  * Introduced a new label wrapper component that automatically handles translations, required/optional indicators, help text, and descriptions.

* **Documentation**
  * Added Storybook stories showcasing label component variants and configurations.

* **Tests**
  * Added comprehensive test coverage for label component functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->