### PR TITLE
fix: restore designsystemet colors for toast notifications

### DIFF
--- a/src/Designer/frontend/packages/shared/src/contexts/ServicesContext.tsx
+++ b/src/Designer/frontend/packages/shared/src/contexts/ServicesContext.tsx
@@ -13,7 +13,6 @@ import type { i18n } from 'i18next';
 import { Trans, useTranslation } from 'react-i18next';
 import type { ApiError } from 'app-shared/types/api/ApiError';
 
-import 'react-toastify/dist/ReactToastify.css';
 import 'app-shared/styles/toast.css';
 import { userLogoutAfterPath } from 'app-shared/api/paths';
 import { ServerCodes } from 'app-shared/enums/ServerCodes';

--- a/src/Designer/frontend/packages/shared/src/styles/toast.css
+++ b/src/Designer/frontend/packages/shared/src/styles/toast.css
@@ -1,4 +1,4 @@
-:root {
+:root:root {
   --toastify-color-info: var(--fds-semantic-surface-action-primary-default);
   --toastify-color-success: var(--fds-semantic-surface-success-default);
   --toastify-color-warning: var(--fds-semantic-surface-warning-default);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix toast colors

| BEFORE | AFTER |
|--------|--------|
| <img width="4112" height="1262" alt="before1" src="https://github.com/user-attachments/assets/b4fe39d7-fb04-4a4a-83df-13c5ca6fa149" /> | <img width="4112" height="1262" alt="after1" src="https://github.com/user-attachments/assets/4a28a4e6-28d8-410a-83a7-ec9bb9ae0e56" /> |
| <img width="4112" height="1262" alt="before2" src="https://github.com/user-attachments/assets/6b248fa6-dc79-416f-999b-0a4fae061fda" /> | <img width="4112" height="1262" alt="after2" src="https://github.com/user-attachments/assets/9f5102fe-8187-41ec-8407-f551a1b6a825" /> | 

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Restructured toast component formatting for improved maintainability.
  * Adjusted CSS selector specificity for toast styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->