### PR TITLE
chore: pin latest app template packages during scaffolding

### DIFF
--- a/src/App/template/src/App/App.csproj
+++ b/src/App/template/src/App/App.csproj
@@ -5,10 +5,10 @@
     <RootNamespace>Altinn.App</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Altinn.App.Api" Version="8.10.1">
+    <PackageReference Include="Altinn.App.Api" Version="*">
       <CopyToOutputDirectory>lib\$(TargetFramework)\*.xml</CopyToOutputDirectory>
     </PackageReference>
-    <PackageReference Include="Altinn.App.Core" Version="8.10.1" />
+    <PackageReference Include="Altinn.App.Core" Version="*" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="wwwroot\css\" />

--- a/src/Designer/backend/src/Designer/Infrastructure/ServiceRegistration.cs
+++ b/src/Designer/backend/src/Designer/Infrastructure/ServiceRegistration.cs
@@ -109,6 +109,7 @@ public static class ServiceRegistration
         services.AddHttpClient<IOrgService, OrgService>();
         services.AddHttpClient<ImageClient>();
         services.AddTransient<IAppVersionService, AppVersionService>();
+        services.AddHttpClient<IAppTemplatePackageVersionService, AppTemplatePackageVersionService>();
         services.AddTransient<IAppDevelopmentService, AppDevelopmentService>();
         services.AddTransient<IUiFoldersService, UiFoldersService>();
         services.AddTransient<ITaskNavigationService, TaskNavigationService>();

--- a/src/Designer/backend/src/Designer/Infrastructure/ServiceRegistration.cs
+++ b/src/Designer/backend/src/Designer/Infrastructure/ServiceRegistration.cs
@@ -109,7 +109,9 @@ public static class ServiceRegistration
         services.AddHttpClient<IOrgService, OrgService>();
         services.AddHttpClient<ImageClient>();
         services.AddTransient<IAppVersionService, AppVersionService>();
-        services.AddHttpClient<IAppTemplatePackageVersionService, AppTemplatePackageVersionService>();
+        services
+            .AddHttpClient<IAppTemplatePackageVersionService, AppTemplatePackageVersionService>()
+            .AddStandardResilienceHandler();
         services.AddTransient<IAppDevelopmentService, AppDevelopmentService>();
         services.AddTransient<IUiFoldersService, UiFoldersService>();
         services.AddTransient<ITaskNavigationService, TaskNavigationService>();

--- a/src/Designer/backend/src/Designer/Services/Implementation/AppTemplatePackageVersionService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/AppTemplatePackageVersionService.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Altinn.Studio.Designer.Services.Interfaces;
+using NuGet.Versioning;
+
+namespace Altinn.Studio.Designer.Services.Implementation;
+
+public class AppTemplatePackageVersionService : IAppTemplatePackageVersionService
+{
+    private const string NugetOrgPackageVersionsUrl = "https://api.nuget.org/v3-flatcontainer/{0}/index.json";
+
+    private static readonly string[] s_appPackageNames = ["Altinn.App.Api", "Altinn.App.Core"];
+
+    private readonly HttpClient _httpClient;
+
+    public AppTemplatePackageVersionService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task<string> GetLatestStableAppPackageVersion(CancellationToken cancellationToken = default)
+    {
+        IReadOnlyCollection<NuGetVersion>[] stableVersionsPerPackage = await Task.WhenAll(
+            s_appPackageNames.Select(packageName => GetStableVersions(packageName, cancellationToken))
+        );
+
+        IEnumerable<NuGetVersion> sharedVersions = stableVersionsPerPackage.First();
+        foreach (IReadOnlyCollection<NuGetVersion> packageVersions in stableVersionsPerPackage.Skip(1))
+        {
+            sharedVersions = sharedVersions.Intersect(packageVersions);
+        }
+
+        NuGetVersion latestVersion = sharedVersions.OrderByDescending(version => version).FirstOrDefault();
+        return latestVersion?.ToNormalizedString()
+            ?? throw new InvalidOperationException(
+                $"Could not find a shared stable version for packages {string.Join(", ", s_appPackageNames)}."
+            );
+    }
+
+    private async Task<IReadOnlyCollection<NuGetVersion>> GetStableVersions(
+        string packageName,
+        CancellationToken cancellationToken
+    )
+    {
+        string packageVersionsUrl = string.Format(NugetOrgPackageVersionsUrl, packageName.ToLowerInvariant());
+        using HttpResponseMessage response = await _httpClient.GetAsync(packageVersionsUrl, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        await using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        PackageVersionsResponse packageVersionsResponse =
+            await JsonSerializer.DeserializeAsync<PackageVersionsResponse>(
+                responseStream,
+                cancellationToken: cancellationToken
+            )
+            ?? throw new InvalidOperationException($"Could not read versions for package {packageName}.");
+
+        if (packageVersionsResponse.Versions is null || packageVersionsResponse.Versions.Count == 0)
+        {
+            throw new InvalidOperationException($"Could not find any versions for package {packageName}.");
+        }
+
+        IReadOnlyCollection<string> versions = packageVersionsResponse.Versions;
+        return versions.Select(NuGetVersion.Parse).Where(version => !version.IsPrerelease).ToList();
+    }
+
+    private sealed record PackageVersionsResponse(
+        [property: JsonPropertyName("versions")] IReadOnlyCollection<string>? Versions
+    );
+}

--- a/src/Designer/backend/src/Designer/Services/Implementation/RepositoryService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/RepositoryService.cs
@@ -39,6 +39,9 @@ public class RepositoryService : IRepository
     // Using Norwegian name of initial page to be consistent
     // with automatic naming from frontend when adding new page
     private const string InitialLayout = "Side1";
+    private const string AppProjectFileName = "App.csproj";
+    private const string AppApiPackageName = "Altinn.App.Api";
+    private const string AppCorePackageName = "Altinn.App.Core";
 
     private readonly string _resourceIdentifierRegex = "^[a-z0-9_æøå-]*$";
 
@@ -55,6 +58,7 @@ public class RepositoryService : IRepository
     private readonly ICustomTemplateService _templateService;
     private readonly IAuthorizationPolicyService _authorizationPolicyService;
     private readonly IAppScopesService _appScopesService;
+    private readonly IAppTemplatePackageVersionService _appTemplatePackageVersionService;
     private readonly JsonSerializerOptions _serializerOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -77,6 +81,7 @@ public class RepositoryService : IRepository
     /// <param name="templateService">The service for handling custom templates</param>
     /// <param name="authorizationPolicyService">The service for policy files</param>
     /// <param name="appScopesService">The service for handling app scopes</param>
+    /// <param name="appTemplatePackageVersionService">The service for resolving app template package versions</param>
     public RepositoryService(
         ServiceRepositorySettings repositorySettings,
         GeneralSettings generalSettings,
@@ -90,7 +95,8 @@ public class RepositoryService : IRepository
         IResourceRegistry resourceRegistryService,
         ICustomTemplateService templateService,
         IAuthorizationPolicyService authorizationPolicyService,
-        IAppScopesService appScopesService
+        IAppScopesService appScopesService,
+        IAppTemplatePackageVersionService appTemplatePackageVersionService
     )
     {
         _settings = repositorySettings;
@@ -106,6 +112,7 @@ public class RepositoryService : IRepository
         _templateService = templateService;
         _authorizationPolicyService = authorizationPolicyService;
         _appScopesService = appScopesService;
+        _appTemplatePackageVersionService = appTemplatePackageVersionService;
     }
 
     /// <summary>
@@ -295,6 +302,7 @@ public class RepositoryService : IRepository
                 // This creates all files
                 CreateServiceMetadata(metadata);
                 await ApplyCustomTemplates(org, serviceConfig.RepositoryName, developer, templates);
+                await PinAppTemplatePackageVersions(org, serviceConfig.RepositoryName, developer);
                 await _textsService.CreateLanguageResources(org, serviceConfig.RepositoryName, developer);
                 await CreateAltinnStudioSettings(org, serviceConfig.RepositoryName, developer, templates);
 
@@ -324,6 +332,25 @@ public class RepositoryService : IRepository
         }
 
         return repository;
+    }
+
+    private async Task PinAppTemplatePackageVersions(string org, string repositoryName, string developer)
+    {
+        string latestStableVersion = await _appTemplatePackageVersionService.GetLatestStableAppPackageVersion();
+        string appCsprojPath = Path.Combine(
+            _settings.GetServicePath(org, repositoryName, developer),
+            _settings.GetAppFolderName(),
+            AppProjectFileName
+        );
+
+        CsprojPatcher.UpsertPackageReferences(
+            appCsprojPath,
+            new List<(string Include, string Version)>
+            {
+                (AppApiPackageName, latestStableVersion),
+                (AppCorePackageName, latestStableVersion),
+            }
+        );
     }
 
     private async Task ApplyCustomTemplates(

--- a/src/Designer/backend/src/Designer/Services/Implementation/RepositoryService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/RepositoryService.cs
@@ -276,6 +276,11 @@ public class RepositoryService : IRepository
                 developer,
                 token
             );
+        AltinnRepoEditingContext editingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(
+            org,
+            serviceConfig.RepositoryName,
+            developer
+        );
         string repoPath = _settings.GetServicePath(org, serviceConfig.RepositoryName, developer);
         var options = new CreateRepoOption(serviceConfig.RepositoryName);
 
@@ -302,7 +307,7 @@ public class RepositoryService : IRepository
                 // This creates all files
                 CreateServiceMetadata(metadata);
                 await ApplyCustomTemplates(org, serviceConfig.RepositoryName, developer, templates);
-                await PinAppTemplatePackageVersions(org, serviceConfig.RepositoryName, developer);
+                await PinAppTemplatePackageVersions(editingContext);
                 await _textsService.CreateLanguageResources(org, serviceConfig.RepositoryName, developer);
                 await CreateAltinnStudioSettings(org, serviceConfig.RepositoryName, developer, templates);
 
@@ -319,9 +324,7 @@ public class RepositoryService : IRepository
                     Message = "App created",
                 };
                 _sourceControl.PushChangesForRepository(authenticatedContext, commitInfo);
-                await _appScopesService.AddDefaultMaskinportenScopesAsync(
-                    AltinnRepoEditingContext.FromOrgRepoDeveloper(org, serviceConfig.RepositoryName, developer)
-                );
+                await _appScopesService.AddDefaultMaskinportenScopesAsync(editingContext);
             }
             catch (Exception)
             {
@@ -334,11 +337,11 @@ public class RepositoryService : IRepository
         return repository;
     }
 
-    private async Task PinAppTemplatePackageVersions(string org, string repositoryName, string developer)
+    private async Task PinAppTemplatePackageVersions(AltinnRepoEditingContext editingContext)
     {
         string latestStableVersion = await _appTemplatePackageVersionService.GetLatestStableAppPackageVersion();
         string appCsprojPath = Path.Combine(
-            _settings.GetServicePath(org, repositoryName, developer),
+            _settings.GetServicePath(editingContext.Org, editingContext.Repo, editingContext.Developer),
             _settings.GetAppFolderName(),
             AppProjectFileName
         );

--- a/src/Designer/backend/src/Designer/Services/Interfaces/IAppTemplatePackageVersionService.cs
+++ b/src/Designer/backend/src/Designer/Services/Interfaces/IAppTemplatePackageVersionService.cs
@@ -1,0 +1,9 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Altinn.Studio.Designer.Services.Interfaces;
+
+public interface IAppTemplatePackageVersionService
+{
+    Task<string> GetLatestStableAppPackageVersion(CancellationToken cancellationToken = default);
+}

--- a/src/Designer/backend/tests/Designer.Tests/Services/RepositoryServiceTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/RepositoryServiceTests.cs
@@ -31,6 +31,8 @@ namespace Designer.Tests.Services;
 
 public class RepositoryServiceTests
 {
+    private const string LatestStableAppPackageVersion = "8.12.6";
+
     [Fact]
     public void GetContents_FindsFolder_ReturnsListOfFileSystemObjects()
     {
@@ -136,6 +138,17 @@ public class RepositoryServiceTests
                 .GetAltinnStudioSettings();
             Assert.Equal(AltinnRepositoryType.App, altinnStudioSettings.RepoType);
             Assert.True(altinnStudioSettings.UseNullableReferenceTypes);
+            string appCsprojPath = Path.Combine(repositoryDirectory, "App", "App.csproj");
+            string appCsproj = await File.ReadAllTextAsync(appCsprojPath);
+            Assert.Contains(
+                $"<PackageReference Include=\"Altinn.App.Api\" Version=\"{LatestStableAppPackageVersion}\">",
+                appCsproj
+            );
+            Assert.Contains(
+                $"<PackageReference Include=\"Altinn.App.Core\" Version=\"{LatestStableAppPackageVersion}\" />",
+                appCsproj
+            );
+            Assert.DoesNotContain("Version=\"*\"", appCsproj);
             appScopesServiceMock.Verify(
                 s =>
                     s.AddDefaultMaskinportenScopesAsync(
@@ -614,7 +627,8 @@ public class RepositoryServiceTests
         string developer,
         ISourceControl sourceControlMock = null,
         ICustomTemplateService customTemplateServiceMock = null,
-        IAppScopesService appScopesServiceMock = null
+        IAppScopesService appScopesServiceMock = null,
+        IAppTemplatePackageVersionService appTemplatePackageVersionServiceMock = null
     )
     {
         HttpContext ctx = GetHttpContextForTestUser(developer);
@@ -682,7 +696,28 @@ public class RepositoryServiceTests
 
         IResourceRegistry resourceRegistryService = new Mock<IResourceRegistry>().Object;
         IAuthorizationPolicyService authorizationPolicyServiceMock = new Mock<IAuthorizationPolicyService>().Object;
-        appScopesServiceMock ??= new Mock<IAppScopesService>().Object;
+        if (appScopesServiceMock is null)
+        {
+            Mock<IAppScopesService> defaultAppScopesServiceMock = new();
+            defaultAppScopesServiceMock
+                .Setup(s =>
+                    s.AddDefaultMaskinportenScopesAsync(
+                        It.IsAny<AltinnRepoEditingContext>(),
+                        It.IsAny<CancellationToken>()
+                    )
+                )
+                .ReturnsAsync(null as AppScopesEntity);
+            appScopesServiceMock = defaultAppScopesServiceMock.Object;
+        }
+
+        if (appTemplatePackageVersionServiceMock is null)
+        {
+            Mock<IAppTemplatePackageVersionService> defaultPackageVersionServiceMock = new();
+            defaultPackageVersionServiceMock
+                .Setup(s => s.GetLatestStableAppPackageVersion(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(LatestStableAppPackageVersion);
+            appTemplatePackageVersionServiceMock = defaultPackageVersionServiceMock.Object;
+        }
 
         RepositoryService service = new(
             repoSettings,
@@ -697,7 +732,8 @@ public class RepositoryServiceTests
             resourceRegistryService,
             customTemplateServiceMock,
             authorizationPolicyServiceMock,
-            appScopesServiceMock
+            appScopesServiceMock,
+            appTemplatePackageVersionServiceMock
         );
 
         return service;


### PR DESCRIPTION
## Description

Alternative to #19310.

This changes the app template package references for `Altinn.App.Api` and `Altinn.App.Core` to use NuGet wildcard versions (`*`). During app creation in Designer, after the base template and any custom templates have been applied, Designer resolves the latest shared stable version from nuget.org and patches the generated `App/App.csproj` to a concrete version before the initial commit is pushed.

This keeps `src/App/template/src/App/App.csproj` independent of Renovate PRs while still ensuring scaffolded apps are pinned to a stable app-lib version instead of committing wildcard package references.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

Verification performed:

- `git diff --check`
- Queried NuGet flat-container indexes for `Altinn.App.Api` and `Altinn.App.Core`; both currently have latest stable `8.12.6`, with `9.0.0-preview.1` excluded by the stable-version filter.

Attempted but blocked:

- `dotnet test src/Designer/backend/tests/Designer.Tests/Designer.Tests.csproj --filter "FullyQualifiedName~RepositoryServiceTests"`
- `dotnet build src/Designer/backend/src/Designer/Designer.csproj --no-restore -v minimal`

Both were blocked by nuget.org package download timeouts for existing Designer dependencies during restore/build in this environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
- App creation now automatically selects the latest stable versions of core application packages available, ensuring newly generated apps use consistent, up-to-date dependencies.

**Improvements**
- Template handling has been updated to resolve and apply specific stable package versions during creation, replacing less predictable wildcard behaviour.

**Tests**
- Updated repository creation tests to assert the generated app project references the expected resolved package versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->