### PR TITLE
fix: use "self" path segment for current user in header nav links

### DIFF
--- a/src/Designer/frontend/packages/shared/src/components/PageHeader/PageHeader.test.tsx
+++ b/src/Designer/frontend/packages/shared/src/components/PageHeader/PageHeader.test.tsx
@@ -156,6 +156,24 @@ describe('PageHeader', () => {
     );
   });
 
+  it('uses "self" in nav link hrefs when owner is the current user', () => {
+    render(
+      <MemoryRouter>
+        <PageHeader
+          owner={mockUser.login}
+          onOrgSelect={mockOrgSelect}
+          onUserSelect={mockUserSelect}
+        />
+      </MemoryRouter>,
+    );
+    expect(
+      screen.getByRole('link', { name: textMock('dashboard.header_item_dashboard') }),
+    ).toHaveAttribute('href', '/dashboard/app-dashboard/self');
+    expect(
+      screen.getByRole('link', { name: textMock('dashboard.header_item_library') }),
+    ).toHaveAttribute('href', '/dashboard/org-library/self');
+  });
+
   describe('dashboard link active state', () => {
     const appDashboardBasePath = `${DASHBOARD_BASENAME}/${APP_DASHBOARD_BASENAME}`;
 

--- a/src/Designer/frontend/packages/shared/src/components/PageHeader/PageHeader.tsx
+++ b/src/Designer/frontend/packages/shared/src/components/PageHeader/PageHeader.tsx
@@ -14,6 +14,7 @@ import type { User } from 'app-shared/types/Repository';
 import { NavigationMenu } from './NavigationMenu/NavigationMenu';
 import type { NavigationMenuItem } from './NavigationMenu/NavigationMenuItem';
 import { ProfileMenu } from './ProfileMenu/ProfileMenu';
+import { useUserQuery } from 'app-shared/hooks/queries';
 
 const isPathActive = (pathname: string, basePath: string): boolean =>
   pathname === basePath || pathname.startsWith(`${basePath}/`);
@@ -26,13 +27,15 @@ type PageHeaderProps = {
 
 export const PageHeader = ({ owner, onOrgSelect, onUserSelect }: PageHeaderProps): ReactElement => {
   const shouldDisplayDesktopMenu = !useMediaQuery(MEDIA_QUERY_MAX_WIDTH);
+  const { data: currentUser } = useUserQuery();
+  const ownerInPath = currentUser?.login === owner ? 'self' : (owner ?? '');
 
   const appDashboardBasePath = `${DASHBOARD_BASENAME}/${APP_DASHBOARD_BASENAME}`;
   const orgLibraryBasePath = `${DASHBOARD_BASENAME}/${ORG_LIBRARY_BASENAME}`;
   const { pathname } = window.location;
   const navigationMenuItems: NavigationMenuItem[] = [
     {
-      href: `${appDashboardBasePath}/${owner ?? ''}`,
+      href: `${appDashboardBasePath}/${ownerInPath}`,
       textKey: 'dashboard.header_item_dashboard',
       isActive: isPathActive(pathname, appDashboardBasePath),
     },
@@ -43,7 +46,7 @@ export const PageHeader = ({ owner, onOrgSelect, onUserSelect }: PageHeaderProps
       isBeta: true,
     },
     {
-      href: `${orgLibraryBasePath}/${owner ?? ''}`,
+      href: `${orgLibraryBasePath}/${ownerInPath}`,
       textKey: 'dashboard.header_item_library',
       isActive: isPathActive(pathname, orgLibraryBasePath),
       isBeta: true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use "self" path segment for current user in header nav links to prevent these errors:

<img width="4112" height="1070" alt="fix1" src="https://github.com/user-attachments/assets/90f5e0c7-cce2-4c3b-9f22-2b956f9e6e38" />
<img width="4112" height="1070" alt="fix2" src="https://github.com/user-attachments/assets/54855d5a-e1b2-4039-b23c-188e830d646f" />

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Updated navigation link generation in PageHeader to use "self" as the path segment when viewing your own content, rather than displaying your username. This provides cleaner and more consistent URLs for personal dashboard and library navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->