### PR TITLE
fix: per-env workflow-engine DatabaseServer name (avoid global FQDN collision)

### DIFF
--- a/infra/admin/workflow-engine-db/prod/kustomization.yaml
+++ b/infra/admin/workflow-engine-db/prod/kustomization.yaml
@@ -10,3 +10,6 @@ patches:
       - op: replace
         path: /spec/serverType
         value: prod
+      - op: replace
+        path: /metadata/name
+        value: workflow-engine-db-server-prod

--- a/infra/admin/workflow-engine-db/test/kustomization.yaml
+++ b/infra/admin/workflow-engine-db/test/kustomization.yaml
@@ -2,3 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+patches:
+  - target:
+      kind: DatabaseServer
+      name: workflow-engine-db-server
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: workflow-engine-db-server-test

--- a/infra/admin/workflow-engine-tenant-db-template/database.yaml
+++ b/infra/admin/workflow-engine-tenant-db-template/database.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   name: ${DISDB_PGNAME}
   server:
-    name: workflow-engine-db-server
+    name: ${DISDB_SERVER}
   access:
     principals:
       - role: Owner


### PR DESCRIPTION
Azure PostgreSQL Flexible Server names are globally unique, but the workflow-engine `DatabaseServer` is named `workflow-engine-db-server` in both admin-test and admin-prod — the second to provision would fail.

Names it per admin env (`workflow-engine-db-server-test` / `-prod`), and the tenant DB template references it via `${DISDB_SERVER}`, substituted at deploy time in the cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected database server naming in the production and test deployment overlays so the right resources are targeted during rollout.
  * Made the tenant database template use a configurable server reference, improving consistency across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->