### PR TITLE
refactor: Move core of DatepickerComponent into Datepicker layout-component in @app/form-component.

### DIFF
--- a/app-libs/form-component/src/app-components/Datepicker/index.ts
+++ b/app-libs/form-component/src/app-components/Datepicker/index.ts
@@ -22,6 +22,7 @@ export {
   strictParseFormat,
   dateFormatCanBeNumericInReactPatternFormat,
   getFormatAsPatternFormat,
+  getDatepickerFormat,
   getMonths,
   getYears,
 } from './utils/dateHelpers';

--- a/app-libs/form-component/src/app-components/Datepicker/utils/dateHelpers.ts
+++ b/app-libs/form-component/src/app-components/Datepicker/utils/dateHelpers.ts
@@ -244,6 +244,27 @@ export function getFormatAsPatternFormat(datePickerFormat: string): string {
   return datePickerFormat.replaceAll(/[dmy]/gi, '#');
 }
 
+/**
+ * This function will massage locale date formats to require a fixed number of characters so that a pattern-format can be used on the text input
+ */
+export function getDatepickerFormat(unicodeFormat: string): string {
+  const tokens = unicodeFormat.split(UNICODE_TOKENS) as Token[];
+  const separators: (string | undefined)[] = unicodeFormat.match(UNICODE_TOKENS) ?? [];
+
+  return tokens.reduce((acc, token: Token, index) => {
+    if (['y', 'yy', 'yyy', 'yyyy', 'u', 'uu', 'uuu', 'uuuu'].includes(token)) {
+      return `${acc}yyyy${separators?.[index] ?? ''}`;
+    }
+    if (['M', 'MM', 'MMM', 'MMMM', 'MMMMM'].includes(token)) {
+      return `${acc}MM${separators?.[index] ?? ''}`;
+    }
+    if (['d', 'dd'].includes(token)) {
+      return `${acc}dd${separators?.[index] ?? ''}`;
+    }
+    return acc;
+  }, '');
+}
+
 export const getMonths = (start: Date, end: Date, current: Date): Date[] => {
   const dropdownMonths: Date[] = [];
 

--- a/app-libs/form-component/src/layout-components/Datepicker/Datepicker.mdx
+++ b/app-libs/form-component/src/layout-components/Datepicker/Datepicker.mdx
@@ -1,0 +1,9 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+import { LayoutComponentDocs } from '../common/storybook';
+import * as DatepickerStories from './Datepicker.stories';
+import { DATEPICKER_PROP_CATEGORIES } from './Datepicker.stories';
+
+<Meta of={DatepickerStories} />
+
+<LayoutComponentDocs categories={DATEPICKER_PROP_CATEGORIES} />

--- a/app-libs/form-component/src/layout-components/Datepicker/Datepicker.stories.tsx
+++ b/app-libs/form-component/src/layout-components/Datepicker/Datepicker.stories.tsx
@@ -69,9 +69,9 @@ type Story = StoryObj<typeof meta>;
 
 export const Preview: Story = {
   args: {
-    title: 'Fødselsdato',
-    description: 'Oppgi datoen du ble født.',
-    help: 'Du finner fødselsdatoen din i passet eller på fødselsattesten.',
+    title: 'Dato for vedtak',
+    description: 'Oppgi datoen vedtaket ble fattet.',
+    help: 'Du finner vedtaksdatoen øverst i vedtaksbrevet du har mottatt.',
   },
 };
 
@@ -91,6 +91,6 @@ export const WithMinMax: Story = {
 
 export const WithValidationMessages: Story = {
   args: {
-    validationMessages: 'You must enter a valid date.',
+    validationMessages: 'Du må oppgi en gyldig dato.',
   },
 };

--- a/app-libs/form-component/src/layout-components/Datepicker/Datepicker.stories.tsx
+++ b/app-libs/form-component/src/layout-components/Datepicker/Datepicker.stories.tsx
@@ -1,17 +1,49 @@
 import { useArgs } from 'storybook/preview-api';
 import { fn } from 'storybook/test';
+import type { PropCategories } from '@app/form-component/layout-components/common/storybook';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { Datepicker } from './Datepicker';
+import type { DatepickerProps } from './Datepicker';
+
+/**
+ * Sorts each prop into a Storybook docs group
+ */
+export const DATEPICKER_PROP_CATEGORIES = {
+  // Text resources — Studio "Tekst" section (textResourceBindings)
+  title: 'text',
+  help: 'text',
+  description: 'text',
+  // Data model binding — Studio "Datamodeller" section (dataModelBindings.simpleBinding)
+  value: 'data',
+  // Configurable options — Studio "Innhold" section
+  componentId: 'content',
+  format: 'content',
+  minDate: 'content',
+  maxDate: 'content',
+  timeStamp: 'content',
+  readOnly: 'content',
+  required: 'content',
+  autoComplete: 'content',
+  showOptionalMarking: 'content',
+  labelGrid: 'content',
+  innerGrid: 'content',
+  validationGrid: 'content',
+  // Injected by the runtime wrapper — not part of the Studio configuration
+  onValueChange: 'runtime',
+  validationMessages: 'runtime',
+} satisfies PropCategories<DatepickerProps>;
 
 const meta = {
   title: 'LayoutComponents/Datepicker',
   component: Datepicker,
+  // DATEPICKER_PROP_CATEGORIES is a docs helper, not a story — keep CSF from rendering it as one.
+  excludeStories: ['DATEPICKER_PROP_CATEGORIES'],
   parameters: {
     layout: 'padded',
   },
   args: {
-    id: 'datepicker-preview',
+    componentId: 'datepicker-preview',
     format: 'dd.MM.yyyy',
     value: '',
     onValueChange: fn(),

--- a/app-libs/form-component/src/layout-components/Datepicker/Datepicker.stories.tsx
+++ b/app-libs/form-component/src/layout-components/Datepicker/Datepicker.stories.tsx
@@ -1,0 +1,58 @@
+import { useArgs } from 'storybook/preview-api';
+import { fn } from 'storybook/test';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Datepicker } from './Datepicker';
+
+const meta = {
+  title: 'LayoutComponents/Datepicker',
+  component: Datepicker,
+  parameters: {
+    layout: 'padded',
+  },
+  args: {
+    id: 'datepicker-preview',
+    format: 'dd.MM.yyyy',
+    value: '',
+    onValueChange: fn(),
+  },
+  render: function Render(args) {
+    const [{ value }, updateArgs] = useArgs();
+    return (
+      <Datepicker
+        {...args}
+        value={value}
+        onValueChange={(newValue) => {
+          args.onValueChange(newValue);
+          updateArgs({ value: newValue });
+        }}
+      />
+    );
+  },
+} satisfies Meta<typeof Datepicker>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Preview: Story = {};
+
+export const ReadOnly: Story = {
+  args: {
+    value: '2025-03-15',
+    readOnly: true,
+  },
+};
+
+export const WithMinMax: Story = {
+  args: {
+    minDate: '2025-01-01',
+    maxDate: '2025-12-31',
+  },
+};
+
+export const WithValidationMessages: Story = {
+  args: {
+    validationMessages: 'You must enter a valid date.',
+  },
+};

--- a/app-libs/form-component/src/layout-components/Datepicker/Datepicker.stories.tsx
+++ b/app-libs/form-component/src/layout-components/Datepicker/Datepicker.stories.tsx
@@ -67,7 +67,13 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Preview: Story = {};
+export const Preview: Story = {
+  args: {
+    title: 'Fødselsdato',
+    description: 'Oppgi datoen du ble født.',
+    help: 'Du finner fødselsdatoen din i passet eller på fødselsattesten.',
+  },
+};
 
 export const ReadOnly: Story = {
   args: {

--- a/app-libs/form-component/src/layout-components/Datepicker/Datepicker.test.tsx
+++ b/app-libs/form-component/src/layout-components/Datepicker/Datepicker.test.tsx
@@ -11,7 +11,7 @@ const render = (
   options?: Parameters<typeof renderWithTranslations>[1],
 ) =>
   renderWithTranslations(
-    <Datepicker id='my-datepicker' value='' onValueChange={() => {}} {...props} />,
+    <Datepicker componentId='my-datepicker' value='' onValueChange={() => {}} {...props} />,
     options,
   );
 

--- a/app-libs/form-component/src/layout-components/Datepicker/Datepicker.test.tsx
+++ b/app-libs/form-component/src/layout-components/Datepicker/Datepicker.test.tsx
@@ -1,0 +1,70 @@
+import type { ComponentProps } from 'react';
+
+import { renderWithTranslations } from '@app/form-component/test/renderWithTranslations';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { Datepicker } from './Datepicker';
+
+const render = (
+  props?: Partial<ComponentProps<typeof Datepicker>>,
+  options?: Parameters<typeof renderWithTranslations>[1],
+) =>
+  renderWithTranslations(
+    <Datepicker id='my-datepicker' value='' onValueChange={() => {}} {...props} />,
+    options,
+  );
+
+describe('Datepicker', () => {
+  it('renders the input with the formatted value', () => {
+    render({ value: '2025-03-15', format: 'dd.MM.yyyy' });
+    expect(screen.getByRole('textbox')).toHaveValue('15.03.2025');
+  });
+
+  it('resolves the calendar button aria-label via the translation context', () => {
+    render();
+    expect(screen.getByRole('button', { name: 'Open date picker' })).toBeInTheDocument();
+  });
+
+  it('calls onValueChange when a date is picked from the calendar', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render({ value: '2025-03-15', format: 'dd.MM.yyyy', timeStamp: false, onValueChange });
+
+    await user.click(screen.getByRole('button', { name: 'Open date picker' }));
+    await user.click(screen.getByRole('button', { name: 'Thursday, March 20th, 2025' }));
+
+    expect(onValueChange).toHaveBeenLastCalledWith('2025-03-20');
+  });
+
+  it('renders a read-only input when readOnly is set', () => {
+    render({ readOnly: true });
+    expect(screen.getByRole('textbox')).toHaveAttribute('readonly');
+  });
+
+  it('renders the label and associates it with the input', () => {
+    render({ title: 'date.label' }, { overrides: { 'date.label': 'Date of birth' } });
+    expect(screen.getByLabelText('Date of birth')).toBe(screen.getByRole('textbox'));
+  });
+
+  it('renders no label when no label title is provided', () => {
+    render();
+    expect(screen.queryByText('Date of birth')).not.toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('renders the validation messages passed in by the app', () => {
+    render({ validationMessages: 'You must enter a valid date.' });
+    expect(screen.getByText('You must enter a valid date.')).toBeInTheDocument();
+  });
+
+  it('calls onValueChange with the ISO date string when a valid date is typed', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render({ format: 'dd.MM.yyyy', timeStamp: false, onValueChange });
+
+    await user.type(screen.getByRole('textbox'), '15.03.2025');
+
+    expect(onValueChange).toHaveBeenLastCalledWith('2025-03-15');
+  });
+});

--- a/app-libs/form-component/src/layout-components/Datepicker/Datepicker.tsx
+++ b/app-libs/form-component/src/layout-components/Datepicker/Datepicker.tsx
@@ -82,7 +82,6 @@ export function Datepicker({
   return (
     <LabelComponent
       htmlFor={componentId}
-      componentId={componentId}
       title={title}
       help={help}
       description={description}

--- a/app-libs/form-component/src/layout-components/Datepicker/Datepicker.tsx
+++ b/app-libs/form-component/src/layout-components/Datepicker/Datepicker.tsx
@@ -17,7 +17,8 @@ import { DatePickerDropdownCaption } from './DatePickerDropdownCaption';
 import 'react-day-picker/style.css';
 
 export interface DatepickerProps {
-  id: string;
+  /** The configured component id (Studio "Komponent-ID"). Rendered as the input's `id` and the label's `htmlFor`. */
+  componentId: string;
   value: string;
   /** Unicode date format from the component config. Falls back to the locale's short date format. */
   format?: string;
@@ -52,7 +53,7 @@ export interface DatepickerProps {
 }
 
 export function Datepicker({
-  id,
+  componentId,
   value,
   format,
   minDate,
@@ -80,8 +81,8 @@ export function Datepicker({
 
   return (
     <LabelComponent
-      htmlFor={id}
-      componentId={id}
+      htmlFor={componentId}
+      componentId={componentId}
       title={title}
       help={help}
       description={description}
@@ -91,14 +92,14 @@ export function Datepicker({
       grid={labelGrid}
     >
       <ComponentStructure
-        componentId={id}
+        componentId={componentId}
         innerGrid={innerGrid}
         validationGrid={validationGrid}
         validationMessages={validationMessages}
       >
         <Flex container item size={{ xs: 12 }}>
           <DatePickerControl
-            id={id}
+            id={componentId}
             value={value}
             dateFormat={dateFormat}
             timeStamp={timeStamp}

--- a/app-libs/form-component/src/layout-components/Datepicker/Datepicker.tsx
+++ b/app-libs/form-component/src/layout-components/Datepicker/Datepicker.tsx
@@ -1,0 +1,126 @@
+import type { ReactNode } from 'react';
+
+import { DatePickerControl } from '@app/form-component/app-components/Datepicker';
+import {
+  getDateConstraint,
+  getDateFormat,
+  getDatepickerFormat,
+} from '@app/form-component/app-components/Datepicker/utils/dateHelpers';
+import { Flex } from '@app/form-component/app-components/Flex';
+import { useCurrentLanguage, useTranslation } from '@app/form-component/LanguageTranslatorProvider';
+import { ComponentStructure } from '@app/form-component/layout-components/common/ComponentStructure';
+import { LabelComponent } from '@app/form-component/layout-components/common/LabelComponent';
+import type { IGridStyling } from '@app/form-component/app-components/Flex';
+
+import { DatePickerDropdownCaption } from './DatePickerDropdownCaption';
+
+import 'react-day-picker/style.css';
+
+export interface DatepickerProps {
+  id: string;
+  value: string;
+  /** Unicode date format from the component config. Falls back to the locale's short date format. */
+  format?: string;
+  /** Min date as an ISO string or a date flag (e.g. `today`). */
+  minDate?: string;
+  /** Max date as an ISO string or a date flag (e.g. `today`). */
+  maxDate?: string;
+  timeStamp?: boolean;
+  readOnly?: boolean;
+  required?: boolean;
+  autoComplete?: 'bday';
+  onValueChange: (isoDateString: string) => void;
+  /** Grid sizing for the inner content. */
+  innerGrid?: IGridStyling;
+  /** Grid sizing for the validation messages. */
+  validationGrid?: IGridStyling;
+  /**
+   * Rendered validation messages. The app owns validation, so it passes the already-rendered
+   * messages in rather than this library reaching into app-specific validation state.
+   */
+  validationMessages?: ReactNode;
+  /** Text-resource key for the label text. When undefined, no label is rendered. */
+  title?: string;
+  /** Text-resource key for the label help text. */
+  help?: string;
+  /** Text-resource key for the label description. */
+  description?: string;
+  /** Whether to show the optional marking on the label for non-required fields. */
+  showOptionalMarking?: boolean;
+  /** Grid sizing for the label. */
+  labelGrid?: IGridStyling;
+}
+
+export function Datepicker({
+  id,
+  value,
+  format,
+  minDate,
+  maxDate,
+  timeStamp = true,
+  readOnly,
+  required,
+  autoComplete,
+  onValueChange,
+  innerGrid,
+  validationGrid,
+  validationMessages,
+  title,
+  help,
+  description,
+  showOptionalMarking,
+  labelGrid,
+}: DatepickerProps) {
+  const { langAsString } = useTranslation();
+  const currentLanguage = useCurrentLanguage();
+
+  const dateFormat = getDatepickerFormat(getDateFormat(format, currentLanguage));
+  const calculatedMinDate = getDateConstraint(minDate, 'min');
+  const calculatedMaxDate = getDateConstraint(maxDate, 'max');
+
+  return (
+    <LabelComponent
+      htmlFor={id}
+      componentId={id}
+      title={title}
+      help={help}
+      description={description}
+      required={required}
+      readOnly={readOnly}
+      showOptionalMarking={showOptionalMarking}
+      grid={labelGrid}
+    >
+      <ComponentStructure
+        componentId={id}
+        innerGrid={innerGrid}
+        validationGrid={validationGrid}
+        validationMessages={validationMessages}
+      >
+        <Flex container item size={{ xs: 12 }}>
+          <DatePickerControl
+            id={id}
+            value={value}
+            dateFormat={dateFormat}
+            timeStamp={timeStamp}
+            onValueChange={onValueChange}
+            readOnly={readOnly}
+            required={required}
+            locale={currentLanguage}
+            minDate={calculatedMinDate}
+            maxDate={calculatedMaxDate}
+            DropdownCaption={(props) => (
+              <DatePickerDropdownCaption
+                {...props}
+                minDate={calculatedMinDate}
+                maxDate={calculatedMaxDate}
+              />
+            )}
+            buttonAriaLabel={langAsString('date_picker.aria_label_icon')}
+            calendarIconTitle={langAsString('date_picker.aria_label_icon')}
+            autoComplete={autoComplete}
+          />
+        </Flex>
+      </ComponentStructure>
+    </LabelComponent>
+  );
+}

--- a/app-libs/form-component/src/layout-components/Datepicker/index.ts
+++ b/app-libs/form-component/src/layout-components/Datepicker/index.ts
@@ -1,1 +1,3 @@
+export { Datepicker } from './Datepicker';
+export type { DatepickerProps } from './Datepicker';
 export { DatePickerDropdownCaption } from './DatePickerDropdownCaption';

--- a/app-libs/form-component/src/layout-components/DemoLayoutComponent/DemoLayoutComponent.stories.tsx
+++ b/app-libs/form-component/src/layout-components/DemoLayoutComponent/DemoLayoutComponent.stories.tsx
@@ -10,11 +10,11 @@ import type { DemoLayoutComponentProps } from './DemoLayoutComponent';
  * PropCategories<DemoLayoutComponentProps>` makes it exhaustive — a new prop must be classified here.
  */
 export const DEMO_PROP_CATEGORIES = {
-  id: 'config',
-  title: 'config',
-  content: 'config',
-  variant: 'config',
-  showLanguageInfo: 'config',
+  id: 'content',
+  title: 'text',
+  content: 'text',
+  variant: 'content',
+  showLanguageInfo: 'content',
   renderedInTable: 'runtime',
   dataValue: 'runtime',
   hidden: 'runtime',

--- a/app-libs/form-component/src/layout-components/common/ComponentStructure/ComponentStructure.test.tsx
+++ b/app-libs/form-component/src/layout-components/common/ComponentStructure/ComponentStructure.test.tsx
@@ -5,12 +5,15 @@ import { ComponentStructure } from './ComponentStructure';
 describe('ComponentStructure', () => {
   it('renders the children and the validation messages', () => {
     const { container } = render(
-      <ComponentStructure id='structure-id' validationMessages={<span>Something is wrong</span>}>
+      <ComponentStructure
+        componentId='structure-id'
+        validationMessages={<span>Something is wrong</span>}
+      >
         <span>Content</span>
       </ComponentStructure>,
     );
 
-    expect(container.querySelector('#structure-id')).toBeInTheDocument();
+    expect(container.querySelector('#form-content-structure-id')).toBeInTheDocument();
     expect(screen.getByText('Content')).toBeInTheDocument();
     expect(screen.getByText('Something is wrong')).toBeInTheDocument();
   });

--- a/app-libs/form-component/src/layout-components/common/ComponentStructure/ComponentStructure.tsx
+++ b/app-libs/form-component/src/layout-components/common/ComponentStructure/ComponentStructure.tsx
@@ -4,8 +4,11 @@ import type { PropsWithChildren, ReactNode } from 'react';
 import { Flex, type IGridStyling } from '@app/form-component/app-components/Flex';
 
 export interface IComponentStructureProps {
-  /** Id for the outer content wrapper element. */
-  id?: string;
+  /**
+   * Id of the configured component. The outer content wrapper element's DOM id is derived from this
+   * as `form-content-${componentId}`, currently only used for e2e tests.
+   */
+  componentId?: string;
   /** Grid sizing for the inner content. */
   innerGrid?: IGridStyling;
   /** Grid sizing for the validation messages. */
@@ -61,7 +64,7 @@ function componentWithValidationSpan(
  * messages in a responsive grid.
  */
 export function ComponentStructure({
-  id,
+  componentId,
   innerGrid,
   validationGrid,
   className,
@@ -75,7 +78,13 @@ export function ComponentStructure({
   );
 
   return (
-    <Flex id={id} className={className} size={{ xs: 12, ...containerSpan }} item container>
+    <Flex
+      id={componentId ? `form-content-${componentId}` : undefined}
+      className={className}
+      size={{ xs: 12, ...containerSpan }}
+      item
+      container
+    >
       <Flex item size={{ xs: 12, ...innerSpan }} style={contentStyle}>
         {children}
       </Flex>

--- a/app-libs/form-component/src/layout-components/common/LabelComponent/LabelComponent.stories.tsx
+++ b/app-libs/form-component/src/layout-components/common/LabelComponent/LabelComponent.stories.tsx
@@ -18,7 +18,6 @@ const meta = {
   ],
   args: {
     htmlFor: 'example',
-    componentId: 'example',
     title: 'First name',
   },
 } satisfies Meta<typeof LabelComponent>;

--- a/app-libs/form-component/src/layout-components/common/LabelComponent/LabelComponent.test.tsx
+++ b/app-libs/form-component/src/layout-components/common/LabelComponent/LabelComponent.test.tsx
@@ -13,7 +13,7 @@ const overrides = {
 describe('LabelComponent', () => {
   const render = (props?: Partial<ILabelComponentProps>) =>
     renderWithTranslations(
-      <LabelComponent htmlFor='example' componentId='example' title='my.title' {...props}>
+      <LabelComponent htmlFor='example' title='my.title' {...props}>
         <input id='example' />
       </LabelComponent>,
       { overrides },

--- a/app-libs/form-component/src/layout-components/common/LabelComponent/LabelComponent.tsx
+++ b/app-libs/form-component/src/layout-components/common/LabelComponent/LabelComponent.tsx
@@ -11,10 +11,11 @@ import type { IGridStyling } from '@app/form-component/app-components/Flex/Flex'
 export interface ILabelComponentProps {
   /** Id for the rendered label element. */
   id?: string;
-  /** Id of the form element this label belongs to. Sets the label's `htmlFor`. */
+  /**
+   * Id of the form element this label belongs to. Sets the label's `htmlFor` and is also used to
+   * build the description element id (so the control can reference it via `aria-describedby`).
+   */
   htmlFor?: string;
-  /** Id of the component, used to build the description element id. */
-  componentId?: string;
   /** Text-resource key for the label text. When undefined, only the children are rendered. */
   title?: string;
   /** Text-resource key for the help text. */
@@ -36,7 +37,6 @@ export interface ILabelComponentProps {
 export function LabelComponent({
   id,
   htmlFor,
-  componentId,
   title,
   help,
   description,
@@ -66,7 +66,7 @@ export function LabelComponent({
       help={help ? <HelpTextContainer title={title} helpText={lang(help)} /> : undefined}
       description={
         description ? (
-          <Description componentId={componentId} description={lang(description)} />
+          <Description componentId={htmlFor} description={lang(description)} />
         ) : undefined
       }
     >

--- a/app-libs/form-component/src/layout-components/common/README.md
+++ b/app-libs/form-component/src/layout-components/common/README.md
@@ -12,9 +12,10 @@ Most likely these will be components migrated from `src/App/frontend/src/compone
 ## Storybook docs setup
 
 Layout components share a single docs page layout so every component's Storybook page looks the
-same: the **Studio configurable** props are shown under a heading, and the **Runtime (injected)**
-props in a collapsed section below them. Both are plain controls tables (not `table.category`
-sections), and every prop stays editable.
+same: the **Studio configurable** props are shown under a heading — grouped into **Text**, **Data**
+and **Innhold** subsections that mirror the configuration sections in Altinn Studio — and the
+**Runtime (injected)** props in a collapsed section below them. They are plain controls tables (not
+`table.category` sections), and every prop stays editable.
 
 `DemoLayoutComponent` is the reference example for this setup. To give a component this page, two
 pieces are needed.
@@ -35,8 +36,8 @@ import type { MyComponentProps } from './MyComponent';
 import type { PropCategories } from '../common/storybook';
 
 export const MY_COMPONENT_PROP_CATEGORIES = {
-  id: 'config', // configurable in Studio
-  title: 'config',
+  id: 'content', // configurable in Studio
+  title: 'text', // text-resource bound
   value: 'runtime', // injected by the runtime wrapper
 } satisfies PropCategories<MyComponentProps>;
 
@@ -48,12 +49,14 @@ const meta = {
 } satisfies Meta<typeof MyComponent>;
 ```
 
-- `config` — props that map 1:1 to the component's Studio-configurable options.
-- `runtime` — internal wiring supplied by the runtime wrapper (data binding, display overrides,
-  validation state, event handlers).
+The first three categories map 1:1 to the component's Studio-configurable options and are shown
+under the headings **Text**, **Data** and **Innhold**:
 
-A component with no runtime props classifies everything as `config`; the "Runtime (injected)"
-section is then omitted automatically.
+- `text` — text-resource bound props (label, help, description, ...). Studio's "Tekst" section.
+- `data` — data-model bound props. Studio's "Datamodeller" section.
+- `content` — the remaining configurable options (formatting, constraints, layout, ...). Studio's
+  "Innhold" section.
+- `runtime` — internal wiring supplied by the runtime wrapper (validation state, event handlers).
 
 ### 2. Add the `*.mdx` docs page
 
@@ -72,5 +75,5 @@ import { MY_COMPONENT_PROP_CATEGORIES } from './MyComponent.stories';
 <LayoutComponentDocs categories={MY_COMPONENT_PROP_CATEGORIES} />
 ```
 
-That's it — `LayoutComponentDocs` renders the title, description, primary preview, the two grouped
+That's it — `LayoutComponentDocs` renders the title, description, primary preview, the grouped
 controls tables and the remaining stories. See `DemoLayoutComponent/` for a working example.

--- a/app-libs/form-component/src/layout-components/common/storybook/LayoutComponentDocs.tsx
+++ b/app-libs/form-component/src/layout-components/common/storybook/LayoutComponentDocs.tsx
@@ -7,7 +7,7 @@ import {
   Title,
 } from '@storybook/addon-docs/blocks';
 
-import { splitPropKeys } from './propCategories';
+import { groupPropKeys, STUDIO_CATEGORIES } from './propCategories';
 import type { PropCategory } from './propCategories';
 
 interface LayoutComponentDocsProps {
@@ -25,7 +25,7 @@ interface LayoutComponentDocsProps {
  * section. Every prop stays editable. The runtime section is omitted when a component has none.
  */
 export function LayoutComponentDocs({ categories }: LayoutComponentDocsProps) {
-  const { configKeys, runtimeKeys } = splitPropKeys(categories);
+  const groups = groupPropKeys(categories);
 
   return (
     <>
@@ -36,9 +36,16 @@ export function LayoutComponentDocs({ categories }: LayoutComponentDocsProps) {
 
       <h2>Studio configurable</h2>
       <p>Props that are configurable in Altinn Studio.</p>
-      <Controls include={configKeys} />
+      {STUDIO_CATEGORIES.map(({ category, label }) =>
+        groups[category].length > 0 ? (
+          <section key={category}>
+            <h3>{label}</h3>
+            <Controls include={groups[category]} />
+          </section>
+        ) : null,
+      )}
 
-      {runtimeKeys.length > 0 && (
+      {groups.runtime.length > 0 && (
         <details>
           <summary>
             <h2 style={{ display: 'inline' }}>Runtime (injected)</h2>
@@ -47,7 +54,7 @@ export function LayoutComponentDocs({ categories }: LayoutComponentDocsProps) {
             Internal wiring supplied by the runtime wrapper — data binding, display overrides,
             validation state and event handlers. Not part of the Studio configuration.
           </p>
-          <Controls include={runtimeKeys} />
+          <Controls include={groups.runtime} />
         </details>
       )}
 

--- a/app-libs/form-component/src/layout-components/common/storybook/index.ts
+++ b/app-libs/form-component/src/layout-components/common/storybook/index.ts
@@ -1,3 +1,3 @@
 export { LayoutComponentDocs } from './LayoutComponentDocs';
-export { splitPropKeys } from './propCategories';
+export { groupPropKeys, STUDIO_CATEGORIES } from './propCategories';
 export type { PropCategory, PropCategories } from './propCategories';

--- a/app-libs/form-component/src/layout-components/common/storybook/propCategories.ts
+++ b/app-libs/form-component/src/layout-components/common/storybook/propCategories.ts
@@ -1,31 +1,35 @@
 /**
- * Shared classification for a layout component's props, used to drive the Storybook docs layout.
- *
- * - `config` — props that map 1:1 to the component's Studio-configurable options.
- * - `runtime` — internal wiring supplied by the runtime wrapper (data binding, display overrides,
- *   validation state, event handlers). NOT part of the Studio configuration.
+ * The Studio-configurable prop categories, in the order they should appear in the docs.
+ * They mirror the configuration sections a service owner sees in Altinn Studio:
  */
-export type PropCategory = 'config' | 'runtime';
+export const STUDIO_CATEGORIES = [
+  { category: 'text', label: 'Text' },
+  { category: 'data', label: 'Data' },
+  { category: 'content', label: 'Innhold' },
+] as const;
+
+/**
+ * All categories for a storybook property.
+ * `runtime` is internal wiring supplied by the runtime wrapper ( display overrides, validation state, event handlers) and is NOT part of the Studio configuration.
+ */
+export type PropCategory = (typeof STUDIO_CATEGORIES)[number]['category'] | 'runtime';
 
 /**
  * An exhaustive map from every prop of `TProps` to its {@link PropCategory}. Use it with `satisfies`
  * so adding a prop without classifying it is a compile error:
  *
  * ```ts
- * export const DEMO_PROP_CATEGORIES = { id: 'config', dataValue: 'runtime', ... } satisfies PropCategories<DemoLayoutComponentProps>;
+ * export const DEMO_PROP_CATEGORIES = { id: 'content', title: 'text', dataValue: 'runtime', ... } satisfies PropCategories<DemoLayoutComponentProps>;
  * ```
  */
 export type PropCategories<TProps> = Record<keyof TProps, PropCategory>;
 
-/** Splits a {@link PropCategories} map into the configurable and runtime prop-name lists. */
-export function splitPropKeys(categories: Record<string, PropCategory>): {
-  configKeys: string[];
-  runtimeKeys: string[];
-} {
-  const configKeys: string[] = [];
-  const runtimeKeys: string[] = [];
+export function groupPropKeys(
+  categories: Record<string, PropCategory>,
+): Record<PropCategory, string[]> {
+  const groups: Record<PropCategory, string[]> = { text: [], data: [], content: [], runtime: [] };
   for (const [key, category] of Object.entries(categories)) {
-    (category === 'config' ? configKeys : runtimeKeys).push(key);
+    groups[category].push(key);
   }
-  return { configKeys, runtimeKeys };
+  return groups;
 }

--- a/app-libs/form-component/src/layout-components/common/storybook/propCategories.ts
+++ b/app-libs/form-component/src/layout-components/common/storybook/propCategories.ts
@@ -3,7 +3,7 @@
  * They mirror the configuration sections a service owner sees in Altinn Studio:
  */
 export const STUDIO_CATEGORIES = [
-  { category: 'text', label: 'Text' },
+  { category: 'text', label: 'Tekst' },
   { category: 'data', label: 'Data' },
   { category: 'content', label: 'Innhold' },
 ] as const;

--- a/src/App/frontend/src/layout/AddToList/AddToList.tsx
+++ b/src/App/frontend/src/layout/AddToList/AddToList.tsx
@@ -5,6 +5,7 @@ import {
   DatePickerDropdownCaption,
   DynamicForm,
   type FormDataObject,
+  getDatepickerFormat,
 } from '@app/form-component';
 import { Button, Dialog } from '@digdir/designsystemet-react';
 import { v4 as uuidv4 } from 'uuid';
@@ -14,7 +15,6 @@ import { FormStore } from 'src/features/form/FormContext';
 import { ALTINN_ROW_ID } from 'src/features/formData/types';
 import { useDataModelBindings } from 'src/features/formData/useDataModelBindings';
 import { useLanguage } from 'src/features/language/useLanguage';
-import { getDatepickerFormat } from 'src/utils/dateUtils';
 import { useDataModelBindingsFor } from 'src/utils/layout/hooks';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { IDataModelReference } from 'src/layout/common.generated';

--- a/src/App/frontend/src/layout/ComponentStructureWrapper.tsx
+++ b/src/App/frontend/src/layout/ComponentStructureWrapper.tsx
@@ -22,11 +22,11 @@ export function ComponentStructureWrapper({
   className,
   style,
 }: PropsWithChildren<ComponentStructureWrapperProps>) {
-  const { id, innerGrid, validationGrid, showValidationMessages } = useComponentStructureData(baseComponentId);
+  const { componentId, innerGrid, validationGrid, showValidationMessages } = useComponentStructureData(baseComponentId);
 
   const componentWithValidations = (
     <ComponentStructure
-      id={id}
+      componentId={componentId}
       innerGrid={innerGrid}
       validationGrid={validationGrid}
       className={className}

--- a/src/App/frontend/src/layout/Datepicker/DatepickerComponent.tsx
+++ b/src/App/frontend/src/layout/Datepicker/DatepickerComponent.tsx
@@ -23,7 +23,7 @@ export function DatepickerComponent({ baseComponentId, overrideDisplay }: PropsF
 
   return (
     <Datepicker
-      id={id}
+      componentId={id}
       value={formData.simpleBinding}
       format={format}
       minDate={minDate}

--- a/src/App/frontend/src/layout/Datepicker/DatepickerComponent.tsx
+++ b/src/App/frontend/src/layout/Datepicker/DatepickerComponent.tsx
@@ -1,103 +1,48 @@
 import React from 'react';
 
-import {
-  ComponentStructure,
-  DatePickerControl,
-  DatePickerDropdownCaption,
-  Flex,
-  getDateConstraint,
-  getDateFormat,
-  LabelComponent,
-} from '@app/form-component';
+import { Datepicker } from '@app/form-component';
 
 import { useDataModelBindings } from 'src/features/formData/useDataModelBindings';
-import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
-import { useLanguage } from 'src/features/language/useLanguage';
 import { AllComponentValidations } from 'src/features/validation/ComponentValidations';
-import { getDatepickerFormat } from 'src/utils/dateUtils';
 import { useComponentStructureData } from 'src/utils/layout/useComponentStructureData';
 import { useLabelData } from 'src/utils/layout/useLabelData';
 import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 
 export function DatepickerComponent({ baseComponentId, overrideDisplay }: PropsFromGenericComponent<'Datepicker'>) {
-  const { langAsString } = useLanguage();
-  const languageLocale = useCurrentLanguage();
-  const {
-    minDate,
-    maxDate,
-    format,
-    timeStamp = true,
-    readOnly,
-    required,
-    id,
-    dataModelBindings,
-    grid,
-    autocomplete,
-  } = useItemWhenType(baseComponentId, 'Datepicker');
-
-  const calculatedMinDate = getDateConstraint(minDate, 'min');
-  const calculatedMaxDate = getDateConstraint(maxDate, 'max');
-  const dateFormat = getDatepickerFormat(getDateFormat(format, languageLocale));
+  const { minDate, maxDate, format, timeStamp, readOnly, required, id, dataModelBindings, grid, autocomplete } =
+    useItemWhenType(baseComponentId, 'Datepicker');
 
   const { setValue, formData } = useDataModelBindings(dataModelBindings);
-  const value = formData.simpleBinding;
 
-  const handleInputValueChange = (isoDateString: string) => {
-    setValue('simpleBinding', isoDateString);
-  };
-
-  const labelData = useLabelData({ baseComponentId, overrideDisplay });
-  const {
-    id: contentId,
-    innerGrid,
-    validationGrid,
-    showValidationMessages,
-  } = useComponentStructureData(baseComponentId);
+  const { title, help, description, showOptionalMarking } = useLabelData({
+    baseComponentId,
+    overrideDisplay,
+  });
+  const { innerGrid, validationGrid, showValidationMessages } = useComponentStructureData(baseComponentId);
 
   return (
-    <LabelComponent
-      htmlFor={id}
-      grid={grid?.labelGrid}
-      {...labelData}
-    >
-      <ComponentStructure
-        id={contentId}
-        innerGrid={innerGrid}
-        validationGrid={validationGrid}
-        validationMessages={
-          showValidationMessages ? <AllComponentValidations baseComponentId={baseComponentId} /> : undefined
-        }
-      >
-        <Flex
-          container
-          item
-          size={{ xs: 12 }}
-        >
-          <DatePickerControl
-            id={id}
-            value={value}
-            dateFormat={dateFormat}
-            timeStamp={timeStamp}
-            onValueChange={handleInputValueChange}
-            readOnly={readOnly}
-            required={required}
-            locale={languageLocale}
-            minDate={calculatedMinDate}
-            maxDate={calculatedMaxDate}
-            DropdownCaption={(props) => (
-              <DatePickerDropdownCaption
-                {...props}
-                minDate={calculatedMinDate}
-                maxDate={calculatedMaxDate}
-              />
-            )}
-            buttonAriaLabel={langAsString('date_picker.aria_label_icon')}
-            calendarIconTitle={langAsString('date_picker.aria_label_icon')}
-            autoComplete={autocomplete}
-          />
-        </Flex>
-      </ComponentStructure>
-    </LabelComponent>
+    <Datepicker
+      id={id}
+      value={formData.simpleBinding}
+      format={format}
+      minDate={minDate}
+      maxDate={maxDate}
+      timeStamp={timeStamp}
+      readOnly={readOnly}
+      required={required}
+      autoComplete={autocomplete}
+      onValueChange={(isoDateString) => setValue('simpleBinding', isoDateString)}
+      innerGrid={innerGrid}
+      validationGrid={validationGrid}
+      validationMessages={
+        showValidationMessages ? <AllComponentValidations baseComponentId={baseComponentId} /> : undefined
+      }
+      title={title}
+      help={help}
+      description={description}
+      showOptionalMarking={showOptionalMarking}
+      labelGrid={grid?.labelGrid}
+    />
   );
 }

--- a/src/App/frontend/src/layout/Datepicker/useDatepickerValidation.ts
+++ b/src/App/frontend/src/layout/Datepicker/useDatepickerValidation.ts
@@ -1,10 +1,9 @@
-import { getDateConstraint, getDateFormat, strictParseISO } from '@app/form-component';
+import { getDateConstraint, getDateFormat, getDatepickerFormat, strictParseISO } from '@app/form-component';
 import { isAfter, isBefore } from 'date-fns';
 
 import { FormStore } from 'src/features/form/FormContext';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { type ComponentValidation, FrontendValidationSource, ValidationMask } from 'src/features/validation';
-import { getDatepickerFormat } from 'src/utils/dateUtils';
 import { useDataModelBindingsFor } from 'src/utils/layout/hooks';
 import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 

--- a/src/App/frontend/src/layout/SimpleTable/SimpleTableComponent.tsx
+++ b/src/App/frontend/src/layout/SimpleTable/SimpleTableComponent.tsx
@@ -5,6 +5,7 @@ import {
   DatePickerDropdownCaption,
   FieldRenderer,
   type FormDataObject,
+  getDatepickerFormat,
   type TableActionButton,
 } from '@app/form-component';
 import { Link } from '@digdir/designsystemet-react';
@@ -20,7 +21,6 @@ import { useLanguage } from 'src/features/language/useLanguage';
 import { useIsMobile } from 'src/hooks/useDeviceWidths';
 import { AddToListModal } from 'src/layout/AddToList/AddToList';
 import { isFormDataObjectArray, isValidItemsSchema } from 'src/layout/SimpleTable/typeguards';
-import { getDatepickerFormat } from 'src/utils/dateUtils';
 import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { IDataModelBindingsForTable } from 'src/layout/SimpleTable/config.generated';

--- a/src/App/frontend/src/utils/dateUtils.ts
+++ b/src/App/frontend/src/utils/dateUtils.ts
@@ -76,27 +76,6 @@ export function formatDateLocale(localeStr: string, date: Date, unicodeFormat?: 
   return output;
 }
 
-/**
- * This function will massage locale date formats to require a fixed number of characters so that a pattern-format can be used on the text input
- */
-export function getDatepickerFormat(unicodeFormat: string): string {
-  const tokens = unicodeFormat.split(UNICODE_TOKENS) as Token[];
-  const separators: Separator[] = unicodeFormat.match(UNICODE_TOKENS) ?? [];
-
-  return tokens.reduce((acc, token: Token, index) => {
-    if (['y', 'yy', 'yyy', 'yyyy', 'u', 'uu', 'uuu', 'uuuu'].includes(token)) {
-      return `${acc}yyyy${separators?.[index] ?? ''}`;
-    }
-    if (['M', 'MM', 'MMM', 'MMMM', 'MMMMM'].includes(token)) {
-      return `${acc}MM${separators?.[index] ?? ''}`;
-    }
-    if (['d', 'dd'].includes(token)) {
-      return `${acc}dd${separators?.[index] ?? ''}`;
-    }
-    return acc;
-  }, '');
-}
-
 function selectPartToUse(parts: Intl.DateTimeFormatPart[], token: Token) {
   if (['G', 'GG', 'GGG', 'GGGG', 'GGGGG'].includes(token)) {
     return parts.find((part) => part.type === 'era');

--- a/src/App/frontend/src/utils/layout/useComponentStructureData.ts
+++ b/src/App/frontend/src/utils/layout/useComponentStructureData.ts
@@ -5,7 +5,7 @@ import { useExternalItem } from 'src/utils/layout/hooks';
 import type { IGridStyling } from 'src/layout/common.generated';
 
 export interface ComponentStructureData {
-  id: string;
+  componentId: string;
   innerGrid: IGridStyling | undefined;
   validationGrid: IGridStyling | undefined;
   showValidationMessages: boolean;
@@ -21,10 +21,10 @@ export function useComponentStructureData(baseComponentId: string): ComponentStr
   const grid = overrideItemProps?.grid ?? component?.grid;
   const layoutComponent = getComponentDef(component.type);
   const showValidationMessages = layoutComponent.renderDefaultValidations();
-  const indexedId = useIndexedId(baseComponentId);
+  const componentId = useIndexedId(baseComponentId);
 
   return {
-    id: `form-content-${indexedId}`,
+    componentId,
     innerGrid: grid?.innerGrid,
     validationGrid: grid?.validationGrid,
     showValidationMessages,


### PR DESCRIPTION
Extracts the presentational core of the app's DatepickerComponent into a reusable Datepicker layout-component in @app/form-component. The app-side component becomes a thin adapter that maps layout config, data-model bindings and validation onto the dumb component.

##Changes
- New Datepicker layout-component with stories, MDX docs and unit tests; renders its own input, calendar, label and validation layout.
- App DatepickerComponent reduced to an adapter; only onValueChange is hardcoded wiring.
- Moved getDatepickerFormat into form-component's dateHelpers.ts and updated consumers.
- Id consolidation: ComponentStructure/useComponentStructureData now take/return componentId and derive the form-content-${id} wrapper id internally (DOM output unchanged); dropped the redundant contentId.
- LabelComponent: removed the redundant componentId prop (description id now derived from htmlFor).
- Storybook prop categories reworked to text | data | content | runtime, mirroring Studio's sections (single array-driven source, Norwegian labels).


## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added/standardised a Datepicker component with formatted date support, min/max constraints, read-only mode, validation messages, and translated labels.
  * Added Storybook documentation and example states for the Datepicker.

* **Bug Fixes**
  * Improved accessibility and label/description wiring, ensuring generated IDs and associations stay consistent.
  * Improved date formatting consistency across related form components.

* **Documentation**
  * Updated shared component prop documentation to reflect the revised prop categorisation model.

* **Chores**
  * Centralised shared date-format helper usage across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->