### PR TITLE
feat: deploy workflow-engine-app with workload identity + shared dis-pgsql (at23)

### DIFF
--- a/infra/runtime/syncroot/at23/kustomization.yaml
+++ b/infra/runtime/syncroot/at23/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - workflow-engine-app.yaml

--- a/infra/runtime/syncroot/at23/workflow-engine-app.yaml
+++ b/infra/runtime/syncroot/at23/workflow-engine-app.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: runtime-workflow-engine-app
+  labels:
+    altinn.studio/runtime: "true"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: runtime-environment
+  namespace: runtime-workflow-engine-app
+data:
+  upgrade_channel: ${UPGRADE_CHANNEL}
+  environment: ${ENVIRONMENT}
+  serviceowner: ${SERVICEOWNER_ID}
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: workflow-engine-app-repo
+  namespace: runtime-workflow-engine-app
+spec:
+  interval: 5m
+  provider: azure
+  ref:
+    tag: ${UPGRADE_CHANNEL}
+  timeout: 5m
+  url: oci://altinncr.azurecr.io/studio-apps/runtime-workflow-engine-app-repo
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: workflow-engine-app
+  namespace: runtime-workflow-engine-app
+spec:
+  targetNamespace: runtime-workflow-engine-app
+  interval: 5m
+  retryInterval: 5m
+  timeout: 1m
+  prune: true
+  force: false
+  wait: true
+  path: ./${ENVIRONMENT}
+  sourceRef:
+    kind: OCIRepository
+    name: workflow-engine-app-repo
+    namespace: runtime-workflow-engine-app
+  postBuild:
+    substitute:
+      SERVICEOWNER_ID: ${SERVICEOWNER_ID}
+      ENVIRONMENT: ${ENVIRONMENT}
+      WORKFLOW_ENGINE_ENTRA_CLIENT_ID: ${STUDIO_WORKFLOW_ENGINE_CLIENT_ID}
+      WORKFLOW_ENGINE_DB_USERNAME: ${STUDIO_WORKFLOW_ENGINE_DB_USERNAME}
+      WORKFLOW_ENGINE_DB_HOST: workflow-engine-db-server-test.postgres.database.azure.com

--- a/src/Runtime/workflow-engine-app/infra/kustomize/at23/kustomization.yaml
+++ b/src/Runtime/workflow-engine-app/infra/kustomize/at23/kustomization.yaml
@@ -2,3 +2,20 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+patches:
+  - target:
+      kind: Deployment
+      name: workflow-engine-app
+    patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: workflow-engine-app
+      spec:
+        template:
+          spec:
+            containers:
+              - name: workflow-engine-app
+                env:
+                  - name: ConnectionStrings__WorkflowEngine
+                    value: "Host=${WORKFLOW_ENGINE_DB_HOST};Port=5432;Database=workflow_engine_${SERVICEOWNER_ID}_${ENVIRONMENT};Username=${WORKFLOW_ENGINE_DB_USERNAME};Ssl Mode=Require"

--- a/src/Runtime/workflow-engine-app/infra/kustomize/base/deployment.yaml
+++ b/src/Runtime/workflow-engine-app/infra/kustomize/base/deployment.yaml
@@ -32,6 +32,7 @@ spec:
     metadata:
       labels:
         app: workflow-engine-app
+        azure.workload.identity/use: "true"
       annotations:
         linkerd.io/inject: enabled
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/src/Runtime/workflow-engine-app/infra/kustomize/base/serviceaccount.yaml
+++ b/src/Runtime/workflow-engine-app/infra/kustomize/base/serviceaccount.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: workflow-engine-app
+  annotations:
+    azure.workload.identity/client-id: "${WORKFLOW_ENGINE_ENTRA_CLIENT_ID}"


### PR DESCRIPTION
Deploys `workflow-engine-app` on **at23** with Azure workload identity and a connection to the shared dis-pgsql Postgres.

`ConnectionStrings__WorkflowEngine` is kept in the **at23 overlay**, not `base`, for now — it's per-env until every cluster is onboarded to the shared DB (a literal connection string in `base` would override other envs' DB config). It promotes to `base` once the rollout is complete. The workload-identity annotation + `use` label live in `base`.

Per-cluster client-id + DB values are substituted by the at23 syncroot wrapper from the platform module (`aks-apps-resources`).

> [!NOTE]
> Passwordless Postgres also needs the engine to supply an Entra access token as the Npgsql password (`WorkflowEngine.Data`) — owned by the workflow-engine team. Until that lands the pod runs but can't authenticate to the database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deployment/configuration for the workflow engine app in the runtime environment.
  * Enabled Azure Workload Identity for the app and linked it to the required client identity.
  * Added environment-specific connection settings and database configuration for the app.

* **Bug Fixes**
  * Ensured the runtime sync includes the new workflow engine app resources so they are applied together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->