### PR TITLE
feat: (fleet-stats) - capture which tasks each layout set serves

### DIFF
--- a/src/tools/altinn-fleet-stats/backend/altinn_fleet/db.py
+++ b/src/tools/altinn-fleet-stats/backend/altinn_fleet/db.py
@@ -45,6 +45,14 @@ CREATE TABLE IF NOT EXISTS layouts (
 );
 CREATE INDEX IF NOT EXISTS idx_layouts_app ON layouts(app_id);
 
+CREATE TABLE IF NOT EXISTS layout_set_tasks (
+    app_id TEXT NOT NULL REFERENCES apps(app_id) ON DELETE CASCADE,
+    layout_set TEXT NOT NULL,
+    task_id TEXT NOT NULL,              -- task id from layout-sets.json "tasks"
+    PRIMARY KEY (app_id, layout_set, task_id)
+);
+CREATE INDEX IF NOT EXISTS idx_lst_app ON layout_set_tasks(app_id);
+
 CREATE TABLE IF NOT EXISTS components (
     component_id INTEGER PRIMARY KEY AUTOINCREMENT,
     layout_id INTEGER NOT NULL REFERENCES layouts(layout_id) ON DELETE CASCADE,

--- a/src/tools/altinn-fleet-stats/backend/altinn_fleet/query.py
+++ b/src/tools/altinn-fleet-stats/backend/altinn_fleet/query.py
@@ -172,6 +172,18 @@ SAMPLE_QUERIES = [
         ),
     },
     {
+        "title": "Layout-sett knyttet til flere tasks",
+        "sql": (
+            "SELECT app_id, layout_set,\n"
+            "       COUNT(*)                    AS task_count,\n"
+            "       GROUP_CONCAT(task_id, ', ') AS tasks\n"
+            "FROM layout_set_tasks\n"
+            "GROUP BY app_id, layout_set\n"
+            "HAVING COUNT(*) > 1\n"
+            "ORDER BY task_count DESC;"
+        ),
+    },
+    {
         "title": "Døde tekstressurser per app (topp 20)",
         "sql": (
             "SELECT tk.app_id,\n"

--- a/src/tools/altinn-fleet-stats/backend/altinn_fleet/query.py
+++ b/src/tools/altinn-fleet-stats/backend/altinn_fleet/query.py
@@ -177,10 +177,12 @@ SAMPLE_QUERIES = [
             "SELECT app_id, layout_set,\n"
             "       COUNT(*)                    AS task_count,\n"
             "       GROUP_CONCAT(task_id, ', ') AS tasks\n"
-            "FROM layout_set_tasks\n"
+            "FROM (SELECT app_id, layout_set, task_id\n"
+            "      FROM layout_set_tasks\n"
+            "      ORDER BY app_id, layout_set, task_id)\n"
             "GROUP BY app_id, layout_set\n"
             "HAVING COUNT(*) > 1\n"
-            "ORDER BY task_count DESC;"
+            "ORDER BY task_count DESC, app_id, layout_set;"
         ),
     },
     {

--- a/src/tools/altinn-fleet-stats/backend/altinn_fleet/scanner.py
+++ b/src/tools/altinn-fleet-stats/backend/altinn_fleet/scanner.py
@@ -127,8 +127,13 @@ def _backend_version(csproj: Path) -> tuple[str, str]:
     return (m.group(1), m.group(2))
 
 
-def _enumerate_layout_sets(app_dir: Path) -> list[tuple[str, Path]]:
-    """Return (layout_set_id, layout_set_dir) pairs."""
+def _enumerate_layout_sets(app_dir: Path) -> list[tuple[str, Path, list[str]]]:
+    """Return (layout_set_id, layout_set_dir, task_ids) triples.
+
+    task_ids is the layout set's "tasks" array from layout-sets.json (v4). For
+    v9 apps the array is absent and the task id equals the layout set id, so we
+    fall back to [layout_set_id].
+    """
     ui = app_dir / "App" / "ui"
     if not ui.exists():
         return []
@@ -139,11 +144,12 @@ def _enumerate_layout_sets(app_dir: Path) -> list[tuple[str, Path]]:
         for s in data.get("sets", []):
             sid = s.get("id", "")
             if sid:
-                result.append((sid, ui / sid))
+                tasks = s.get("tasks") or [sid]
+                result.append((sid, ui / sid, tasks))
         return result
     # Legacy: layouts directly under App/ui
     if (ui / "layouts").exists() or (ui / "Settings.json").exists() or (ui / "FormLayout.json").exists():
-        return [("(default)", ui)]
+        return [("(default)", ui, [])]
     return []
 
 
@@ -401,7 +407,14 @@ def scan_app(conn: sqlite3.Connection, app_dir: Path, env: str,
                 (name, "application_metadata", key, kind),
             )
 
-    for layout_set_id, layout_set_dir in layout_sets:
+    for layout_set_id, layout_set_dir, task_ids in layout_sets:
+        for task_id in task_ids:
+            conn.execute(
+                """INSERT OR IGNORE INTO layout_set_tasks (app_id, layout_set, task_id)
+                   VALUES (?, ?, ?)""",
+                (name, layout_set_id, task_id),
+            )
+
         settings_path = layout_set_dir / "Settings.json"
         active_pages = _settings_pages(settings_path)
         settings_data = _read_json(settings_path) or {}

--- a/src/tools/altinn-fleet-stats/backend/altinn_fleet/scanner.py
+++ b/src/tools/altinn-fleet-stats/backend/altinn_fleet/scanner.py
@@ -144,8 +144,14 @@ def _enumerate_layout_sets(app_dir: Path) -> list[tuple[str, Path, list[str]]]:
         for s in data.get("sets", []):
             sid = s.get("id", "")
             if sid:
-                tasks = s.get("tasks") or [sid]
-                result.append((sid, ui / sid, tasks))
+                raw_tasks = s.get("tasks")
+                tasks = (
+                    [t for t in raw_tasks if isinstance(t, str) and t]
+                    if isinstance(raw_tasks, list)
+                    else []
+                )
+                # v9 apps omit "tasks"; the task id then equals the layout set id.
+                result.append((sid, ui / sid, tasks or [sid]))
         return result
     # Legacy: layouts directly under App/ui
     if (ui / "layouts").exists() or (ui / "Settings.json").exists() or (ui / "FormLayout.json").exists():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Persist the layout-set→task linkage from layout-sets.json into a new layout_set_tasks table, joining the process (bpmn_tasks) to the UI (layouts/components).

<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for showing tasks linked to each layout set in fleet statistics.
  * Introduced a new sample query: “Layout-sett knyttet til flere tasks”, highlighting layout sets associated with multiple tasks.

* **Bug Fixes**
  * Improved layout-set scanning to reliably capture task information across supported app formats (including newer and legacy layouts).
  * Enhanced query performance for app-scoped lookups of layout-set task data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->