### PR TITLE
chore: automerge app template package updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -64,6 +64,17 @@
       "commitMessageSuffix": " (app)"
     },
     {
+      "description": "Automerge non-major Altinn app template package updates",
+      "matchManagers": ["nuget"],
+      "matchFileNames": ["src/App/template/src/App/App.csproj"],
+      "matchPackageNames": ["Altinn.App.Api", "Altinn.App.Core"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "Altinn app template NuGet packages",
+      "groupSlug": "app-template-nuget",
+      "addLabels": ["approve"],
+      "automerge": true
+    },
+    {
       "matchFileNames": ["src/Runtime/localtest/**"],
       "additionalBranchPrefix": "localtest/",
       "commitMessageSuffix": " (localtest)"


### PR DESCRIPTION
## Description

Adds a Renovate package rule for `src/App/template/src/App/App.csproj` so non-major updates for `Altinn.App.Api` and `Altinn.App.Core` get their own grouped PR instead of being part of the broader App NuGet group.

The rule also adds the `approve` label and enables Renovate automerge. This keeps the existing required-review flow in place: the PR must still receive the repository's auto-approval and pass required checks before Renovate can merge it.

## Verification

- [x] Related issues are connected (if applicable): N/A
- [x] **Your** code builds clean without any errors or warnings: N/A, Renovate config only
- [x] Manual testing done (required): inspected current Renovate dashboard/previous PR behavior and verified the rule is scoped to the app template packages only
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out): N/A, config-only change

Commands run:

```sh
npx --yes --package renovate@43.66.4 renovate-config-validator renovate.json
jq empty renovate.json
git diff --check
```

Results:

```text
INFO: Validating renovate.json as global config
INFO: Config validated successfully
```
