### PR TITLE
feat: sign workflow-engine callback state blob

### DIFF
--- a/src/App/backend/src/Altinn.App.Api/Controllers/WorkflowEngineCallbackController.cs
+++ b/src/App/backend/src/Altinn.App.Api/Controllers/WorkflowEngineCallbackController.cs
@@ -181,8 +181,17 @@ public class WorkflowEngineCallbackController : ControllerBase
                     string collectionKey = Request.Headers[CollectionKeyHeader].ToString();
                     if (string.IsNullOrWhiteSpace(collectionKey))
                     {
-                        throw new InvalidOperationException(
-                            "Workflow callback is missing Collection-Key header required for auto-advance process next."
+                        _logger.LogError(
+                            "Workflow callback is missing the '{Header}' header required for auto-advance. CommandKey: {CommandKey}, Instance: {InstanceId}.",
+                            CollectionKeyHeader,
+                            commandKey,
+                            instanceId
+                        );
+                        activity?.SetStatus(ActivityStatusCode.Error, "Missing Collection-Key header");
+                        return NonRetryableProblem(
+                            "Missing Collection-Key",
+                            "Workflow callback is missing the Collection-Key header required for auto-advance process next.",
+                            StatusCodes.Status422UnprocessableEntity
                         );
                     }
 

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/DependencyInjection/ServiceCollectionExtensions.cs
@@ -20,6 +20,7 @@ internal static class ServiceCollectionExtensions
         // Process engine callback helpers
         services.AddTransient<ProcessTaskResolver>();
         services.AddTransient<ProcessNextRequestFactory>();
+        services.AddTransient<WorkflowStateSigner>();
         services.AddTransient<WorkflowCallbackStateService>();
         services.AddTransient<IWorkflowEngineService, WorkflowEngineService>();
         services.AddHttpClient<IWorkflowEngineClient, WorkflowEngineClient>();

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Models/SignedWorkflowState.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Models/SignedWorkflowState.cs
@@ -1,0 +1,34 @@
+using System.Text.Json.Serialization;
+
+namespace Altinn.App.Core.Internal.WorkflowEngine.Models;
+
+/// <summary>
+/// Tamper-evident envelope around the opaque workflow callback state blob.
+///
+/// The app both produces (at enqueue) and consumes (at callback) this blob; the engine only round-trips it
+/// opaquely. A detached HMAC-SHA256 signature — keyed by the per-app <c>WorkflowEngineCallback</c> app-code —
+/// binds the transported <see cref="Payload"/> to a secret only the app holds, so a leaked callback token
+/// alone can no longer be combined with a forged or tampered blob to drive ServiceOwner writes.
+/// </summary>
+internal sealed record SignedWorkflowState
+{
+    /// <summary>
+    /// The serialized <see cref="WorkflowCallbackState"/> JSON. The signature is computed over these exact
+    /// transmitted bytes (UTF-8), never over a re-serialized object, to avoid canonicalization drift.
+    /// </summary>
+    [JsonPropertyName("payload")]
+    public required string Payload { get; init; }
+
+    /// <summary>
+    /// Base64(HMACSHA256(key = UTF8(appCode.Code), data = UTF8(<see cref="Payload"/>))).
+    /// </summary>
+    [JsonPropertyName("signature")]
+    public required string Signature { get; init; }
+
+    /// <summary>
+    /// The id of the <c>WorkflowEngineCallback</c> app-code used to sign <see cref="Payload"/>. Used to select
+    /// the right validation secret during key rotation, mirroring the callback token validator.
+    /// </summary>
+    [JsonPropertyName("secretId")]
+    public required string SecretId { get; init; }
+}

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/WorkflowCallbackStateService.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/WorkflowCallbackStateService.cs
@@ -19,22 +19,25 @@ internal sealed class WorkflowCallbackStateService
     private readonly ModelSerializationService _modelSerializationService;
     private readonly IAppMetadata _appMetadata;
     private readonly IAppModel _appModel;
+    private readonly WorkflowStateSigner _stateSigner;
 
     public WorkflowCallbackStateService(
         InstanceDataUnitOfWorkInitializer unitOfWorkInitializer,
         ModelSerializationService modelSerializationService,
         IAppMetadata appMetadata,
-        IAppModel appModel
+        IAppModel appModel,
+        WorkflowStateSigner stateSigner
     )
     {
         _unitOfWorkInitializer = unitOfWorkInitializer;
         _modelSerializationService = modelSerializationService;
         _appMetadata = appMetadata;
         _appModel = appModel;
+        _stateSigner = stateSigner;
     }
 
     /// <summary>
-    /// Captures the current state of the unit of work into an opaque string for transport.
+    /// Captures the current state of the unit of work into an opaque, signed string for transport.
     /// </summary>
     public async Task<string> CaptureState(InstanceDataUnitOfWork unitOfWork)
     {
@@ -48,7 +51,8 @@ internal sealed class WorkflowCallbackStateService
             })
             .ToList();
         var callbackState = new WorkflowCallbackState { Instance = unitOfWork.Instance, FormData = formData };
-        return JsonSerializer.Serialize(callbackState);
+        string payload = JsonSerializer.Serialize(callbackState);
+        return _stateSigner.Sign(payload);
     }
 
     /// <summary>
@@ -66,8 +70,13 @@ internal sealed class WorkflowCallbackStateService
         string? language
     )
     {
+        // Verify the detached HMAC signature and unwrap the inner payload before trusting any of it. A leaked
+        // callback token cannot be combined with a forged/tampered blob: the inner payload is bound to a
+        // secret only the app holds. Any failure (tampering, unknown/expired secret) throws and maps to 422.
+        string payload = _stateSigner.Verify(state);
+
         WorkflowCallbackState callbackState =
-            JsonSerializer.Deserialize<WorkflowCallbackState>(state)
+            JsonSerializer.Deserialize<WorkflowCallbackState>(payload)
             ?? throw new WorkflowCallbackStateException(
                 "Failed to deserialize workflow callback state from callback payload"
             );

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/WorkflowStateSigner.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/WorkflowStateSigner.cs
@@ -1,0 +1,138 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Altinn.App.Core.Infrastructure.Clients.Secrets;
+using Altinn.App.Core.Internal.WorkflowEngine.Authentication;
+using Altinn.App.Core.Internal.WorkflowEngine.Models;
+
+namespace Altinn.App.Core.Internal.WorkflowEngine;
+
+/// <summary>
+/// Computes and verifies the detached HMAC-SHA256 signature that wraps the opaque workflow callback state
+/// blob. Capture and restore both go through this single helper so the two paths cannot diverge.
+/// </summary>
+internal sealed class WorkflowStateSigner
+{
+    // Mirror the callback token validator: a code that is itself expired (beyond this skew) must not validate
+    // a blob, so a leaked-but-still-mounted expired code stops being a usable signing boundary, and blob and
+    // token fail together during rotation.
+    private static readonly TimeSpan _clockSkew = TimeSpan.FromMinutes(5);
+
+    private readonly IWorkflowCallbackSecretProvider _secretProvider;
+    private readonly TimeProvider _timeProvider;
+
+    public WorkflowStateSigner(IWorkflowCallbackSecretProvider secretProvider, TimeProvider? timeProvider = null)
+    {
+        _secretProvider = secretProvider;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    /// <summary>
+    /// Wraps <paramref name="payload"/> in a signed envelope, signing the exact transmitted bytes with the
+    /// current signing code.
+    /// </summary>
+    public string Sign(string payload)
+    {
+        AppCode signingCode = _secretProvider.GetSigningSecret();
+        string signature = ComputeSignature(signingCode.Code, payload);
+        var envelope = new SignedWorkflowState
+        {
+            Payload = payload,
+            Signature = signature,
+            SecretId = signingCode.Id,
+        };
+        return JsonSerializer.Serialize(envelope);
+    }
+
+    /// <summary>
+    /// Verifies <paramref name="envelopeJson"/> and returns the inner payload string on success.
+    /// Throws <see cref="WorkflowCallbackStateException"/> on any failure (malformed envelope, unknown or
+    /// expired secret id, signature mismatch) — never reveals which check failed.
+    /// </summary>
+    public string Verify(string envelopeJson)
+    {
+        SignedWorkflowState envelope;
+        try
+        {
+            envelope =
+                JsonSerializer.Deserialize<SignedWorkflowState>(envelopeJson)
+                ?? throw new WorkflowCallbackStateException("Workflow callback state envelope deserialized to null.");
+        }
+        catch (JsonException ex)
+        {
+            throw new WorkflowCallbackStateException("Failed to deserialize workflow callback state envelope.", ex);
+        }
+
+        IReadOnlyList<AppCode> validationCodes;
+        try
+        {
+            validationCodes = _secretProvider.GetValidationSecrets();
+        }
+        catch (WorkflowCallbackSecretNotFoundException ex)
+        {
+            throw new WorkflowCallbackStateException(
+                "No workflow callback signing secret is available to verify the state envelope.",
+                ex
+            );
+        }
+
+        AppCode? code = null;
+        for (int i = 0; i < validationCodes.Count; i++)
+        {
+            if (validationCodes[i].Id == envelope.SecretId)
+            {
+                code = validationCodes[i];
+                break;
+            }
+        }
+
+        if (code is null)
+        {
+            throw new WorkflowCallbackStateException(
+                "Workflow callback state envelope references an unknown signing secret."
+            );
+        }
+
+        // Reject codes that are themselves expired (with the same clock skew the token validator applies), so
+        // the blob and the callback token fail together during rotation.
+        if (_timeProvider.GetUtcNow() > code.ExpiresAt + _clockSkew)
+        {
+            throw new WorkflowCallbackStateException(
+                "Workflow callback state envelope was signed with an expired secret."
+            );
+        }
+
+        string expected = ComputeSignature(code.Code, envelope.Payload);
+        if (!FixedTimeEquals(expected, envelope.Signature))
+        {
+            throw new WorkflowCallbackStateException("Workflow callback state envelope signature is invalid.");
+        }
+
+        return envelope.Payload;
+    }
+
+    private static string ComputeSignature(string secret, string payload)
+    {
+        byte[] key = Encoding.UTF8.GetBytes(secret);
+        byte[] data = Encoding.UTF8.GetBytes(payload);
+        byte[] hash = HMACSHA256.HashData(key, data);
+        return Convert.ToBase64String(hash);
+    }
+
+    private static bool FixedTimeEquals(string a, string b)
+    {
+        // Compare the raw signature bytes in constant time. Decoding failures (malformed Base64) are treated
+        // as a non-match rather than thrown, so a forged signature value cannot be distinguished by behavior.
+        Span<byte> bufferA = stackalloc byte[32];
+        Span<byte> bufferB = stackalloc byte[32];
+        if (
+            !Convert.TryFromBase64String(a, bufferA, out int writtenA)
+            || !Convert.TryFromBase64String(b, bufferB, out int writtenB)
+        )
+        {
+            return false;
+        }
+
+        return CryptographicOperations.FixedTimeEquals(bufferA[..writtenA], bufferB[..writtenB]);
+    }
+}

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/WorkflowStateSigner.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/WorkflowStateSigner.cs
@@ -76,22 +76,11 @@ internal sealed class WorkflowStateSigner
             );
         }
 
-        AppCode? code = null;
-        for (int i = 0; i < validationCodes.Count; i++)
-        {
-            if (validationCodes[i].Id == envelope.SecretId)
-            {
-                code = validationCodes[i];
-                break;
-            }
-        }
-
-        if (code is null)
-        {
-            throw new WorkflowCallbackStateException(
+        AppCode code =
+            validationCodes.FirstOrDefault(t => t.Id == envelope.SecretId)
+            ?? throw new WorkflowCallbackStateException(
                 "Workflow callback state envelope references an unknown signing secret."
             );
-        }
 
         // Reject codes that are themselves expired (with the same clock skew the token validator applies), so
         // the blob and the callback token fail together during rotation.

--- a/src/App/backend/test/Altinn.App.Api.Tests/Controllers/WorkflowEngineCallbackControllerAuthTests.cs
+++ b/src/App/backend/test/Altinn.App.Api.Tests/Controllers/WorkflowEngineCallbackControllerAuthTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using Altinn.App.Api.Tests.Data;
+using Altinn.App.Core.Internal.WorkflowEngine;
 using Altinn.App.Core.Internal.WorkflowEngine.Authentication;
 using Altinn.App.Core.Internal.WorkflowEngine.Commands;
 using Altinn.App.Core.Internal.WorkflowEngine.Models;
@@ -31,6 +32,13 @@ public class WorkflowEngineCallbackControllerAuthTests : ApiTestBase, IClassFixt
 
     private string GenerateToken(Guid instanceGuid) =>
         Services.GetRequiredService<IWorkflowCallbackTokenGenerator>().GenerateToken(instanceGuid);
+
+    /// <summary>
+    /// Produces a properly HMAC-signed state envelope around the given inner state, as the app would at enqueue
+    /// time. The callback controller verifies this signature before trusting any of the blob.
+    /// </summary>
+    private string SignState(WorkflowCallbackState state) =>
+        Services.GetRequiredService<WorkflowStateSigner>().Sign(JsonSerializer.Serialize(state));
 
     private static string CallbackUrl(Guid instanceGuid) =>
         $"{Org}/{App}/instances/{InstanceOwnerPartyId}/{instanceGuid}/workflow-engine-callbacks/some-command";
@@ -109,7 +117,97 @@ public class WorkflowEngineCallbackControllerAuthTests : ApiTestBase, IClassFixt
             Actor = new Actor { Language = "nb" },
             LockToken = "lock-token",
             WorkflowId = Guid.NewGuid(),
+            // Properly signed so the instance-mismatch check (not the signature check) is what rejects it.
+            State = SignState(new WorkflowCallbackState { Instance = stateInstance, FormData = [] }),
+        };
+        using var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+
+        using var response = await client.PostAsync(
+            $"{Org}/{App}/instances/{InstanceOwnerPartyId}/{routeInstanceGuid}/workflow-engine-callbacks/{MutateProcessState.Key}",
+            content
+        );
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Callback_WithUnsignedStateBlob_IsRejected()
+    {
+        // A leaked callback token combined with a hand-crafted (unsigned) state blob must not be honored:
+        // the HMAC envelope is missing, so verification fails and the controller returns a non-retryable 422.
+        var routeInstanceGuid = Guid.NewGuid();
+
+        using var client = GetRootedClient(Org, App);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Bearer",
+            GenerateToken(routeInstanceGuid)
+        );
+
+        var stateInstance = new Instance
+        {
+            Id = $"{InstanceOwnerPartyId}/{routeInstanceGuid}",
+            AppId = $"{Org}/{App}",
+            Org = Org,
+            InstanceOwner = new InstanceOwner { PartyId = InstanceOwnerPartyId.ToString() },
+            Data = [],
+        };
+        var payload = new AppCallbackPayload
+        {
+            CommandKey = MutateProcessState.Key,
+            Actor = new Actor { Language = "nb" },
+            LockToken = "lock-token",
+            WorkflowId = Guid.NewGuid(),
+            // Raw inner state, NOT wrapped in a signed envelope.
             State = JsonSerializer.Serialize(new WorkflowCallbackState { Instance = stateInstance, FormData = [] }),
+        };
+        using var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+
+        using var response = await client.PostAsync(
+            $"{Org}/{App}/instances/{InstanceOwnerPartyId}/{routeInstanceGuid}/workflow-engine-callbacks/{MutateProcessState.Key}",
+            content
+        );
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Callback_WithTamperedSignedStateBlob_IsRejected()
+    {
+        // Take a validly signed envelope, then mutate the signed payload bytes. The detached HMAC no longer
+        // matches, so the controller rejects it with a non-retryable 422.
+        var routeInstanceGuid = Guid.NewGuid();
+
+        using var client = GetRootedClient(Org, App);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Bearer",
+            GenerateToken(routeInstanceGuid)
+        );
+
+        var stateInstance = new Instance
+        {
+            Id = $"{InstanceOwnerPartyId}/{routeInstanceGuid}",
+            AppId = $"{Org}/{App}",
+            Org = Org,
+            InstanceOwner = new InstanceOwner { PartyId = InstanceOwnerPartyId.ToString() },
+            Data = [],
+        };
+        string signed = SignState(new WorkflowCallbackState { Instance = stateInstance, FormData = [] });
+        var envelope = JsonSerializer.Deserialize<SignedWorkflowState>(signed)!;
+        string tampered = JsonSerializer.Serialize(
+            envelope with
+            {
+                // Mutate the signed payload bytes; the detached HMAC will no longer match.
+                Payload = envelope.Payload.Replace(Org, "evil"),
+            }
+        );
+
+        var payload = new AppCallbackPayload
+        {
+            CommandKey = MutateProcessState.Key,
+            Actor = new Actor { Language = "nb" },
+            LockToken = "lock-token",
+            WorkflowId = Guid.NewGuid(),
+            State = tampered,
         };
         using var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
 

--- a/src/App/backend/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.cs
@@ -2636,7 +2636,22 @@ public sealed class ProcessEngineTest
             callbackTokenGeneratorMock.Setup(g => g.GenerateToken(It.IsAny<Guid>())).Returns("test-callback-token");
             services.TryAddTransient<IWorkflowCallbackTokenGenerator>(_ => callbackTokenGeneratorMock.Object);
 
+            // WorkflowCallbackStateService now signs the captured state with WorkflowStateSigner, which needs
+            // a callback secret. Provide a deterministic non-expired code so capture produces a real envelope.
+            var secretProviderMock = new Mock<IWorkflowCallbackSecretProvider>(MockBehavior.Strict);
+            var stateSigningCode = new Altinn.App.Core.Infrastructure.Clients.Secrets.AppCode
+            {
+                Id = "test-secret-id",
+                Code = "test-state-signing-secret-long-enough",
+                IssuedAt = DateTimeOffset.UtcNow.AddDays(-1),
+                ExpiresAt = DateTimeOffset.UtcNow.AddDays(186),
+            };
+            secretProviderMock.Setup(p => p.GetSigningSecret()).Returns(stateSigningCode);
+            secretProviderMock.Setup(p => p.GetValidationSecrets()).Returns([stateSigningCode]);
+            services.TryAddSingleton<IWorkflowCallbackSecretProvider>(_ => secretProviderMock.Object);
+
             services.TryAddTransient<ProcessNextRequestFactory>();
+            services.TryAddTransient<WorkflowStateSigner>();
             services.TryAddTransient<WorkflowCallbackStateService>();
 
             if (registerProcessEnd)

--- a/src/App/backend/test/Altinn.App.Core.Tests/Internal/WorkflowEngine/WorkflowStateSignerTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Internal/WorkflowEngine/WorkflowStateSignerTests.cs
@@ -1,0 +1,233 @@
+using System.Text.Json;
+using Altinn.App.Core.Infrastructure.Clients.Secrets;
+using Altinn.App.Core.Internal.WorkflowEngine;
+using Altinn.App.Core.Internal.WorkflowEngine.Authentication;
+using Altinn.App.Core.Internal.WorkflowEngine.Models;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+
+namespace Altinn.App.Core.Tests.Internal.WorkflowEngine;
+
+public class WorkflowStateSignerTests
+{
+    private const string Payload = """{"instance":{"id":"501337/abc"},"formData":[]}""";
+
+    private readonly Mock<IWorkflowCallbackSecretProvider> _secretProviderMock = new(MockBehavior.Strict);
+
+    private WorkflowStateSigner CreateSut(TimeProvider? timeProvider = null) =>
+        new(_secretProviderMock.Object, timeProvider);
+
+    private static AppCode Code(string id, string code, DateTimeOffset? expiresAt = null) =>
+        new()
+        {
+            Id = id,
+            Code = code,
+            IssuedAt = DateTimeOffset.UtcNow.AddDays(-1),
+            ExpiresAt = expiresAt ?? DateTimeOffset.UtcNow.AddDays(186),
+        };
+
+    [Fact]
+    public void SignThenVerify_RoundTrips_ReturnsOriginalPayload()
+    {
+        var code = Code("id-1", "secret-code-long-enough-for-hmac");
+        _secretProviderMock.Setup(x => x.GetSigningSecret()).Returns(code);
+        _secretProviderMock.Setup(x => x.GetValidationSecrets()).Returns([code]);
+        var sut = CreateSut();
+
+        string envelope = sut.Sign(Payload);
+        string restored = sut.Verify(envelope);
+
+        Assert.Equal(Payload, restored);
+    }
+
+    [Fact]
+    public void Sign_ProducesEnvelopeWithSecretIdAndExactPayload()
+    {
+        var code = Code("id-1", "secret-code-long-enough-for-hmac");
+        _secretProviderMock.Setup(x => x.GetSigningSecret()).Returns(code);
+        var sut = CreateSut();
+
+        string envelopeJson = sut.Sign(Payload);
+        var envelope = JsonSerializer.Deserialize<SignedWorkflowState>(envelopeJson);
+
+        Assert.NotNull(envelope);
+        Assert.Equal("id-1", envelope.SecretId);
+        // Signed over the exact transmitted payload bytes, never a re-serialized object.
+        Assert.Equal(Payload, envelope.Payload);
+        Assert.False(string.IsNullOrEmpty(envelope.Signature));
+    }
+
+    [Fact]
+    public void Verify_TamperedPayload_Throws()
+    {
+        var code = Code("id-1", "secret-code-long-enough-for-hmac");
+        _secretProviderMock.Setup(x => x.GetSigningSecret()).Returns(code);
+        _secretProviderMock.Setup(x => x.GetValidationSecrets()).Returns([code]);
+        var sut = CreateSut();
+
+        var envelope = JsonSerializer.Deserialize<SignedWorkflowState>(sut.Sign(Payload))!;
+        // Keep the original (valid) signature but swap in a different payload.
+        string tampered = JsonSerializer.Serialize(
+            envelope with
+            {
+                Payload = """{"instance":{"id":"501337/EVIL"},"formData":[]}""",
+            }
+        );
+
+        Assert.Throws<WorkflowCallbackStateException>(() => sut.Verify(tampered));
+    }
+
+    [Fact]
+    public void Verify_TamperedSignature_Throws()
+    {
+        var code = Code("id-1", "secret-code-long-enough-for-hmac");
+        _secretProviderMock.Setup(x => x.GetSigningSecret()).Returns(code);
+        _secretProviderMock.Setup(x => x.GetValidationSecrets()).Returns([code]);
+        var sut = CreateSut();
+
+        var envelope = JsonSerializer.Deserialize<SignedWorkflowState>(sut.Sign(Payload))!;
+        // Valid Base64 of the wrong length/content — must be rejected, not throw on decode.
+        string tampered = JsonSerializer.Serialize(envelope with { Signature = Convert.ToBase64String(new byte[32]) });
+
+        Assert.Throws<WorkflowCallbackStateException>(() => sut.Verify(tampered));
+    }
+
+    [Fact]
+    public void Verify_MalformedBase64Signature_Throws()
+    {
+        var code = Code("id-1", "secret-code-long-enough-for-hmac");
+        _secretProviderMock.Setup(x => x.GetSigningSecret()).Returns(code);
+        _secretProviderMock.Setup(x => x.GetValidationSecrets()).Returns([code]);
+        var sut = CreateSut();
+
+        var envelope = JsonSerializer.Deserialize<SignedWorkflowState>(sut.Sign(Payload))!;
+        string tampered = JsonSerializer.Serialize(envelope with { Signature = "!!!not-base64!!!" });
+
+        Assert.Throws<WorkflowCallbackStateException>(() => sut.Verify(tampered));
+    }
+
+    [Fact]
+    public void Verify_UnknownSecretId_Throws()
+    {
+        var signingCode = Code("id-1", "secret-code-long-enough-for-hmac");
+        _secretProviderMock.Setup(x => x.GetSigningSecret()).Returns(signingCode);
+        // Validation set has a different id only.
+        _secretProviderMock.Setup(x => x.GetValidationSecrets()).Returns([Code("id-other", "other-code-long-enough")]);
+        var sut = CreateSut();
+
+        string envelope = sut.Sign(Payload);
+
+        Assert.Throws<WorkflowCallbackStateException>(() => sut.Verify(envelope));
+    }
+
+    [Fact]
+    public void Verify_MissingSecretId_Throws()
+    {
+        var code = Code("id-1", "secret-code-long-enough-for-hmac");
+        _secretProviderMock.Setup(x => x.GetValidationSecrets()).Returns([code]);
+        var sut = CreateSut();
+
+        // Hand-built envelope with no matching secret id.
+        string envelope = JsonSerializer.Serialize(
+            new SignedWorkflowState
+            {
+                Payload = Payload,
+                Signature = Convert.ToBase64String(new byte[32]),
+                SecretId = "",
+            }
+        );
+
+        Assert.Throws<WorkflowCallbackStateException>(() => sut.Verify(envelope));
+    }
+
+    [Fact]
+    public void Verify_MalformedEnvelope_Throws()
+    {
+        var code = Code("id-1", "secret-code-long-enough-for-hmac");
+        _secretProviderMock.Setup(x => x.GetValidationSecrets()).Returns([code]);
+        var sut = CreateSut();
+
+        Assert.Throws<WorkflowCallbackStateException>(() => sut.Verify("not json at all"));
+    }
+
+    [Fact]
+    public void Verify_ExpiredSecretBeyondClockSkew_Throws()
+    {
+        var now = new DateTimeOffset(2025, 6, 1, 12, 0, 0, TimeSpan.Zero);
+        // Signed while valid; verified after the code expired beyond the 5-minute skew.
+        var signingCode = Code("id-1", "secret-code-long-enough-for-hmac", expiresAt: now.AddMinutes(-6));
+        _secretProviderMock.Setup(x => x.GetSigningSecret()).Returns(signingCode);
+        _secretProviderMock.Setup(x => x.GetValidationSecrets()).Returns([signingCode]);
+        var sut = CreateSut(new FakeTimeProvider(now));
+
+        string envelope = sut.Sign(Payload);
+
+        Assert.Throws<WorkflowCallbackStateException>(() => sut.Verify(envelope));
+    }
+
+    [Fact]
+    public void Verify_ExpiredSecretWithinClockSkew_Succeeds()
+    {
+        var now = new DateTimeOffset(2025, 6, 1, 12, 0, 0, TimeSpan.Zero);
+        // Expired 4 minutes ago — inside the 5-minute clock skew, so still accepted.
+        var signingCode = Code("id-1", "secret-code-long-enough-for-hmac", expiresAt: now.AddMinutes(-4));
+        _secretProviderMock.Setup(x => x.GetSigningSecret()).Returns(signingCode);
+        _secretProviderMock.Setup(x => x.GetValidationSecrets()).Returns([signingCode]);
+        var sut = CreateSut(new FakeTimeProvider(now));
+
+        string envelope = sut.Sign(Payload);
+
+        Assert.Equal(Payload, sut.Verify(envelope));
+    }
+
+    [Fact]
+    public void Verify_RotationOverlap_OldCodeStillValidates()
+    {
+        // Signed with the old code; by callback time a new code has been prepended (rotation), but the old
+        // code is still mounted and not expired, so the blob still verifies.
+        var oldCode = Code("id-old", "old-secret-code-long-enough-hmac");
+        var newCode = Code("id-new", "new-secret-code-long-enough-hmac");
+        _secretProviderMock.Setup(x => x.GetSigningSecret()).Returns(oldCode);
+        _secretProviderMock.Setup(x => x.GetValidationSecrets()).Returns([newCode, oldCode]);
+        var sut = CreateSut();
+
+        string envelope = sut.Sign(Payload);
+
+        Assert.Equal(Payload, sut.Verify(envelope));
+    }
+
+    [Fact]
+    public void Verify_DifferentSecretSameId_Throws()
+    {
+        // Same id but a rotated secret value (an attacker cannot forge under a fresh secret).
+        _secretProviderMock.Setup(x => x.GetSigningSecret()).Returns(Code("id-1", "original-secret-long-enough-ok"));
+        _secretProviderMock
+            .Setup(x => x.GetValidationSecrets())
+            .Returns([Code("id-1", "rotated-secret-long-enough-ok")]);
+        var sut = CreateSut();
+
+        string envelope = sut.Sign(Payload);
+
+        Assert.Throws<WorkflowCallbackStateException>(() => sut.Verify(envelope));
+    }
+
+    [Fact]
+    public void Verify_NoSecretsConfigured_Throws()
+    {
+        _secretProviderMock
+            .Setup(x => x.GetValidationSecrets())
+            .Throws(new WorkflowCallbackSecretNotFoundException("no codes"));
+        var sut = CreateSut();
+
+        string envelope = JsonSerializer.Serialize(
+            new SignedWorkflowState
+            {
+                Payload = Payload,
+                Signature = Convert.ToBase64String(new byte[32]),
+                SecretId = "id-1",
+            }
+        );
+
+        Assert.Throws<WorkflowCallbackStateException>(() => sut.Verify(envelope));
+    }
+}


### PR DESCRIPTION
## Summary

Implements finding **2.2A** from the #18735 review.

The workflow-engine callback state blob was previously **plaintext, unsigned JSON**. The app both produces it (at enqueue) and consumes it (at callback); the engine only round-trips it opaquely. This means a leaked callback token could be combined with a **forged or tampered blob** to drive ServiceOwner writes against an instance — the token authenticates the caller, but nothing bound the blob's contents to a secret only the app holds.

This PR adds a detached HMAC-SHA256 signature over the blob.