### PR TITLE
fix: terminate oidc sso session when logging out of designer

### DIFF
--- a/src/Designer/backend/src/Designer/Controllers/HomeController.cs
+++ b/src/Designer/backend/src/Designer/Controllers/HomeController.cs
@@ -7,6 +7,7 @@ using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Services.Interfaces;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -95,7 +96,7 @@ public class HomeController : Controller
     /// Logout
     /// </summary>
     /// <returns>The logout page</returns>
-    public async Task<IActionResult> Logout()
+    public IActionResult Logout()
     {
         HttpContext.Response.Cookies.Append(
             _generalSettings.SessionTimeoutCookieName,
@@ -103,8 +104,12 @@ public class HomeController : Controller
             new CookieOptions { HttpOnly = true, Expires = DateTime.Now.AddDays(-10) }
         );
 
-        await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
-        return LocalRedirect("/");
+        if (User.Identity?.IsAuthenticated != true)
+        {
+            return LocalRedirect("/");
+        }
+
+        return SignOut(CookieAuthenticationDefaults.AuthenticationScheme, OpenIdConnectDefaults.AuthenticationScheme);
     }
 
     /// <summary>

--- a/src/Designer/backend/src/Designer/Infrastructure/StudioOidc/StudioOidcAuthenticationExtensions.cs
+++ b/src/Designer/backend/src/Designer/Infrastructure/StudioOidc/StudioOidcAuthenticationExtensions.cs
@@ -166,6 +166,12 @@ public static class StudioOidcAuthenticationExtensions
                         }
                     };
 
+                    options.Events.OnRedirectToIdentityProviderForSignOut = context =>
+                    {
+                        context.ProtocolMessage.ClientId = oidcSettings.ClientId;
+                        return Task.CompletedTask;
+                    };
+
                     // Temporarily using client_secret_basic (Authorization header) instead of client_secret_post to support the same client that Gitea uses
                     options.Events.OnAuthorizationCodeReceived = context =>
                     {
@@ -321,11 +327,21 @@ public static class StudioOidcAuthenticationExtensions
                 .AddSeconds(expiresIn)
                 .ToString("o", CultureInfo.InvariantCulture);
 
-            properties.StoreTokens([
-                new AuthenticationToken { Name = "access_token", Value = newAccessToken },
-                new AuthenticationToken { Name = "refresh_token", Value = resolvedRefreshToken },
-                new AuthenticationToken { Name = "expires_at", Value = newExpiresAt },
-            ]);
+            var tokens = new List<AuthenticationToken>
+            {
+                new() { Name = "access_token", Value = newAccessToken },
+                new() { Name = "refresh_token", Value = resolvedRefreshToken },
+                new() { Name = "expires_at", Value = newExpiresAt },
+            };
+
+            bool newIdTokenIssued = root.TryGetProperty("id_token", out var idt);
+            string? resolvedIdToken = newIdTokenIssued ? idt.GetString() : properties.GetTokenValue("id_token");
+            if (!string.IsNullOrEmpty(resolvedIdToken))
+            {
+                tokens.Add(new AuthenticationToken { Name = "id_token", Value = resolvedIdToken });
+            }
+
+            properties.StoreTokens(tokens);
 
             context.ShouldRenew = true;
 

--- a/src/Designer/backend/tests/Designer.Tests/StudioOidcGiteaIntegrationTests/LogoutStudioOidcTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/StudioOidcGiteaIntegrationTests/LogoutStudioOidcTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Designer.Tests.Fixtures;
+using Designer.Tests.Helpers;
+using Xunit;
+
+namespace Designer.Tests.StudioOidcGiteaIntegrationTests;
+
+public class LogoutStudioOidcTests : StudioOidcGiteaIntegrationTestsBase<LogoutStudioOidcTests>
+{
+    private readonly StudioOidcGiteaWebAppApplicationFactoryFixture<Program> _factory;
+
+    public LogoutStudioOidcTests(
+        StudioOidcGiteaWebAppApplicationFactoryFixture<Program> factory,
+        StudioOidcGiteaFixture giteaFixture,
+        StudioOidcSharedDesignerHttpClientProvider sharedDesignerHttpClientProvider
+    )
+        : base(factory, giteaFixture, sharedDesignerHttpClientProvider)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task Logout_WhenAuthenticated_RedirectsToEndSessionEndpointAndClearsCookie()
+    {
+        using HttpResponseMessage loginResponse = await HttpClient.GetAsync("designer/api/user/current");
+        Assert.Equal(HttpStatusCode.OK, loginResponse.StatusCode);
+
+        using HttpResponseMessage logoutResponse = await HttpClient.GetAsync("Home/Logout");
+
+        Assert.Equal(HttpStatusCode.Redirect, logoutResponse.StatusCode);
+
+        string location = logoutResponse.Headers.Location!.ToString();
+        Assert.StartsWith(GiteaFixture.FakeAnsattportenUrl, location);
+        Assert.Contains("/endsession", location);
+        Assert.Contains("id_token_hint=", location);
+        Assert.Contains("client_id=", location);
+        Assert.Contains("post_logout_redirect_uri=", location);
+        Assert.Contains("signout-callback-oidc", location);
+
+        Assert.Contains(
+            logoutResponse.GetCookies("AltinnStudioDesigner"),
+            cookie => cookie.Contains("AltinnStudioDesigner=;")
+        );
+    }
+
+    [Fact]
+    public async Task Logout_AfterTokenRefresh_StillIncludesIdTokenHint()
+    {
+        using HttpResponseMessage initialResponse = await HttpClient.GetAsync("designer/api/user/current");
+        Assert.Equal(HttpStatusCode.OK, initialResponse.StatusCode);
+
+        _factory.FakeTimeProvider.Advance(TimeSpan.FromMinutes(60));
+
+        using HttpResponseMessage refreshedResponse = await HttpClient.GetAsync("designer/api/user/current");
+        Assert.Equal(HttpStatusCode.OK, refreshedResponse.StatusCode);
+
+        using HttpResponseMessage logoutResponse = await HttpClient.GetAsync("Home/Logout");
+
+        Assert.Equal(HttpStatusCode.Redirect, logoutResponse.StatusCode);
+        Assert.Contains("id_token_hint=", logoutResponse.Headers.Location!.ToString());
+    }
+}

--- a/src/Designer/backend/tests/Designer.Tests/StudioOidcGiteaIntegrationTests/LogoutStudioOidcTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/StudioOidcGiteaIntegrationTests/LogoutStudioOidcTests.cs
@@ -35,8 +35,8 @@ public class LogoutStudioOidcTests : StudioOidcGiteaIntegrationTestsBase<LogoutS
         string location = logoutResponse.Headers.Location!.ToString();
         Assert.StartsWith(GiteaFixture.FakeAnsattportenUrl, location);
         Assert.Contains("/endsession", location);
-        Assert.Contains("id_token_hint=", location);
-        Assert.Contains("client_id=", location);
+        Assert.Matches(@"[?&]id_token_hint=[^&]+", location);
+        Assert.Matches(@"[?&]client_id=[^&]+", location);
         Assert.Contains("post_logout_redirect_uri=", location);
         Assert.Contains("signout-callback-oidc", location);
 
@@ -60,6 +60,6 @@ public class LogoutStudioOidcTests : StudioOidcGiteaIntegrationTestsBase<LogoutS
         using HttpResponseMessage logoutResponse = await HttpClient.GetAsync("Home/Logout");
 
         Assert.Equal(HttpStatusCode.Redirect, logoutResponse.StatusCode);
-        Assert.Contains("id_token_hint=", logoutResponse.Headers.Location!.ToString());
+        Assert.Matches(@"[?&]id_token_hint=[^&]+", logoutResponse.Headers.Location!.ToString());
     }
 }

--- a/src/Designer/development/fake-ansattporten/main.go
+++ b/src/Designer/development/fake-ansattporten/main.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"math/big"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -244,7 +245,7 @@ func handleEndSession(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(redirectURI, "?") {
 			sep = "&"
 		}
-		location = fmt.Sprintf("%s%sstate=%s", redirectURI, sep, state)
+		location = fmt.Sprintf("%s%sstate=%s", redirectURI, sep, url.QueryEscape(state))
 	}
 	http.Redirect(w, r, location, http.StatusFound)
 }

--- a/src/Designer/development/fake-ansattporten/main.go
+++ b/src/Designer/development/fake-ansattporten/main.go
@@ -82,6 +82,7 @@ func main() {
 	mux.HandleFunc("/org-select", handleOrgSelect)
 	mux.HandleFunc("/token", handleToken)
 	mux.HandleFunc("/userinfo", handleUserInfo)
+	mux.HandleFunc("/endsession", handleEndSession)
 
 	log.Printf("Fake Ansattporten listening on :%s", port)
 	log.Fatal(http.ListenAndServe(":"+port, mux))
@@ -113,6 +114,7 @@ func handleDiscovery(w http.ResponseWriter, r *http.Request) {
 		"authorization_endpoint":                browserBaseURL() + "/authorize",
 		"token_endpoint":                        base + "/token",
 		"userinfo_endpoint":                     base + "/userinfo",
+		"end_session_endpoint":                  browserBaseURL() + "/endsession",
 		"jwks_uri":                              base + "/jwks",
 		"response_types_supported":              []string{"code"},
 		"subject_types_supported":               []string{"public"},
@@ -222,6 +224,29 @@ func handleAuthorize(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	pickerTemplate.Execute(w, data)
+}
+
+func handleEndSession(w http.ResponseWriter, r *http.Request) {
+	redirectURI := r.URL.Query().Get("post_logout_redirect_uri")
+	state := r.URL.Query().Get("state")
+	idTokenHint := r.URL.Query().Get("id_token_hint")
+	clientID := r.URL.Query().Get("client_id")
+
+	if redirectURI == "" || (idTokenHint == "" && clientID == "") {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write([]byte("<!DOCTYPE html><html><body>Logged out. You can close this window now.</body></html>"))
+		return
+	}
+
+	location := redirectURI
+	if state != "" {
+		sep := "?"
+		if strings.Contains(redirectURI, "?") {
+			sep = "&"
+		}
+		location = fmt.Sprintf("%s%sstate=%s", redirectURI, sep, state)
+	}
+	http.Redirect(w, r, location, http.StatusFound)
 }
 
 func handleOrgSelect(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`/signout-callback-oidc` needs to be added to post logout redirect URI's on Designer's oidc clients.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Improved sign-out flow to route users via the identity provider’s end-session endpoint and return them to the app afterwards.
  * Updated the fake Ansattporten OIDC server to support end-session discovery and redirects.

* **Bug Fixes**
  * Logout now handles unauthenticated users immediately and clears the session cookie as expected.
  * Token refresh during the session preserves the required `id_token_hint` for logout.

* **Tests**
  * Added integration tests covering end-session redirect parameters, cookie clearing, and logout after token refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->