### PR TITLE
test: guard workflow-engine wire contract against app/engine drift

### DIFF
--- a/.github/workflows/app-backend-tests.yml
+++ b/.github/workflows/app-backend-tests.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'src/App/backend/**'
       - 'src/Runtime/localtest/**'
+      # Workflow-engine wire-contract drift guard: the app's contract test consumes these files
+      # (shared describer + committed engine contract) directly, so changes must re-run it.
+      - 'src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/Contract/**'
       - '.github/workflows/app-backend-tests.yml'
   workflow_dispatch:
 

--- a/src/App/backend/test/Altinn.App.Core.Tests/Altinn.App.Core.Tests.csproj
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Altinn.App.Core.Tests.csproj
@@ -54,4 +54,16 @@
     <Content Include="secrets.json" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" />
   </ItemGroup>
 
+  <!--
+    Workflow-engine wire-contract drift guard. The engine owns the contract; these two files are
+    consumed (not copied) directly from the engine host's test project so there is a single source of
+    truth in the monorepo. The shared describer is compiled in; the engine's committed contract
+    description is embedded. Neither affects the shipped Altinn.App.Core NuGet package — this is a
+    test project. See Internal/WorkflowEngine/ContractTests/AppWireContractTests.cs.
+  -->
+  <ItemGroup>
+    <Compile Include="../../../../Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/Contract/WireContract.cs" Link="Internal/WorkflowEngine/ContractTests/WireContract.cs" />
+    <EmbeddedResource Include="../../../../Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/Contract/wire-contract.verified.json" Link="Internal/WorkflowEngine/ContractTests/wire-contract.verified.json" />
+  </ItemGroup>
+
 </Project>

--- a/src/App/backend/test/Altinn.App.Core.Tests/Internal/WorkflowEngine/ContractTests/AppWireContractTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Internal/WorkflowEngine/ContractTests/AppWireContractTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Altinn.App.Core.Internal.WorkflowEngine.Models.AppCommand;
+using Altinn.App.Core.Internal.WorkflowEngine.Models.Engine;
+using Altinn.WorkflowEngine.ContractTesting;
+using Xunit;
+
+namespace Altinn.App.Core.Tests.Internal.WorkflowEngine.ContractTests;
+
+/// <summary>
+/// Guards the app's curated copies of the workflow-engine wire models against drift from the engine.
+///
+/// The engine owns the contract: its test suite reflects over its real DTO types and commits the
+/// canonical description as <c>wire-contract.verified.json</c> (embedded here at build time). This test
+/// reflects over the app's curated copies and asserts they remain wire-compatible with that description.
+///
+/// The two model sets are intentionally <em>not</em> identical — the app copies are internal, omit
+/// engine-only response variants, and may use different (but wire-equivalent) JSON converters. The
+/// check therefore verifies compatibility, not equality: every field the app models must exist on the
+/// engine with the same shape, and every value the engine always sends must be modelled by the app.
+///
+/// When this test fails, the engine contract changed. Reconcile the app copies in
+/// <c>Internal/WorkflowEngine/Models/</c> with the committed engine description and update this test's
+/// type list if a type was added or removed.
+/// </summary>
+public class AppWireContractTests
+{
+    /// <summary>
+    /// The app's copies of the engine wire contract. Mirrors the engine's root type list; nested object
+    /// types (WorkflowResult, CommandDetails, CollectionHeadStatus, ...) are discovered automatically.
+    /// </summary>
+    private static IReadOnlyList<Type> AppContractTypes =>
+        [
+            typeof(WorkflowEnqueueRequest),
+            typeof(WorkflowRequest),
+            typeof(StepRequest),
+            typeof(CommandDefinition),
+            typeof(RetryStrategy),
+            typeof(WorkflowEnqueueResponse.Accepted),
+            typeof(WorkflowStatusResponse),
+            typeof(StepStatusResponse),
+            typeof(PaginatedResponse<WorkflowStatusResponse>),
+            typeof(WorkflowCollectionDetailResponse),
+            typeof(CancelWorkflowResponse),
+            typeof(ResumeWorkflowResponse),
+            typeof(Actor),
+            typeof(AppCommandData),
+            typeof(AppWorkflowContext),
+            typeof(AppCallbackPayload),
+            typeof(AppCallbackResponse),
+        ];
+
+    [Fact]
+    public void AppContract_IsCompatibleWithEngineContract()
+    {
+        var engine = WireContract.Deserialize(ReadEngineContract());
+        var app = WireContract.Describe(AppContractTypes);
+
+        var problems = WireContract.FindIncompatibilities(app, engine);
+
+        Assert.True(
+            problems.Count == 0,
+            "Workflow engine wire-contract drift detected between the app's copies and the engine's "
+                + "committed contract:\n  - "
+                + string.Join("\n  - ", problems)
+        );
+    }
+
+    private static string ReadEngineContract()
+    {
+        var assembly = typeof(AppWireContractTests).Assembly;
+        var resourceName = assembly
+            .GetManifestResourceNames()
+            .Single(name => name.EndsWith("wire-contract.verified.json", StringComparison.Ordinal));
+
+        using var stream =
+            assembly.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidOperationException($"Embedded engine contract '{resourceName}' could not be opened.");
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+}

--- a/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/Contract/EngineWireContractTests.cs
+++ b/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/Contract/EngineWireContractTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Altinn.WorkflowEngine.ContractTesting;
+using WorkflowEngine.App.Commands.AppCommand;
+using WorkflowEngine.Models;
+using WorkflowEngine.Resilience.Models;
+
+namespace WorkflowEngine.App.Tests.Contract;
+
+/// <summary>
+/// Owns the canonical wire-contract description. This test reflects over the engine's real DTO types
+/// (the single source of truth for the workflow-engine HTTP contract) and asserts they still match the
+/// committed <c>wire-contract.verified.json</c>.
+///
+/// When the engine intentionally changes the contract, regenerate the snapshot by running this test
+/// once with the environment variable <c>UPDATE_WIRE_CONTRACT=1</c>, then review and commit the diff.
+/// The committed file is what the app-side contract test (in Altinn.App.Core.Tests) verifies against,
+/// so any engine contract change surfaces in both repositories' test suites.
+/// </summary>
+public class EngineWireContractTests
+{
+    private static readonly string _snapshotPath = Path.Combine(
+        WireContract.ContractDirectory(),
+        "wire-contract.verified.json"
+    );
+
+    /// <summary>
+    /// The set of types that make up the engine's HTTP wire contract with Altinn apps: enqueue
+    /// requests, status/collection responses, retry configuration, and the AppCommand callback shapes.
+    /// Nested object types (e.g. WorkflowResult, CommandDetails, CollectionHeadStatus) are discovered
+    /// automatically by the describer, so only the entry points are listed here.
+    /// </summary>
+    private static IReadOnlyList<Type> EngineContractTypes =>
+        [
+            // Enqueue request graph
+            typeof(WorkflowEnqueueRequest),
+            typeof(WorkflowRequest),
+            typeof(StepRequest),
+            typeof(CommandDefinition),
+            typeof(RetryStrategy),
+            // Enqueue response
+            typeof(WorkflowEnqueueResponse.Accepted),
+            // Status + collection responses
+            typeof(WorkflowStatusResponse),
+            typeof(StepStatusResponse),
+            typeof(PaginatedResponse<WorkflowStatusResponse>),
+            typeof(WorkflowCollectionDetailResponse),
+            typeof(CancelWorkflowResponse),
+            typeof(ResumeWorkflowResponse),
+            // AppCommand callback contract (owned by the engine host)
+            typeof(Actor),
+            typeof(AppCommandData),
+            typeof(AppWorkflowContext),
+            typeof(AppCallbackPayload),
+            typeof(AppCallbackResponse),
+        ];
+
+    [Fact]
+    public void EngineContract_MatchesCommittedSnapshot()
+    {
+        var actual = WireContract.Serialize(WireContract.Describe(EngineContractTypes));
+
+        if (Environment.GetEnvironmentVariable("UPDATE_WIRE_CONTRACT") == "1")
+        {
+            File.WriteAllText(_snapshotPath, actual);
+        }
+
+        Assert.True(
+            File.Exists(_snapshotPath),
+            $"Missing wire contract snapshot at '{_snapshotPath}'. Generate it by running this test with UPDATE_WIRE_CONTRACT=1."
+        );
+
+        var expected = File.ReadAllText(_snapshotPath);
+        Assert.Equal(Normalize(expected), Normalize(actual));
+    }
+
+    private static string Normalize(string value) => value.Replace("\r\n", "\n", StringComparison.Ordinal).Trim();
+}

--- a/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/Contract/README.md
+++ b/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/Contract/README.md
@@ -1,0 +1,51 @@
+# Workflow engine wire-contract drift guard
+
+The workflow engine and the Altinn app backend (`Altinn.App.Core`, shipped as a NuGet package)
+exchange data only over HTTP/JSON. The engine **owns** the contract; the app keeps its own curated,
+internal copies of the request/response models rather than taking a binary dependency on the engine.
+
+This folder holds the machinery that keeps those two model sets from drifting apart, without coupling
+the two builds or shipping an engine DLL in the app's NuGet package.
+
+## How it works
+
+```
+engine canonical types  ──describe──▶  wire-contract.verified.json  ◀──compare──  app curated copies
+   (this project)                          (committed artifact)              (Altinn.App.Core.Tests)
+```
+
+- **`WireContract.cs`** — a shared, framework-agnostic reflection describer. It reduces a set of DTO
+  types to a normalized, language-neutral description of their JSON wire shapes (property names,
+  normalized kinds, nullability), deliberately ignoring CLR namespaces, accessibility, methods, and
+  wire-equivalent converter differences (e.g. `JsonStringEnumConverter` vs `FlexibleEnumConverter`).
+  This file is also compiled (as a linked source) into `Altinn.App.Core.Tests`.
+
+- **`wire-contract.verified.json`** — the committed, canonical description of the engine contract.
+  This is the single source of truth that both repositories check against.
+
+- **`EngineWireContractTests`** (this project) — reflects over the engine's **real** types and asserts
+  they still match `wire-contract.verified.json`. This keeps the committed artifact honest to the
+  engine.
+
+- **`AppWireContractTests`** (in `Altinn.App.Core.Tests`) — reflects over the app's curated copies and
+  asserts they remain **compatible** with the committed artifact. The embedded copy of the JSON is
+  pulled directly from this folder at build time.
+
+The app check is directional (the app is a consumer, not a mirror): every field the app models must
+exist on the engine with the same shape, and every non-nullable engine field must be modelled by the
+app — but the app may omit optional engine fields and engine-only response variants.
+
+## When the engine contract changes
+
+1. Change the engine model(s).
+2. Regenerate the snapshot:
+   ```
+   UPDATE_WIRE_CONTRACT=1 dotnet test --filter FullyQualifiedName~EngineWireContractTests
+   ```
+3. Review the `wire-contract.verified.json` diff and commit it.
+4. Reconcile the app's copies in
+   `src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Models/` until `AppWireContractTests`
+   passes again.
+
+Because the committed JSON is in `app-backend-tests.yml`'s path triggers, an engine contract change
+runs the app-side test too, so incompatibilities surface in the same PR.

--- a/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/Contract/WireContract.cs
+++ b/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/Contract/WireContract.cs
@@ -1,0 +1,377 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Altinn.WorkflowEngine.ContractTesting;
+
+/// <summary>
+/// A single JSON field in the workflow-engine wire contract, reduced to the parts that are
+/// observable on the wire: its JSON property name, a normalized type <see cref="Kind"/>, and
+/// whether it may be <c>null</c>. CLR namespaces, visibility, method bodies, attributes that do
+/// not affect the wire, and XML documentation are deliberately excluded so that the engine's
+/// canonical types and the app's curated copies describe to the same value when they agree.
+/// </summary>
+internal sealed record WireField(string Name, string Kind, bool Nullable);
+
+/// <summary>
+/// A single object type in the wire contract: its simple (namespace-free) name and its fields,
+/// always sorted by name so the description is deterministic regardless of reflection order.
+/// </summary>
+internal sealed record WireType(string Name, IReadOnlyList<WireField> Fields);
+
+/// <summary>
+/// Reflects over a set of DTO types and produces a normalized, language-neutral description of the
+/// JSON wire shapes they participate in. Two type sets that serialize to and from the same JSON —
+/// even if they live in different assemblies, use different accessibility, or use different (but
+/// wire-equivalent) JSON converters — produce equal descriptions.
+///
+/// This is the shared engine of the workflow-engine contract-drift tests. The engine side describes
+/// its canonical types and commits the result as <c>wire-contract.verified.json</c>; the app side
+/// describes its curated copies and asserts they remain compatible with that committed description.
+/// </summary>
+internal static class WireContract
+{
+    private static readonly JsonSerializerOptions _serializerOptions = new()
+    {
+        WriteIndented = true,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+
+    /// <summary>
+    /// Returns the absolute directory that holds this source file (and the committed
+    /// <c>wire-contract.verified.json</c> next to it). Resolves via <see cref="CallerFilePathAttribute"/>
+    /// so it works even when this file is compiled as a linked source into another project.
+    /// </summary>
+    public static string ContractDirectory([CallerFilePath] string path = "") =>
+        Path.GetDirectoryName(path) ?? throw new InvalidOperationException("Could not resolve the contract directory.");
+
+    /// <summary>
+    /// Builds the normalized wire description for the given root types, expanding nested object
+    /// types reachable through fields, arrays, dictionaries, and generic arguments.
+    /// </summary>
+    public static IReadOnlyDictionary<string, WireType> Describe(IEnumerable<Type> roots) =>
+        new Describer().Build(roots);
+
+    /// <summary>Serializes a description to canonical (sorted, indented) JSON.</summary>
+    public static string Serialize(IReadOnlyDictionary<string, WireType> types)
+    {
+        var sorted = new SortedDictionary<string, WireType>(StringComparer.Ordinal);
+        foreach (var (name, type) in types)
+        {
+            sorted[name] = type;
+        }
+
+        return JsonSerializer.Serialize(sorted, _serializerOptions);
+    }
+
+    /// <summary>Deserializes a description previously produced by <see cref="Serialize"/>.</summary>
+    public static IReadOnlyDictionary<string, WireType> Deserialize(string json) =>
+        JsonSerializer.Deserialize<Dictionary<string, WireType>>(json, _serializerOptions)
+        ?? throw new InvalidOperationException("Could not deserialize the wire contract description.");
+
+    /// <summary>
+    /// Compares an app-side description against the engine's canonical description and returns a list
+    /// of human-readable incompatibilities (empty when the app is compatible).
+    ///
+    /// The check is directional, reflecting that the app is a deliberate, curated consumer of the
+    /// engine contract rather than a mirror of it:
+    /// <list type="bullet">
+    ///   <item>Every type and field the app models must exist on the engine with the same kind and
+    ///         nullability — the app must never introduce or reshape a field the engine does not know.</item>
+    ///   <item>Every non-nullable engine field must be modelled by the app — the app must not silently
+    ///         drop a value the engine always sends or requires.</item>
+    ///   <item>Optional (nullable) engine fields and engine-only types may be omitted by the app —
+    ///         this is the legitimate subsetting the app relies on.</item>
+    /// </list>
+    /// </summary>
+    public static IReadOnlyList<string> FindIncompatibilities(
+        IReadOnlyDictionary<string, WireType> app,
+        IReadOnlyDictionary<string, WireType> engine
+    )
+    {
+        var problems = new List<string>();
+
+        foreach (var (name, appType) in app.OrderBy(x => x.Key, StringComparer.Ordinal))
+        {
+            if (!engine.TryGetValue(name, out var engineType))
+            {
+                problems.Add($"Type '{name}': modelled by the app but absent from the engine contract.");
+                continue;
+            }
+
+            var engineFields = engineType.Fields.ToDictionary(f => f.Name, StringComparer.Ordinal);
+            var appFields = appType.Fields.Select(f => f.Name).ToHashSet(StringComparer.Ordinal);
+
+            foreach (var appField in appType.Fields)
+            {
+                if (!engineFields.TryGetValue(appField.Name, out var engineField))
+                {
+                    problems.Add($"{name}.{appField.Name}: present in the app but not in the engine contract.");
+                    continue;
+                }
+
+                if (!string.Equals(appField.Kind, engineField.Kind, StringComparison.Ordinal))
+                {
+                    problems.Add(
+                        $"{name}.{appField.Name}: type mismatch (app '{appField.Kind}', engine '{engineField.Kind}')."
+                    );
+                }
+
+                if (appField.Nullable != engineField.Nullable)
+                {
+                    problems.Add(
+                        $"{name}.{appField.Name}: nullability mismatch (app nullable={appField.Nullable}, engine nullable={engineField.Nullable})."
+                    );
+                }
+            }
+
+            foreach (var engineField in engineType.Fields.Where(f => !f.Nullable && !appFields.Contains(f.Name)))
+            {
+                problems.Add(
+                    $"{name}.{engineField.Name}: required by the engine (non-nullable) but not modelled by the app."
+                );
+            }
+        }
+
+        return problems;
+    }
+
+    private sealed class Describer
+    {
+        private readonly Queue<Type> _queue = new();
+        private readonly Dictionary<string, WireType> _types = new(StringComparer.Ordinal);
+        private readonly HashSet<string> _done = new(StringComparer.Ordinal);
+        private readonly NullabilityInfoContext _nullability = new();
+
+        public Dictionary<string, WireType> Build(IEnumerable<Type> roots)
+        {
+            foreach (var root in roots)
+            {
+                _queue.Enqueue(root);
+            }
+
+            while (_queue.Count > 0)
+            {
+                var type = _queue.Dequeue();
+
+                // Enums and scalars carry their full wire shape inline at each use site (e.g.
+                // "enum<string>{...}"), so they are never registered as standalone object types.
+                if (type.IsEnum || ScalarKind(type) is not null)
+                {
+                    continue;
+                }
+
+                var name = TypeName(type);
+                if (_done.Add(name))
+                {
+                    _types[name] = DescribeObject(type, name);
+                }
+            }
+
+            return _types;
+        }
+
+        private WireType DescribeObject(Type type, string name)
+        {
+            var fields = new List<WireField>();
+            foreach (var property in SerializableProperties(type))
+            {
+                var nullable = IsNullable(property);
+                var kind = ResolveKind(Unwrap(property.PropertyType), property);
+                fields.Add(new WireField(JsonName(property), kind, nullable));
+            }
+
+            fields.Sort((a, b) => string.CompareOrdinal(a.Name, b.Name));
+            return new WireType(name, fields);
+        }
+
+        private string ResolveKind(Type type, ICustomAttributeProvider? member)
+        {
+            var converter = ConverterName(member) ?? ConverterName(type);
+            if (converter == "WorkflowRefConverter")
+            {
+                return "string";
+            }
+
+            if (type == typeof(JsonElement))
+            {
+                return "json";
+            }
+
+            if (type.IsEnum)
+            {
+                return EnumKind(type, converter);
+            }
+
+            if (ScalarKind(type) is { } scalar)
+            {
+                return scalar;
+            }
+
+            if (DictionaryInterface(type) is { } dictionary)
+            {
+                var args = dictionary.GetGenericArguments();
+                return $"map<{ResolveKind(Unwrap(args[0]), null)},{ResolveKind(Unwrap(args[1]), null)}>";
+            }
+
+            if (EnumerableElement(type) is { } element)
+            {
+                return $"array<{ResolveKind(Unwrap(element), null)}>";
+            }
+
+            _queue.Enqueue(type);
+            return $"object<{TypeName(type)}>";
+        }
+
+        private static string? ScalarKind(Type type)
+        {
+            if (type == typeof(string))
+            {
+                return "string";
+            }
+            if (type == typeof(bool))
+            {
+                return "bool";
+            }
+            if (type == typeof(Guid))
+            {
+                return "guid";
+            }
+            if (type == typeof(DateTimeOffset) || type == typeof(DateTime))
+            {
+                return "datetimeoffset";
+            }
+            if (type == typeof(TimeSpan))
+            {
+                return "timespan";
+            }
+            if (type == typeof(long) || type == typeof(ulong))
+            {
+                return "long";
+            }
+            if (
+                type == typeof(byte)
+                || type == typeof(sbyte)
+                || type == typeof(short)
+                || type == typeof(ushort)
+                || type == typeof(int)
+                || type == typeof(uint)
+            )
+            {
+                return "int";
+            }
+            if (type == typeof(float) || type == typeof(double) || type == typeof(decimal))
+            {
+                return "number";
+            }
+
+            return null;
+        }
+
+        private static string EnumKind(Type type, string? converter)
+        {
+            var asString = converter is "JsonStringEnumConverter" or "FlexibleEnumConverter";
+            var members = Enum.GetValues(type)
+                .Cast<object>()
+                .Select(value =>
+                    (Name: Enum.GetName(type, value), Value: Convert.ToInt64(value, CultureInfo.InvariantCulture))
+                )
+                .OrderBy(member => member.Value)
+                .Select(member => $"{member.Name}={member.Value.ToString(CultureInfo.InvariantCulture)}");
+            return $"enum<{(asString ? "string" : "int")}>{{{string.Join(",", members)}}}";
+        }
+
+        private bool IsNullable(PropertyInfo property)
+        {
+            if (property.PropertyType.IsValueType)
+            {
+                return Nullable.GetUnderlyingType(property.PropertyType) is not null;
+            }
+
+            return _nullability.Create(property).ReadState == NullabilityState.Nullable;
+        }
+
+        private static string JsonName(PropertyInfo property) =>
+            property.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name
+            ?? JsonNamingPolicy.CamelCase.ConvertName(property.Name);
+
+        private static IEnumerable<PropertyInfo> SerializableProperties(Type type) =>
+            type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(p => p.GetIndexParameters().Length == 0)
+                .Where(p => p.GetMethod is { IsPublic: true })
+                .Where(p => !IsAlwaysIgnored(p));
+
+        private static bool IsAlwaysIgnored(PropertyInfo property)
+        {
+            var ignore = property.GetCustomAttribute<JsonIgnoreAttribute>();
+            return ignore is not null && ignore.Condition == JsonIgnoreCondition.Always;
+        }
+
+        private static string? ConverterName(ICustomAttributeProvider? provider)
+        {
+            var converterType = (provider?.GetCustomAttributes(typeof(JsonConverterAttribute), false) ?? [])
+                .Cast<JsonConverterAttribute>()
+                .FirstOrDefault()
+                ?.ConverterType;
+            if (converterType is null)
+            {
+                return null;
+            }
+
+            var name = converterType.Name;
+            var tick = name.IndexOf('`', StringComparison.Ordinal);
+            return tick >= 0 ? name[..tick] : name;
+        }
+
+        private static Type Unwrap(Type type) => Nullable.GetUnderlyingType(type) ?? type;
+
+        private static Type? DictionaryInterface(Type type) =>
+            Interfaces(type)
+                .FirstOrDefault(i =>
+                    i.IsGenericType
+                    && (
+                        i.GetGenericTypeDefinition() == typeof(IReadOnlyDictionary<,>)
+                        || i.GetGenericTypeDefinition() == typeof(IDictionary<,>)
+                    )
+                );
+
+        private static Type? EnumerableElement(Type type)
+        {
+            if (type == typeof(string))
+            {
+                return null;
+            }
+
+            return Interfaces(type)
+                .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+                ?.GetGenericArguments()[0];
+        }
+
+        private static IEnumerable<Type> Interfaces(Type type) =>
+            type.IsInterface ? type.GetInterfaces().Prepend(type) : type.GetInterfaces();
+
+        private static string TypeName(Type type)
+        {
+            if (!type.IsGenericType)
+            {
+                return type.Name;
+            }
+
+            var name = type.Name;
+            var tick = name.IndexOf('`', StringComparison.Ordinal);
+            if (tick >= 0)
+            {
+                name = name[..tick];
+            }
+
+            return $"{name}<{string.Join(",", type.GetGenericArguments().Select(TypeName))}>";
+        }
+    }
+}

--- a/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/Contract/wire-contract.verified.json
+++ b/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/Contract/wire-contract.verified.json
@@ -1,0 +1,622 @@
+{
+  "Accepted": {
+    "Name": "Accepted",
+    "Fields": [
+      {
+        "Name": "workflows",
+        "Kind": "array<object<WorkflowResult>>",
+        "Nullable": false
+      }
+    ]
+  },
+  "Actor": {
+    "Name": "Actor",
+    "Fields": [
+      {
+        "Name": "authenticationLevel",
+        "Kind": "int",
+        "Nullable": true
+      },
+      {
+        "Name": "language",
+        "Kind": "string",
+        "Nullable": true
+      },
+      {
+        "Name": "nationalIdentityNumber",
+        "Kind": "string",
+        "Nullable": true
+      },
+      {
+        "Name": "orgId",
+        "Kind": "string",
+        "Nullable": true
+      },
+      {
+        "Name": "systemUserId",
+        "Kind": "guid",
+        "Nullable": true
+      },
+      {
+        "Name": "systemUserName",
+        "Kind": "string",
+        "Nullable": true
+      },
+      {
+        "Name": "systemUserOwnerOrgNo",
+        "Kind": "string",
+        "Nullable": true
+      },
+      {
+        "Name": "userId",
+        "Kind": "int",
+        "Nullable": true
+      }
+    ]
+  },
+  "AppCallbackPayload": {
+    "Name": "AppCallbackPayload",
+    "Fields": [
+      {
+        "Name": "actor",
+        "Kind": "object<Actor>",
+        "Nullable": false
+      },
+      {
+        "Name": "commandKey",
+        "Kind": "string",
+        "Nullable": false
+      },
+      {
+        "Name": "lockToken",
+        "Kind": "string",
+        "Nullable": false
+      },
+      {
+        "Name": "payload",
+        "Kind": "string",
+        "Nullable": true
+      },
+      {
+        "Name": "state",
+        "Kind": "string",
+        "Nullable": true
+      },
+      {
+        "Name": "workflowId",
+        "Kind": "guid",
+        "Nullable": false
+      }
+    ]
+  },
+  "AppCallbackResponse": {
+    "Name": "AppCallbackResponse",
+    "Fields": [
+      {
+        "Name": "state",
+        "Kind": "string",
+        "Nullable": true
+      }
+    ]
+  },
+  "AppCommandData": {
+    "Name": "AppCommandData",
+    "Fields": [
+      {
+        "Name": "commandKey",
+        "Kind": "string",
+        "Nullable": false
+      },
+      {
+        "Name": "payload",
+        "Kind": "string",
+        "Nullable": true
+      }
+    ]
+  },
+  "AppWorkflowContext": {
+    "Name": "AppWorkflowContext",
+    "Fields": [
+      {
+        "Name": "actor",
+        "Kind": "object<Actor>",
+        "Nullable": false
+      },
+      {
+        "Name": "app",
+        "Kind": "string",
+        "Nullable": false
+      },
+      {
+        "Name": "callbackToken",
+        "Kind": "string",
+        "Nullable": false
+      },
+      {
+        "Name": "instanceGuid",
+        "Kind": "guid",
+        "Nullable": false
+      },
+      {
+        "Name": "instanceOwnerPartyId",
+        "Kind": "int",
+        "Nullable": false
+      },
+      {
+        "Name": "lockToken",
+        "Kind": "string",
+        "Nullable": false
+      },
+      {
+        "Name": "org",
+        "Kind": "string",
+        "Nullable": false
+      }
+    ]
+  },
+  "CancelWorkflowResponse": {
+    "Name": "CancelWorkflowResponse",
+    "Fields": [
+      {
+        "Name": "canceledImmediately",
+        "Kind": "bool",
+        "Nullable": false
+      },
+      {
+        "Name": "cancellationRequestedAt",
+        "Kind": "datetimeoffset",
+        "Nullable": false
+      },
+      {
+        "Name": "workflowId",
+        "Kind": "guid",
+        "Nullable": false
+      }
+    ]
+  },
+  "CollectionHeadStatus": {
+    "Name": "CollectionHeadStatus",
+    "Fields": [
+      {
+        "Name": "databaseId",
+        "Kind": "guid",
+        "Nullable": false
+      },
+      {
+        "Name": "status",
+        "Kind": "enum<string>{Enqueued=0,Processing=1,Requeued=2,Completed=3,Failed=4,Canceled=5,DependencyFailed=6}",
+        "Nullable": false
+      }
+    ]
+  },
+  "CommandDefinition": {
+    "Name": "CommandDefinition",
+    "Fields": [
+      {
+        "Name": "data",
+        "Kind": "json",
+        "Nullable": true
+      },
+      {
+        "Name": "maxExecutionTime",
+        "Kind": "timespan",
+        "Nullable": true
+      },
+      {
+        "Name": "type",
+        "Kind": "string",
+        "Nullable": false
+      }
+    ]
+  },
+  "CommandDetails": {
+    "Name": "CommandDetails",
+    "Fields": [
+      {
+        "Name": "type",
+        "Kind": "string",
+        "Nullable": false
+      }
+    ]
+  },
+  "ErrorEntry": {
+    "Name": "ErrorEntry",
+    "Fields": [
+      {
+        "Name": "httpStatusCode",
+        "Kind": "int",
+        "Nullable": true
+      },
+      {
+        "Name": "message",
+        "Kind": "string",
+        "Nullable": false
+      },
+      {
+        "Name": "timestamp",
+        "Kind": "datetimeoffset",
+        "Nullable": false
+      },
+      {
+        "Name": "wasRetryable",
+        "Kind": "bool",
+        "Nullable": false
+      }
+    ]
+  },
+  "PaginatedResponse<WorkflowStatusResponse>": {
+    "Name": "PaginatedResponse<WorkflowStatusResponse>",
+    "Fields": [
+      {
+        "Name": "data",
+        "Kind": "array<object<WorkflowStatusResponse>>",
+        "Nullable": false
+      },
+      {
+        "Name": "nextCursor",
+        "Kind": "guid",
+        "Nullable": true
+      },
+      {
+        "Name": "pageSize",
+        "Kind": "int",
+        "Nullable": false
+      },
+      {
+        "Name": "totalCount",
+        "Kind": "int",
+        "Nullable": false
+      }
+    ]
+  },
+  "ResumeWorkflowResponse": {
+    "Name": "ResumeWorkflowResponse",
+    "Fields": [
+      {
+        "Name": "cascadeResumed",
+        "Kind": "array<guid>",
+        "Nullable": false
+      },
+      {
+        "Name": "resumedAt",
+        "Kind": "datetimeoffset",
+        "Nullable": false
+      },
+      {
+        "Name": "workflowId",
+        "Kind": "guid",
+        "Nullable": false
+      }
+    ]
+  },
+  "RetryStrategy": {
+    "Name": "RetryStrategy",
+    "Fields": [
+      {
+        "Name": "backoffType",
+        "Kind": "enum<string>{Constant=0,Linear=1,Exponential=2}",
+        "Nullable": false
+      },
+      {
+        "Name": "baseInterval",
+        "Kind": "timespan",
+        "Nullable": false
+      },
+      {
+        "Name": "maxDelay",
+        "Kind": "timespan",
+        "Nullable": true
+      },
+      {
+        "Name": "maxDuration",
+        "Kind": "timespan",
+        "Nullable": true
+      },
+      {
+        "Name": "maxRetries",
+        "Kind": "int",
+        "Nullable": true
+      },
+      {
+        "Name": "nonRetryableHttpStatusCodes",
+        "Kind": "array<int>",
+        "Nullable": true
+      }
+    ]
+  },
+  "StepRequest": {
+    "Name": "StepRequest",
+    "Fields": [
+      {
+        "Name": "command",
+        "Kind": "object<CommandDefinition>",
+        "Nullable": false
+      },
+      {
+        "Name": "labels",
+        "Kind": "map<string,string>",
+        "Nullable": true
+      },
+      {
+        "Name": "operationId",
+        "Kind": "string",
+        "Nullable": false
+      },
+      {
+        "Name": "retryStrategy",
+        "Kind": "object<RetryStrategy>",
+        "Nullable": true
+      }
+    ]
+  },
+  "StepStatusResponse": {
+    "Name": "StepStatusResponse",
+    "Fields": [
+      {
+        "Name": "command",
+        "Kind": "object<CommandDetails>",
+        "Nullable": false
+      },
+      {
+        "Name": "databaseId",
+        "Kind": "guid",
+        "Nullable": false
+      },
+      {
+        "Name": "errorHistory",
+        "Kind": "array<object<ErrorEntry>>",
+        "Nullable": true
+      },
+      {
+        "Name": "labels",
+        "Kind": "map<string,string>",
+        "Nullable": true
+      },
+      {
+        "Name": "operationId",
+        "Kind": "string",
+        "Nullable": false
+      },
+      {
+        "Name": "processingOrder",
+        "Kind": "int",
+        "Nullable": false
+      },
+      {
+        "Name": "retryCount",
+        "Kind": "int",
+        "Nullable": false
+      },
+      {
+        "Name": "retryStrategy",
+        "Kind": "object<RetryStrategy>",
+        "Nullable": true
+      },
+      {
+        "Name": "stateOut",
+        "Kind": "string",
+        "Nullable": true
+      },
+      {
+        "Name": "status",
+        "Kind": "enum<string>{Enqueued=0,Processing=1,Requeued=2,Completed=3,Failed=4,Canceled=5,DependencyFailed=6}",
+        "Nullable": false
+      },
+      {
+        "Name": "updatedAt",
+        "Kind": "datetimeoffset",
+        "Nullable": true
+      }
+    ]
+  },
+  "WorkflowCollectionDetailResponse": {
+    "Name": "WorkflowCollectionDetailResponse",
+    "Fields": [
+      {
+        "Name": "createdAt",
+        "Kind": "datetimeoffset",
+        "Nullable": false
+      },
+      {
+        "Name": "heads",
+        "Kind": "array<object<CollectionHeadStatus>>",
+        "Nullable": false
+      },
+      {
+        "Name": "key",
+        "Kind": "string",
+        "Nullable": false
+      },
+      {
+        "Name": "namespace",
+        "Kind": "string",
+        "Nullable": false
+      },
+      {
+        "Name": "updatedAt",
+        "Kind": "datetimeoffset",
+        "Nullable": true
+      }
+    ]
+  },
+  "WorkflowEnqueueRequest": {
+    "Name": "WorkflowEnqueueRequest",
+    "Fields": [
+      {
+        "Name": "context",
+        "Kind": "json",
+        "Nullable": true
+      },
+      {
+        "Name": "labels",
+        "Kind": "map<string,string>",
+        "Nullable": true
+      },
+      {
+        "Name": "workflows",
+        "Kind": "array<object<WorkflowRequest>>",
+        "Nullable": false
+      }
+    ]
+  },
+  "WorkflowRequest": {
+    "Name": "WorkflowRequest",
+    "Fields": [
+      {
+        "Name": "dependsOn",
+        "Kind": "array<string>",
+        "Nullable": true
+      },
+      {
+        "Name": "dependsOnHeads",
+        "Kind": "bool",
+        "Nullable": false
+      },
+      {
+        "Name": "isHead",
+        "Kind": "bool",
+        "Nullable": true
+      },
+      {
+        "Name": "links",
+        "Kind": "array<string>",
+        "Nullable": true
+      },
+      {
+        "Name": "operationId",
+        "Kind": "string",
+        "Nullable": false
+      },
+      {
+        "Name": "ref",
+        "Kind": "string",
+        "Nullable": true
+      },
+      {
+        "Name": "startAt",
+        "Kind": "datetimeoffset",
+        "Nullable": true
+      },
+      {
+        "Name": "state",
+        "Kind": "string",
+        "Nullable": true
+      },
+      {
+        "Name": "steps",
+        "Kind": "array<object<StepRequest>>",
+        "Nullable": false
+      }
+    ]
+  },
+  "WorkflowResult": {
+    "Name": "WorkflowResult",
+    "Fields": [
+      {
+        "Name": "databaseId",
+        "Kind": "guid",
+        "Nullable": false
+      },
+      {
+        "Name": "namespace",
+        "Kind": "string",
+        "Nullable": false
+      },
+      {
+        "Name": "ref",
+        "Kind": "string",
+        "Nullable": true
+      }
+    ]
+  },
+  "WorkflowStatusResponse": {
+    "Name": "WorkflowStatusResponse",
+    "Fields": [
+      {
+        "Name": "backoffUntil",
+        "Kind": "datetimeoffset",
+        "Nullable": true
+      },
+      {
+        "Name": "cancellationRequestedAt",
+        "Kind": "datetimeoffset",
+        "Nullable": true
+      },
+      {
+        "Name": "collectionKey",
+        "Kind": "string",
+        "Nullable": true
+      },
+      {
+        "Name": "createdAt",
+        "Kind": "datetimeoffset",
+        "Nullable": false
+      },
+      {
+        "Name": "databaseId",
+        "Kind": "guid",
+        "Nullable": false
+      },
+      {
+        "Name": "dependencies",
+        "Kind": "map<guid,enum<string>{Enqueued=0,Processing=1,Requeued=2,Completed=3,Failed=4,Canceled=5,DependencyFailed=6}>",
+        "Nullable": true
+      },
+      {
+        "Name": "dependents",
+        "Kind": "map<guid,enum<string>{Enqueued=0,Processing=1,Requeued=2,Completed=3,Failed=4,Canceled=5,DependencyFailed=6}>",
+        "Nullable": true
+      },
+      {
+        "Name": "idempotencyKey",
+        "Kind": "string",
+        "Nullable": false
+      },
+      {
+        "Name": "initialState",
+        "Kind": "string",
+        "Nullable": true
+      },
+      {
+        "Name": "labels",
+        "Kind": "map<string,string>",
+        "Nullable": true
+      },
+      {
+        "Name": "links",
+        "Kind": "map<guid,enum<string>{Enqueued=0,Processing=1,Requeued=2,Completed=3,Failed=4,Canceled=5,DependencyFailed=6}>",
+        "Nullable": true
+      },
+      {
+        "Name": "namespace",
+        "Kind": "string",
+        "Nullable": false
+      },
+      {
+        "Name": "operationId",
+        "Kind": "string",
+        "Nullable": false
+      },
+      {
+        "Name": "overallStatus",
+        "Kind": "enum<string>{Enqueued=0,Processing=1,Requeued=2,Completed=3,Failed=4,Canceled=5,DependencyFailed=6}",
+        "Nullable": false
+      },
+      {
+        "Name": "startAt",
+        "Kind": "datetimeoffset",
+        "Nullable": true
+      },
+      {
+        "Name": "steps",
+        "Kind": "array<object<StepStatusResponse>>",
+        "Nullable": false
+      },
+      {
+        "Name": "updatedAt",
+        "Kind": "datetimeoffset",
+        "Nullable": true
+      }
+    ]
+  }
+}


### PR DESCRIPTION
> **Stacked on `feat/workflow-engine-integration`** (PR #18735), not `main`. This depends on the App-backend WorkflowEngine integration code that only exists on the feature branch, so it targets the feature branch and shows just the contract-guard diff in isolation. Draft for team input.

## Problem

The workflow engine and `Altinn.App.Core` exchange I/O models over **HTTP/JSON only** — the app POSTs to the engine and handles callbacks; it never links the engine. The engine ships on our own infra; the app ships as a public NuGet package, so a shared DLL / NuGet dependency is undesirable. **The engine owns the contract.**

We deliberately keep **curated, internal copies** of the request/response models on the app side rather than taking a binary dependency. The risk with curated copies is silent drift. This PR adds a test guard that proves the two sides stay in sync — with no build coupling and nothing shipped in the NuGet package (test-only).

## Approach

```
engine canonical types ──describe──▶ wire-contract.verified.json ◀──compare── app curated copies
   (engine-app tests)                   (committed artifact)            (Altinn.App.Core.Tests)
```

Neither test project can see both type sets (no shared assembly — by design), so the engine **publishes its wire shape as committed data** that the app checks against. This keeps the two builds fully decoupled.

- **`WireContract.cs`** — shared, framework-agnostic reflection describer. Reduces DTOs to a normalized wire shape (json name, kind, nullability), deliberately ignoring CLR namespace, accessibility, methods, and **wire-equivalent converter differences** (e.g. engine's `FlexibleEnumConverter` vs app's `JsonStringEnumConverter`). Compiled into both test projects from one source.
- **`wire-contract.verified.json`** — committed, engine-owned canonical description: the single source of truth.
- **`EngineWireContractTests`** — asserts the engine's **real types** match the committed JSON. Regenerate intentionally with `UPDATE_WIRE_CONTRACT=1`.
- **`AppWireContractTests`** (in `Altinn.App.Core.Tests`) — asserts the app's copies stay **compatible** with the committed JSON. Directional check: the app may subset (omit optional fields / engine-only response variants) but must never reshape a field or drop one the engine always sends.
- **`app-backend-tests.yml`** — engine contract changes now re-trigger the app-side test, so drift surfaces in the same PR.

## Validation

- Both tests pass against current code; both projects build clean under CI strictness (`AnalysisMode=All` + Sonar + warnings-as-errors).
- **Negative-tested the guard**: injected an app-side field rename → app test failed with a precise message (`Actor.lang: present in the app but not in the engine contract`); perturbed the snapshot → engine test failed on mismatch. Both reverted to green.

## Notes for reviewers

- Test-only. Nothing here ships in the `Altinn.App.Core` NuGet package.
- Relies on the monorepo invariant that app-backend CI checks out the whole repo (verified). The shared describer and committed JSON are consumed directly from the engine test project via `<Compile Link>` / `<EmbeddedResource>`, so there is one source of truth.
- See `src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/Contract/README.md` for the full mechanism and the regen workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)