### PR TITLE
refactor: Move core of ComponentStructureWrapper into new component ComponentStructure in app-libs/form-component

### DIFF
--- a/app-libs/form-component/src/index.ts
+++ b/app-libs/form-component/src/index.ts
@@ -15,6 +15,7 @@ export type { ParserReplace } from './text/parseAndCleanText';
 
 export * from './app-components';
 export * from './layout-components';
+export * from './layout-components/common/ComponentStructure';
 export * from './layout-components/common/HelpTextContainer';
 export * from './layout-components/common/LabelComponent';
 export * from './layout-components/common/Description';

--- a/app-libs/form-component/src/layout-components/common/ComponentStructure/ComponentStructure.test.tsx
+++ b/app-libs/form-component/src/layout-components/common/ComponentStructure/ComponentStructure.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+
+import { ComponentStructure } from './ComponentStructure';
+
+describe('ComponentStructure', () => {
+  it('renders the children and the validation messages', () => {
+    const { container } = render(
+      <ComponentStructure
+        id='form-content-example'
+        validationMessages={<span>Something is wrong</span>}
+      >
+        <span>Content</span>
+      </ComponentStructure>,
+    );
+
+    expect(container.querySelector('#form-content-example')).toBeInTheDocument();
+    expect(screen.getByText('Content')).toBeInTheDocument();
+    expect(screen.getByText('Something is wrong')).toBeInTheDocument();
+  });
+});

--- a/app-libs/form-component/src/layout-components/common/ComponentStructure/ComponentStructure.test.tsx
+++ b/app-libs/form-component/src/layout-components/common/ComponentStructure/ComponentStructure.test.tsx
@@ -5,15 +5,12 @@ import { ComponentStructure } from './ComponentStructure';
 describe('ComponentStructure', () => {
   it('renders the children and the validation messages', () => {
     const { container } = render(
-      <ComponentStructure
-        id='form-content-example'
-        validationMessages={<span>Something is wrong</span>}
-      >
+      <ComponentStructure id='structure-id' validationMessages={<span>Something is wrong</span>}>
         <span>Content</span>
       </ComponentStructure>,
     );
 
-    expect(container.querySelector('#form-content-example')).toBeInTheDocument();
+    expect(container.querySelector('#structure-id')).toBeInTheDocument();
     expect(screen.getByText('Content')).toBeInTheDocument();
     expect(screen.getByText('Something is wrong')).toBeInTheDocument();
   });

--- a/app-libs/form-component/src/layout-components/common/ComponentStructure/ComponentStructure.tsx
+++ b/app-libs/form-component/src/layout-components/common/ComponentStructure/ComponentStructure.tsx
@@ -18,10 +18,19 @@ export interface IComponentStructureProps {
   validationMessages?: ReactNode;
 }
 
-type GridSize = IGridStyling['xs'];
+type GridSize = NonNullable<IGridStyling['xs']>;
 
-const toNumber = (grid: GridSize | undefined): number | undefined =>
-  typeof grid === 'number' ? grid : undefined;
+function toWidth(size: GridSize | undefined): number | undefined {
+  return typeof size === 'number' ? size : undefined;
+}
+
+/**
+ * Re-normalizes a column width to a 12-column span within a container `containerWidth` columns wide.
+ * Falls back to full width (12) when the width is absent.
+ */
+function toSpan(width: number | undefined, containerWidth: number): GridSize {
+  return width != null ? (Math.round((width / containerWidth) * 12) as GridSize) : 12;
+}
 
 function componentWithValidationSpan(
   innerGrid: IGridStyling | undefined,
@@ -31,21 +40,17 @@ function componentWithValidationSpan(
   const innerSpan: IGridStyling = {};
   const validationSpan: IGridStyling = {};
 
-  for (const breakpoints of ['xs', 'sm', 'md', 'lg', 'xl'] as const) {
-    const innerGridNumber = toNumber(innerGrid?.[breakpoints]);
-    const validationGridNumber = toNumber(validationGrid?.[breakpoints]);
-    if (innerGridNumber == null && validationGridNumber == null) {
+  for (const breakpoint of ['xs', 'sm', 'md', 'lg', 'xl'] as const) {
+    const innerWidth = toWidth(innerGrid?.[breakpoint]);
+    const validationWidth = toWidth(validationGrid?.[breakpoint]);
+    if (innerWidth == null && validationWidth == null) {
       continue;
     }
 
-    const maxWidth = Math.max(innerGridNumber ?? 0, validationGridNumber ?? 0);
-    containerSpan[breakpoints] = maxWidth as GridSize;
-    innerSpan[breakpoints] =
-      innerGridNumber != null ? (Math.round((innerGridNumber / maxWidth) * 12) as GridSize) : 12;
-    validationSpan[breakpoints] =
-      validationGridNumber != null
-        ? (Math.round((validationGridNumber / maxWidth) * 12) as GridSize)
-        : 12;
+    const containerWidth = Math.max(innerWidth ?? 0, validationWidth ?? 0);
+    containerSpan[breakpoint] = containerWidth as GridSize;
+    innerSpan[breakpoint] = toSpan(innerWidth, containerWidth);
+    validationSpan[breakpoint] = toSpan(validationWidth, containerWidth);
   }
 
   return { containerSpan, innerSpan, validationSpan };

--- a/app-libs/form-component/src/layout-components/common/ComponentStructure/ComponentStructure.tsx
+++ b/app-libs/form-component/src/layout-components/common/ComponentStructure/ComponentStructure.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import type { PropsWithChildren, ReactNode } from 'react';
+
+import { Flex, type IGridStyling } from '@app/form-component/app-components/Flex';
+
+export interface IComponentStructureProps {
+  /** Id for the outer content wrapper element. */
+  id?: string;
+  /** Grid sizing for the inner content. */
+  innerGrid?: IGridStyling;
+  /** Grid sizing for the validation messages. */
+  validationGrid?: IGridStyling;
+  className?: string;
+  style?: React.CSSProperties;
+  /** Validation messages to render. When provided, a dedicated validation area is rendered. */
+  validationMessages?: ReactNode;
+}
+
+type GridSize = IGridStyling['xs'];
+
+const toNumber = (grid: GridSize | undefined): number | undefined =>
+  typeof grid === 'number' ? grid : undefined;
+
+function componentWithValidationSpan(
+  innerGrid: IGridStyling | undefined,
+  validationGrid: IGridStyling | undefined,
+): { containerSpan: IGridStyling; innerSpan: IGridStyling; validationSpan: IGridStyling } {
+  const containerSpan: IGridStyling = {};
+  const innerSpan: IGridStyling = {};
+  const validationSpan: IGridStyling = {};
+
+  for (const breakpoints of ['xs', 'sm', 'md', 'lg', 'xl'] as const) {
+    const innerGridNumber = toNumber(innerGrid?.[breakpoints]);
+    const validationGridNumber = toNumber(validationGrid?.[breakpoints]);
+    if (innerGridNumber == null && validationGridNumber == null) {
+      continue;
+    }
+
+    const maxWidth = Math.max(innerGridNumber ?? 0, validationGridNumber ?? 0);
+    containerSpan[breakpoints] = maxWidth as GridSize;
+    innerSpan[breakpoints] =
+      innerGridNumber != null ? (Math.round((innerGridNumber / maxWidth) * 12) as GridSize) : 12;
+    validationSpan[breakpoints] =
+      validationGridNumber != null
+        ? (Math.round((validationGridNumber / maxWidth) * 12) as GridSize)
+        : 12;
+  }
+
+  return { containerSpan, innerSpan, validationSpan };
+}
+
+/**
+ * Lays out the children (layout component) and its validation
+ * messages in a responsive grid.
+ */
+export function ComponentStructure({
+  id,
+  innerGrid,
+  validationGrid,
+  className,
+  style,
+  validationMessages,
+  children,
+}: PropsWithChildren<IComponentStructureProps>) {
+  const { containerSpan, innerSpan, validationSpan } = componentWithValidationSpan(
+    innerGrid,
+    validationGrid,
+  );
+
+  return (
+    <Flex id={id} className={className} size={{ xs: 12, ...containerSpan }} item container>
+      <Flex item size={{ xs: 12, ...innerSpan }} style={style}>
+        {children}
+      </Flex>
+      {validationMessages && (
+        <Flex item size={{ xs: 12, ...validationSpan }}>
+          {validationMessages}
+        </Flex>
+      )}
+    </Flex>
+  );
+}

--- a/app-libs/form-component/src/layout-components/common/ComponentStructure/ComponentStructure.tsx
+++ b/app-libs/form-component/src/layout-components/common/ComponentStructure/ComponentStructure.tsx
@@ -10,8 +10,10 @@ export interface IComponentStructureProps {
   innerGrid?: IGridStyling;
   /** Grid sizing for the validation messages. */
   validationGrid?: IGridStyling;
+  /** Class name for the outer container element. */
   className?: string;
-  style?: React.CSSProperties;
+  /** Inline style for the inner content wrapper (the element wrapping the children). */
+  contentStyle?: React.CSSProperties;
   /** Validation messages to render. When provided, a dedicated validation area is rendered. */
   validationMessages?: ReactNode;
 }
@@ -58,7 +60,7 @@ export function ComponentStructure({
   innerGrid,
   validationGrid,
   className,
-  style,
+  contentStyle,
   validationMessages,
   children,
 }: PropsWithChildren<IComponentStructureProps>) {
@@ -69,7 +71,7 @@ export function ComponentStructure({
 
   return (
     <Flex id={id} className={className} size={{ xs: 12, ...containerSpan }} item container>
-      <Flex item size={{ xs: 12, ...innerSpan }} style={style}>
+      <Flex item size={{ xs: 12, ...innerSpan }} style={contentStyle}>
         {children}
       </Flex>
       {validationMessages && (

--- a/app-libs/form-component/src/layout-components/common/ComponentStructure/index.ts
+++ b/app-libs/form-component/src/layout-components/common/ComponentStructure/index.ts
@@ -1,0 +1,2 @@
+export { ComponentStructure } from './ComponentStructure';
+export type { IComponentStructureProps } from './ComponentStructure';

--- a/src/App/frontend/src/layout/ComponentStructureWrapper.tsx
+++ b/src/App/frontend/src/layout/ComponentStructureWrapper.tsx
@@ -30,7 +30,7 @@ export function ComponentStructureWrapper({
       innerGrid={innerGrid}
       validationGrid={validationGrid}
       className={className}
-      style={style}
+      contentStyle={style}
       validationMessages={
         showValidationMessages ? <AllComponentValidations baseComponentId={baseComponentId} /> : undefined
       }

--- a/src/App/frontend/src/layout/ComponentStructureWrapper.tsx
+++ b/src/App/frontend/src/layout/ComponentStructureWrapper.tsx
@@ -1,16 +1,12 @@
 import React from 'react';
 import type { PropsWithChildren } from 'react';
 
-import { Flex } from '@app/form-component';
+import { ComponentStructure } from '@app/form-component';
 
 import { Label } from 'src/components/label/Label';
 import { AllComponentValidations } from 'src/features/validation/ComponentValidations';
-import { useFormComponentCtx } from 'src/layout/FormComponentContext';
-import { getComponentDef } from 'src/layout/index';
-import { useIndexedId } from 'src/utils/layout/DataModelLocation';
-import { useExternalItem } from 'src/utils/layout/hooks';
+import { useComponentStructureData } from 'src/utils/layout/useComponentStructureData';
 import type { LabelProps } from 'src/components/label/Label';
-import type { IGridSize, IGridStyling } from 'src/layout/common.generated';
 
 type ComponentStructureWrapperProps = {
   baseComponentId: string;
@@ -19,34 +15,6 @@ type ComponentStructureWrapperProps = {
   style?: React.CSSProperties;
 };
 
-const toNumber = (grid: IGridSize | undefined): number | undefined => (typeof grid === 'number' ? grid : undefined);
-
-function componentWithValidationSpan(
-  innerGrid: IGridStyling | undefined,
-  validationGrid: IGridStyling | undefined,
-): { containerSpan: IGridStyling; innerSpan: IGridStyling; validationSpan: IGridStyling } {
-  const containerSpan: IGridStyling = {};
-  const innerSpan: IGridStyling = {};
-  const validationSpan: IGridStyling = {};
-
-  for (const breakpoints of ['xs', 'sm', 'md', 'lg', 'xl'] as const) {
-    const innerGridNumber = toNumber(innerGrid?.[breakpoints]);
-    const validationGridNumber = toNumber(validationGrid?.[breakpoints]);
-    if (innerGridNumber == null && validationGridNumber == null) {
-      continue;
-    }
-
-    const maxWidth = Math.max(innerGridNumber ?? 0, validationGridNumber ?? 0);
-    containerSpan[breakpoints] = maxWidth as IGridSize;
-    innerSpan[breakpoints] =
-      innerGridNumber != null ? (Math.round((innerGridNumber / maxWidth) * 12) as IGridSize) : 12;
-    validationSpan[breakpoints] =
-      validationGridNumber != null ? (Math.round((validationGridNumber / maxWidth) * 12) as IGridSize) : 12;
-  }
-
-  return { containerSpan, innerSpan, validationSpan };
-}
-
 export function ComponentStructureWrapper({
   baseComponentId,
   children,
@@ -54,42 +22,21 @@ export function ComponentStructureWrapper({
   className,
   style,
 }: PropsWithChildren<ComponentStructureWrapperProps>) {
-  const overrideItemProps = useFormComponentCtx()?.overrideItemProps;
-  const component = useExternalItem(baseComponentId);
-  const grid = overrideItemProps?.grid ?? component?.grid;
-  const layoutComponent = getComponentDef(component.type);
-  const showValidationMessages = layoutComponent.renderDefaultValidations();
-  const indexedId = useIndexedId(baseComponentId);
-
-  const { containerSpan, innerSpan, validationSpan } = componentWithValidationSpan(
-    grid?.innerGrid,
-    grid?.validationGrid,
-  );
+  const { id, innerGrid, validationGrid, showValidationMessages } = useComponentStructureData(baseComponentId);
 
   const componentWithValidations = (
-    <Flex
-      id={`form-content-${indexedId}`}
+    <ComponentStructure
+      id={id}
+      innerGrid={innerGrid}
+      validationGrid={validationGrid}
       className={className}
-      size={{ xs: 12, ...containerSpan }}
-      item
-      container
+      style={style}
+      validationMessages={
+        showValidationMessages ? <AllComponentValidations baseComponentId={baseComponentId} /> : undefined
+      }
     >
-      <Flex
-        item
-        size={{ xs: 12, ...innerSpan }}
-        style={style}
-      >
-        {children}
-      </Flex>
-      {showValidationMessages && (
-        <Flex
-          item
-          size={{ xs: 12, ...validationSpan }}
-        >
-          <AllComponentValidations baseComponentId={baseComponentId} />
-        </Flex>
-      )}
-    </Flex>
+      {children}
+    </ComponentStructure>
   );
 
   return label ? <Label {...label}>{componentWithValidations}</Label> : componentWithValidations;

--- a/src/App/frontend/src/layout/Datepicker/DatepickerComponent.tsx
+++ b/src/App/frontend/src/layout/Datepicker/DatepickerComponent.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {
+  ComponentStructure,
   DatePickerControl,
   DatePickerDropdownCaption,
   Flex,
@@ -12,8 +13,9 @@ import {
 import { useDataModelBindings } from 'src/features/formData/useDataModelBindings';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useLanguage } from 'src/features/language/useLanguage';
-import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
+import { AllComponentValidations } from 'src/features/validation/ComponentValidations';
 import { getDatepickerFormat } from 'src/utils/dateUtils';
+import { useComponentStructureData } from 'src/utils/layout/useComponentStructureData';
 import { useLabelData } from 'src/utils/layout/useLabelData';
 import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
@@ -46,6 +48,12 @@ export function DatepickerComponent({ baseComponentId, overrideDisplay }: PropsF
   };
 
   const labelData = useLabelData({ baseComponentId, overrideDisplay });
+  const {
+    id: contentId,
+    innerGrid,
+    validationGrid,
+    showValidationMessages,
+  } = useComponentStructureData(baseComponentId);
 
   return (
     <LabelComponent
@@ -53,7 +61,14 @@ export function DatepickerComponent({ baseComponentId, overrideDisplay }: PropsF
       grid={grid?.labelGrid}
       {...labelData}
     >
-      <ComponentStructureWrapper baseComponentId={baseComponentId}>
+      <ComponentStructure
+        id={contentId}
+        innerGrid={innerGrid}
+        validationGrid={validationGrid}
+        validationMessages={
+          showValidationMessages ? <AllComponentValidations baseComponentId={baseComponentId} /> : undefined
+        }
+      >
         <Flex
           container
           item
@@ -82,7 +97,7 @@ export function DatepickerComponent({ baseComponentId, overrideDisplay }: PropsF
             autoComplete={autocomplete}
           />
         </Flex>
-      </ComponentStructureWrapper>
+      </ComponentStructure>
     </LabelComponent>
   );
 }

--- a/src/App/frontend/src/utils/layout/useComponentStructureData.ts
+++ b/src/App/frontend/src/utils/layout/useComponentStructureData.ts
@@ -1,0 +1,32 @@
+import { useFormComponentCtx } from 'src/layout/FormComponentContext';
+import { getComponentDef } from 'src/layout/index';
+import { useIndexedId } from 'src/utils/layout/DataModelLocation';
+import { useExternalItem } from 'src/utils/layout/hooks';
+import type { IGridStyling } from 'src/layout/common.generated';
+
+export interface ComponentStructureData {
+  id: string;
+  innerGrid: IGridStyling | undefined;
+  validationGrid: IGridStyling | undefined;
+  showValidationMessages: boolean;
+}
+
+/**
+ * Returns the data needed to render the structural wrapper around a layout component
+ * (grid sizing + whether default validation messages should be shown).
+ */
+export function useComponentStructureData(baseComponentId: string): ComponentStructureData {
+  const overrideItemProps = useFormComponentCtx()?.overrideItemProps;
+  const component = useExternalItem(baseComponentId);
+  const grid = overrideItemProps?.grid ?? component?.grid;
+  const layoutComponent = getComponentDef(component.type);
+  const showValidationMessages = layoutComponent.renderDefaultValidations();
+  const indexedId = useIndexedId(baseComponentId);
+
+  return {
+    id: `form-content-${indexedId}`,
+    innerGrid: grid?.innerGrid,
+    validationGrid: grid?.validationGrid,
+    showValidationMessages,
+  };
+}


### PR DESCRIPTION
The motivation behind this refac is to be able to move components that use ComponentStructureWrapper into app-libs/form-component later (like DatePickerComponent, InputComponent)

## Description

- New ComponentStructure component (app-libs/form-component) — a "dumb" component that takes only what it needs as props (id, innerGrid, validationGrid, className, style, validationMessages, children). The grid-span math (componentWithValidationSpan) moved here. App-specific concerns are kept out: instead of rendering AllComponentValidations itself, it accepts a validationMessages node and renders the validation area only when one is provided. Exported from the package barrel.

- New useComponentStructureData hook (app) — resolves the app-side data the component needs (id, innerGrid, validationGrid, showValidationMessages) from the existing contexts/hooks, mirroring how useLabelData feeds LabelComponent.

- ComponentStructureWrapper kept — its label logic is intentionally not moved. It now sources data via useComponentStructureData and delegates layout to ComponentStructure, still wrapping in Label when a label prop is passed.

- DatepickerComponent updated to consume the new ComponentStructure + useComponentStructureData directly. 


<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `ComponentStructure` layout to render form content and optional validation messages in a consistent responsive grid.
* **Refactor**
  * Updated the layout wrapper and Datepicker to use the new structure, simplifying rendering logic and keeping validation placement aligned.
  * Consolidated structure configuration via a single data hook.
* **Tests**
  * Added coverage for the new layout component, verifying content, validation output, and stable ids.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->