### PR TITLE
refactor: tidy workflow-engine public API surface

### DIFF
--- a/src/App/backend/src/Altinn.App.Api/Controllers/WorkflowEngineCallbackController.cs
+++ b/src/App/backend/src/Altinn.App.Api/Controllers/WorkflowEngineCallbackController.cs
@@ -181,8 +181,17 @@ public class WorkflowEngineCallbackController : ControllerBase
                     string collectionKey = Request.Headers[CollectionKeyHeader].ToString();
                     if (string.IsNullOrWhiteSpace(collectionKey))
                     {
-                        throw new InvalidOperationException(
-                            "Workflow callback is missing Collection-Key header required for auto-advance process next."
+                        _logger.LogError(
+                            "Workflow callback is missing the '{Header}' header required for auto-advance. CommandKey: {CommandKey}, Instance: {InstanceId}.",
+                            CollectionKeyHeader,
+                            commandKey,
+                            instanceId
+                        );
+                        activity?.SetStatus(ActivityStatusCode.Error, "Missing Collection-Key header");
+                        return NonRetryableProblem(
+                            "Missing Collection-Key",
+                            "Workflow callback is missing the Collection-Key header required for auto-advance process next.",
+                            StatusCodes.Status422UnprocessableEntity
                         );
                     }
 

--- a/src/App/backend/src/Altinn.App.Core/Features/Process/HookResult.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Process/HookResult.cs
@@ -1,9 +1,63 @@
 namespace Altinn.App.Core.Features.Process;
 
 /// <summary>
-/// Base type for task hook execution results.
+/// Base type for task hook execution results. Construct via <see cref="Success"/>,
+/// <see cref="FailedRetryable"/>, or <see cref="FailedPermanent"/>.
 /// </summary>
-public abstract record HookResult { }
+public abstract record HookResult
+{
+    /// <summary>
+    /// Creates a result representing successful hook execution.
+    /// </summary>
+    public static SuccessfulHookResult Success() => new();
+
+    /// <summary>
+    /// Creates a retryable failure. The workflow engine will retry the step with backoff.
+    /// Use this for transient errors (external service down, timeout, rate limit, etc.).
+    /// </summary>
+    /// <param name="errorMessage">Human-readable error message describing the failure.</param>
+    public static FailedHookResult FailedRetryable(string errorMessage)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(errorMessage);
+        return new FailedHookResult { ErrorMessage = errorMessage, Kind = FailureKind.Retryable };
+    }
+
+    /// <summary>
+    /// Creates a permanent (non-retryable) failure. The workflow engine will stop retrying
+    /// and mark the step as failed immediately.
+    /// Use this for errors that won't resolve by retrying (validation failure, missing config, bad data, etc.).
+    /// </summary>
+    /// <param name="errorMessage">Human-readable error message describing the failure.</param>
+    public static FailedHookResult FailedPermanent(string errorMessage)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(errorMessage);
+        return new FailedHookResult { ErrorMessage = errorMessage, Kind = FailureKind.Permanent };
+    }
+}
+
+/// <summary>
+/// Represents a successful hook execution.
+/// </summary>
+public sealed record SuccessfulHookResult : HookResult;
+
+/// <summary>
+/// Represents a failed hook execution. Construct via <see cref="HookResult.FailedRetryable"/>
+/// or <see cref="HookResult.FailedPermanent"/>.
+/// </summary>
+public sealed record FailedHookResult : HookResult
+{
+    internal FailedHookResult() { }
+
+    /// <summary>
+    /// Human-readable error message describing the failure.
+    /// </summary>
+    public required string ErrorMessage { get; init; }
+
+    /// <summary>
+    /// Whether the failure is retryable or permanent.
+    /// </summary>
+    internal FailureKind Kind { get; init; }
+}
 
 /// <summary>
 /// Classifies how a failed hook or service task result should be handled by the workflow engine.

--- a/src/App/backend/src/Altinn.App.Core/Features/Process/HookResult.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Process/HookResult.cs
@@ -4,3 +4,19 @@ namespace Altinn.App.Core.Features.Process;
 /// Base type for task hook execution results.
 /// </summary>
 public abstract record HookResult { }
+
+/// <summary>
+/// Classifies how a failed hook or service task result should be handled by the workflow engine.
+/// </summary>
+internal enum FailureKind
+{
+    /// <summary>
+    /// The failure is transient. The workflow engine will retry the step with backoff.
+    /// </summary>
+    Retryable,
+
+    /// <summary>
+    /// The failure is permanent. The workflow engine will stop retrying and mark the step as failed.
+    /// </summary>
+    Permanent,
+}

--- a/src/App/backend/src/Altinn.App.Core/Features/Process/IOnProcessEndingHandler.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Process/IOnProcessEndingHandler.cs
@@ -14,7 +14,7 @@ public interface IOnProcessEndingHandler
     /// </summary>
     /// <param name="context">A context object with relevant parameters and data.</param>
     /// <returns>An end process result indicating success or failure.</returns>
-    public Task<OnProcessEndingHandlerResult> ExecuteAsync(OnProcessEndingHandlerContext context);
+    public Task<OnProcessEndingHandlerResult> Execute(OnProcessEndingHandlerContext context);
 }
 
 /// <summary>

--- a/src/App/backend/src/Altinn.App.Core/Features/Process/IOnProcessEndingHandler.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Process/IOnProcessEndingHandler.cs
@@ -18,8 +18,11 @@ public interface IOnProcessEndingHandler
     /// Executes the end process hook logic.
     /// </summary>
     /// <param name="context">A context object with relevant parameters and data.</param>
-    /// <returns>An end process result indicating success or failure.</returns>
-    public Task<OnProcessEndingResult> Execute(OnProcessEndingContext context);
+    /// <returns>
+    /// A result indicating success or failure. Construct via <see cref="HookResult.Success"/>,
+    /// <see cref="HookResult.FailedRetryable"/>, or <see cref="HookResult.FailedPermanent"/>.
+    /// </returns>
+    public Task<HookResult> Execute(OnProcessEndingContext context);
 }
 
 /// <summary>
@@ -36,62 +39,4 @@ public sealed class OnProcessEndingContext
     /// Cancellation token for the hook execution.
     /// </summary>
     public CancellationToken CancellationToken { get; init; } = CancellationToken.None;
-}
-
-/// <summary>
-/// Base type for end process hook execution results.
-/// </summary>
-public abstract record OnProcessEndingResult : HookResult
-{
-    /// <summary>
-    /// Creates a result representing successful hook execution.
-    /// </summary>
-    public static SuccessfulOnProcessEndingResult Success() => new();
-
-    /// <summary>
-    /// Creates a retryable failure. The workflow engine will retry the step with backoff.
-    /// Use this for transient errors (external service down, timeout, rate limit, etc.).
-    /// </summary>
-    /// <param name="errorMessage">Human-readable error message describing the failure.</param>
-    public static FailedOnProcessEndingResult FailedRetryable(string errorMessage)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(errorMessage);
-        return new FailedOnProcessEndingResult { ErrorMessage = errorMessage, Kind = FailureKind.Retryable };
-    }
-
-    /// <summary>
-    /// Creates a permanent (non-retryable) failure. The workflow engine will stop retrying
-    /// and mark the step as failed immediately.
-    /// Use this for errors that won't resolve by retrying (validation failure, missing config, bad data, etc.).
-    /// </summary>
-    /// <param name="errorMessage">Human-readable error message describing the failure.</param>
-    public static FailedOnProcessEndingResult FailedPermanent(string errorMessage)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(errorMessage);
-        return new FailedOnProcessEndingResult { ErrorMessage = errorMessage, Kind = FailureKind.Permanent };
-    }
-}
-
-/// <summary>
-/// Represents a successful end process hook execution.
-/// </summary>
-public sealed record SuccessfulOnProcessEndingResult : OnProcessEndingResult;
-
-/// <summary>
-/// Represents a failed end process hook execution. Construct via
-/// <see cref="OnProcessEndingResult.FailedRetryable"/> or <see cref="OnProcessEndingResult.FailedPermanent"/>.
-/// </summary>
-public sealed record FailedOnProcessEndingResult : OnProcessEndingResult
-{
-    internal FailedOnProcessEndingResult() { }
-
-    /// <summary>
-    /// Human-readable error message describing the failure.
-    /// </summary>
-    public required string ErrorMessage { get; init; }
-
-    /// <summary>
-    /// Whether the failure is retryable or permanent.
-    /// </summary>
-    internal FailureKind Kind { get; init; }
 }

--- a/src/App/backend/src/Altinn.App.Core/Features/Process/IOnProcessEndingHandler.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Process/IOnProcessEndingHandler.cs
@@ -14,13 +14,13 @@ public interface IOnProcessEndingHandler
     /// </summary>
     /// <param name="context">A context object with relevant parameters and data.</param>
     /// <returns>An end process result indicating success or failure.</returns>
-    public Task<OnProcessEndingHandlerResult> Execute(OnProcessEndingHandlerContext context);
+    public Task<OnProcessEndingResult> Execute(OnProcessEndingContext context);
 }
 
 /// <summary>
 /// Parameters for end process hook execution.
 /// </summary>
-public sealed class OnProcessEndingHandlerContext
+public sealed class OnProcessEndingContext
 {
     /// <summary>
     /// An instance data mutator that can be used to access and modify instance data. Changes made will be automatically saved if the hook execution is successful.
@@ -36,19 +36,19 @@ public sealed class OnProcessEndingHandlerContext
 /// <summary>
 /// Base type for end process hook execution results.
 /// </summary>
-public abstract record OnProcessEndingHandlerResult : HookResult
+public abstract record OnProcessEndingResult : HookResult
 {
     /// <summary>
     /// Creates a result representing successful hook execution.
     /// </summary>
-    public static SuccessfulOnProcessEndingHandlerResult Success() => new();
+    public static SuccessfulOnProcessEndingResult Success() => new();
 
     /// <summary>
     /// Creates a retryable failure. The workflow engine will retry the step with backoff.
     /// Use this for transient errors (external service down, timeout, rate limit, etc.).
     /// </summary>
     /// <param name="errorMessage">Human-readable error message describing the failure.</param>
-    public static FailedOnProcessEndingHandlerResult FailedRetryable(string errorMessage) =>
+    public static FailedOnProcessEndingResult FailedRetryable(string errorMessage) =>
         new(errorMessage, NonRetryable: false);
 
     /// <summary>
@@ -57,14 +57,14 @@ public abstract record OnProcessEndingHandlerResult : HookResult
     /// Use this for errors that won't resolve by retrying (validation failure, missing config, bad data, etc.).
     /// </summary>
     /// <param name="errorMessage">Human-readable error message describing the failure.</param>
-    public static FailedOnProcessEndingHandlerResult FailedPermanent(string errorMessage) =>
+    public static FailedOnProcessEndingResult FailedPermanent(string errorMessage) =>
         new(errorMessage, NonRetryable: true);
 }
 
 /// <summary>
 /// Represents a successful end process hook execution.
 /// </summary>
-public sealed record SuccessfulOnProcessEndingHandlerResult : OnProcessEndingHandlerResult;
+public sealed record SuccessfulOnProcessEndingResult : OnProcessEndingResult;
 
 /// <summary>
 /// Represents a failed end process hook execution.
@@ -74,5 +74,4 @@ public sealed record SuccessfulOnProcessEndingHandlerResult : OnProcessEndingHan
 /// If true, the workflow engine will not retry this step (permanent failure).
 /// If false, the workflow engine will retry with backoff (transient failure).
 /// </param>
-public sealed record FailedOnProcessEndingHandlerResult(string ErrorMessage, bool NonRetryable)
-    : OnProcessEndingHandlerResult;
+public sealed record FailedOnProcessEndingResult(string ErrorMessage, bool NonRetryable) : OnProcessEndingResult;

--- a/src/App/backend/src/Altinn.App.Core/Features/Process/IOnProcessEndingHandler.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Process/IOnProcessEndingHandler.cs
@@ -4,7 +4,12 @@ namespace Altinn.App.Core.Features.Process;
 /// Hook interface for custom end process logic.
 /// </summary>
 /// <remarks>
-/// <strong>IMPORTANT: Implementations MUST be idempotent - this hook may be retried on failure.</strong>
+/// <para><strong>IMPORTANT: Implementations MUST be idempotent - this hook may be retried on failure.</strong></para>
+/// <para>
+/// Unlike the legacy <c>IProcessEnd</c>, this hook does not receive a <c>List&lt;InstanceEvent&gt;</c>. This is
+/// intentional: under the per-callback workflow-engine model there is no in-memory events list to mutate, so the
+/// parameter was dropped deliberately rather than overlooked.
+/// </para>
 /// </remarks>
 [ImplementableByApps]
 public interface IOnProcessEndingHandler

--- a/src/App/backend/src/Altinn.App.Core/Features/Process/IOnProcessEndingHandler.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Process/IOnProcessEndingHandler.cs
@@ -48,8 +48,11 @@ public abstract record OnProcessEndingResult : HookResult
     /// Use this for transient errors (external service down, timeout, rate limit, etc.).
     /// </summary>
     /// <param name="errorMessage">Human-readable error message describing the failure.</param>
-    public static FailedOnProcessEndingResult FailedRetryable(string errorMessage) =>
-        new(errorMessage, NonRetryable: false);
+    public static FailedOnProcessEndingResult FailedRetryable(string errorMessage)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(errorMessage);
+        return new FailedOnProcessEndingResult { ErrorMessage = errorMessage, Kind = FailureKind.Retryable };
+    }
 
     /// <summary>
     /// Creates a permanent (non-retryable) failure. The workflow engine will stop retrying
@@ -57,8 +60,11 @@ public abstract record OnProcessEndingResult : HookResult
     /// Use this for errors that won't resolve by retrying (validation failure, missing config, bad data, etc.).
     /// </summary>
     /// <param name="errorMessage">Human-readable error message describing the failure.</param>
-    public static FailedOnProcessEndingResult FailedPermanent(string errorMessage) =>
-        new(errorMessage, NonRetryable: true);
+    public static FailedOnProcessEndingResult FailedPermanent(string errorMessage)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(errorMessage);
+        return new FailedOnProcessEndingResult { ErrorMessage = errorMessage, Kind = FailureKind.Permanent };
+    }
 }
 
 /// <summary>
@@ -67,11 +73,20 @@ public abstract record OnProcessEndingResult : HookResult
 public sealed record SuccessfulOnProcessEndingResult : OnProcessEndingResult;
 
 /// <summary>
-/// Represents a failed end process hook execution.
+/// Represents a failed end process hook execution. Construct via
+/// <see cref="OnProcessEndingResult.FailedRetryable"/> or <see cref="OnProcessEndingResult.FailedPermanent"/>.
 /// </summary>
-/// <param name="ErrorMessage">Human-readable error message describing the failure.</param>
-/// <param name="NonRetryable">
-/// If true, the workflow engine will not retry this step (permanent failure).
-/// If false, the workflow engine will retry with backoff (transient failure).
-/// </param>
-public sealed record FailedOnProcessEndingResult(string ErrorMessage, bool NonRetryable) : OnProcessEndingResult;
+public sealed record FailedOnProcessEndingResult : OnProcessEndingResult
+{
+    internal FailedOnProcessEndingResult() { }
+
+    /// <summary>
+    /// Human-readable error message describing the failure.
+    /// </summary>
+    public required string ErrorMessage { get; init; }
+
+    /// <summary>
+    /// Whether the failure is retryable or permanent.
+    /// </summary>
+    internal FailureKind Kind { get; init; }
+}

--- a/src/App/backend/src/Altinn.App.Core/Features/Process/IOnTaskAbandonHandler.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Process/IOnTaskAbandonHandler.cs
@@ -55,8 +55,11 @@ public abstract record OnTaskAbandonResult : HookResult
     /// Use this for transient errors (external service down, timeout, rate limit, etc.).
     /// </summary>
     /// <param name="errorMessage">Human-readable error message describing the failure.</param>
-    public static FailedOnTaskAbandonResult FailedRetryable(string errorMessage) =>
-        new(errorMessage, NonRetryable: false);
+    public static FailedOnTaskAbandonResult FailedRetryable(string errorMessage)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(errorMessage);
+        return new FailedOnTaskAbandonResult { ErrorMessage = errorMessage, Kind = FailureKind.Retryable };
+    }
 
     /// <summary>
     /// Creates a permanent (non-retryable) failure. The workflow engine will stop retrying
@@ -64,8 +67,11 @@ public abstract record OnTaskAbandonResult : HookResult
     /// Use this for errors that won't resolve by retrying (validation failure, missing config, bad data, etc.).
     /// </summary>
     /// <param name="errorMessage">Human-readable error message describing the failure.</param>
-    public static FailedOnTaskAbandonResult FailedPermanent(string errorMessage) =>
-        new(errorMessage, NonRetryable: true);
+    public static FailedOnTaskAbandonResult FailedPermanent(string errorMessage)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(errorMessage);
+        return new FailedOnTaskAbandonResult { ErrorMessage = errorMessage, Kind = FailureKind.Permanent };
+    }
 }
 
 /// <summary>
@@ -74,11 +80,20 @@ public abstract record OnTaskAbandonResult : HookResult
 public sealed record SuccessfulOnTaskAbandonResult : OnTaskAbandonResult;
 
 /// <summary>
-/// Represents a failed abandon task hook execution.
+/// Represents a failed abandon task hook execution. Construct via
+/// <see cref="OnTaskAbandonResult.FailedRetryable"/> or <see cref="OnTaskAbandonResult.FailedPermanent"/>.
 /// </summary>
-/// <param name="ErrorMessage">Human-readable error message describing the failure.</param>
-/// <param name="NonRetryable">
-/// If true, the workflow engine will not retry this step (permanent failure).
-/// If false, the workflow engine will retry with backoff (transient failure).
-/// </param>
-public sealed record FailedOnTaskAbandonResult(string ErrorMessage, bool NonRetryable) : OnTaskAbandonResult;
+public sealed record FailedOnTaskAbandonResult : OnTaskAbandonResult
+{
+    internal FailedOnTaskAbandonResult() { }
+
+    /// <summary>
+    /// Human-readable error message describing the failure.
+    /// </summary>
+    public required string ErrorMessage { get; init; }
+
+    /// <summary>
+    /// Whether the failure is retryable or permanent.
+    /// </summary>
+    internal FailureKind Kind { get; init; }
+}

--- a/src/App/backend/src/Altinn.App.Core/Features/Process/IOnTaskAbandonHandler.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Process/IOnTaskAbandonHandler.cs
@@ -21,13 +21,13 @@ public interface IOnTaskAbandonHandler
     /// </summary>
     /// <param name="context">A context object with relevant parameters and data.</param>
     /// <returns>An abandon task result indicating success or failure.</returns>
-    public Task<OnAbandonHandlerResult> Execute(OnTaskAbandonHandlerContext context);
+    public Task<OnTaskAbandonResult> Execute(OnTaskAbandonContext context);
 }
 
 /// <summary>
 /// Parameters for abandon task hook execution.
 /// </summary>
-public sealed class OnTaskAbandonHandlerContext
+public sealed class OnTaskAbandonContext
 {
     /// <summary>
     /// An instance data mutator that can be used to access and modify instance data. Changes made will be automatically saved if the hook execution is successful.
@@ -43,19 +43,19 @@ public sealed class OnTaskAbandonHandlerContext
 /// <summary>
 /// Base type for abandon task hook execution results.
 /// </summary>
-public abstract record OnAbandonHandlerResult : HookResult
+public abstract record OnTaskAbandonResult : HookResult
 {
     /// <summary>
     /// Creates a result representing successful hook execution.
     /// </summary>
-    public static SuccessfulOnAbandonHandlerResult Success() => new();
+    public static SuccessfulOnTaskAbandonResult Success() => new();
 
     /// <summary>
     /// Creates a retryable failure. The workflow engine will retry the step with backoff.
     /// Use this for transient errors (external service down, timeout, rate limit, etc.).
     /// </summary>
     /// <param name="errorMessage">Human-readable error message describing the failure.</param>
-    public static FailedOnTaskAbandonHandlerResult FailedRetryable(string errorMessage) =>
+    public static FailedOnTaskAbandonResult FailedRetryable(string errorMessage) =>
         new(errorMessage, NonRetryable: false);
 
     /// <summary>
@@ -64,14 +64,14 @@ public abstract record OnAbandonHandlerResult : HookResult
     /// Use this for errors that won't resolve by retrying (validation failure, missing config, bad data, etc.).
     /// </summary>
     /// <param name="errorMessage">Human-readable error message describing the failure.</param>
-    public static FailedOnTaskAbandonHandlerResult FailedPermanent(string errorMessage) =>
+    public static FailedOnTaskAbandonResult FailedPermanent(string errorMessage) =>
         new(errorMessage, NonRetryable: true);
 }
 
 /// <summary>
 /// Represents a successful abandon task hook execution.
 /// </summary>
-public sealed record SuccessfulOnAbandonHandlerResult : OnAbandonHandlerResult;
+public sealed record SuccessfulOnTaskAbandonResult : OnTaskAbandonResult;
 
 /// <summary>
 /// Represents a failed abandon task hook execution.
@@ -81,4 +81,4 @@ public sealed record SuccessfulOnAbandonHandlerResult : OnAbandonHandlerResult;
 /// If true, the workflow engine will not retry this step (permanent failure).
 /// If false, the workflow engine will retry with backoff (transient failure).
 /// </param>
-public sealed record FailedOnTaskAbandonHandlerResult(string ErrorMessage, bool NonRetryable) : OnAbandonHandlerResult;
+public sealed record FailedOnTaskAbandonResult(string ErrorMessage, bool NonRetryable) : OnTaskAbandonResult;

--- a/src/App/backend/src/Altinn.App.Core/Features/Process/IOnTaskAbandonHandler.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Process/IOnTaskAbandonHandler.cs
@@ -21,7 +21,7 @@ public interface IOnTaskAbandonHandler
     /// </summary>
     /// <param name="context">A context object with relevant parameters and data.</param>
     /// <returns>An abandon task result indicating success or failure.</returns>
-    public Task<OnAbandonHandlerResult> ExecuteAsync(OnTaskAbandonHandlerContext context);
+    public Task<OnAbandonHandlerResult> Execute(OnTaskAbandonHandlerContext context);
 }
 
 /// <summary>

--- a/src/App/backend/src/Altinn.App.Core/Features/Process/IOnTaskAbandonHandler.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Process/IOnTaskAbandonHandler.cs
@@ -20,8 +20,11 @@ public interface IOnTaskAbandonHandler
     /// Executes the abandon task hook logic.
     /// </summary>
     /// <param name="context">A context object with relevant parameters and data.</param>
-    /// <returns>An abandon task result indicating success or failure.</returns>
-    public Task<OnTaskAbandonResult> Execute(OnTaskAbandonContext context);
+    /// <returns>
+    /// A result indicating success or failure. Construct via <see cref="HookResult.Success"/>,
+    /// <see cref="HookResult.FailedRetryable"/>, or <see cref="HookResult.FailedPermanent"/>.
+    /// </returns>
+    public Task<HookResult> Execute(OnTaskAbandonContext context);
 }
 
 /// <summary>
@@ -44,62 +47,4 @@ public sealed class OnTaskAbandonContext
     /// Cancellation token for the hook execution.
     /// </summary>
     public CancellationToken CancellationToken { get; init; } = CancellationToken.None;
-}
-
-/// <summary>
-/// Base type for abandon task hook execution results.
-/// </summary>
-public abstract record OnTaskAbandonResult : HookResult
-{
-    /// <summary>
-    /// Creates a result representing successful hook execution.
-    /// </summary>
-    public static SuccessfulOnTaskAbandonResult Success() => new();
-
-    /// <summary>
-    /// Creates a retryable failure. The workflow engine will retry the step with backoff.
-    /// Use this for transient errors (external service down, timeout, rate limit, etc.).
-    /// </summary>
-    /// <param name="errorMessage">Human-readable error message describing the failure.</param>
-    public static FailedOnTaskAbandonResult FailedRetryable(string errorMessage)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(errorMessage);
-        return new FailedOnTaskAbandonResult { ErrorMessage = errorMessage, Kind = FailureKind.Retryable };
-    }
-
-    /// <summary>
-    /// Creates a permanent (non-retryable) failure. The workflow engine will stop retrying
-    /// and mark the step as failed immediately.
-    /// Use this for errors that won't resolve by retrying (validation failure, missing config, bad data, etc.).
-    /// </summary>
-    /// <param name="errorMessage">Human-readable error message describing the failure.</param>
-    public static FailedOnTaskAbandonResult FailedPermanent(string errorMessage)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(errorMessage);
-        return new FailedOnTaskAbandonResult { ErrorMessage = errorMessage, Kind = FailureKind.Permanent };
-    }
-}
-
-/// <summary>
-/// Represents a successful abandon task hook execution.
-/// </summary>
-public sealed record SuccessfulOnTaskAbandonResult : OnTaskAbandonResult;
-
-/// <summary>
-/// Represents a failed abandon task hook execution. Construct via
-/// <see cref="OnTaskAbandonResult.FailedRetryable"/> or <see cref="OnTaskAbandonResult.FailedPermanent"/>.
-/// </summary>
-public sealed record FailedOnTaskAbandonResult : OnTaskAbandonResult
-{
-    internal FailedOnTaskAbandonResult() { }
-
-    /// <summary>
-    /// Human-readable error message describing the failure.
-    /// </summary>
-    public required string ErrorMessage { get; init; }
-
-    /// <summary>
-    /// Whether the failure is retryable or permanent.
-    /// </summary>
-    internal FailureKind Kind { get; init; }
 }

--- a/src/App/backend/src/Altinn.App.Core/Features/Process/IOnTaskAbandonHandler.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Process/IOnTaskAbandonHandler.cs
@@ -30,6 +30,12 @@ public interface IOnTaskAbandonHandler
 public sealed class OnTaskAbandonContext
 {
     /// <summary>
+    /// The ID of the task this hook is running for (the task being abandoned).
+    /// Matches the <c>taskId</c> passed to <see cref="IOnTaskAbandonHandler.ShouldRunForTask"/>.
+    /// </summary>
+    public required string TaskId { get; init; }
+
+    /// <summary>
     /// An instance data mutator that can be used to access and modify instance data. Changes made will be automatically saved if the hook execution is successful.
     /// </summary>
     public required IInstanceDataMutator InstanceDataMutator { get; init; }

--- a/src/App/backend/src/Altinn.App.Core/Features/Process/IOnTaskEndingHandler.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Process/IOnTaskEndingHandler.cs
@@ -30,6 +30,12 @@ public interface IOnTaskEndingHandler
 public sealed class OnTaskEndingContext
 {
     /// <summary>
+    /// The ID of the task this hook is running for (the task being ended).
+    /// Matches the <c>taskId</c> passed to <see cref="IOnTaskEndingHandler.ShouldRunForTask"/>.
+    /// </summary>
+    public required string TaskId { get; init; }
+
+    /// <summary>
     /// An instance data mutator that can be used to access and modify instance data. Changes made will be automatically saved if the hook execution is successful.
     /// </summary>
     public required IInstanceDataMutator InstanceDataMutator { get; init; }

--- a/src/App/backend/src/Altinn.App.Core/Features/Process/IOnTaskEndingHandler.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Process/IOnTaskEndingHandler.cs
@@ -55,8 +55,11 @@ public abstract record OnTaskEndingResult : HookResult
     /// Use this for transient errors (external service down, timeout, rate limit, etc.).
     /// </summary>
     /// <param name="errorMessage">Human-readable error message describing the failure.</param>
-    public static FailedOnTaskEndingResult FailedRetryable(string errorMessage) =>
-        new(errorMessage, NonRetryable: false);
+    public static FailedOnTaskEndingResult FailedRetryable(string errorMessage)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(errorMessage);
+        return new FailedOnTaskEndingResult { ErrorMessage = errorMessage, Kind = FailureKind.Retryable };
+    }
 
     /// <summary>
     /// Creates a permanent (non-retryable) failure. The workflow engine will stop retrying
@@ -64,8 +67,11 @@ public abstract record OnTaskEndingResult : HookResult
     /// Use this for errors that won't resolve by retrying (validation failure, missing config, bad data, etc.).
     /// </summary>
     /// <param name="errorMessage">Human-readable error message describing the failure.</param>
-    public static FailedOnTaskEndingResult FailedPermanent(string errorMessage) =>
-        new(errorMessage, NonRetryable: true);
+    public static FailedOnTaskEndingResult FailedPermanent(string errorMessage)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(errorMessage);
+        return new FailedOnTaskEndingResult { ErrorMessage = errorMessage, Kind = FailureKind.Permanent };
+    }
 }
 
 /// <summary>
@@ -74,11 +80,20 @@ public abstract record OnTaskEndingResult : HookResult
 public sealed record SuccessfulOnTaskEndingResult : OnTaskEndingResult;
 
 /// <summary>
-/// Represents a failed end task hook execution.
+/// Represents a failed end task hook execution. Construct via
+/// <see cref="OnTaskEndingResult.FailedRetryable"/> or <see cref="OnTaskEndingResult.FailedPermanent"/>.
 /// </summary>
-/// <param name="ErrorMessage">Human-readable error message describing the failure.</param>
-/// <param name="NonRetryable">
-/// If true, the workflow engine will not retry this step (permanent failure).
-/// If false, the workflow engine will retry with backoff (transient failure).
-/// </param>
-public sealed record FailedOnTaskEndingResult(string ErrorMessage, bool NonRetryable) : OnTaskEndingResult;
+public sealed record FailedOnTaskEndingResult : OnTaskEndingResult
+{
+    internal FailedOnTaskEndingResult() { }
+
+    /// <summary>
+    /// Human-readable error message describing the failure.
+    /// </summary>
+    public required string ErrorMessage { get; init; }
+
+    /// <summary>
+    /// Whether the failure is retryable or permanent.
+    /// </summary>
+    internal FailureKind Kind { get; init; }
+}

--- a/src/App/backend/src/Altinn.App.Core/Features/Process/IOnTaskEndingHandler.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Process/IOnTaskEndingHandler.cs
@@ -20,8 +20,11 @@ public interface IOnTaskEndingHandler
     /// Executes the end task hook logic.
     /// </summary>
     /// <param name="context">A context object with relevant parameters and data.</param>
-    /// <returns>An end task result indicating success or failure.</returns>
-    public Task<OnTaskEndingResult> Execute(OnTaskEndingContext context);
+    /// <returns>
+    /// A result indicating success or failure. Construct via <see cref="HookResult.Success"/>,
+    /// <see cref="HookResult.FailedRetryable"/>, or <see cref="HookResult.FailedPermanent"/>.
+    /// </returns>
+    public Task<HookResult> Execute(OnTaskEndingContext context);
 }
 
 /// <summary>
@@ -44,62 +47,4 @@ public sealed class OnTaskEndingContext
     /// Cancellation token for the hook execution.
     /// </summary>
     public CancellationToken CancellationToken { get; init; } = CancellationToken.None;
-}
-
-/// <summary>
-/// Base type for end task hook execution results.
-/// </summary>
-public abstract record OnTaskEndingResult : HookResult
-{
-    /// <summary>
-    /// Creates a result representing successful hook execution.
-    /// </summary>
-    public static SuccessfulOnTaskEndingResult Success() => new();
-
-    /// <summary>
-    /// Creates a retryable failure. The workflow engine will retry the step with backoff.
-    /// Use this for transient errors (external service down, timeout, rate limit, etc.).
-    /// </summary>
-    /// <param name="errorMessage">Human-readable error message describing the failure.</param>
-    public static FailedOnTaskEndingResult FailedRetryable(string errorMessage)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(errorMessage);
-        return new FailedOnTaskEndingResult { ErrorMessage = errorMessage, Kind = FailureKind.Retryable };
-    }
-
-    /// <summary>
-    /// Creates a permanent (non-retryable) failure. The workflow engine will stop retrying
-    /// and mark the step as failed immediately.
-    /// Use this for errors that won't resolve by retrying (validation failure, missing config, bad data, etc.).
-    /// </summary>
-    /// <param name="errorMessage">Human-readable error message describing the failure.</param>
-    public static FailedOnTaskEndingResult FailedPermanent(string errorMessage)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(errorMessage);
-        return new FailedOnTaskEndingResult { ErrorMessage = errorMessage, Kind = FailureKind.Permanent };
-    }
-}
-
-/// <summary>
-/// Represents a successful end task hook execution.
-/// </summary>
-public sealed record SuccessfulOnTaskEndingResult : OnTaskEndingResult;
-
-/// <summary>
-/// Represents a failed end task hook execution. Construct via
-/// <see cref="OnTaskEndingResult.FailedRetryable"/> or <see cref="OnTaskEndingResult.FailedPermanent"/>.
-/// </summary>
-public sealed record FailedOnTaskEndingResult : OnTaskEndingResult
-{
-    internal FailedOnTaskEndingResult() { }
-
-    /// <summary>
-    /// Human-readable error message describing the failure.
-    /// </summary>
-    public required string ErrorMessage { get; init; }
-
-    /// <summary>
-    /// Whether the failure is retryable or permanent.
-    /// </summary>
-    internal FailureKind Kind { get; init; }
 }

--- a/src/App/backend/src/Altinn.App.Core/Features/Process/IOnTaskEndingHandler.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Process/IOnTaskEndingHandler.cs
@@ -21,13 +21,13 @@ public interface IOnTaskEndingHandler
     /// </summary>
     /// <param name="context">A context object with relevant parameters and data.</param>
     /// <returns>An end task result indicating success or failure.</returns>
-    public Task<OnEndingHandlerResult> Execute(OnTaskEndingHandlerContext context);
+    public Task<OnTaskEndingResult> Execute(OnTaskEndingContext context);
 }
 
 /// <summary>
 /// Parameters for end task hook execution.
 /// </summary>
-public sealed class OnTaskEndingHandlerContext
+public sealed class OnTaskEndingContext
 {
     /// <summary>
     /// An instance data mutator that can be used to access and modify instance data. Changes made will be automatically saved if the hook execution is successful.
@@ -43,19 +43,19 @@ public sealed class OnTaskEndingHandlerContext
 /// <summary>
 /// Base type for end task hook execution results.
 /// </summary>
-public abstract record OnEndingHandlerResult : HookResult
+public abstract record OnTaskEndingResult : HookResult
 {
     /// <summary>
     /// Creates a result representing successful hook execution.
     /// </summary>
-    public static SuccessfulOnEndingHandlerResult Success() => new();
+    public static SuccessfulOnTaskEndingResult Success() => new();
 
     /// <summary>
     /// Creates a retryable failure. The workflow engine will retry the step with backoff.
     /// Use this for transient errors (external service down, timeout, rate limit, etc.).
     /// </summary>
     /// <param name="errorMessage">Human-readable error message describing the failure.</param>
-    public static FailedOnTaskEndingHandlerResult FailedRetryable(string errorMessage) =>
+    public static FailedOnTaskEndingResult FailedRetryable(string errorMessage) =>
         new(errorMessage, NonRetryable: false);
 
     /// <summary>
@@ -64,14 +64,14 @@ public abstract record OnEndingHandlerResult : HookResult
     /// Use this for errors that won't resolve by retrying (validation failure, missing config, bad data, etc.).
     /// </summary>
     /// <param name="errorMessage">Human-readable error message describing the failure.</param>
-    public static FailedOnTaskEndingHandlerResult FailedPermanent(string errorMessage) =>
+    public static FailedOnTaskEndingResult FailedPermanent(string errorMessage) =>
         new(errorMessage, NonRetryable: true);
 }
 
 /// <summary>
 /// Represents a successful end task hook execution.
 /// </summary>
-public sealed record SuccessfulOnEndingHandlerResult : OnEndingHandlerResult;
+public sealed record SuccessfulOnTaskEndingResult : OnTaskEndingResult;
 
 /// <summary>
 /// Represents a failed end task hook execution.
@@ -81,4 +81,4 @@ public sealed record SuccessfulOnEndingHandlerResult : OnEndingHandlerResult;
 /// If true, the workflow engine will not retry this step (permanent failure).
 /// If false, the workflow engine will retry with backoff (transient failure).
 /// </param>
-public sealed record FailedOnTaskEndingHandlerResult(string ErrorMessage, bool NonRetryable) : OnEndingHandlerResult;
+public sealed record FailedOnTaskEndingResult(string ErrorMessage, bool NonRetryable) : OnTaskEndingResult;

--- a/src/App/backend/src/Altinn.App.Core/Features/Process/IOnTaskEndingHandler.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Process/IOnTaskEndingHandler.cs
@@ -21,7 +21,7 @@ public interface IOnTaskEndingHandler
     /// </summary>
     /// <param name="context">A context object with relevant parameters and data.</param>
     /// <returns>An end task result indicating success or failure.</returns>
-    public Task<OnEndingHandlerResult> ExecuteAsync(OnTaskEndingHandlerContext context);
+    public Task<OnEndingHandlerResult> Execute(OnTaskEndingHandlerContext context);
 }
 
 /// <summary>

--- a/src/App/backend/src/Altinn.App.Core/Features/Process/IOnTaskStartingHandler.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Process/IOnTaskStartingHandler.cs
@@ -21,7 +21,7 @@ public interface IOnTaskStartingHandler
     /// </summary>
     /// <param name="context">A context object with relevant parameters and data.</param>
     /// <returns>A start task result indicating success or failure.</returns>
-    public Task<OnTaskStartingHandlerResult> Execute(OnTaskStartingContext context);
+    public Task<OnTaskStartingResult> Execute(OnTaskStartingContext context);
 }
 
 /// <summary>
@@ -43,19 +43,19 @@ public sealed class OnTaskStartingContext
 /// <summary>
 /// Base type for start task hook execution results.
 /// </summary>
-public abstract record OnTaskStartingHandlerResult : HookResult
+public abstract record OnTaskStartingResult : HookResult
 {
     /// <summary>
     /// Creates a result representing successful hook execution.
     /// </summary>
-    public static SuccessfulOnTaskStartingHandlerResult Success() => new();
+    public static SuccessfulOnTaskStartingResult Success() => new();
 
     /// <summary>
     /// Creates a retryable failure. The workflow engine will retry the step with backoff.
     /// Use this for transient errors (external service down, timeout, rate limit, etc.).
     /// </summary>
     /// <param name="errorMessage">Human-readable error message describing the failure.</param>
-    public static FailedOnTaskStartingHandlerResult FailedRetryable(string errorMessage) =>
+    public static FailedOnTaskStartingResult FailedRetryable(string errorMessage) =>
         new(errorMessage, NonRetryable: false);
 
     /// <summary>
@@ -64,14 +64,14 @@ public abstract record OnTaskStartingHandlerResult : HookResult
     /// Use this for errors that won't resolve by retrying (validation failure, missing config, bad data, etc.).
     /// </summary>
     /// <param name="errorMessage">Human-readable error message describing the failure.</param>
-    public static FailedOnTaskStartingHandlerResult FailedPermanent(string errorMessage) =>
+    public static FailedOnTaskStartingResult FailedPermanent(string errorMessage) =>
         new(errorMessage, NonRetryable: true);
 }
 
 /// <summary>
 /// Represents a successful start task hook execution.
 /// </summary>
-public sealed record SuccessfulOnTaskStartingHandlerResult : OnTaskStartingHandlerResult;
+public sealed record SuccessfulOnTaskStartingResult : OnTaskStartingResult;
 
 /// <summary>
 /// Represents a failed start task hook execution.
@@ -81,5 +81,4 @@ public sealed record SuccessfulOnTaskStartingHandlerResult : OnTaskStartingHandl
 /// If true, the workflow engine will not retry this step (permanent failure).
 /// If false, the workflow engine will retry with backoff (transient failure).
 /// </param>
-public sealed record FailedOnTaskStartingHandlerResult(string ErrorMessage, bool NonRetryable)
-    : OnTaskStartingHandlerResult;
+public sealed record FailedOnTaskStartingResult(string ErrorMessage, bool NonRetryable) : OnTaskStartingResult;

--- a/src/App/backend/src/Altinn.App.Core/Features/Process/IOnTaskStartingHandler.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Process/IOnTaskStartingHandler.cs
@@ -21,7 +21,7 @@ public interface IOnTaskStartingHandler
     /// </summary>
     /// <param name="context">A context object with relevant parameters and data.</param>
     /// <returns>A start task result indicating success or failure.</returns>
-    public Task<OnTaskStartingHandlerResult> ExecuteAsync(OnTaskStartingContext context);
+    public Task<OnTaskStartingHandlerResult> Execute(OnTaskStartingContext context);
 }
 
 /// <summary>

--- a/src/App/backend/src/Altinn.App.Core/Features/Process/IOnTaskStartingHandler.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Process/IOnTaskStartingHandler.cs
@@ -55,8 +55,11 @@ public abstract record OnTaskStartingResult : HookResult
     /// Use this for transient errors (external service down, timeout, rate limit, etc.).
     /// </summary>
     /// <param name="errorMessage">Human-readable error message describing the failure.</param>
-    public static FailedOnTaskStartingResult FailedRetryable(string errorMessage) =>
-        new(errorMessage, NonRetryable: false);
+    public static FailedOnTaskStartingResult FailedRetryable(string errorMessage)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(errorMessage);
+        return new FailedOnTaskStartingResult { ErrorMessage = errorMessage, Kind = FailureKind.Retryable };
+    }
 
     /// <summary>
     /// Creates a permanent (non-retryable) failure. The workflow engine will stop retrying
@@ -64,8 +67,11 @@ public abstract record OnTaskStartingResult : HookResult
     /// Use this for errors that won't resolve by retrying (validation failure, missing config, bad data, etc.).
     /// </summary>
     /// <param name="errorMessage">Human-readable error message describing the failure.</param>
-    public static FailedOnTaskStartingResult FailedPermanent(string errorMessage) =>
-        new(errorMessage, NonRetryable: true);
+    public static FailedOnTaskStartingResult FailedPermanent(string errorMessage)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(errorMessage);
+        return new FailedOnTaskStartingResult { ErrorMessage = errorMessage, Kind = FailureKind.Permanent };
+    }
 }
 
 /// <summary>
@@ -74,11 +80,20 @@ public abstract record OnTaskStartingResult : HookResult
 public sealed record SuccessfulOnTaskStartingResult : OnTaskStartingResult;
 
 /// <summary>
-/// Represents a failed start task hook execution.
+/// Represents a failed start task hook execution. Construct via
+/// <see cref="OnTaskStartingResult.FailedRetryable"/> or <see cref="OnTaskStartingResult.FailedPermanent"/>.
 /// </summary>
-/// <param name="ErrorMessage">Human-readable error message describing the failure.</param>
-/// <param name="NonRetryable">
-/// If true, the workflow engine will not retry this step (permanent failure).
-/// If false, the workflow engine will retry with backoff (transient failure).
-/// </param>
-public sealed record FailedOnTaskStartingResult(string ErrorMessage, bool NonRetryable) : OnTaskStartingResult;
+public sealed record FailedOnTaskStartingResult : OnTaskStartingResult
+{
+    internal FailedOnTaskStartingResult() { }
+
+    /// <summary>
+    /// Human-readable error message describing the failure.
+    /// </summary>
+    public required string ErrorMessage { get; init; }
+
+    /// <summary>
+    /// Whether the failure is retryable or permanent.
+    /// </summary>
+    internal FailureKind Kind { get; init; }
+}

--- a/src/App/backend/src/Altinn.App.Core/Features/Process/IOnTaskStartingHandler.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Process/IOnTaskStartingHandler.cs
@@ -20,8 +20,11 @@ public interface IOnTaskStartingHandler
     /// Executes the start task hook logic.
     /// </summary>
     /// <param name="context">A context object with relevant parameters and data.</param>
-    /// <returns>A start task result indicating success or failure.</returns>
-    public Task<OnTaskStartingResult> Execute(OnTaskStartingContext context);
+    /// <returns>
+    /// A result indicating success or failure. Construct via <see cref="HookResult.Success"/>,
+    /// <see cref="HookResult.FailedRetryable"/>, or <see cref="HookResult.FailedPermanent"/>.
+    /// </returns>
+    public Task<HookResult> Execute(OnTaskStartingContext context);
 }
 
 /// <summary>
@@ -44,62 +47,4 @@ public sealed class OnTaskStartingContext
     /// Cancellation token for the hook execution.
     /// </summary>
     public CancellationToken CancellationToken { get; init; } = CancellationToken.None;
-}
-
-/// <summary>
-/// Base type for start task hook execution results.
-/// </summary>
-public abstract record OnTaskStartingResult : HookResult
-{
-    /// <summary>
-    /// Creates a result representing successful hook execution.
-    /// </summary>
-    public static SuccessfulOnTaskStartingResult Success() => new();
-
-    /// <summary>
-    /// Creates a retryable failure. The workflow engine will retry the step with backoff.
-    /// Use this for transient errors (external service down, timeout, rate limit, etc.).
-    /// </summary>
-    /// <param name="errorMessage">Human-readable error message describing the failure.</param>
-    public static FailedOnTaskStartingResult FailedRetryable(string errorMessage)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(errorMessage);
-        return new FailedOnTaskStartingResult { ErrorMessage = errorMessage, Kind = FailureKind.Retryable };
-    }
-
-    /// <summary>
-    /// Creates a permanent (non-retryable) failure. The workflow engine will stop retrying
-    /// and mark the step as failed immediately.
-    /// Use this for errors that won't resolve by retrying (validation failure, missing config, bad data, etc.).
-    /// </summary>
-    /// <param name="errorMessage">Human-readable error message describing the failure.</param>
-    public static FailedOnTaskStartingResult FailedPermanent(string errorMessage)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(errorMessage);
-        return new FailedOnTaskStartingResult { ErrorMessage = errorMessage, Kind = FailureKind.Permanent };
-    }
-}
-
-/// <summary>
-/// Represents a successful start task hook execution.
-/// </summary>
-public sealed record SuccessfulOnTaskStartingResult : OnTaskStartingResult;
-
-/// <summary>
-/// Represents a failed start task hook execution. Construct via
-/// <see cref="OnTaskStartingResult.FailedRetryable"/> or <see cref="OnTaskStartingResult.FailedPermanent"/>.
-/// </summary>
-public sealed record FailedOnTaskStartingResult : OnTaskStartingResult
-{
-    internal FailedOnTaskStartingResult() { }
-
-    /// <summary>
-    /// Human-readable error message describing the failure.
-    /// </summary>
-    public required string ErrorMessage { get; init; }
-
-    /// <summary>
-    /// Whether the failure is retryable or permanent.
-    /// </summary>
-    internal FailureKind Kind { get; init; }
 }

--- a/src/App/backend/src/Altinn.App.Core/Features/Process/IOnTaskStartingHandler.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Process/IOnTaskStartingHandler.cs
@@ -30,6 +30,12 @@ public interface IOnTaskStartingHandler
 public sealed class OnTaskStartingContext
 {
     /// <summary>
+    /// The ID of the task this hook is running for (the task being started).
+    /// Matches the <c>taskId</c> passed to <see cref="IOnTaskStartingHandler.ShouldRunForTask"/>.
+    /// </summary>
+    public required string TaskId { get; init; }
+
+    /// <summary>
     /// An instance data mutator that can be used to access and modify instance data. Changes made will be automatically saved if the hook execution is successful.
     /// </summary>
     public required IInstanceDataMutator InstanceDataMutator { get; init; }

--- a/src/App/backend/src/Altinn.App.Core/Features/Process/IServiceTask.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Process/IServiceTask.cs
@@ -61,8 +61,11 @@ public abstract record ServiceTaskResult
     /// Use this for transient errors (external service down, timeout, rate limit, etc.).
     /// </summary>
     /// <param name="errorMessage">Human-readable error message describing the failure.</param>
-    public static ServiceTaskFailedResult FailedRetryable(string errorMessage) =>
-        new(errorMessage, NonRetryable: false);
+    public static ServiceTaskFailedResult FailedRetryable(string errorMessage)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(errorMessage);
+        return new ServiceTaskFailedResult { ErrorMessage = errorMessage, Kind = FailureKind.Retryable };
+    }
 
     /// <summary>
     /// Creates a permanent (non-retryable) failure. The workflow engine will stop retrying
@@ -70,7 +73,11 @@ public abstract record ServiceTaskResult
     /// Use this for errors that won't resolve by retrying (validation failure, missing config, bad data, etc.).
     /// </summary>
     /// <param name="errorMessage">Human-readable error message describing the failure.</param>
-    public static ServiceTaskFailedResult FailedPermanent(string errorMessage) => new(errorMessage, NonRetryable: true);
+    public static ServiceTaskFailedResult FailedPermanent(string errorMessage)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(errorMessage);
+        return new ServiceTaskFailedResult { ErrorMessage = errorMessage, Kind = FailureKind.Permanent };
+    }
 }
 
 /// <summary>
@@ -92,11 +99,20 @@ public sealed record ServiceTaskSuccessResult : ServiceTaskResult
 }
 
 /// <summary>
-/// Represents a failed result of executing a service task.
+/// Represents a failed result of executing a service task. Construct via
+/// <see cref="ServiceTaskResult.FailedRetryable"/> or <see cref="ServiceTaskResult.FailedPermanent"/>.
 /// </summary>
-/// <param name="ErrorMessage">Human-readable error message describing the failure.</param>
-/// <param name="NonRetryable">
-/// If true, the workflow engine will not retry this step (permanent failure).
-/// If false, the workflow engine will retry with backoff (transient failure).
-/// </param>
-public sealed record ServiceTaskFailedResult(string ErrorMessage, bool NonRetryable) : ServiceTaskResult;
+public sealed record ServiceTaskFailedResult : ServiceTaskResult
+{
+    internal ServiceTaskFailedResult() { }
+
+    /// <summary>
+    /// Human-readable error message describing the failure.
+    /// </summary>
+    public required string ErrorMessage { get; init; }
+
+    /// <summary>
+    /// Whether the failure is retryable or permanent.
+    /// </summary>
+    internal FailureKind Kind { get; init; }
+}

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ExecuteServiceTask.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ExecuteServiceTask.cs
@@ -45,7 +45,7 @@ internal sealed class ExecuteServiceTask(AppImplementationFactory appImplementat
             {
                 string errorMessage = $"Service task '{serviceTask.Type}' failed: {failedResult.ErrorMessage}";
 
-                return failedResult.NonRetryable
+                return failedResult.Kind == FailureKind.Permanent
                     ? FailedProcessEngineCommandResult.Permanent(errorMessage, "ServiceTaskFailedException")
                     : FailedProcessEngineCommandResult.Retryable(errorMessage, "ServiceTaskFailedException");
             }

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/ProcessEnd/OnProcessEndingHook.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/ProcessEnd/OnProcessEndingHook.cs
@@ -40,7 +40,7 @@ internal sealed class OnProcessEndingHook : IWorkflowEngineCommand
             return new SuccessfulProcessEngineCommandResult();
         }
 
-        var hookParameters = new OnProcessEndingHandlerContext
+        var hookParameters = new OnProcessEndingContext
         {
             InstanceDataMutator = dataMutator,
             CancellationToken = parameters.CancellationToken,
@@ -48,16 +48,16 @@ internal sealed class OnProcessEndingHook : IWorkflowEngineCommand
 
         try
         {
-            OnProcessEndingHandlerResult result = await hook.Execute(hookParameters);
+            OnProcessEndingResult result = await hook.Execute(hookParameters);
 
             return result switch
             {
-                SuccessfulOnProcessEndingHandlerResult => new SuccessfulProcessEngineCommandResult(),
-                FailedOnProcessEndingHandlerResult failed => failed.NonRetryable
+                SuccessfulOnProcessEndingResult => new SuccessfulProcessEngineCommandResult(),
+                FailedOnProcessEndingResult failed => failed.NonRetryable
                     ? FailedProcessEngineCommandResult.Permanent(failed.ErrorMessage)
                     : FailedProcessEngineCommandResult.Retryable(failed.ErrorMessage),
                 _ => throw new InvalidOperationException(
-                    $"Unexpected {nameof(OnEndingHandlerResult)} type: {result.GetType().Name}"
+                    $"Unexpected {nameof(OnProcessEndingResult)} type: {result.GetType().Name}"
                 ),
             };
         }

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/ProcessEnd/OnProcessEndingHook.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/ProcessEnd/OnProcessEndingHook.cs
@@ -48,16 +48,16 @@ internal sealed class OnProcessEndingHook : IWorkflowEngineCommand
 
         try
         {
-            OnProcessEndingResult result = await hook.Execute(hookParameters);
+            HookResult result = await hook.Execute(hookParameters);
 
             return result switch
             {
-                SuccessfulOnProcessEndingResult => new SuccessfulProcessEngineCommandResult(),
-                FailedOnProcessEndingResult failed => failed.Kind == FailureKind.Permanent
+                SuccessfulHookResult => new SuccessfulProcessEngineCommandResult(),
+                FailedHookResult failed => failed.Kind == FailureKind.Permanent
                     ? FailedProcessEngineCommandResult.Permanent(failed.ErrorMessage)
                     : FailedProcessEngineCommandResult.Retryable(failed.ErrorMessage),
                 _ => throw new InvalidOperationException(
-                    $"Unexpected {nameof(OnProcessEndingResult)} type: {result.GetType().Name}"
+                    $"Unexpected {nameof(HookResult)} type: {result.GetType().Name}"
                 ),
             };
         }

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/ProcessEnd/OnProcessEndingHook.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/ProcessEnd/OnProcessEndingHook.cs
@@ -53,7 +53,7 @@ internal sealed class OnProcessEndingHook : IWorkflowEngineCommand
             return result switch
             {
                 SuccessfulOnProcessEndingResult => new SuccessfulProcessEngineCommandResult(),
-                FailedOnProcessEndingResult failed => failed.NonRetryable
+                FailedOnProcessEndingResult failed => failed.Kind == FailureKind.Permanent
                     ? FailedProcessEngineCommandResult.Permanent(failed.ErrorMessage)
                     : FailedProcessEngineCommandResult.Retryable(failed.ErrorMessage),
                 _ => throw new InvalidOperationException(

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/ProcessEnd/OnProcessEndingHook.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/ProcessEnd/OnProcessEndingHook.cs
@@ -48,7 +48,7 @@ internal sealed class OnProcessEndingHook : IWorkflowEngineCommand
 
         try
         {
-            OnProcessEndingHandlerResult result = await hook.ExecuteAsync(hookParameters);
+            OnProcessEndingHandlerResult result = await hook.Execute(hookParameters);
 
             return result switch
             {

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/TaskAbandon/OnTaskAbandonHook.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/TaskAbandon/OnTaskAbandonHook.cs
@@ -52,7 +52,7 @@ internal sealed class OnTaskAbandonHook : IWorkflowEngineCommand
             return result switch
             {
                 SuccessfulOnTaskAbandonResult => new SuccessfulProcessEngineCommandResult(),
-                FailedOnTaskAbandonResult failed => failed.NonRetryable
+                FailedOnTaskAbandonResult failed => failed.Kind == FailureKind.Permanent
                     ? FailedProcessEngineCommandResult.Permanent(failed.ErrorMessage)
                     : FailedProcessEngineCommandResult.Retryable(failed.ErrorMessage),
                 _ => throw new InvalidOperationException(

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/TaskAbandon/OnTaskAbandonHook.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/TaskAbandon/OnTaskAbandonHook.cs
@@ -48,16 +48,16 @@ internal sealed class OnTaskAbandonHook : IWorkflowEngineCommand
 
         try
         {
-            OnTaskAbandonResult result = await hook.Execute(hookParameters);
+            HookResult result = await hook.Execute(hookParameters);
 
             return result switch
             {
-                SuccessfulOnTaskAbandonResult => new SuccessfulProcessEngineCommandResult(),
-                FailedOnTaskAbandonResult failed => failed.Kind == FailureKind.Permanent
+                SuccessfulHookResult => new SuccessfulProcessEngineCommandResult(),
+                FailedHookResult failed => failed.Kind == FailureKind.Permanent
                     ? FailedProcessEngineCommandResult.Permanent(failed.ErrorMessage)
                     : FailedProcessEngineCommandResult.Retryable(failed.ErrorMessage),
                 _ => throw new InvalidOperationException(
-                    $"Unexpected {nameof(OnTaskAbandonResult)} type: {result.GetType().Name}"
+                    $"Unexpected {nameof(HookResult)} type: {result.GetType().Name}"
                 ),
             };
         }

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/TaskAbandon/OnTaskAbandonHook.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/TaskAbandon/OnTaskAbandonHook.cs
@@ -41,6 +41,7 @@ internal sealed class OnTaskAbandonHook : IWorkflowEngineCommand
 
         var hookParameters = new OnTaskAbandonContext
         {
+            TaskId = taskId,
             InstanceDataMutator = dataMutator,
             CancellationToken = parameters.CancellationToken,
         };

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/TaskAbandon/OnTaskAbandonHook.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/TaskAbandon/OnTaskAbandonHook.cs
@@ -47,7 +47,7 @@ internal sealed class OnTaskAbandonHook : IWorkflowEngineCommand
 
         try
         {
-            OnAbandonHandlerResult result = await hook.ExecuteAsync(hookParameters);
+            OnAbandonHandlerResult result = await hook.Execute(hookParameters);
 
             return result switch
             {

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/TaskAbandon/OnTaskAbandonHook.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/TaskAbandon/OnTaskAbandonHook.cs
@@ -39,7 +39,7 @@ internal sealed class OnTaskAbandonHook : IWorkflowEngineCommand
             return new SuccessfulProcessEngineCommandResult();
         }
 
-        var hookParameters = new OnTaskAbandonHandlerContext
+        var hookParameters = new OnTaskAbandonContext
         {
             InstanceDataMutator = dataMutator,
             CancellationToken = parameters.CancellationToken,
@@ -47,16 +47,16 @@ internal sealed class OnTaskAbandonHook : IWorkflowEngineCommand
 
         try
         {
-            OnAbandonHandlerResult result = await hook.Execute(hookParameters);
+            OnTaskAbandonResult result = await hook.Execute(hookParameters);
 
             return result switch
             {
-                SuccessfulOnAbandonHandlerResult => new SuccessfulProcessEngineCommandResult(),
-                FailedOnTaskAbandonHandlerResult failed => failed.NonRetryable
+                SuccessfulOnTaskAbandonResult => new SuccessfulProcessEngineCommandResult(),
+                FailedOnTaskAbandonResult failed => failed.NonRetryable
                     ? FailedProcessEngineCommandResult.Permanent(failed.ErrorMessage)
                     : FailedProcessEngineCommandResult.Retryable(failed.ErrorMessage),
                 _ => throw new InvalidOperationException(
-                    $"Unexpected {nameof(OnAbandonHandlerResult)} type: {result.GetType().Name}"
+                    $"Unexpected {nameof(OnTaskAbandonResult)} type: {result.GetType().Name}"
                 ),
             };
         }

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/TaskEnd/OnTaskEndingHook.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/TaskEnd/OnTaskEndingHook.cs
@@ -41,6 +41,7 @@ internal sealed class OnTaskEndingHook : IWorkflowEngineCommand
 
         var hookParameters = new OnTaskEndingContext
         {
+            TaskId = taskId,
             InstanceDataMutator = dataMutator,
             CancellationToken = parameters.CancellationToken,
         };

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/TaskEnd/OnTaskEndingHook.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/TaskEnd/OnTaskEndingHook.cs
@@ -52,7 +52,7 @@ internal sealed class OnTaskEndingHook : IWorkflowEngineCommand
             return result switch
             {
                 SuccessfulOnTaskEndingResult => new SuccessfulProcessEngineCommandResult(),
-                FailedOnTaskEndingResult failed => failed.NonRetryable
+                FailedOnTaskEndingResult failed => failed.Kind == FailureKind.Permanent
                     ? FailedProcessEngineCommandResult.Permanent(failed.ErrorMessage)
                     : FailedProcessEngineCommandResult.Retryable(failed.ErrorMessage),
                 _ => throw new InvalidOperationException(

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/TaskEnd/OnTaskEndingHook.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/TaskEnd/OnTaskEndingHook.cs
@@ -47,7 +47,7 @@ internal sealed class OnTaskEndingHook : IWorkflowEngineCommand
 
         try
         {
-            OnEndingHandlerResult result = await hook.ExecuteAsync(hookParameters);
+            OnEndingHandlerResult result = await hook.Execute(hookParameters);
 
             return result switch
             {

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/TaskEnd/OnTaskEndingHook.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/TaskEnd/OnTaskEndingHook.cs
@@ -48,16 +48,16 @@ internal sealed class OnTaskEndingHook : IWorkflowEngineCommand
 
         try
         {
-            OnTaskEndingResult result = await hook.Execute(hookParameters);
+            HookResult result = await hook.Execute(hookParameters);
 
             return result switch
             {
-                SuccessfulOnTaskEndingResult => new SuccessfulProcessEngineCommandResult(),
-                FailedOnTaskEndingResult failed => failed.Kind == FailureKind.Permanent
+                SuccessfulHookResult => new SuccessfulProcessEngineCommandResult(),
+                FailedHookResult failed => failed.Kind == FailureKind.Permanent
                     ? FailedProcessEngineCommandResult.Permanent(failed.ErrorMessage)
                     : FailedProcessEngineCommandResult.Retryable(failed.ErrorMessage),
                 _ => throw new InvalidOperationException(
-                    $"Unexpected {nameof(OnTaskEndingResult)} type: {result.GetType().Name}"
+                    $"Unexpected {nameof(HookResult)} type: {result.GetType().Name}"
                 ),
             };
         }

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/TaskEnd/OnTaskEndingHook.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/TaskEnd/OnTaskEndingHook.cs
@@ -39,7 +39,7 @@ internal sealed class OnTaskEndingHook : IWorkflowEngineCommand
             return new SuccessfulProcessEngineCommandResult();
         }
 
-        var hookParameters = new OnTaskEndingHandlerContext
+        var hookParameters = new OnTaskEndingContext
         {
             InstanceDataMutator = dataMutator,
             CancellationToken = parameters.CancellationToken,
@@ -47,16 +47,16 @@ internal sealed class OnTaskEndingHook : IWorkflowEngineCommand
 
         try
         {
-            OnEndingHandlerResult result = await hook.Execute(hookParameters);
+            OnTaskEndingResult result = await hook.Execute(hookParameters);
 
             return result switch
             {
-                SuccessfulOnEndingHandlerResult => new SuccessfulProcessEngineCommandResult(),
-                FailedOnTaskEndingHandlerResult failed => failed.NonRetryable
+                SuccessfulOnTaskEndingResult => new SuccessfulProcessEngineCommandResult(),
+                FailedOnTaskEndingResult failed => failed.NonRetryable
                     ? FailedProcessEngineCommandResult.Permanent(failed.ErrorMessage)
                     : FailedProcessEngineCommandResult.Retryable(failed.ErrorMessage),
                 _ => throw new InvalidOperationException(
-                    $"Unexpected {nameof(OnEndingHandlerResult)} type: {result.GetType().Name}"
+                    $"Unexpected {nameof(OnTaskEndingResult)} type: {result.GetType().Name}"
                 ),
             };
         }

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/TaskStart/OnTaskStartingHook.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/TaskStart/OnTaskStartingHook.cs
@@ -41,6 +41,7 @@ internal sealed class OnTaskStartingHook : IWorkflowEngineCommand
 
         var hookParameters = new OnTaskStartingContext
         {
+            TaskId = taskId,
             InstanceDataMutator = dataMutator,
             CancellationToken = parameters.CancellationToken,
         };

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/TaskStart/OnTaskStartingHook.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/TaskStart/OnTaskStartingHook.cs
@@ -52,7 +52,7 @@ internal sealed class OnTaskStartingHook : IWorkflowEngineCommand
             return handlerResult switch
             {
                 SuccessfulOnTaskStartingResult => new SuccessfulProcessEngineCommandResult(),
-                FailedOnTaskStartingResult failed => failed.NonRetryable
+                FailedOnTaskStartingResult failed => failed.Kind == FailureKind.Permanent
                     ? FailedProcessEngineCommandResult.Permanent(failed.ErrorMessage)
                     : FailedProcessEngineCommandResult.Retryable(failed.ErrorMessage),
                 _ => throw new InvalidOperationException(

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/TaskStart/OnTaskStartingHook.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/TaskStart/OnTaskStartingHook.cs
@@ -47,16 +47,16 @@ internal sealed class OnTaskStartingHook : IWorkflowEngineCommand
 
         try
         {
-            OnTaskStartingHandlerResult handlerResult = await hook.Execute(hookParameters);
+            OnTaskStartingResult handlerResult = await hook.Execute(hookParameters);
 
             return handlerResult switch
             {
-                SuccessfulOnTaskStartingHandlerResult => new SuccessfulProcessEngineCommandResult(),
-                FailedOnTaskStartingHandlerResult failed => failed.NonRetryable
+                SuccessfulOnTaskStartingResult => new SuccessfulProcessEngineCommandResult(),
+                FailedOnTaskStartingResult failed => failed.NonRetryable
                     ? FailedProcessEngineCommandResult.Permanent(failed.ErrorMessage)
                     : FailedProcessEngineCommandResult.Retryable(failed.ErrorMessage),
                 _ => throw new InvalidOperationException(
-                    $"Unexpected {nameof(OnTaskStartingHandlerResult)} type: {handlerResult.GetType().Name}"
+                    $"Unexpected {nameof(OnTaskStartingResult)} type: {handlerResult.GetType().Name}"
                 ),
             };
         }

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/TaskStart/OnTaskStartingHook.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/TaskStart/OnTaskStartingHook.cs
@@ -48,16 +48,16 @@ internal sealed class OnTaskStartingHook : IWorkflowEngineCommand
 
         try
         {
-            OnTaskStartingResult handlerResult = await hook.Execute(hookParameters);
+            HookResult handlerResult = await hook.Execute(hookParameters);
 
             return handlerResult switch
             {
-                SuccessfulOnTaskStartingResult => new SuccessfulProcessEngineCommandResult(),
-                FailedOnTaskStartingResult failed => failed.Kind == FailureKind.Permanent
+                SuccessfulHookResult => new SuccessfulProcessEngineCommandResult(),
+                FailedHookResult failed => failed.Kind == FailureKind.Permanent
                     ? FailedProcessEngineCommandResult.Permanent(failed.ErrorMessage)
                     : FailedProcessEngineCommandResult.Retryable(failed.ErrorMessage),
                 _ => throw new InvalidOperationException(
-                    $"Unexpected {nameof(OnTaskStartingResult)} type: {handlerResult.GetType().Name}"
+                    $"Unexpected {nameof(HookResult)} type: {handlerResult.GetType().Name}"
                 ),
             };
         }

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/TaskStart/OnTaskStartingHook.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Commands/ProcessNext/TaskStart/OnTaskStartingHook.cs
@@ -47,7 +47,7 @@ internal sealed class OnTaskStartingHook : IWorkflowEngineCommand
 
         try
         {
-            OnTaskStartingHandlerResult handlerResult = await hook.ExecuteAsync(hookParameters);
+            OnTaskStartingHandlerResult handlerResult = await hook.Execute(hookParameters);
 
             return handlerResult switch
             {

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Models/AppCommand/AppCallbackResponse.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Models/AppCommand/AppCallbackResponse.cs
@@ -5,7 +5,7 @@ namespace Altinn.App.Core.Internal.WorkflowEngine.Models.AppCommand;
 /// <summary>
 /// Response body from a successful Altinn app callback.
 /// </summary>
-public sealed record AppCallbackResponse
+internal sealed record AppCallbackResponse
 {
     /// <summary>
     /// Updated opaque state blob to pass to the next command.

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Models/Engine/BackoffType.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Models/Engine/BackoffType.cs
@@ -6,7 +6,7 @@ namespace Altinn.App.Core.Internal.WorkflowEngine.Models.Engine;
 /// Defines backoff types for retry strategies.
 /// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter))]
-public enum BackoffType
+internal enum BackoffType
 {
     /// <summary>
     /// Constant backoff type. The delay between retries remains the same regardless of the number of attempts.

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Models/Engine/PersistentItemStatus.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Models/Engine/PersistentItemStatus.cs
@@ -6,7 +6,7 @@ namespace Altinn.App.Core.Internal.WorkflowEngine.Models.Engine;
 /// Represents the status of a persistent workflow item.
 /// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter))]
-public enum PersistentItemStatus
+internal enum PersistentItemStatus
 {
     /// <summary>The item has been enqueued for processing.</summary>
     Enqueued = 0,

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Models/Engine/RetryStrategy.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Models/Engine/RetryStrategy.cs
@@ -5,7 +5,7 @@ namespace Altinn.App.Core.Internal.WorkflowEngine.Models.Engine;
 /// <summary>
 /// Defines a retry strategy for process engine tasks.
 /// </summary>
-public sealed record RetryStrategy
+internal sealed record RetryStrategy
 {
     /// <summary>
     /// The type of backoff to use.

--- a/src/App/backend/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/FiksArkivServiceTaskTest.cs
+++ b/src/App/backend/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/FiksArkivServiceTaskTest.cs
@@ -106,7 +106,7 @@ public class FiksArkivServiceTaskTest
 
         // Assert
         var failedResult = Assert.IsType<ServiceTaskFailedResult>(result);
-        Assert.False(failedResult.NonRetryable);
+        Assert.Equal(FailureKind.Retryable, failedResult.Kind);
     }
 
     private static Mock<IInstanceDataMutator> InstanceDataMutatorMockFactory(Instance instance)

--- a/src/App/backend/test/Altinn.App.Core.Tests/Internal/WorkflowEngine/Commands/ProcessNext/ProcessEnd/OnProcessEndingHookTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Internal/WorkflowEngine/Commands/ProcessNext/ProcessEnd/OnProcessEndingHookTests.cs
@@ -76,7 +76,7 @@ public class OnProcessEndingHookTests
     {
         // Arrange
         var handler = new Mock<IOnProcessEndingHandler>();
-        handler.Setup(x => x.Execute(It.IsAny<OnProcessEndingContext>())).ReturnsAsync(OnProcessEndingResult.Success());
+        handler.Setup(x => x.Execute(It.IsAny<OnProcessEndingContext>())).ReturnsAsync(HookResult.Success());
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
 
@@ -124,7 +124,7 @@ public class OnProcessEndingHookTests
         var handler = new Mock<IOnProcessEndingHandler>();
         handler
             .Setup(x => x.Execute(It.IsAny<OnProcessEndingContext>()))
-            .ReturnsAsync(OnProcessEndingResult.FailedPermanent("Hook failed"));
+            .ReturnsAsync(HookResult.FailedPermanent("Hook failed"));
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
 
@@ -144,7 +144,7 @@ public class OnProcessEndingHookTests
         var handler = new Mock<IOnProcessEndingHandler>();
         handler
             .Setup(x => x.Execute(It.IsAny<OnProcessEndingContext>()))
-            .ReturnsAsync(OnProcessEndingResult.FailedRetryable("Transient error"));
+            .ReturnsAsync(HookResult.FailedRetryable("Transient error"));
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
 

--- a/src/App/backend/test/Altinn.App.Core.Tests/Internal/WorkflowEngine/Commands/ProcessNext/ProcessEnd/OnProcessEndingHookTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Internal/WorkflowEngine/Commands/ProcessNext/ProcessEnd/OnProcessEndingHookTests.cs
@@ -77,7 +77,7 @@ public class OnProcessEndingHookTests
         // Arrange
         var handler = new Mock<IOnProcessEndingHandler>();
         handler
-            .Setup(x => x.ExecuteAsync(It.IsAny<OnProcessEndingHandlerContext>()))
+            .Setup(x => x.Execute(It.IsAny<OnProcessEndingHandlerContext>()))
             .ReturnsAsync(OnProcessEndingHandlerResult.Success());
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
@@ -89,7 +89,7 @@ public class OnProcessEndingHookTests
         Assert.IsType<SuccessfulProcessEngineCommandResult>(result);
         handler.Verify(
             x =>
-                x.ExecuteAsync(
+                x.Execute(
                     It.Is<OnProcessEndingHandlerContext>(c =>
                         c.InstanceDataMutator == context.InstanceDataMutator
                         && c.CancellationToken.Equals(context.CancellationToken)
@@ -125,7 +125,7 @@ public class OnProcessEndingHookTests
         // Arrange
         var handler = new Mock<IOnProcessEndingHandler>();
         handler
-            .Setup(x => x.ExecuteAsync(It.IsAny<OnProcessEndingHandlerContext>()))
+            .Setup(x => x.Execute(It.IsAny<OnProcessEndingHandlerContext>()))
             .ReturnsAsync(OnProcessEndingHandlerResult.FailedPermanent("Hook failed"));
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
@@ -145,7 +145,7 @@ public class OnProcessEndingHookTests
         // Arrange
         var handler = new Mock<IOnProcessEndingHandler>();
         handler
-            .Setup(x => x.ExecuteAsync(It.IsAny<OnProcessEndingHandlerContext>()))
+            .Setup(x => x.Execute(It.IsAny<OnProcessEndingHandlerContext>()))
             .ReturnsAsync(OnProcessEndingHandlerResult.FailedRetryable("Transient error"));
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
@@ -165,7 +165,7 @@ public class OnProcessEndingHookTests
         // Arrange
         var handler = new Mock<IOnProcessEndingHandler>();
         handler
-            .Setup(x => x.ExecuteAsync(It.IsAny<OnProcessEndingHandlerContext>()))
+            .Setup(x => x.Execute(It.IsAny<OnProcessEndingHandlerContext>()))
             .ThrowsAsync(new InvalidOperationException("Handler exploded"));
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());

--- a/src/App/backend/test/Altinn.App.Core.Tests/Internal/WorkflowEngine/Commands/ProcessNext/ProcessEnd/OnProcessEndingHookTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Internal/WorkflowEngine/Commands/ProcessNext/ProcessEnd/OnProcessEndingHookTests.cs
@@ -76,9 +76,7 @@ public class OnProcessEndingHookTests
     {
         // Arrange
         var handler = new Mock<IOnProcessEndingHandler>();
-        handler
-            .Setup(x => x.Execute(It.IsAny<OnProcessEndingHandlerContext>()))
-            .ReturnsAsync(OnProcessEndingHandlerResult.Success());
+        handler.Setup(x => x.Execute(It.IsAny<OnProcessEndingContext>())).ReturnsAsync(OnProcessEndingResult.Success());
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
 
@@ -90,7 +88,7 @@ public class OnProcessEndingHookTests
         handler.Verify(
             x =>
                 x.Execute(
-                    It.Is<OnProcessEndingHandlerContext>(c =>
+                    It.Is<OnProcessEndingContext>(c =>
                         c.InstanceDataMutator == context.InstanceDataMutator
                         && c.CancellationToken.Equals(context.CancellationToken)
                     )
@@ -125,8 +123,8 @@ public class OnProcessEndingHookTests
         // Arrange
         var handler = new Mock<IOnProcessEndingHandler>();
         handler
-            .Setup(x => x.Execute(It.IsAny<OnProcessEndingHandlerContext>()))
-            .ReturnsAsync(OnProcessEndingHandlerResult.FailedPermanent("Hook failed"));
+            .Setup(x => x.Execute(It.IsAny<OnProcessEndingContext>()))
+            .ReturnsAsync(OnProcessEndingResult.FailedPermanent("Hook failed"));
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
 
@@ -145,8 +143,8 @@ public class OnProcessEndingHookTests
         // Arrange
         var handler = new Mock<IOnProcessEndingHandler>();
         handler
-            .Setup(x => x.Execute(It.IsAny<OnProcessEndingHandlerContext>()))
-            .ReturnsAsync(OnProcessEndingHandlerResult.FailedRetryable("Transient error"));
+            .Setup(x => x.Execute(It.IsAny<OnProcessEndingContext>()))
+            .ReturnsAsync(OnProcessEndingResult.FailedRetryable("Transient error"));
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
 
@@ -165,7 +163,7 @@ public class OnProcessEndingHookTests
         // Arrange
         var handler = new Mock<IOnProcessEndingHandler>();
         handler
-            .Setup(x => x.Execute(It.IsAny<OnProcessEndingHandlerContext>()))
+            .Setup(x => x.Execute(It.IsAny<OnProcessEndingContext>()))
             .ThrowsAsync(new InvalidOperationException("Handler exploded"));
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());

--- a/src/App/backend/test/Altinn.App.Core.Tests/Internal/WorkflowEngine/Commands/ProcessNext/TaskAbandon/OnTaskAbandonHookTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Internal/WorkflowEngine/Commands/ProcessNext/TaskAbandon/OnTaskAbandonHookTests.cs
@@ -78,7 +78,7 @@ public class OnTaskAbandonHookTests
         var handler = new Mock<IOnTaskAbandonHandler>();
         handler.Setup(x => x.ShouldRunForTask("Task_1")).Returns(true);
         handler
-            .Setup(x => x.ExecuteAsync(It.IsAny<OnTaskAbandonHandlerContext>()))
+            .Setup(x => x.Execute(It.IsAny<OnTaskAbandonHandlerContext>()))
             .ReturnsAsync(OnAbandonHandlerResult.Success());
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
@@ -90,7 +90,7 @@ public class OnTaskAbandonHookTests
         Assert.IsType<SuccessfulProcessEngineCommandResult>(result);
         handler.Verify(
             x =>
-                x.ExecuteAsync(
+                x.Execute(
                     It.Is<OnTaskAbandonHandlerContext>(c =>
                         c.InstanceDataMutator == context.InstanceDataMutator
                         && c.CancellationToken.Equals(context.CancellationToken)
@@ -130,7 +130,7 @@ public class OnTaskAbandonHookTests
         var handler = new Mock<IOnTaskAbandonHandler>();
         handler.Setup(x => x.ShouldRunForTask("Task_1")).Returns(true);
         handler
-            .Setup(x => x.ExecuteAsync(It.IsAny<OnTaskAbandonHandlerContext>()))
+            .Setup(x => x.Execute(It.IsAny<OnTaskAbandonHandlerContext>()))
             .ReturnsAsync(OnAbandonHandlerResult.FailedPermanent("Hook failed"));
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
@@ -151,7 +151,7 @@ public class OnTaskAbandonHookTests
         var handler = new Mock<IOnTaskAbandonHandler>();
         handler.Setup(x => x.ShouldRunForTask("Task_1")).Returns(true);
         handler
-            .Setup(x => x.ExecuteAsync(It.IsAny<OnTaskAbandonHandlerContext>()))
+            .Setup(x => x.Execute(It.IsAny<OnTaskAbandonHandlerContext>()))
             .ReturnsAsync(OnAbandonHandlerResult.FailedRetryable("Transient error"));
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
@@ -172,7 +172,7 @@ public class OnTaskAbandonHookTests
         var handler = new Mock<IOnTaskAbandonHandler>();
         handler.Setup(x => x.ShouldRunForTask("Task_1")).Returns(true);
         handler
-            .Setup(x => x.ExecuteAsync(It.IsAny<OnTaskAbandonHandlerContext>()))
+            .Setup(x => x.Execute(It.IsAny<OnTaskAbandonHandlerContext>()))
             .ThrowsAsync(new InvalidOperationException("Handler exploded"));
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());

--- a/src/App/backend/test/Altinn.App.Core.Tests/Internal/WorkflowEngine/Commands/ProcessNext/TaskAbandon/OnTaskAbandonHookTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Internal/WorkflowEngine/Commands/ProcessNext/TaskAbandon/OnTaskAbandonHookTests.cs
@@ -77,7 +77,7 @@ public class OnTaskAbandonHookTests
         // Arrange
         var handler = new Mock<IOnTaskAbandonHandler>();
         handler.Setup(x => x.ShouldRunForTask("Task_1")).Returns(true);
-        handler.Setup(x => x.Execute(It.IsAny<OnTaskAbandonContext>())).ReturnsAsync(OnTaskAbandonResult.Success());
+        handler.Setup(x => x.Execute(It.IsAny<OnTaskAbandonContext>())).ReturnsAsync(HookResult.Success());
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
 
@@ -129,7 +129,7 @@ public class OnTaskAbandonHookTests
         handler.Setup(x => x.ShouldRunForTask("Task_1")).Returns(true);
         handler
             .Setup(x => x.Execute(It.IsAny<OnTaskAbandonContext>()))
-            .ReturnsAsync(OnTaskAbandonResult.FailedPermanent("Hook failed"));
+            .ReturnsAsync(HookResult.FailedPermanent("Hook failed"));
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
 
@@ -150,7 +150,7 @@ public class OnTaskAbandonHookTests
         handler.Setup(x => x.ShouldRunForTask("Task_1")).Returns(true);
         handler
             .Setup(x => x.Execute(It.IsAny<OnTaskAbandonContext>()))
-            .ReturnsAsync(OnTaskAbandonResult.FailedRetryable("Transient error"));
+            .ReturnsAsync(HookResult.FailedRetryable("Transient error"));
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
 

--- a/src/App/backend/test/Altinn.App.Core.Tests/Internal/WorkflowEngine/Commands/ProcessNext/TaskAbandon/OnTaskAbandonHookTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Internal/WorkflowEngine/Commands/ProcessNext/TaskAbandon/OnTaskAbandonHookTests.cs
@@ -77,9 +77,7 @@ public class OnTaskAbandonHookTests
         // Arrange
         var handler = new Mock<IOnTaskAbandonHandler>();
         handler.Setup(x => x.ShouldRunForTask("Task_1")).Returns(true);
-        handler
-            .Setup(x => x.Execute(It.IsAny<OnTaskAbandonHandlerContext>()))
-            .ReturnsAsync(OnAbandonHandlerResult.Success());
+        handler.Setup(x => x.Execute(It.IsAny<OnTaskAbandonContext>())).ReturnsAsync(OnTaskAbandonResult.Success());
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
 
@@ -91,7 +89,7 @@ public class OnTaskAbandonHookTests
         handler.Verify(
             x =>
                 x.Execute(
-                    It.Is<OnTaskAbandonHandlerContext>(c =>
+                    It.Is<OnTaskAbandonContext>(c =>
                         c.InstanceDataMutator == context.InstanceDataMutator
                         && c.CancellationToken.Equals(context.CancellationToken)
                     )
@@ -130,8 +128,8 @@ public class OnTaskAbandonHookTests
         var handler = new Mock<IOnTaskAbandonHandler>();
         handler.Setup(x => x.ShouldRunForTask("Task_1")).Returns(true);
         handler
-            .Setup(x => x.Execute(It.IsAny<OnTaskAbandonHandlerContext>()))
-            .ReturnsAsync(OnAbandonHandlerResult.FailedPermanent("Hook failed"));
+            .Setup(x => x.Execute(It.IsAny<OnTaskAbandonContext>()))
+            .ReturnsAsync(OnTaskAbandonResult.FailedPermanent("Hook failed"));
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
 
@@ -151,8 +149,8 @@ public class OnTaskAbandonHookTests
         var handler = new Mock<IOnTaskAbandonHandler>();
         handler.Setup(x => x.ShouldRunForTask("Task_1")).Returns(true);
         handler
-            .Setup(x => x.Execute(It.IsAny<OnTaskAbandonHandlerContext>()))
-            .ReturnsAsync(OnAbandonHandlerResult.FailedRetryable("Transient error"));
+            .Setup(x => x.Execute(It.IsAny<OnTaskAbandonContext>()))
+            .ReturnsAsync(OnTaskAbandonResult.FailedRetryable("Transient error"));
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
 
@@ -172,7 +170,7 @@ public class OnTaskAbandonHookTests
         var handler = new Mock<IOnTaskAbandonHandler>();
         handler.Setup(x => x.ShouldRunForTask("Task_1")).Returns(true);
         handler
-            .Setup(x => x.Execute(It.IsAny<OnTaskAbandonHandlerContext>()))
+            .Setup(x => x.Execute(It.IsAny<OnTaskAbandonContext>()))
             .ThrowsAsync(new InvalidOperationException("Handler exploded"));
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());

--- a/src/App/backend/test/Altinn.App.Core.Tests/Internal/WorkflowEngine/Commands/ProcessNext/TaskEnd/OnTaskEndingHookTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Internal/WorkflowEngine/Commands/ProcessNext/TaskEnd/OnTaskEndingHookTests.cs
@@ -77,9 +77,7 @@ public class OnTaskEndingHookTests
         // Arrange
         var handler = new Mock<IOnTaskEndingHandler>();
         handler.Setup(x => x.ShouldRunForTask("Task_1")).Returns(true);
-        handler
-            .Setup(x => x.Execute(It.IsAny<OnTaskEndingHandlerContext>()))
-            .ReturnsAsync(OnEndingHandlerResult.Success());
+        handler.Setup(x => x.Execute(It.IsAny<OnTaskEndingContext>())).ReturnsAsync(OnTaskEndingResult.Success());
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
 
@@ -91,7 +89,7 @@ public class OnTaskEndingHookTests
         handler.Verify(
             x =>
                 x.Execute(
-                    It.Is<OnTaskEndingHandlerContext>(c =>
+                    It.Is<OnTaskEndingContext>(c =>
                         c.InstanceDataMutator == context.InstanceDataMutator
                         && c.CancellationToken.Equals(context.CancellationToken)
                     )
@@ -130,8 +128,8 @@ public class OnTaskEndingHookTests
         var handler = new Mock<IOnTaskEndingHandler>();
         handler.Setup(x => x.ShouldRunForTask("Task_1")).Returns(true);
         handler
-            .Setup(x => x.Execute(It.IsAny<OnTaskEndingHandlerContext>()))
-            .ReturnsAsync(OnEndingHandlerResult.FailedPermanent("Hook failed"));
+            .Setup(x => x.Execute(It.IsAny<OnTaskEndingContext>()))
+            .ReturnsAsync(OnTaskEndingResult.FailedPermanent("Hook failed"));
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
 
@@ -151,8 +149,8 @@ public class OnTaskEndingHookTests
         var handler = new Mock<IOnTaskEndingHandler>();
         handler.Setup(x => x.ShouldRunForTask("Task_1")).Returns(true);
         handler
-            .Setup(x => x.Execute(It.IsAny<OnTaskEndingHandlerContext>()))
-            .ReturnsAsync(OnEndingHandlerResult.FailedRetryable("Transient error"));
+            .Setup(x => x.Execute(It.IsAny<OnTaskEndingContext>()))
+            .ReturnsAsync(OnTaskEndingResult.FailedRetryable("Transient error"));
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
 
@@ -172,7 +170,7 @@ public class OnTaskEndingHookTests
         var handler = new Mock<IOnTaskEndingHandler>();
         handler.Setup(x => x.ShouldRunForTask("Task_1")).Returns(true);
         handler
-            .Setup(x => x.Execute(It.IsAny<OnTaskEndingHandlerContext>()))
+            .Setup(x => x.Execute(It.IsAny<OnTaskEndingContext>()))
             .ThrowsAsync(new InvalidOperationException("Handler exploded"));
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());

--- a/src/App/backend/test/Altinn.App.Core.Tests/Internal/WorkflowEngine/Commands/ProcessNext/TaskEnd/OnTaskEndingHookTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Internal/WorkflowEngine/Commands/ProcessNext/TaskEnd/OnTaskEndingHookTests.cs
@@ -78,7 +78,7 @@ public class OnTaskEndingHookTests
         var handler = new Mock<IOnTaskEndingHandler>();
         handler.Setup(x => x.ShouldRunForTask("Task_1")).Returns(true);
         handler
-            .Setup(x => x.ExecuteAsync(It.IsAny<OnTaskEndingHandlerContext>()))
+            .Setup(x => x.Execute(It.IsAny<OnTaskEndingHandlerContext>()))
             .ReturnsAsync(OnEndingHandlerResult.Success());
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
@@ -90,7 +90,7 @@ public class OnTaskEndingHookTests
         Assert.IsType<SuccessfulProcessEngineCommandResult>(result);
         handler.Verify(
             x =>
-                x.ExecuteAsync(
+                x.Execute(
                     It.Is<OnTaskEndingHandlerContext>(c =>
                         c.InstanceDataMutator == context.InstanceDataMutator
                         && c.CancellationToken.Equals(context.CancellationToken)
@@ -130,7 +130,7 @@ public class OnTaskEndingHookTests
         var handler = new Mock<IOnTaskEndingHandler>();
         handler.Setup(x => x.ShouldRunForTask("Task_1")).Returns(true);
         handler
-            .Setup(x => x.ExecuteAsync(It.IsAny<OnTaskEndingHandlerContext>()))
+            .Setup(x => x.Execute(It.IsAny<OnTaskEndingHandlerContext>()))
             .ReturnsAsync(OnEndingHandlerResult.FailedPermanent("Hook failed"));
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
@@ -151,7 +151,7 @@ public class OnTaskEndingHookTests
         var handler = new Mock<IOnTaskEndingHandler>();
         handler.Setup(x => x.ShouldRunForTask("Task_1")).Returns(true);
         handler
-            .Setup(x => x.ExecuteAsync(It.IsAny<OnTaskEndingHandlerContext>()))
+            .Setup(x => x.Execute(It.IsAny<OnTaskEndingHandlerContext>()))
             .ReturnsAsync(OnEndingHandlerResult.FailedRetryable("Transient error"));
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
@@ -172,7 +172,7 @@ public class OnTaskEndingHookTests
         var handler = new Mock<IOnTaskEndingHandler>();
         handler.Setup(x => x.ShouldRunForTask("Task_1")).Returns(true);
         handler
-            .Setup(x => x.ExecuteAsync(It.IsAny<OnTaskEndingHandlerContext>()))
+            .Setup(x => x.Execute(It.IsAny<OnTaskEndingHandlerContext>()))
             .ThrowsAsync(new InvalidOperationException("Handler exploded"));
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());

--- a/src/App/backend/test/Altinn.App.Core.Tests/Internal/WorkflowEngine/Commands/ProcessNext/TaskEnd/OnTaskEndingHookTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Internal/WorkflowEngine/Commands/ProcessNext/TaskEnd/OnTaskEndingHookTests.cs
@@ -77,7 +77,7 @@ public class OnTaskEndingHookTests
         // Arrange
         var handler = new Mock<IOnTaskEndingHandler>();
         handler.Setup(x => x.ShouldRunForTask("Task_1")).Returns(true);
-        handler.Setup(x => x.Execute(It.IsAny<OnTaskEndingContext>())).ReturnsAsync(OnTaskEndingResult.Success());
+        handler.Setup(x => x.Execute(It.IsAny<OnTaskEndingContext>())).ReturnsAsync(HookResult.Success());
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
 
@@ -129,7 +129,7 @@ public class OnTaskEndingHookTests
         handler.Setup(x => x.ShouldRunForTask("Task_1")).Returns(true);
         handler
             .Setup(x => x.Execute(It.IsAny<OnTaskEndingContext>()))
-            .ReturnsAsync(OnTaskEndingResult.FailedPermanent("Hook failed"));
+            .ReturnsAsync(HookResult.FailedPermanent("Hook failed"));
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
 
@@ -150,7 +150,7 @@ public class OnTaskEndingHookTests
         handler.Setup(x => x.ShouldRunForTask("Task_1")).Returns(true);
         handler
             .Setup(x => x.Execute(It.IsAny<OnTaskEndingContext>()))
-            .ReturnsAsync(OnTaskEndingResult.FailedRetryable("Transient error"));
+            .ReturnsAsync(HookResult.FailedRetryable("Transient error"));
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
 

--- a/src/App/backend/test/Altinn.App.Core.Tests/Internal/WorkflowEngine/Commands/ProcessNext/TaskStart/OnTaskStartingHookTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Internal/WorkflowEngine/Commands/ProcessNext/TaskStart/OnTaskStartingHookTests.cs
@@ -77,9 +77,7 @@ public class OnTaskStartingHookTests
         // Arrange
         var handler = new Mock<IOnTaskStartingHandler>();
         handler.Setup(x => x.ShouldRunForTask("Task_1")).Returns(true);
-        handler
-            .Setup(x => x.Execute(It.IsAny<OnTaskStartingContext>()))
-            .ReturnsAsync(OnTaskStartingHandlerResult.Success());
+        handler.Setup(x => x.Execute(It.IsAny<OnTaskStartingContext>())).ReturnsAsync(OnTaskStartingResult.Success());
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
 
@@ -131,7 +129,7 @@ public class OnTaskStartingHookTests
         handler.Setup(x => x.ShouldRunForTask("Task_1")).Returns(true);
         handler
             .Setup(x => x.Execute(It.IsAny<OnTaskStartingContext>()))
-            .ReturnsAsync(OnTaskStartingHandlerResult.FailedPermanent("Hook failed"));
+            .ReturnsAsync(OnTaskStartingResult.FailedPermanent("Hook failed"));
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
 
@@ -152,7 +150,7 @@ public class OnTaskStartingHookTests
         handler.Setup(x => x.ShouldRunForTask("Task_1")).Returns(true);
         handler
             .Setup(x => x.Execute(It.IsAny<OnTaskStartingContext>()))
-            .ReturnsAsync(OnTaskStartingHandlerResult.FailedRetryable("Transient error"));
+            .ReturnsAsync(OnTaskStartingResult.FailedRetryable("Transient error"));
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
 

--- a/src/App/backend/test/Altinn.App.Core.Tests/Internal/WorkflowEngine/Commands/ProcessNext/TaskStart/OnTaskStartingHookTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Internal/WorkflowEngine/Commands/ProcessNext/TaskStart/OnTaskStartingHookTests.cs
@@ -78,7 +78,7 @@ public class OnTaskStartingHookTests
         var handler = new Mock<IOnTaskStartingHandler>();
         handler.Setup(x => x.ShouldRunForTask("Task_1")).Returns(true);
         handler
-            .Setup(x => x.ExecuteAsync(It.IsAny<OnTaskStartingContext>()))
+            .Setup(x => x.Execute(It.IsAny<OnTaskStartingContext>()))
             .ReturnsAsync(OnTaskStartingHandlerResult.Success());
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
@@ -90,7 +90,7 @@ public class OnTaskStartingHookTests
         Assert.IsType<SuccessfulProcessEngineCommandResult>(result);
         handler.Verify(
             x =>
-                x.ExecuteAsync(
+                x.Execute(
                     It.Is<OnTaskStartingContext>(c =>
                         c.InstanceDataMutator == context.InstanceDataMutator
                         && c.CancellationToken.Equals(context.CancellationToken)
@@ -130,7 +130,7 @@ public class OnTaskStartingHookTests
         var handler = new Mock<IOnTaskStartingHandler>();
         handler.Setup(x => x.ShouldRunForTask("Task_1")).Returns(true);
         handler
-            .Setup(x => x.ExecuteAsync(It.IsAny<OnTaskStartingContext>()))
+            .Setup(x => x.Execute(It.IsAny<OnTaskStartingContext>()))
             .ReturnsAsync(OnTaskStartingHandlerResult.FailedPermanent("Hook failed"));
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
@@ -151,7 +151,7 @@ public class OnTaskStartingHookTests
         var handler = new Mock<IOnTaskStartingHandler>();
         handler.Setup(x => x.ShouldRunForTask("Task_1")).Returns(true);
         handler
-            .Setup(x => x.ExecuteAsync(It.IsAny<OnTaskStartingContext>()))
+            .Setup(x => x.Execute(It.IsAny<OnTaskStartingContext>()))
             .ReturnsAsync(OnTaskStartingHandlerResult.FailedRetryable("Transient error"));
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
@@ -172,7 +172,7 @@ public class OnTaskStartingHookTests
         var handler = new Mock<IOnTaskStartingHandler>();
         handler.Setup(x => x.ShouldRunForTask("Task_1")).Returns(true);
         handler
-            .Setup(x => x.ExecuteAsync(It.IsAny<OnTaskStartingContext>()))
+            .Setup(x => x.Execute(It.IsAny<OnTaskStartingContext>()))
             .ThrowsAsync(new InvalidOperationException("Handler exploded"));
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());

--- a/src/App/backend/test/Altinn.App.Core.Tests/Internal/WorkflowEngine/Commands/ProcessNext/TaskStart/OnTaskStartingHookTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Internal/WorkflowEngine/Commands/ProcessNext/TaskStart/OnTaskStartingHookTests.cs
@@ -77,7 +77,7 @@ public class OnTaskStartingHookTests
         // Arrange
         var handler = new Mock<IOnTaskStartingHandler>();
         handler.Setup(x => x.ShouldRunForTask("Task_1")).Returns(true);
-        handler.Setup(x => x.Execute(It.IsAny<OnTaskStartingContext>())).ReturnsAsync(OnTaskStartingResult.Success());
+        handler.Setup(x => x.Execute(It.IsAny<OnTaskStartingContext>())).ReturnsAsync(HookResult.Success());
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
 
@@ -129,7 +129,7 @@ public class OnTaskStartingHookTests
         handler.Setup(x => x.ShouldRunForTask("Task_1")).Returns(true);
         handler
             .Setup(x => x.Execute(It.IsAny<OnTaskStartingContext>()))
-            .ReturnsAsync(OnTaskStartingResult.FailedPermanent("Hook failed"));
+            .ReturnsAsync(HookResult.FailedPermanent("Hook failed"));
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
 
@@ -150,7 +150,7 @@ public class OnTaskStartingHookTests
         handler.Setup(x => x.ShouldRunForTask("Task_1")).Returns(true);
         handler
             .Setup(x => x.Execute(It.IsAny<OnTaskStartingContext>()))
-            .ReturnsAsync(OnTaskStartingResult.FailedRetryable("Transient error"));
+            .ReturnsAsync(HookResult.FailedRetryable("Transient error"));
         var command = CreateCommand(handler.Object);
         var context = CreateContext(CreateInstance());
 

--- a/src/App/backend/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/src/App/backend/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -2036,29 +2036,21 @@ namespace Altinn.App.Core.Features.Pdf
 }
 namespace Altinn.App.Core.Features.Process
 {
-    public sealed class FailedOnProcessEndingHandlerResult : Altinn.App.Core.Features.Process.OnProcessEndingHandlerResult, System.IEquatable<Altinn.App.Core.Features.Process.FailedOnProcessEndingHandlerResult>
+    public sealed class FailedOnProcessEndingResult : Altinn.App.Core.Features.Process.OnProcessEndingResult, System.IEquatable<Altinn.App.Core.Features.Process.FailedOnProcessEndingResult>
     {
-        public FailedOnProcessEndingHandlerResult(string ErrorMessage, bool NonRetryable) { }
-        public string ErrorMessage { get; init; }
-        public bool NonRetryable { get; init; }
+        public required string ErrorMessage { get; init; }
     }
-    public sealed class FailedOnTaskAbandonHandlerResult : Altinn.App.Core.Features.Process.OnAbandonHandlerResult, System.IEquatable<Altinn.App.Core.Features.Process.FailedOnTaskAbandonHandlerResult>
+    public sealed class FailedOnTaskAbandonResult : Altinn.App.Core.Features.Process.OnTaskAbandonResult, System.IEquatable<Altinn.App.Core.Features.Process.FailedOnTaskAbandonResult>
     {
-        public FailedOnTaskAbandonHandlerResult(string ErrorMessage, bool NonRetryable) { }
-        public string ErrorMessage { get; init; }
-        public bool NonRetryable { get; init; }
+        public required string ErrorMessage { get; init; }
     }
-    public sealed class FailedOnTaskEndingHandlerResult : Altinn.App.Core.Features.Process.OnEndingHandlerResult, System.IEquatable<Altinn.App.Core.Features.Process.FailedOnTaskEndingHandlerResult>
+    public sealed class FailedOnTaskEndingResult : Altinn.App.Core.Features.Process.OnTaskEndingResult, System.IEquatable<Altinn.App.Core.Features.Process.FailedOnTaskEndingResult>
     {
-        public FailedOnTaskEndingHandlerResult(string ErrorMessage, bool NonRetryable) { }
-        public string ErrorMessage { get; init; }
-        public bool NonRetryable { get; init; }
+        public required string ErrorMessage { get; init; }
     }
-    public sealed class FailedOnTaskStartingHandlerResult : Altinn.App.Core.Features.Process.OnTaskStartingHandlerResult, System.IEquatable<Altinn.App.Core.Features.Process.FailedOnTaskStartingHandlerResult>
+    public sealed class FailedOnTaskStartingResult : Altinn.App.Core.Features.Process.OnTaskStartingResult, System.IEquatable<Altinn.App.Core.Features.Process.FailedOnTaskStartingResult>
     {
-        public FailedOnTaskStartingHandlerResult(string ErrorMessage, bool NonRetryable) { }
-        public string ErrorMessage { get; init; }
-        public bool NonRetryable { get; init; }
+        public required string ErrorMessage { get; init; }
     }
     public abstract class HookResult : System.IEquatable<Altinn.App.Core.Features.Process.HookResult>
     {
@@ -2066,78 +2058,81 @@ namespace Altinn.App.Core.Features.Process
     }
     public interface IOnProcessEndingHandler
     {
-        System.Threading.Tasks.Task<Altinn.App.Core.Features.Process.OnProcessEndingHandlerResult> ExecuteAsync(Altinn.App.Core.Features.Process.OnProcessEndingHandlerContext context);
+        System.Threading.Tasks.Task<Altinn.App.Core.Features.Process.OnProcessEndingResult> Execute(Altinn.App.Core.Features.Process.OnProcessEndingContext context);
     }
     public interface IOnTaskAbandonHandler
     {
-        System.Threading.Tasks.Task<Altinn.App.Core.Features.Process.OnAbandonHandlerResult> ExecuteAsync(Altinn.App.Core.Features.Process.OnTaskAbandonHandlerContext context);
+        System.Threading.Tasks.Task<Altinn.App.Core.Features.Process.OnTaskAbandonResult> Execute(Altinn.App.Core.Features.Process.OnTaskAbandonContext context);
         bool ShouldRunForTask(string taskId);
     }
     public interface IOnTaskEndingHandler
     {
-        System.Threading.Tasks.Task<Altinn.App.Core.Features.Process.OnEndingHandlerResult> ExecuteAsync(Altinn.App.Core.Features.Process.OnTaskEndingHandlerContext context);
+        System.Threading.Tasks.Task<Altinn.App.Core.Features.Process.OnTaskEndingResult> Execute(Altinn.App.Core.Features.Process.OnTaskEndingContext context);
         bool ShouldRunForTask(string taskId);
     }
     public interface IOnTaskStartingHandler
     {
-        System.Threading.Tasks.Task<Altinn.App.Core.Features.Process.OnTaskStartingHandlerResult> ExecuteAsync(Altinn.App.Core.Features.Process.OnTaskStartingContext context);
+        System.Threading.Tasks.Task<Altinn.App.Core.Features.Process.OnTaskStartingResult> Execute(Altinn.App.Core.Features.Process.OnTaskStartingContext context);
         bool ShouldRunForTask(string taskId);
     }
     public interface IServiceTask : Altinn.App.Core.Internal.Process.ProcessTasks.IProcessTask
     {
         System.Threading.Tasks.Task<Altinn.App.Core.Features.Process.ServiceTaskResult> Execute(Altinn.App.Core.Features.Process.ServiceTaskContext context);
     }
-    public abstract class OnAbandonHandlerResult : Altinn.App.Core.Features.Process.HookResult, System.IEquatable<Altinn.App.Core.Features.Process.OnAbandonHandlerResult>
+    public sealed class OnProcessEndingContext
     {
-        protected OnAbandonHandlerResult() { }
-        public static Altinn.App.Core.Features.Process.FailedOnTaskAbandonHandlerResult FailedPermanent(string errorMessage) { }
-        public static Altinn.App.Core.Features.Process.FailedOnTaskAbandonHandlerResult FailedRetryable(string errorMessage) { }
-        public static Altinn.App.Core.Features.Process.SuccessfulOnAbandonHandlerResult Success() { }
-    }
-    public abstract class OnEndingHandlerResult : Altinn.App.Core.Features.Process.HookResult, System.IEquatable<Altinn.App.Core.Features.Process.OnEndingHandlerResult>
-    {
-        protected OnEndingHandlerResult() { }
-        public static Altinn.App.Core.Features.Process.FailedOnTaskEndingHandlerResult FailedPermanent(string errorMessage) { }
-        public static Altinn.App.Core.Features.Process.FailedOnTaskEndingHandlerResult FailedRetryable(string errorMessage) { }
-        public static Altinn.App.Core.Features.Process.SuccessfulOnEndingHandlerResult Success() { }
-    }
-    public sealed class OnProcessEndingHandlerContext
-    {
-        public OnProcessEndingHandlerContext() { }
+        public OnProcessEndingContext() { }
         public System.Threading.CancellationToken CancellationToken { get; init; }
         public required Altinn.App.Core.Features.IInstanceDataMutator InstanceDataMutator { get; init; }
     }
-    public abstract class OnProcessEndingHandlerResult : Altinn.App.Core.Features.Process.HookResult, System.IEquatable<Altinn.App.Core.Features.Process.OnProcessEndingHandlerResult>
+    public abstract class OnProcessEndingResult : Altinn.App.Core.Features.Process.HookResult, System.IEquatable<Altinn.App.Core.Features.Process.OnProcessEndingResult>
     {
-        protected OnProcessEndingHandlerResult() { }
-        public static Altinn.App.Core.Features.Process.FailedOnProcessEndingHandlerResult FailedPermanent(string errorMessage) { }
-        public static Altinn.App.Core.Features.Process.FailedOnProcessEndingHandlerResult FailedRetryable(string errorMessage) { }
-        public static Altinn.App.Core.Features.Process.SuccessfulOnProcessEndingHandlerResult Success() { }
+        protected OnProcessEndingResult() { }
+        public static Altinn.App.Core.Features.Process.FailedOnProcessEndingResult FailedPermanent(string errorMessage) { }
+        public static Altinn.App.Core.Features.Process.FailedOnProcessEndingResult FailedRetryable(string errorMessage) { }
+        public static Altinn.App.Core.Features.Process.SuccessfulOnProcessEndingResult Success() { }
     }
-    public sealed class OnTaskAbandonHandlerContext
+    public sealed class OnTaskAbandonContext
     {
-        public OnTaskAbandonHandlerContext() { }
+        public OnTaskAbandonContext() { }
         public System.Threading.CancellationToken CancellationToken { get; init; }
         public required Altinn.App.Core.Features.IInstanceDataMutator InstanceDataMutator { get; init; }
+        public required string TaskId { get; init; }
     }
-    public sealed class OnTaskEndingHandlerContext
+    public abstract class OnTaskAbandonResult : Altinn.App.Core.Features.Process.HookResult, System.IEquatable<Altinn.App.Core.Features.Process.OnTaskAbandonResult>
     {
-        public OnTaskEndingHandlerContext() { }
+        protected OnTaskAbandonResult() { }
+        public static Altinn.App.Core.Features.Process.FailedOnTaskAbandonResult FailedPermanent(string errorMessage) { }
+        public static Altinn.App.Core.Features.Process.FailedOnTaskAbandonResult FailedRetryable(string errorMessage) { }
+        public static Altinn.App.Core.Features.Process.SuccessfulOnTaskAbandonResult Success() { }
+    }
+    public sealed class OnTaskEndingContext
+    {
+        public OnTaskEndingContext() { }
         public System.Threading.CancellationToken CancellationToken { get; init; }
         public required Altinn.App.Core.Features.IInstanceDataMutator InstanceDataMutator { get; init; }
+        public required string TaskId { get; init; }
+    }
+    public abstract class OnTaskEndingResult : Altinn.App.Core.Features.Process.HookResult, System.IEquatable<Altinn.App.Core.Features.Process.OnTaskEndingResult>
+    {
+        protected OnTaskEndingResult() { }
+        public static Altinn.App.Core.Features.Process.FailedOnTaskEndingResult FailedPermanent(string errorMessage) { }
+        public static Altinn.App.Core.Features.Process.FailedOnTaskEndingResult FailedRetryable(string errorMessage) { }
+        public static Altinn.App.Core.Features.Process.SuccessfulOnTaskEndingResult Success() { }
     }
     public sealed class OnTaskStartingContext
     {
         public OnTaskStartingContext() { }
         public System.Threading.CancellationToken CancellationToken { get; init; }
         public required Altinn.App.Core.Features.IInstanceDataMutator InstanceDataMutator { get; init; }
+        public required string TaskId { get; init; }
     }
-    public abstract class OnTaskStartingHandlerResult : Altinn.App.Core.Features.Process.HookResult, System.IEquatable<Altinn.App.Core.Features.Process.OnTaskStartingHandlerResult>
+    public abstract class OnTaskStartingResult : Altinn.App.Core.Features.Process.HookResult, System.IEquatable<Altinn.App.Core.Features.Process.OnTaskStartingResult>
     {
-        protected OnTaskStartingHandlerResult() { }
-        public static Altinn.App.Core.Features.Process.FailedOnTaskStartingHandlerResult FailedPermanent(string errorMessage) { }
-        public static Altinn.App.Core.Features.Process.FailedOnTaskStartingHandlerResult FailedRetryable(string errorMessage) { }
-        public static Altinn.App.Core.Features.Process.SuccessfulOnTaskStartingHandlerResult Success() { }
+        protected OnTaskStartingResult() { }
+        public static Altinn.App.Core.Features.Process.FailedOnTaskStartingResult FailedPermanent(string errorMessage) { }
+        public static Altinn.App.Core.Features.Process.FailedOnTaskStartingResult FailedRetryable(string errorMessage) { }
+        public static Altinn.App.Core.Features.Process.SuccessfulOnTaskStartingResult Success() { }
     }
     public sealed class ServiceTaskContext : System.IEquatable<Altinn.App.Core.Features.Process.ServiceTaskContext>
     {
@@ -2147,9 +2142,7 @@ namespace Altinn.App.Core.Features.Process
     }
     public sealed class ServiceTaskFailedResult : Altinn.App.Core.Features.Process.ServiceTaskResult, System.IEquatable<Altinn.App.Core.Features.Process.ServiceTaskFailedResult>
     {
-        public ServiceTaskFailedResult(string ErrorMessage, bool NonRetryable) { }
-        public string ErrorMessage { get; init; }
-        public bool NonRetryable { get; init; }
+        public required string ErrorMessage { get; init; }
     }
     public abstract class ServiceTaskResult : System.IEquatable<Altinn.App.Core.Features.Process.ServiceTaskResult>
     {
@@ -2165,21 +2158,21 @@ namespace Altinn.App.Core.Features.Process
         public string? Action { get; init; }
         public bool AutoAdvanceProcess { get; init; }
     }
-    public sealed class SuccessfulOnAbandonHandlerResult : Altinn.App.Core.Features.Process.OnAbandonHandlerResult, System.IEquatable<Altinn.App.Core.Features.Process.SuccessfulOnAbandonHandlerResult>
+    public sealed class SuccessfulOnProcessEndingResult : Altinn.App.Core.Features.Process.OnProcessEndingResult, System.IEquatable<Altinn.App.Core.Features.Process.SuccessfulOnProcessEndingResult>
     {
-        public SuccessfulOnAbandonHandlerResult() { }
+        public SuccessfulOnProcessEndingResult() { }
     }
-    public sealed class SuccessfulOnEndingHandlerResult : Altinn.App.Core.Features.Process.OnEndingHandlerResult, System.IEquatable<Altinn.App.Core.Features.Process.SuccessfulOnEndingHandlerResult>
+    public sealed class SuccessfulOnTaskAbandonResult : Altinn.App.Core.Features.Process.OnTaskAbandonResult, System.IEquatable<Altinn.App.Core.Features.Process.SuccessfulOnTaskAbandonResult>
     {
-        public SuccessfulOnEndingHandlerResult() { }
+        public SuccessfulOnTaskAbandonResult() { }
     }
-    public sealed class SuccessfulOnProcessEndingHandlerResult : Altinn.App.Core.Features.Process.OnProcessEndingHandlerResult, System.IEquatable<Altinn.App.Core.Features.Process.SuccessfulOnProcessEndingHandlerResult>
+    public sealed class SuccessfulOnTaskEndingResult : Altinn.App.Core.Features.Process.OnTaskEndingResult, System.IEquatable<Altinn.App.Core.Features.Process.SuccessfulOnTaskEndingResult>
     {
-        public SuccessfulOnProcessEndingHandlerResult() { }
+        public SuccessfulOnTaskEndingResult() { }
     }
-    public sealed class SuccessfulOnTaskStartingHandlerResult : Altinn.App.Core.Features.Process.OnTaskStartingHandlerResult, System.IEquatable<Altinn.App.Core.Features.Process.SuccessfulOnTaskStartingHandlerResult>
+    public sealed class SuccessfulOnTaskStartingResult : Altinn.App.Core.Features.Process.OnTaskStartingResult, System.IEquatable<Altinn.App.Core.Features.Process.SuccessfulOnTaskStartingResult>
     {
-        public SuccessfulOnTaskStartingHandlerResult() { }
+        public SuccessfulOnTaskStartingResult() { }
     }
 }
 namespace Altinn.App.Core.Features.Redirect
@@ -4215,55 +4208,6 @@ namespace Altinn.App.Core.Internal.WorkflowEngine.Models.AppCommand
         public string? State { get; init; }
         [System.Text.Json.Serialization.JsonPropertyName("workflowId")]
         public required System.Guid WorkflowId { get; init; }
-    }
-    public sealed class AppCallbackResponse : System.IEquatable<Altinn.App.Core.Internal.WorkflowEngine.Models.AppCommand.AppCallbackResponse>
-    {
-        public AppCallbackResponse() { }
-        [System.Text.Json.Serialization.JsonPropertyName("state")]
-        public string? State { get; init; }
-    }
-}
-namespace Altinn.App.Core.Internal.WorkflowEngine.Models.Engine
-{
-    [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
-    public enum BackoffType
-    {
-        Constant = 0,
-        Linear = 1,
-        Exponential = 2,
-    }
-    [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
-    public enum PersistentItemStatus
-    {
-        Enqueued = 0,
-        Processing = 1,
-        Requeued = 2,
-        Completed = 3,
-        Failed = 4,
-        Canceled = 5,
-        DependencyFailed = 6,
-    }
-    public sealed class RetryStrategy : System.IEquatable<Altinn.App.Core.Internal.WorkflowEngine.Models.Engine.RetryStrategy>
-    {
-        public static readonly System.Collections.Generic.IReadOnlyList<int> DefaultNonRetryableHttpStatusCodes;
-        public RetryStrategy() { }
-        [System.Text.Json.Serialization.JsonPropertyName("backoffType")]
-        public Altinn.App.Core.Internal.WorkflowEngine.Models.Engine.BackoffType BackoffType { get; init; }
-        [System.Text.Json.Serialization.JsonPropertyName("baseInterval")]
-        public System.TimeSpan BaseInterval { get; init; }
-        [System.Text.Json.Serialization.JsonPropertyName("maxDelay")]
-        public System.TimeSpan? MaxDelay { get; init; }
-        [System.Text.Json.Serialization.JsonPropertyName("maxDuration")]
-        public System.TimeSpan? MaxDuration { get; init; }
-        [System.Text.Json.Serialization.JsonPropertyName("maxRetries")]
-        public int? MaxRetries { get; init; }
-        [System.Text.Json.Serialization.JsonPropertyName("nonRetryableHttpStatusCodes")]
-        public System.Collections.Generic.IReadOnlyList<int>? NonRetryableHttpStatusCodes { get; init; }
-        public static Altinn.App.Core.Internal.WorkflowEngine.Models.Engine.RetryStrategy Constant(System.TimeSpan interval, int? maxRetries = default, System.TimeSpan? maxDuration = default, System.Collections.Generic.IReadOnlyList<int>? nonRetryableHttpStatusCodes = null) { }
-        public static Altinn.App.Core.Internal.WorkflowEngine.Models.Engine.RetryStrategy Exponential(System.TimeSpan baseInterval, int? maxRetries = default, System.TimeSpan? maxDelay = default, System.TimeSpan? maxDuration = default, System.Collections.Generic.IReadOnlyList<int>? nonRetryableHttpStatusCodes = null) { }
-        public static Altinn.App.Core.Internal.WorkflowEngine.Models.Engine.RetryStrategy Fixed(System.TimeSpan intervalDelay, int? maxRetries = default, System.TimeSpan? maxDuration = default, System.Collections.Generic.IReadOnlyList<int>? nonRetryableHttpStatusCodes = null) { }
-        public static Altinn.App.Core.Internal.WorkflowEngine.Models.Engine.RetryStrategy Linear(System.TimeSpan baseInterval, int? maxRetries = default, System.TimeSpan? maxDelay = default, System.TimeSpan? maxDuration = default, System.Collections.Generic.IReadOnlyList<int>? nonRetryableHttpStatusCodes = null) { }
-        public static Altinn.App.Core.Internal.WorkflowEngine.Models.Engine.RetryStrategy None() { }
     }
 }
 namespace Altinn.App.Core.Models

--- a/src/App/backend/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/src/App/backend/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -2036,43 +2036,34 @@ namespace Altinn.App.Core.Features.Pdf
 }
 namespace Altinn.App.Core.Features.Process
 {
-    public sealed class FailedOnProcessEndingResult : Altinn.App.Core.Features.Process.OnProcessEndingResult, System.IEquatable<Altinn.App.Core.Features.Process.FailedOnProcessEndingResult>
-    {
-        public required string ErrorMessage { get; init; }
-    }
-    public sealed class FailedOnTaskAbandonResult : Altinn.App.Core.Features.Process.OnTaskAbandonResult, System.IEquatable<Altinn.App.Core.Features.Process.FailedOnTaskAbandonResult>
-    {
-        public required string ErrorMessage { get; init; }
-    }
-    public sealed class FailedOnTaskEndingResult : Altinn.App.Core.Features.Process.OnTaskEndingResult, System.IEquatable<Altinn.App.Core.Features.Process.FailedOnTaskEndingResult>
-    {
-        public required string ErrorMessage { get; init; }
-    }
-    public sealed class FailedOnTaskStartingResult : Altinn.App.Core.Features.Process.OnTaskStartingResult, System.IEquatable<Altinn.App.Core.Features.Process.FailedOnTaskStartingResult>
+    public sealed class FailedHookResult : Altinn.App.Core.Features.Process.HookResult, System.IEquatable<Altinn.App.Core.Features.Process.FailedHookResult>
     {
         public required string ErrorMessage { get; init; }
     }
     public abstract class HookResult : System.IEquatable<Altinn.App.Core.Features.Process.HookResult>
     {
         protected HookResult() { }
+        public static Altinn.App.Core.Features.Process.FailedHookResult FailedPermanent(string errorMessage) { }
+        public static Altinn.App.Core.Features.Process.FailedHookResult FailedRetryable(string errorMessage) { }
+        public static Altinn.App.Core.Features.Process.SuccessfulHookResult Success() { }
     }
     public interface IOnProcessEndingHandler
     {
-        System.Threading.Tasks.Task<Altinn.App.Core.Features.Process.OnProcessEndingResult> Execute(Altinn.App.Core.Features.Process.OnProcessEndingContext context);
+        System.Threading.Tasks.Task<Altinn.App.Core.Features.Process.HookResult> Execute(Altinn.App.Core.Features.Process.OnProcessEndingContext context);
     }
     public interface IOnTaskAbandonHandler
     {
-        System.Threading.Tasks.Task<Altinn.App.Core.Features.Process.OnTaskAbandonResult> Execute(Altinn.App.Core.Features.Process.OnTaskAbandonContext context);
+        System.Threading.Tasks.Task<Altinn.App.Core.Features.Process.HookResult> Execute(Altinn.App.Core.Features.Process.OnTaskAbandonContext context);
         bool ShouldRunForTask(string taskId);
     }
     public interface IOnTaskEndingHandler
     {
-        System.Threading.Tasks.Task<Altinn.App.Core.Features.Process.OnTaskEndingResult> Execute(Altinn.App.Core.Features.Process.OnTaskEndingContext context);
+        System.Threading.Tasks.Task<Altinn.App.Core.Features.Process.HookResult> Execute(Altinn.App.Core.Features.Process.OnTaskEndingContext context);
         bool ShouldRunForTask(string taskId);
     }
     public interface IOnTaskStartingHandler
     {
-        System.Threading.Tasks.Task<Altinn.App.Core.Features.Process.OnTaskStartingResult> Execute(Altinn.App.Core.Features.Process.OnTaskStartingContext context);
+        System.Threading.Tasks.Task<Altinn.App.Core.Features.Process.HookResult> Execute(Altinn.App.Core.Features.Process.OnTaskStartingContext context);
         bool ShouldRunForTask(string taskId);
     }
     public interface IServiceTask : Altinn.App.Core.Internal.Process.ProcessTasks.IProcessTask
@@ -2085,26 +2076,12 @@ namespace Altinn.App.Core.Features.Process
         public System.Threading.CancellationToken CancellationToken { get; init; }
         public required Altinn.App.Core.Features.IInstanceDataMutator InstanceDataMutator { get; init; }
     }
-    public abstract class OnProcessEndingResult : Altinn.App.Core.Features.Process.HookResult, System.IEquatable<Altinn.App.Core.Features.Process.OnProcessEndingResult>
-    {
-        protected OnProcessEndingResult() { }
-        public static Altinn.App.Core.Features.Process.FailedOnProcessEndingResult FailedPermanent(string errorMessage) { }
-        public static Altinn.App.Core.Features.Process.FailedOnProcessEndingResult FailedRetryable(string errorMessage) { }
-        public static Altinn.App.Core.Features.Process.SuccessfulOnProcessEndingResult Success() { }
-    }
     public sealed class OnTaskAbandonContext
     {
         public OnTaskAbandonContext() { }
         public System.Threading.CancellationToken CancellationToken { get; init; }
         public required Altinn.App.Core.Features.IInstanceDataMutator InstanceDataMutator { get; init; }
         public required string TaskId { get; init; }
-    }
-    public abstract class OnTaskAbandonResult : Altinn.App.Core.Features.Process.HookResult, System.IEquatable<Altinn.App.Core.Features.Process.OnTaskAbandonResult>
-    {
-        protected OnTaskAbandonResult() { }
-        public static Altinn.App.Core.Features.Process.FailedOnTaskAbandonResult FailedPermanent(string errorMessage) { }
-        public static Altinn.App.Core.Features.Process.FailedOnTaskAbandonResult FailedRetryable(string errorMessage) { }
-        public static Altinn.App.Core.Features.Process.SuccessfulOnTaskAbandonResult Success() { }
     }
     public sealed class OnTaskEndingContext
     {
@@ -2113,26 +2090,12 @@ namespace Altinn.App.Core.Features.Process
         public required Altinn.App.Core.Features.IInstanceDataMutator InstanceDataMutator { get; init; }
         public required string TaskId { get; init; }
     }
-    public abstract class OnTaskEndingResult : Altinn.App.Core.Features.Process.HookResult, System.IEquatable<Altinn.App.Core.Features.Process.OnTaskEndingResult>
-    {
-        protected OnTaskEndingResult() { }
-        public static Altinn.App.Core.Features.Process.FailedOnTaskEndingResult FailedPermanent(string errorMessage) { }
-        public static Altinn.App.Core.Features.Process.FailedOnTaskEndingResult FailedRetryable(string errorMessage) { }
-        public static Altinn.App.Core.Features.Process.SuccessfulOnTaskEndingResult Success() { }
-    }
     public sealed class OnTaskStartingContext
     {
         public OnTaskStartingContext() { }
         public System.Threading.CancellationToken CancellationToken { get; init; }
         public required Altinn.App.Core.Features.IInstanceDataMutator InstanceDataMutator { get; init; }
         public required string TaskId { get; init; }
-    }
-    public abstract class OnTaskStartingResult : Altinn.App.Core.Features.Process.HookResult, System.IEquatable<Altinn.App.Core.Features.Process.OnTaskStartingResult>
-    {
-        protected OnTaskStartingResult() { }
-        public static Altinn.App.Core.Features.Process.FailedOnTaskStartingResult FailedPermanent(string errorMessage) { }
-        public static Altinn.App.Core.Features.Process.FailedOnTaskStartingResult FailedRetryable(string errorMessage) { }
-        public static Altinn.App.Core.Features.Process.SuccessfulOnTaskStartingResult Success() { }
     }
     public sealed class ServiceTaskContext : System.IEquatable<Altinn.App.Core.Features.Process.ServiceTaskContext>
     {
@@ -2158,21 +2121,9 @@ namespace Altinn.App.Core.Features.Process
         public string? Action { get; init; }
         public bool AutoAdvanceProcess { get; init; }
     }
-    public sealed class SuccessfulOnProcessEndingResult : Altinn.App.Core.Features.Process.OnProcessEndingResult, System.IEquatable<Altinn.App.Core.Features.Process.SuccessfulOnProcessEndingResult>
+    public sealed class SuccessfulHookResult : Altinn.App.Core.Features.Process.HookResult, System.IEquatable<Altinn.App.Core.Features.Process.SuccessfulHookResult>
     {
-        public SuccessfulOnProcessEndingResult() { }
-    }
-    public sealed class SuccessfulOnTaskAbandonResult : Altinn.App.Core.Features.Process.OnTaskAbandonResult, System.IEquatable<Altinn.App.Core.Features.Process.SuccessfulOnTaskAbandonResult>
-    {
-        public SuccessfulOnTaskAbandonResult() { }
-    }
-    public sealed class SuccessfulOnTaskEndingResult : Altinn.App.Core.Features.Process.OnTaskEndingResult, System.IEquatable<Altinn.App.Core.Features.Process.SuccessfulOnTaskEndingResult>
-    {
-        public SuccessfulOnTaskEndingResult() { }
-    }
-    public sealed class SuccessfulOnTaskStartingResult : Altinn.App.Core.Features.Process.OnTaskStartingResult, System.IEquatable<Altinn.App.Core.Features.Process.SuccessfulOnTaskStartingResult>
-    {
-        public SuccessfulOnTaskStartingResult() { }
+        public SuccessfulHookResult() { }
     }
 }
 namespace Altinn.App.Core.Features.Redirect

--- a/src/App/backend/test/Altinn.App.Integration.Tests/_testapps/basic/_scenarios/workflow-engine-duplicate-task-ending-hooks/services/DuplicateTaskEndingHooks.cs
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/_testapps/basic/_scenarios/workflow-engine-duplicate-task-ending-hooks/services/DuplicateTaskEndingHooks.cs
@@ -8,16 +8,16 @@ public sealed class FirstTaskEndingHook : IOnTaskEndingHandler
 {
     public bool ShouldRunForTask(string taskId) => taskId == "Task_1";
 
-    public Task<OnEndingHandlerResult> Execute(OnTaskEndingHandlerContext context) =>
-        Task.FromResult<OnEndingHandlerResult>(OnEndingHandlerResult.Success());
+    public Task<OnTaskEndingResult> Execute(OnTaskEndingContext context) =>
+        Task.FromResult<OnTaskEndingResult>(OnTaskEndingResult.Success());
 }
 
 public sealed class SecondTaskEndingHook : IOnTaskEndingHandler
 {
     public bool ShouldRunForTask(string taskId) => taskId == "Task_1";
 
-    public Task<OnEndingHandlerResult> Execute(OnTaskEndingHandlerContext context) =>
-        Task.FromResult<OnEndingHandlerResult>(OnEndingHandlerResult.Success());
+    public Task<OnTaskEndingResult> Execute(OnTaskEndingContext context) =>
+        Task.FromResult<OnTaskEndingResult>(OnTaskEndingResult.Success());
 }
 
 public static class ServiceRegistration

--- a/src/App/backend/test/Altinn.App.Integration.Tests/_testapps/basic/_scenarios/workflow-engine-duplicate-task-ending-hooks/services/DuplicateTaskEndingHooks.cs
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/_testapps/basic/_scenarios/workflow-engine-duplicate-task-ending-hooks/services/DuplicateTaskEndingHooks.cs
@@ -8,7 +8,7 @@ public sealed class FirstTaskEndingHook : IOnTaskEndingHandler
 {
     public bool ShouldRunForTask(string taskId) => taskId == "Task_1";
 
-    public Task<OnEndingHandlerResult> ExecuteAsync(OnTaskEndingHandlerContext context) =>
+    public Task<OnEndingHandlerResult> Execute(OnTaskEndingHandlerContext context) =>
         Task.FromResult<OnEndingHandlerResult>(OnEndingHandlerResult.Success());
 }
 
@@ -16,7 +16,7 @@ public sealed class SecondTaskEndingHook : IOnTaskEndingHandler
 {
     public bool ShouldRunForTask(string taskId) => taskId == "Task_1";
 
-    public Task<OnEndingHandlerResult> ExecuteAsync(OnTaskEndingHandlerContext context) =>
+    public Task<OnEndingHandlerResult> Execute(OnTaskEndingHandlerContext context) =>
         Task.FromResult<OnEndingHandlerResult>(OnEndingHandlerResult.Success());
 }
 

--- a/src/App/backend/test/Altinn.App.Integration.Tests/_testapps/basic/_scenarios/workflow-engine-duplicate-task-ending-hooks/services/DuplicateTaskEndingHooks.cs
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/_testapps/basic/_scenarios/workflow-engine-duplicate-task-ending-hooks/services/DuplicateTaskEndingHooks.cs
@@ -8,16 +8,14 @@ public sealed class FirstTaskEndingHook : IOnTaskEndingHandler
 {
     public bool ShouldRunForTask(string taskId) => taskId == "Task_1";
 
-    public Task<OnTaskEndingResult> Execute(OnTaskEndingContext context) =>
-        Task.FromResult<OnTaskEndingResult>(OnTaskEndingResult.Success());
+    public Task<HookResult> Execute(OnTaskEndingContext context) => Task.FromResult<HookResult>(HookResult.Success());
 }
 
 public sealed class SecondTaskEndingHook : IOnTaskEndingHandler
 {
     public bool ShouldRunForTask(string taskId) => taskId == "Task_1";
 
-    public Task<OnTaskEndingResult> Execute(OnTaskEndingContext context) =>
-        Task.FromResult<OnTaskEndingResult>(OnTaskEndingResult.Success());
+    public Task<HookResult> Execute(OnTaskEndingContext context) => Task.FromResult<HookResult>(HookResult.Success());
 }
 
 public static class ServiceRegistration

--- a/src/App/backend/test/Altinn.App.Integration.Tests/_testapps/basic/_scenarios/workflow-engine-hooks/services/WorkflowEngineHookServices.cs
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/_testapps/basic/_scenarios/workflow-engine-hooks/services/WorkflowEngineHookServices.cs
@@ -11,10 +11,10 @@ public sealed class Task1StartingHook : IOnTaskStartingHandler
 {
     public bool ShouldRunForTask(string taskId) => taskId == "Task_1";
 
-    public Task<OnTaskStartingResult> Execute(OnTaskStartingContext context)
+    public Task<HookResult> Execute(OnTaskStartingContext context)
     {
         SnapshotLogger.LogInfo("WorkflowEngineHooks.OnTaskStarting.Task_1");
-        return Task.FromResult<OnTaskStartingResult>(OnTaskStartingResult.Success());
+        return Task.FromResult<HookResult>(HookResult.Success());
     }
 }
 
@@ -22,10 +22,10 @@ public sealed class ServiceTaskStartingHook : IOnTaskStartingHandler
 {
     public bool ShouldRunForTask(string taskId) => taskId == "Task_Service";
 
-    public Task<OnTaskStartingResult> Execute(OnTaskStartingContext context)
+    public Task<HookResult> Execute(OnTaskStartingContext context)
     {
         SnapshotLogger.LogInfo("WorkflowEngineHooks.OnTaskStarting.Task_Service");
-        return Task.FromResult<OnTaskStartingResult>(OnTaskStartingResult.Success());
+        return Task.FromResult<HookResult>(HookResult.Success());
     }
 }
 
@@ -33,18 +33,16 @@ public sealed class Task1EndingHook : IOnTaskEndingHandler
 {
     public bool ShouldRunForTask(string taskId) => taskId == "Task_1";
 
-    public Task<OnTaskEndingResult> Execute(OnTaskEndingContext context)
+    public Task<HookResult> Execute(OnTaskEndingContext context)
     {
         if (WorkflowEngineHooksState.FailTask1Ending)
         {
             SnapshotLogger.LogInfo("WorkflowEngineHooks.OnTaskEnding.Task_1.Failed");
-            return Task.FromResult<OnTaskEndingResult>(
-                OnTaskEndingResult.FailedPermanent("Scenario task ending failed permanently.")
-            );
+            return Task.FromResult<HookResult>(HookResult.FailedPermanent("Scenario task ending failed permanently."));
         }
 
         SnapshotLogger.LogInfo("WorkflowEngineHooks.OnTaskEnding.Task_1.Success");
-        return Task.FromResult<OnTaskEndingResult>(OnTaskEndingResult.Success());
+        return Task.FromResult<HookResult>(HookResult.Success());
     }
 }
 
@@ -52,10 +50,10 @@ public sealed class ServiceTaskEndingHook : IOnTaskEndingHandler
 {
     public bool ShouldRunForTask(string taskId) => taskId == "Task_Service";
 
-    public Task<OnTaskEndingResult> Execute(OnTaskEndingContext context)
+    public Task<HookResult> Execute(OnTaskEndingContext context)
     {
         SnapshotLogger.LogInfo("WorkflowEngineHooks.OnTaskEnding.Task_Service");
-        return Task.FromResult<OnTaskEndingResult>(OnTaskEndingResult.Success());
+        return Task.FromResult<HookResult>(HookResult.Success());
     }
 }
 
@@ -63,19 +61,19 @@ public sealed class Task1AbandonHook : IOnTaskAbandonHandler
 {
     public bool ShouldRunForTask(string taskId) => taskId == "Task_1";
 
-    public Task<OnTaskAbandonResult> Execute(OnTaskAbandonContext context)
+    public Task<HookResult> Execute(OnTaskAbandonContext context)
     {
         SnapshotLogger.LogInfo("WorkflowEngineHooks.OnTaskAbandon.Task_1");
-        return Task.FromResult<OnTaskAbandonResult>(OnTaskAbandonResult.Success());
+        return Task.FromResult<HookResult>(HookResult.Success());
     }
 }
 
 public sealed class ProcessEndingHook : IOnProcessEndingHandler
 {
-    public Task<OnProcessEndingResult> Execute(OnProcessEndingContext context)
+    public Task<HookResult> Execute(OnProcessEndingContext context)
     {
         SnapshotLogger.LogInfo("WorkflowEngineHooks.OnProcessEnding");
-        return Task.FromResult<OnProcessEndingResult>(OnProcessEndingResult.Success());
+        return Task.FromResult<HookResult>(HookResult.Success());
     }
 }
 

--- a/src/App/backend/test/Altinn.App.Integration.Tests/_testapps/basic/_scenarios/workflow-engine-hooks/services/WorkflowEngineHookServices.cs
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/_testapps/basic/_scenarios/workflow-engine-hooks/services/WorkflowEngineHookServices.cs
@@ -11,10 +11,10 @@ public sealed class Task1StartingHook : IOnTaskStartingHandler
 {
     public bool ShouldRunForTask(string taskId) => taskId == "Task_1";
 
-    public Task<OnTaskStartingHandlerResult> Execute(OnTaskStartingContext context)
+    public Task<OnTaskStartingResult> Execute(OnTaskStartingContext context)
     {
         SnapshotLogger.LogInfo("WorkflowEngineHooks.OnTaskStarting.Task_1");
-        return Task.FromResult<OnTaskStartingHandlerResult>(OnTaskStartingHandlerResult.Success());
+        return Task.FromResult<OnTaskStartingResult>(OnTaskStartingResult.Success());
     }
 }
 
@@ -22,10 +22,10 @@ public sealed class ServiceTaskStartingHook : IOnTaskStartingHandler
 {
     public bool ShouldRunForTask(string taskId) => taskId == "Task_Service";
 
-    public Task<OnTaskStartingHandlerResult> Execute(OnTaskStartingContext context)
+    public Task<OnTaskStartingResult> Execute(OnTaskStartingContext context)
     {
         SnapshotLogger.LogInfo("WorkflowEngineHooks.OnTaskStarting.Task_Service");
-        return Task.FromResult<OnTaskStartingHandlerResult>(OnTaskStartingHandlerResult.Success());
+        return Task.FromResult<OnTaskStartingResult>(OnTaskStartingResult.Success());
     }
 }
 
@@ -33,18 +33,18 @@ public sealed class Task1EndingHook : IOnTaskEndingHandler
 {
     public bool ShouldRunForTask(string taskId) => taskId == "Task_1";
 
-    public Task<OnEndingHandlerResult> Execute(OnTaskEndingHandlerContext context)
+    public Task<OnTaskEndingResult> Execute(OnTaskEndingContext context)
     {
         if (WorkflowEngineHooksState.FailTask1Ending)
         {
             SnapshotLogger.LogInfo("WorkflowEngineHooks.OnTaskEnding.Task_1.Failed");
-            return Task.FromResult<OnEndingHandlerResult>(
-                OnEndingHandlerResult.FailedPermanent("Scenario task ending failed permanently.")
+            return Task.FromResult<OnTaskEndingResult>(
+                OnTaskEndingResult.FailedPermanent("Scenario task ending failed permanently.")
             );
         }
 
         SnapshotLogger.LogInfo("WorkflowEngineHooks.OnTaskEnding.Task_1.Success");
-        return Task.FromResult<OnEndingHandlerResult>(OnEndingHandlerResult.Success());
+        return Task.FromResult<OnTaskEndingResult>(OnTaskEndingResult.Success());
     }
 }
 
@@ -52,10 +52,10 @@ public sealed class ServiceTaskEndingHook : IOnTaskEndingHandler
 {
     public bool ShouldRunForTask(string taskId) => taskId == "Task_Service";
 
-    public Task<OnEndingHandlerResult> Execute(OnTaskEndingHandlerContext context)
+    public Task<OnTaskEndingResult> Execute(OnTaskEndingContext context)
     {
         SnapshotLogger.LogInfo("WorkflowEngineHooks.OnTaskEnding.Task_Service");
-        return Task.FromResult<OnEndingHandlerResult>(OnEndingHandlerResult.Success());
+        return Task.FromResult<OnTaskEndingResult>(OnTaskEndingResult.Success());
     }
 }
 
@@ -63,19 +63,19 @@ public sealed class Task1AbandonHook : IOnTaskAbandonHandler
 {
     public bool ShouldRunForTask(string taskId) => taskId == "Task_1";
 
-    public Task<OnAbandonHandlerResult> Execute(OnTaskAbandonHandlerContext context)
+    public Task<OnTaskAbandonResult> Execute(OnTaskAbandonContext context)
     {
         SnapshotLogger.LogInfo("WorkflowEngineHooks.OnTaskAbandon.Task_1");
-        return Task.FromResult<OnAbandonHandlerResult>(OnAbandonHandlerResult.Success());
+        return Task.FromResult<OnTaskAbandonResult>(OnTaskAbandonResult.Success());
     }
 }
 
 public sealed class ProcessEndingHook : IOnProcessEndingHandler
 {
-    public Task<OnProcessEndingHandlerResult> Execute(OnProcessEndingHandlerContext context)
+    public Task<OnProcessEndingResult> Execute(OnProcessEndingContext context)
     {
         SnapshotLogger.LogInfo("WorkflowEngineHooks.OnProcessEnding");
-        return Task.FromResult<OnProcessEndingHandlerResult>(OnProcessEndingHandlerResult.Success());
+        return Task.FromResult<OnProcessEndingResult>(OnProcessEndingResult.Success());
     }
 }
 

--- a/src/App/backend/test/Altinn.App.Integration.Tests/_testapps/basic/_scenarios/workflow-engine-hooks/services/WorkflowEngineHookServices.cs
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/_testapps/basic/_scenarios/workflow-engine-hooks/services/WorkflowEngineHookServices.cs
@@ -11,7 +11,7 @@ public sealed class Task1StartingHook : IOnTaskStartingHandler
 {
     public bool ShouldRunForTask(string taskId) => taskId == "Task_1";
 
-    public Task<OnTaskStartingHandlerResult> ExecuteAsync(OnTaskStartingContext context)
+    public Task<OnTaskStartingHandlerResult> Execute(OnTaskStartingContext context)
     {
         SnapshotLogger.LogInfo("WorkflowEngineHooks.OnTaskStarting.Task_1");
         return Task.FromResult<OnTaskStartingHandlerResult>(OnTaskStartingHandlerResult.Success());
@@ -22,7 +22,7 @@ public sealed class ServiceTaskStartingHook : IOnTaskStartingHandler
 {
     public bool ShouldRunForTask(string taskId) => taskId == "Task_Service";
 
-    public Task<OnTaskStartingHandlerResult> ExecuteAsync(OnTaskStartingContext context)
+    public Task<OnTaskStartingHandlerResult> Execute(OnTaskStartingContext context)
     {
         SnapshotLogger.LogInfo("WorkflowEngineHooks.OnTaskStarting.Task_Service");
         return Task.FromResult<OnTaskStartingHandlerResult>(OnTaskStartingHandlerResult.Success());
@@ -33,7 +33,7 @@ public sealed class Task1EndingHook : IOnTaskEndingHandler
 {
     public bool ShouldRunForTask(string taskId) => taskId == "Task_1";
 
-    public Task<OnEndingHandlerResult> ExecuteAsync(OnTaskEndingHandlerContext context)
+    public Task<OnEndingHandlerResult> Execute(OnTaskEndingHandlerContext context)
     {
         if (WorkflowEngineHooksState.FailTask1Ending)
         {
@@ -52,7 +52,7 @@ public sealed class ServiceTaskEndingHook : IOnTaskEndingHandler
 {
     public bool ShouldRunForTask(string taskId) => taskId == "Task_Service";
 
-    public Task<OnEndingHandlerResult> ExecuteAsync(OnTaskEndingHandlerContext context)
+    public Task<OnEndingHandlerResult> Execute(OnTaskEndingHandlerContext context)
     {
         SnapshotLogger.LogInfo("WorkflowEngineHooks.OnTaskEnding.Task_Service");
         return Task.FromResult<OnEndingHandlerResult>(OnEndingHandlerResult.Success());
@@ -63,7 +63,7 @@ public sealed class Task1AbandonHook : IOnTaskAbandonHandler
 {
     public bool ShouldRunForTask(string taskId) => taskId == "Task_1";
 
-    public Task<OnAbandonHandlerResult> ExecuteAsync(OnTaskAbandonHandlerContext context)
+    public Task<OnAbandonHandlerResult> Execute(OnTaskAbandonHandlerContext context)
     {
         SnapshotLogger.LogInfo("WorkflowEngineHooks.OnTaskAbandon.Task_1");
         return Task.FromResult<OnAbandonHandlerResult>(OnAbandonHandlerResult.Success());
@@ -72,7 +72,7 @@ public sealed class Task1AbandonHook : IOnTaskAbandonHandler
 
 public sealed class ProcessEndingHook : IOnProcessEndingHandler
 {
-    public Task<OnProcessEndingHandlerResult> ExecuteAsync(OnProcessEndingHandlerContext context)
+    public Task<OnProcessEndingHandlerResult> Execute(OnProcessEndingHandlerContext context)
     {
         SnapshotLogger.LogInfo("WorkflowEngineHooks.OnProcessEnding");
         return Task.FromResult<OnProcessEndingHandlerResult>(OnProcessEndingHandlerResult.Success());

--- a/src/App/backend/test/Altinn.App.Integration.Tests/_testapps/basic/_scenarios/workflow-engine-instantiation-failure/services/FailingTaskStartHandler.cs
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/_testapps/basic/_scenarios/workflow-engine-instantiation-failure/services/FailingTaskStartHandler.cs
@@ -8,7 +8,7 @@ public sealed class FailingTaskStartHandler : IOnTaskStartingHandler
 {
     public bool ShouldRunForTask(string taskId) => taskId == "Task_1";
 
-    public Task<OnTaskStartingHandlerResult> ExecuteAsync(OnTaskStartingContext context) =>
+    public Task<OnTaskStartingHandlerResult> Execute(OnTaskStartingContext context) =>
         Task.FromResult<OnTaskStartingHandlerResult>(
             OnTaskStartingHandlerResult.FailedPermanent("Scenario task start failed permanently.")
         );

--- a/src/App/backend/test/Altinn.App.Integration.Tests/_testapps/basic/_scenarios/workflow-engine-instantiation-failure/services/FailingTaskStartHandler.cs
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/_testapps/basic/_scenarios/workflow-engine-instantiation-failure/services/FailingTaskStartHandler.cs
@@ -8,9 +8,9 @@ public sealed class FailingTaskStartHandler : IOnTaskStartingHandler
 {
     public bool ShouldRunForTask(string taskId) => taskId == "Task_1";
 
-    public Task<OnTaskStartingHandlerResult> Execute(OnTaskStartingContext context) =>
-        Task.FromResult<OnTaskStartingHandlerResult>(
-            OnTaskStartingHandlerResult.FailedPermanent("Scenario task start failed permanently.")
+    public Task<OnTaskStartingResult> Execute(OnTaskStartingContext context) =>
+        Task.FromResult<OnTaskStartingResult>(
+            OnTaskStartingResult.FailedPermanent("Scenario task start failed permanently.")
         );
 }
 

--- a/src/App/backend/test/Altinn.App.Integration.Tests/_testapps/basic/_scenarios/workflow-engine-instantiation-failure/services/FailingTaskStartHandler.cs
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/_testapps/basic/_scenarios/workflow-engine-instantiation-failure/services/FailingTaskStartHandler.cs
@@ -8,10 +8,8 @@ public sealed class FailingTaskStartHandler : IOnTaskStartingHandler
 {
     public bool ShouldRunForTask(string taskId) => taskId == "Task_1";
 
-    public Task<OnTaskStartingResult> Execute(OnTaskStartingContext context) =>
-        Task.FromResult<OnTaskStartingResult>(
-            OnTaskStartingResult.FailedPermanent("Scenario task start failed permanently.")
-        );
+    public Task<HookResult> Execute(OnTaskStartingContext context) =>
+        Task.FromResult<HookResult>(HookResult.FailedPermanent("Scenario task start failed permanently."));
 }
 
 public static class ServiceRegistration


### PR DESCRIPTION
## Summary

Tidies the newly-introduced workflow-engine public API surface, addressing review findings **1.1** and **3.1–3.5** from the [#18735](https://github.com/Altinn/app-lib-dotnet/pull/18735) review. These are NEW, never-shipped `[ImplementableByApps]` interfaces and `Internal/` model types, so the changes are in-scope for this v9 major and frozen-contract conventions apply once shipped — better to get them right now.

The app↔engine **wire contract is unchanged**: no JSON property name/kind/nullability was touched. `AppWireContractTests` still passes, and the `Altinn.App.Api` public-API and OpenAPI snapshots are byte-identical. Only the `Altinn.App.Core` public-API snapshot shifted (intentionally), reflecting exactly these changes.
