### PR TITLE
feat: Authenticated.App auth type for process callbacks

### DIFF
--- a/src/App/backend/src/Altinn.App.Core/Features/Auth/Authenticated.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Auth/Authenticated.cs
@@ -99,22 +99,27 @@ public abstract class Authenticated
     }
 
     /// <summary>
-    /// The caller is the Altinn workflow engine invoking a process callback for a specific instance.
-    /// Authenticated via the <c>WorkflowEngineCallback</c> scheme using an app-minted token bound to the
-    /// instance; it carries no Altinn user/org identity — only the instance it is authorized to act on.
+    /// The caller is the app itself — its own machinery (the workflow engine invoking a process callback via
+    /// the <c>WorkflowEngineCallback</c> scheme) authenticated by an app-minted token. Carries the app
+    /// identity and, when the callback targets a specific instance, the identifier for that instance.
     /// </summary>
-    public sealed class WorkflowEngineCallback : Authenticated
+    public sealed class App : Authenticated
     {
         /// <summary>
-        /// The instance this callback is authorized to act on (the token's <c>jti</c>, validated against the
-        /// callback route).
+        /// The app this callback is running as.
         /// </summary>
-        public Guid InstanceGuid { get; }
+        public AppIdentifier AppId { get; }
 
-        internal WorkflowEngineCallback(Guid instanceGuid, ref ParseContext context)
+        /// <summary>
+        /// The instance the callback targets when it is instance-scoped; otherwise <c>null</c>.
+        /// </summary>
+        public InstanceIdentifier? InstanceId { get; }
+
+        internal App(AppIdentifier appId, InstanceIdentifier? instanceId, ref ParseContext context)
             : base(ref context)
         {
-            InstanceGuid = instanceGuid;
+            AppId = appId;
+            InstanceId = instanceId;
         }
     }
 
@@ -560,7 +565,6 @@ public abstract class Authenticated
     }
 
     // TODO: app token?
-    // public sealed record App(string Token) : Authenticated;
 
     internal delegate Authenticated Parser(
         string tokenStr,
@@ -830,15 +834,16 @@ public abstract class Authenticated
     }
 
     /// <summary>
-    /// Builds the authentication info for a workflow-engine process callback. The callback is authenticated by
-    /// the <c>WorkflowEngineCallback</c> scheme with an app-minted token bound to <paramref name="instanceGuid"/>
-    /// and carries no Altinn user/org identity, so it maps directly to <see cref="WorkflowEngineCallback"/>
-    /// instead of being run through the standard user/org/system-user token classification.
+    /// Builds the authentication info for an app process callback (the workflow engine invoking the
+    /// <c>WorkflowEngineCallback</c> scheme). The principal carries no Altinn user/org identity, so it maps
+    /// directly to <see cref="App"/> instead of being run through the standard token classification. The app
+    /// identity is taken from <paramref name="appMetadata"/> (the running app), and <paramref name="instanceId"/>
+    /// is the instance the callback targets, when instance-scoped.
     /// </summary>
-    internal static Authenticated FromWorkflowEngineCallback(
+    internal static Authenticated FromApp(
         string tokenStr,
         JwtSecurityToken? parsedToken,
-        Guid instanceGuid,
+        InstanceIdentifier? instanceId,
         ApplicationMetadata appMetadata
     )
     {
@@ -852,7 +857,7 @@ public abstract class Authenticated
             static _ => Task.FromResult<Party?>(null),
             static _ =>
                 throw new InvalidOperationException(
-                    "Org party lookup is not applicable for a workflow-engine callback principal."
+                    "Org party lookup is not applicable for an app callback principal."
                 ),
             static _ => Task.FromResult<List<Party>?>(null),
             static (_, _) => Task.FromResult<bool?>(null)
@@ -868,7 +873,7 @@ public abstract class Authenticated
             context.ResolveIssuer();
         }
 
-        return new WorkflowEngineCallback(instanceGuid, ref context);
+        return new App(appMetadata.AppIdentifier, instanceId, ref context);
     }
 
     internal static Authenticated From(

--- a/src/App/backend/src/Altinn.App.Core/Features/Auth/Authenticated.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Auth/Authenticated.cs
@@ -564,8 +564,6 @@ public abstract class Authenticated
         }
     }
 
-    // TODO: app token?
-
     internal delegate Authenticated Parser(
         string tokenStr,
         JwtSecurityToken? parsedToken,

--- a/src/App/backend/src/Altinn.App.Core/Features/Auth/Authenticated.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Auth/Authenticated.cs
@@ -836,13 +836,14 @@ public abstract class Authenticated
     /// <summary>
     /// Builds the authentication info for an app process callback (the workflow engine invoking the
     /// <c>WorkflowEngineCallback</c> scheme). The principal carries no Altinn user/org identity, so it maps
-    /// directly to <see cref="App"/> instead of being run through the standard token classification. The app
-    /// identity is taken from <paramref name="appMetadata"/> (the running app), and <paramref name="instanceId"/>
-    /// is the instance the callback targets, when instance-scoped.
+    /// directly to <see cref="App"/> instead of being run through the standard token classification.
+    /// <paramref name="appId"/> identifies the targeted app (resolved from the request route), and
+    /// <paramref name="instanceId"/> is the instance the callback targets, when instance-scoped.
     /// </summary>
     internal static Authenticated FromApp(
         string tokenStr,
         JwtSecurityToken? parsedToken,
+        AppIdentifier appId,
         InstanceIdentifier? instanceId,
         ApplicationMetadata appMetadata
     )
@@ -873,7 +874,7 @@ public abstract class Authenticated
             context.ResolveIssuer();
         }
 
-        return new App(appMetadata.AppIdentifier, instanceId, ref context);
+        return new App(appId, instanceId, ref context);
     }
 
     internal static Authenticated From(

--- a/src/App/backend/src/Altinn.App.Core/Features/Auth/Authenticated.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Auth/Authenticated.cs
@@ -99,6 +99,26 @@ public abstract class Authenticated
     }
 
     /// <summary>
+    /// The caller is the Altinn workflow engine invoking a process callback for a specific instance.
+    /// Authenticated via the <c>WorkflowEngineCallback</c> scheme using an app-minted token bound to the
+    /// instance; it carries no Altinn user/org identity — only the instance it is authorized to act on.
+    /// </summary>
+    public sealed class WorkflowEngineCallback : Authenticated
+    {
+        /// <summary>
+        /// The instance this callback is authorized to act on (the token's <c>jti</c>, validated against the
+        /// callback route).
+        /// </summary>
+        public Guid InstanceGuid { get; }
+
+        internal WorkflowEngineCallback(Guid instanceGuid, ref ParseContext context)
+            : base(ref context)
+        {
+            InstanceGuid = instanceGuid;
+        }
+    }
+
+    /// <summary>
     /// The logged in client is a user (e.g. Altinn portal/ID-porten)
     /// </summary>
     public sealed class User : Authenticated
@@ -807,6 +827,48 @@ public abstract class Authenticated
             }
             return false;
         }
+    }
+
+    /// <summary>
+    /// Builds the authentication info for a workflow-engine process callback. The callback is authenticated by
+    /// the <c>WorkflowEngineCallback</c> scheme with an app-minted token bound to <paramref name="instanceGuid"/>
+    /// and carries no Altinn user/org identity, so it maps directly to <see cref="WorkflowEngineCallback"/>
+    /// instead of being run through the standard user/org/system-user token classification.
+    /// </summary>
+    internal static Authenticated FromWorkflowEngineCallback(
+        string tokenStr,
+        JwtSecurityToken? parsedToken,
+        Guid instanceGuid,
+        ApplicationMetadata appMetadata
+    )
+    {
+        // The callback principal has no user/party/profile dimension, so the lookup delegates are never invoked.
+        var context = new ParseContext(
+            tokenStr,
+            true,
+            appMetadata,
+            static () => null,
+            static _ => Task.FromResult<UserProfile?>(null),
+            static _ => Task.FromResult<Party?>(null),
+            static _ =>
+                throw new InvalidOperationException(
+                    "Org party lookup is not applicable for a workflow-engine callback principal."
+                ),
+            static _ => Task.FromResult<List<Party>?>(null),
+            static (_, _) => Task.FromResult<bool?>(null)
+        );
+
+        if (!string.IsNullOrWhiteSpace(tokenStr))
+        {
+            JwtSecurityToken token = parsedToken ?? new JwtSecurityTokenHandler().ReadJwtToken(tokenStr);
+            context.ReadClaims(token);
+            context.Scopes = context.ScopeClaim.IsValidString(out var scopeClaimValue)
+                ? new Scopes(scopeClaimValue)
+                : new Scopes(null);
+            context.ResolveIssuer();
+        }
+
+        return new WorkflowEngineCallback(instanceGuid, ref context);
     }
 
     internal static Authenticated From(

--- a/src/App/backend/src/Altinn.App.Core/Features/Auth/AuthenticationContext.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Auth/AuthenticationContext.cs
@@ -95,16 +95,21 @@ internal sealed class AuthenticationContext : IAuthenticationContext
 
                 if (isWorkflowCallback)
                 {
-                    var appMetadata = _appConfigurationCache.ApplicationMetadata;
                     // The route is the authority for the app identity (it is what the request targeted and what
-                    // routing matched); fall back to the running app's metadata only if the route omits it.
-                    var appId = ResolveCallbackApp(httpContext) ?? appMetadata.AppIdentifier;
+                    // routing matched). The callback scheme only ever applies to the callback route, which
+                    // always carries {org}/{app}, so a missing app here is a broken invariant — fail loudly
+                    // rather than silently falling back to the running app's metadata.
+                    var appId =
+                        ResolveCallbackApp(httpContext)
+                        ?? throw new AuthenticationContextException(
+                            "Workflow-engine callback request is missing the org/app route values required to identify the app."
+                        );
                     authInfo = Authenticated.FromApp(
                         tokenStr: token,
                         parsedToken,
                         appId,
                         ResolveCallbackInstance(httpContext),
-                        appMetadata
+                        _appConfigurationCache.ApplicationMetadata
                     );
                 }
                 else

--- a/src/App/backend/src/Altinn.App.Core/Features/Auth/AuthenticationContext.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Auth/AuthenticationContext.cs
@@ -95,10 +95,6 @@ internal sealed class AuthenticationContext : IAuthenticationContext
 
                 if (isWorkflowCallback)
                 {
-                    // The route is the authority for the app identity (it is what the request targeted and what
-                    // routing matched). The callback scheme only ever applies to the callback route, which
-                    // always carries {org}/{app}, so a missing app here is a broken invariant — fail loudly
-                    // rather than silently falling back to the running app's metadata.
                     var appId =
                         ResolveAppFromRoute(httpContext)
                         ?? throw new AuthenticationContextException(

--- a/src/App/backend/src/Altinn.App.Core/Features/Auth/AuthenticationContext.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Auth/AuthenticationContext.cs
@@ -1,5 +1,4 @@
 using System.IdentityModel.Tokens.Jwt;
-using System.Security.Claims;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Features.Cache;
 using Altinn.App.Core.Internal;
@@ -7,6 +6,7 @@ using Altinn.App.Core.Internal.Auth;
 using Altinn.App.Core.Internal.Profile;
 using Altinn.App.Core.Internal.Registers;
 using Altinn.App.Core.Internal.WorkflowEngine.Authentication;
+using Altinn.App.Core.Models;
 using Altinn.Platform.Register.Models;
 using AltinnCore.Authentication.Utils;
 using Microsoft.AspNetCore.Http;
@@ -81,11 +81,12 @@ internal sealed class AuthenticationContext : IAuthenticationContext
                         parsedToken.Payload.TryGetValue("actual_iss", out var actualIss) && actualIss is "localtest";
                 }
 
-                // Workflow-engine callbacks authenticate via their own scheme. Their principal is bound to an
-                // instance and carries no Altinn user/org claims, so it maps to a dedicated
-                // Authenticated.WorkflowEngineCallback rather than being run through the user/org token
-                // classification (which the legacy localtest parser would even throw on). The instance binding
-                // comes from the validated principal's NameIdentifier claim (set by the callback auth handler).
+                // Workflow-engine callbacks authenticate via their own scheme. Their principal carries no Altinn
+                // user/org claims, so it maps to a dedicated Authenticated.App rather than being run through the
+                // user/org token classification (which the legacy localtest parser would even throw on). The app
+                // identity comes from the running app's metadata; the targeted instance (when the callback is
+                // instance-scoped) is taken from the route, whose instance guid the callback auth handler has
+                // already validated against the token.
                 var isWorkflowCallback = string.Equals(
                     httpContext.User?.Identity?.AuthenticationType,
                     WorkflowCallbackAuthentication.Scheme,
@@ -94,12 +95,10 @@ internal sealed class AuthenticationContext : IAuthenticationContext
 
                 if (isWorkflowCallback)
                 {
-                    var instanceGuidClaim = httpContext.User?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-                    _ = Guid.TryParse(instanceGuidClaim, out var callbackInstanceGuid);
-                    authInfo = Authenticated.FromWorkflowEngineCallback(
+                    authInfo = Authenticated.FromApp(
                         tokenStr: token,
                         parsedToken,
-                        callbackInstanceGuid,
+                        ResolveCallbackInstance(httpContext),
                         _appConfigurationCache.ApplicationMetadata
                     );
                 }
@@ -151,5 +150,26 @@ internal sealed class AuthenticationContext : IAuthenticationContext
             }
             return authInfo;
         }
+    }
+
+    /// <summary>
+    /// Resolves the instance a workflow-engine callback targets from the route values
+    /// (<c>{instanceOwnerPartyId}/{instanceGuid}</c>). Returns <c>null</c> when the callback is not
+    /// instance-scoped or the route does not carry a valid instance identifier.
+    /// </summary>
+    private static InstanceIdentifier? ResolveCallbackInstance(HttpContext httpContext)
+    {
+        var routeValues = httpContext.Request.RouteValues;
+        if (
+            routeValues.TryGetValue("instanceOwnerPartyId", out var partyValue)
+            && int.TryParse(partyValue?.ToString(), out var instanceOwnerPartyId)
+            && routeValues.TryGetValue("instanceGuid", out var guidValue)
+            && Guid.TryParse(guidValue?.ToString(), out var instanceGuid)
+        )
+        {
+            return new InstanceIdentifier(instanceOwnerPartyId, instanceGuid);
+        }
+
+        return null;
     }
 }

--- a/src/App/backend/src/Altinn.App.Core/Features/Auth/AuthenticationContext.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Auth/AuthenticationContext.cs
@@ -95,11 +95,16 @@ internal sealed class AuthenticationContext : IAuthenticationContext
 
                 if (isWorkflowCallback)
                 {
+                    var appMetadata = _appConfigurationCache.ApplicationMetadata;
+                    // The route is the authority for the app identity (it is what the request targeted and what
+                    // routing matched); fall back to the running app's metadata only if the route omits it.
+                    var appId = ResolveCallbackApp(httpContext) ?? appMetadata.AppIdentifier;
                     authInfo = Authenticated.FromApp(
                         tokenStr: token,
                         parsedToken,
+                        appId,
                         ResolveCallbackInstance(httpContext),
-                        _appConfigurationCache.ApplicationMetadata
+                        appMetadata
                     );
                 }
                 else
@@ -150,6 +155,26 @@ internal sealed class AuthenticationContext : IAuthenticationContext
             }
             return authInfo;
         }
+    }
+
+    /// <summary>
+    /// Resolves the app a workflow-engine callback targets from the route values (<c>{org}/{app}</c>).
+    /// Returns <c>null</c> when the route does not carry both values.
+    /// </summary>
+    private static AppIdentifier? ResolveCallbackApp(HttpContext httpContext)
+    {
+        var routeValues = httpContext.Request.RouteValues;
+        if (
+            routeValues.TryGetValue("org", out var orgValue)
+            && orgValue?.ToString() is { Length: > 0 } org
+            && routeValues.TryGetValue("app", out var appValue)
+            && appValue?.ToString() is { Length: > 0 } app
+        )
+        {
+            return new AppIdentifier(org, app);
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/src/App/backend/src/Altinn.App.Core/Features/Auth/AuthenticationContext.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Auth/AuthenticationContext.cs
@@ -1,4 +1,5 @@
 using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Features.Cache;
 using Altinn.App.Core.Internal;
@@ -80,48 +81,62 @@ internal sealed class AuthenticationContext : IAuthenticationContext
                         parsedToken.Payload.TryGetValue("actual_iss", out var actualIss) && actualIss is "localtest";
                 }
 
-                // Workflow-engine callbacks authenticate via their own scheme. Their principal is bound to
-                // an instance and carries no Altinn user/org claims, so the legacy localtest parser would
-                // throw trying to classify it as a user token. The standard parser correctly treats an
-                // authenticated principal without identity claims as Authenticated.Unknown, so we use it for
-                // callbacks regardless of environment.
+                // Workflow-engine callbacks authenticate via their own scheme. Their principal is bound to an
+                // instance and carries no Altinn user/org claims, so it maps to a dedicated
+                // Authenticated.WorkflowEngineCallback rather than being run through the user/org token
+                // classification (which the legacy localtest parser would even throw on). The instance binding
+                // comes from the validated principal's NameIdentifier claim (set by the callback auth handler).
                 var isWorkflowCallback = string.Equals(
                     httpContext.User?.Identity?.AuthenticationType,
                     WorkflowCallbackAuthentication.Scheme,
                     StringComparison.Ordinal
                 );
 
-                var isLocaltest = _runtimeEnvironment.IsLocaltestPlatform() && !generalSettings.IsTest;
-                if (isLocaltest && !isNewLocaltestToken && !isWorkflowCallback)
+                if (isWorkflowCallback)
                 {
-                    authInfo = Authenticated.FromOldLocalTest(
+                    var instanceGuidClaim = httpContext.User?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+                    _ = Guid.TryParse(instanceGuidClaim, out var callbackInstanceGuid);
+                    authInfo = Authenticated.FromWorkflowEngineCallback(
                         tokenStr: token,
                         parsedToken,
-                        isAuthenticated: !string.IsNullOrWhiteSpace(token),
-                        _appConfigurationCache.ApplicationMetadata,
-                        () => _httpContext.Request.Cookies[_generalSettings.CurrentValue.GetAltinnPartyCookieName],
-                        (int userId) => _profileClient.GetUserProfile(userId),
-                        (int partyId) => _altinnPartyClient.GetParty(partyId),
-                        (string orgNr) => _altinnPartyClient.LookupParty(new PartyLookup { OrgNo = orgNr }),
-                        (int userId) => _authorizationClient.GetPartyList(userId),
-                        (int userId, int partyId) => _authorizationClient.ValidateSelectedParty(userId, partyId)
+                        callbackInstanceGuid,
+                        _appConfigurationCache.ApplicationMetadata
                     );
                 }
                 else
                 {
-                    var isAuthenticated = httpContext.User?.Identity?.IsAuthenticated ?? false;
-                    authInfo = Authenticated.From(
-                        tokenStr: token,
-                        parsedToken,
-                        isAuthenticated: isAuthenticated,
-                        _appConfigurationCache.ApplicationMetadata,
-                        () => _httpContext.Request.Cookies[_generalSettings.CurrentValue.GetAltinnPartyCookieName],
-                        (int userId) => _profileClient.GetUserProfile(userId),
-                        (int partyId) => _altinnPartyClient.GetParty(partyId),
-                        (string orgNr) => _altinnPartyClient.LookupParty(new PartyLookup { OrgNo = orgNr }),
-                        (int userId) => _authorizationClient.GetPartyList(userId),
-                        (int userId, int partyId) => _authorizationClient.ValidateSelectedParty(userId, partyId)
-                    );
+                    var isLocaltest = _runtimeEnvironment.IsLocaltestPlatform() && !generalSettings.IsTest;
+                    if (isLocaltest && !isNewLocaltestToken)
+                    {
+                        authInfo = Authenticated.FromOldLocalTest(
+                            tokenStr: token,
+                            parsedToken,
+                            isAuthenticated: !string.IsNullOrWhiteSpace(token),
+                            _appConfigurationCache.ApplicationMetadata,
+                            () => _httpContext.Request.Cookies[_generalSettings.CurrentValue.GetAltinnPartyCookieName],
+                            (int userId) => _profileClient.GetUserProfile(userId),
+                            (int partyId) => _altinnPartyClient.GetParty(partyId),
+                            (string orgNr) => _altinnPartyClient.LookupParty(new PartyLookup { OrgNo = orgNr }),
+                            (int userId) => _authorizationClient.GetPartyList(userId),
+                            (int userId, int partyId) => _authorizationClient.ValidateSelectedParty(userId, partyId)
+                        );
+                    }
+                    else
+                    {
+                        var isAuthenticated = httpContext.User?.Identity?.IsAuthenticated ?? false;
+                        authInfo = Authenticated.From(
+                            tokenStr: token,
+                            parsedToken,
+                            isAuthenticated: isAuthenticated,
+                            _appConfigurationCache.ApplicationMetadata,
+                            () => _httpContext.Request.Cookies[_generalSettings.CurrentValue.GetAltinnPartyCookieName],
+                            (int userId) => _profileClient.GetUserProfile(userId),
+                            (int partyId) => _altinnPartyClient.GetParty(partyId),
+                            (string orgNr) => _altinnPartyClient.LookupParty(new PartyLookup { OrgNo = orgNr }),
+                            (int userId) => _authorizationClient.GetPartyList(userId),
+                            (int userId, int partyId) => _authorizationClient.ValidateSelectedParty(userId, partyId)
+                        );
+                    }
                 }
 
                 httpContext.Items[ItemsKey] = authInfo;

--- a/src/App/backend/src/Altinn.App.Core/Features/Auth/AuthenticationContext.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Auth/AuthenticationContext.cs
@@ -100,7 +100,7 @@ internal sealed class AuthenticationContext : IAuthenticationContext
                     // always carries {org}/{app}, so a missing app here is a broken invariant — fail loudly
                     // rather than silently falling back to the running app's metadata.
                     var appId =
-                        ResolveCallbackApp(httpContext)
+                        ResolveAppFromRoute(httpContext)
                         ?? throw new AuthenticationContextException(
                             "Workflow-engine callback request is missing the org/app route values required to identify the app."
                         );
@@ -108,7 +108,7 @@ internal sealed class AuthenticationContext : IAuthenticationContext
                         tokenStr: token,
                         parsedToken,
                         appId,
-                        ResolveCallbackInstance(httpContext),
+                        ResolveInstanceFromRoute(httpContext),
                         _appConfigurationCache.ApplicationMetadata
                     );
                 }
@@ -163,10 +163,10 @@ internal sealed class AuthenticationContext : IAuthenticationContext
     }
 
     /// <summary>
-    /// Resolves the app a workflow-engine callback targets from the route values (<c>{org}/{app}</c>).
+    /// Resolves an <see cref="AppIdentifier"/> from the route values (<c>{org}/{app}</c>).
     /// Returns <c>null</c> when the route does not carry both values.
     /// </summary>
-    private static AppIdentifier? ResolveCallbackApp(HttpContext httpContext)
+    private static AppIdentifier? ResolveAppFromRoute(HttpContext httpContext)
     {
         var routeValues = httpContext.Request.RouteValues;
         if (
@@ -183,11 +183,10 @@ internal sealed class AuthenticationContext : IAuthenticationContext
     }
 
     /// <summary>
-    /// Resolves the instance a workflow-engine callback targets from the route values
-    /// (<c>{instanceOwnerPartyId}/{instanceGuid}</c>). Returns <c>null</c> when the callback is not
-    /// instance-scoped or the route does not carry a valid instance identifier.
+    /// Resolves an <see cref="InstanceIdentifier"/> from the route values (<c>{instanceOwnerPartyId}/{instanceGuid}</c>).
+    /// Returns <c>null</c> when the route does not carry a valid instance identifier.
     /// </summary>
-    private static InstanceIdentifier? ResolveCallbackInstance(HttpContext httpContext)
+    private static InstanceIdentifier? ResolveInstanceFromRoute(HttpContext httpContext)
     {
         var routeValues = httpContext.Request.RouteValues;
         if (

--- a/src/App/backend/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.IdentityModel.Tokens.Jwt;
 using System.IO.Hashing;
+using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
 using Altinn.App.Core.Features.Auth;
@@ -211,6 +212,28 @@ public class AuthenticatedTests
             },
             $"type={tokenType}_{hash[0..4]}"
         );
+    }
+
+    [Fact]
+    public void Can_Classify_WorkflowEngineCallback()
+    {
+        var instanceGuid = Guid.NewGuid();
+        var jwt = new JwtSecurityToken(claims: [new Claim("jti", instanceGuid.ToString())]);
+        var token = new JwtSecurityTokenHandler().WriteToken(jwt);
+
+        var auth = Authenticated.FromWorkflowEngineCallback(
+            tokenStr: token,
+            parsedToken: null,
+            instanceGuid: instanceGuid,
+            appMetadata: TestAuthentication.NewApplicationMetadata()
+        );
+
+        var callback = Assert.IsType<Authenticated.WorkflowEngineCallback>(auth);
+        Assert.Equal(instanceGuid, callback.InstanceGuid);
+        Assert.Equal(token, callback.Token);
+        // Callback principals carry no Altinn identity scopes and are not exchanged tokens.
+        Assert.False(callback.Scopes.HasScope("altinn:portal/enduser"));
+        Assert.False(callback.TokenIsExchanged);
     }
 
     [Fact]

--- a/src/App/backend/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.cs
@@ -219,19 +219,21 @@ public class AuthenticatedTests
     {
         var instanceGuid = Guid.NewGuid();
         var instanceId = new InstanceIdentifier(512345, instanceGuid);
+        // AppId is the route authority — deliberately distinct from the app metadata identity.
+        var appId = new AppIdentifier("ttd", "callback-app");
         var jwt = new JwtSecurityToken(claims: [new Claim("jti", instanceGuid.ToString())]);
         var token = new JwtSecurityTokenHandler().WriteToken(jwt);
-        var appMetadata = TestAuthentication.NewApplicationMetadata();
 
         var auth = Authenticated.FromApp(
             tokenStr: token,
             parsedToken: null,
+            appId: appId,
             instanceId: instanceId,
-            appMetadata: appMetadata
+            appMetadata: TestAuthentication.NewApplicationMetadata()
         );
 
         var app = Assert.IsType<Authenticated.App>(auth);
-        Assert.Equal(appMetadata.AppIdentifier, app.AppId);
+        Assert.Equal(appId, app.AppId);
         Assert.Equal(instanceId, app.InstanceId);
         Assert.Equal(token, app.Token);
         // Callback principals carry no Altinn identity scopes and are not exchanged tokens.
@@ -242,19 +244,20 @@ public class AuthenticatedTests
     [Fact]
     public void Can_Classify_App_Callback_WithoutInstance()
     {
-        var appMetadata = TestAuthentication.NewApplicationMetadata();
+        var appId = new AppIdentifier("ttd", "callback-app");
         var jwt = new JwtSecurityToken(claims: [new Claim("jti", Guid.NewGuid().ToString())]);
         var token = new JwtSecurityTokenHandler().WriteToken(jwt);
 
         var auth = Authenticated.FromApp(
             tokenStr: token,
             parsedToken: null,
+            appId: appId,
             instanceId: null,
-            appMetadata: appMetadata
+            appMetadata: TestAuthentication.NewApplicationMetadata()
         );
 
         var app = Assert.IsType<Authenticated.App>(auth);
-        Assert.Equal(appMetadata.AppIdentifier, app.AppId);
+        Assert.Equal(appId, app.AppId);
         Assert.Null(app.InstanceId);
     }
 

--- a/src/App/backend/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.cs
@@ -215,25 +215,47 @@ public class AuthenticatedTests
     }
 
     [Fact]
-    public void Can_Classify_WorkflowEngineCallback()
+    public void Can_Classify_App_Callback_WithInstance()
     {
         var instanceGuid = Guid.NewGuid();
+        var instanceId = new InstanceIdentifier(512345, instanceGuid);
         var jwt = new JwtSecurityToken(claims: [new Claim("jti", instanceGuid.ToString())]);
         var token = new JwtSecurityTokenHandler().WriteToken(jwt);
+        var appMetadata = TestAuthentication.NewApplicationMetadata();
 
-        var auth = Authenticated.FromWorkflowEngineCallback(
+        var auth = Authenticated.FromApp(
             tokenStr: token,
             parsedToken: null,
-            instanceGuid: instanceGuid,
-            appMetadata: TestAuthentication.NewApplicationMetadata()
+            instanceId: instanceId,
+            appMetadata: appMetadata
         );
 
-        var callback = Assert.IsType<Authenticated.WorkflowEngineCallback>(auth);
-        Assert.Equal(instanceGuid, callback.InstanceGuid);
-        Assert.Equal(token, callback.Token);
+        var app = Assert.IsType<Authenticated.App>(auth);
+        Assert.Equal(appMetadata.AppIdentifier, app.AppId);
+        Assert.Equal(instanceId, app.InstanceId);
+        Assert.Equal(token, app.Token);
         // Callback principals carry no Altinn identity scopes and are not exchanged tokens.
-        Assert.False(callback.Scopes.HasScope("altinn:portal/enduser"));
-        Assert.False(callback.TokenIsExchanged);
+        Assert.False(app.Scopes.HasScope("altinn:portal/enduser"));
+        Assert.False(app.TokenIsExchanged);
+    }
+
+    [Fact]
+    public void Can_Classify_App_Callback_WithoutInstance()
+    {
+        var appMetadata = TestAuthentication.NewApplicationMetadata();
+        var jwt = new JwtSecurityToken(claims: [new Claim("jti", Guid.NewGuid().ToString())]);
+        var token = new JwtSecurityTokenHandler().WriteToken(jwt);
+
+        var auth = Authenticated.FromApp(
+            tokenStr: token,
+            parsedToken: null,
+            instanceId: null,
+            appMetadata: appMetadata
+        );
+
+        var app = Assert.IsType<Authenticated.App>(auth);
+        Assert.Equal(appMetadata.AppIdentifier, app.AppId);
+        Assert.Null(app.InstanceId);
     }
 
     [Fact]

--- a/src/App/backend/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/src/App/backend/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -372,6 +372,10 @@ namespace Altinn.App.Core.Features.Auth
                 public bool CanRepresentParty(int partyId) { }
             }
         }
+        public sealed class WorkflowEngineCallback : Altinn.App.Core.Features.Auth.Authenticated
+        {
+            public System.Guid InstanceGuid { get; }
+        }
     }
     public class AuthenticationContextException : System.Exception
     {

--- a/src/App/backend/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/src/App/backend/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -301,6 +301,11 @@ namespace Altinn.App.Core.Features.Auth
         public bool TokenIsExchanged { get; }
         public Altinn.App.Core.Features.Auth.TokenIssuer TokenIssuer { get; }
         public System.Threading.Tasks.Task<string> GetLanguage() { }
+        public sealed class App : Altinn.App.Core.Features.Auth.Authenticated
+        {
+            public Altinn.App.Core.Models.AppIdentifier AppId { get; }
+            public Altinn.App.Core.Models.InstanceIdentifier? InstanceId { get; }
+        }
         public sealed class None : Altinn.App.Core.Features.Auth.Authenticated { }
         public sealed class Org : Altinn.App.Core.Features.Auth.Authenticated
         {
@@ -371,10 +376,6 @@ namespace Altinn.App.Core.Features.Auth
                 public bool CanInstantiateAsParty(int partyId) { }
                 public bool CanRepresentParty(int partyId) { }
             }
-        }
-        public sealed class WorkflowEngineCallback : Altinn.App.Core.Features.Auth.Authenticated
-        {
-            public System.Guid InstanceGuid { get; }
         }
     }
     public class AuthenticationContextException : System.Exception


### PR DESCRIPTION
## Description

Per domain-owner feedback, workflow-engine callbacks should not piggy-back on `Authenticated.Unknown` and the localtest token-parsing fallback. This introduces a dedicated, first-class **`Authenticated.App`** identity for app process callbacks.

### What changed

- **New auth type `Authenticated.App`** (sealed, alongside `User`/`Org`/`ServiceOwner`/`SystemUser`/`Unknown`/`None`), representing the app's own machinery calling back via the `WorkflowEngineCallback` scheme. It carries the established identifier types:
  - `AppId` — non-nullable `AppIdentifier`.
  - `InstanceId` — nullable `InstanceIdentifier` (`null` when a callback isn't instance-scoped).
- **New factory** `Authenticated.FromApp(...)` constructs it directly — the callback principal has no Altinn user/org dimension, so it bypasses the standard user/org/system-user token classification entirely.
- **`AuthenticationContext`** routes callback requests (identified by the `WorkflowEngineCallback` scheme) to a dedicated branch. The localtest parser's `!isWorkflowCallback` guard is gone — callbacks no longer touch the localtest/standard classification paths.

### The route is the authority

`AppId` and `InstanceId` are resolved from the **request route** (`{org}/{app}/instances/{instanceOwnerPartyId}/{instanceGuid}`), not from `ApplicationMetadata` — the route is what the request targeted and what routing matched, and the callback auth handler has already validated the route's instance guid against the token.
- `ResolveAppFromRoute` → the app identity. The callback scheme only ever applies to the callback route (which always carries `{org}/{app}`), so a missing app is a broken invariant: it **throws `AuthenticationContextException`** rather than silently falling back to metadata.
- `ResolveInstanceFromRoute` → the targeted instance, or `null` if the route isn't instance-scoped.

### Scope checks unchanged

Scope authorization is still skipped for callbacks via the existing `ScopeAuthorizationMiddleware` → `IsCallbackRequest` exemption. This change only makes `IAuthenticationContext.Current` resolve to a meaningful type instead of `Unknown`; it does not alter authorization behavior.

### Blast radius

The `Authenticated` hierarchy is open (abstract base), so all existing consumer `switch`es already have default arms — adding a subtype is non-breaking, and callbacks only reach the one callback controller, so anywhere that previously saw `Unknown` during a callback behaves identically. Confirmed nothing pattern-matches `Authenticated.Unknown` for behavior.

## Verification

- Full solution builds clean (warnings-as-errors).
- `Features.Auth` (95, incl. new `Can_Classify_App_Callback_WithInstance` / `...WithoutInstance`) and Api `WorkflowEngineCallback` + `Authentication` (22) tests pass.
- Core `PublicApiTests` snapshot updated to exactly the new public type — `App { AppId: AppIdentifier, InstanceId: InstanceIdentifier? }`; no other public-API or OpenAPI snapshot moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)