### PR TITLE
refactor: Make norwegian the default language for static texts in storybook

### DIFF
--- a/app-libs/form-component/.storybook/preview.tsx
+++ b/app-libs/form-component/.storybook/preview.tsx
@@ -15,7 +15,7 @@ const preview: Preview = {
   },
   tags: ['autodocs'],
   initialGlobals: {
-    locale: 'en' satisfies StaticLanguageCode,
+    locale: 'nb' satisfies StaticLanguageCode,
   },
   globalTypes: {
     locale: {
@@ -25,9 +25,9 @@ const preview: Preview = {
         title: 'Language',
         icon: 'globe',
         items: [
-          { value: 'en', title: 'English' },
           { value: 'nb', title: 'Norsk (nb)' },
           { value: 'nn', title: 'Norsk (nn)' },
+          { value: 'en', title: 'English' },
         ] satisfies { value: StaticLanguageCode; title: string }[],
         dynamicTitle: true,
       },

--- a/app-libs/form-component/src/layout-components/DemoLayoutComponent/DemoLayoutComponent.stories.tsx
+++ b/app-libs/form-component/src/layout-components/DemoLayoutComponent/DemoLayoutComponent.stories.tsx
@@ -37,7 +37,7 @@ const meta = {
   },
   args: {
     id: 'demo-preview',
-    content: 'This is a plain text',
+    content: 'Dette er ren tekst',
   },
 } satisfies Meta<typeof DemoLayoutComponent>;
 
@@ -49,37 +49,37 @@ export const Preview: Story = {};
 
 export const WithTitle: Story = {
   args: {
-    title: 'A configurable heading',
+    title: 'En konfigurerbar overskrift',
   },
 };
 
 export const Warning: Story = {
   args: {
     variant: 'warning',
-    title: 'Heads up',
-    content: 'This variant draws attention with a coloured accent.',
+    title: 'Vær oppmerksom',
+    content: 'Denne varianten fanger oppmerksomheten med en annen farge.',
   },
 };
 
 export const WithHtml: Story = {
   args: {
-    content: `<h3>This is content set with props a html, but can be html or mark down</h3>
-      <p>And this is a <strong>paragraph</strong></p>
+    content: `<h3>Dette er innhold satt med props som html, men kan være html eller markdown</h3>
+      <p>Og dette er et <strong>avsnitt</strong></p>
       <ul>
-        <li>And this is a list item</li>
-        <li>And this is another list item</li>
+        <li>Og dette er et listeelement</li>
+        <li>Og dette er enda et listeelement</li>
       </ul>`,
   },
 };
 
 export const WithMarkdown: Story = {
   args: {
-    content: `### This is content set with props a text, but can be **html** or **mark down**
+    content: `### Dette er innhold satt med props som tekst, men kan være **html** eller **markdown**
 
-And this is a **paragraph**
+Og dette er et **avsnitt**
 
-- And this is a list item
-- And this is another list item`,
+- Og dette er et listeelement
+- Og dette er enda et listeelement`,
   },
 };
 
@@ -87,13 +87,13 @@ And this is a **paragraph**
 
 export const RuntimeBoundValue: Story = {
   args: {
-    dataValue: 'a value injected by the runtime wrapper',
+    dataValue: 'en verdi injisert av runtime-wrapperen',
   },
 };
 
 export const RenderedInTable: Story = {
   args: {
-    title: 'Title is suppressed when rendered in a table',
+    title: 'Tittelen skjules når den vises i en tabell',
     renderedInTable: true,
   },
 };

--- a/app-libs/form-component/src/layout-components/Paragraph/Paragraph.stories.tsx
+++ b/app-libs/form-component/src/layout-components/Paragraph/Paragraph.stories.tsx
@@ -19,35 +19,35 @@ type Story = StoryObj<typeof meta>;
 
 export const Preview: Story = {
   args: {
-    title: 'This is a plain text paragraph shown in a form.',
+    title: 'Dette er et avsnitt med ren tekst som vises i et skjema.',
   },
 };
 
 export const WithHtml: Story = {
   args: {
-    title: `<h3>This is content set with props as html, but can be html or markdown</h3>
-      <p>And this is a <strong>paragraph</strong></p>
+    title: `<h3>Dette er innhold satt med props som html, men kan være html eller markdown</h3>
+      <p>Og dette er et <strong>avsnitt</strong></p>
       <ul>
-        <li>And this is a list item</li>
-        <li>And this is another list item</li>
+        <li>Og dette er et listeelement</li>
+        <li>Og dette er enda et listeelement</li>
       </ul>`,
   },
 };
 
 export const WithMarkdown: Story = {
   args: {
-    title: `### This is content set with props as text, but can be **html** or **markdown**
+    title: `### Dette er innhold satt med props som tekst, men kan være **html** eller **markdown**
 
-And this is a **paragraph**
+Og dette er et **avsnitt**
 
-- And this is a list item
-- And this is another list item`,
+- Og dette er et listeelement
+- Og dette er enda et listeelement`,
   },
 };
 
 export const WithHelpText: Story = {
   args: {
-    title: 'This is a paragraph with an accompanying help text.',
-    help: 'This **help text** gives the user more context about the paragraph.',
+    title: 'Dette er et avsnitt med en tilhørende hjelpetekst.',
+    help: 'Denne **hjelpeteksten** gir brukeren mer kontekst om avsnittet.',
   },
 };

--- a/app-libs/form-component/src/layout-components/common/Description/Description.stories.tsx
+++ b/app-libs/form-component/src/layout-components/common/Description/Description.stories.tsx
@@ -6,7 +6,7 @@ const meta = {
   title: 'LayoutComponents/Common/Description',
   component: Description,
   args: {
-    description: 'A short description that explains the field.',
+    description: 'En kort beskrivelse som forklarer feltet.',
     componentId: 'example',
   },
 } satisfies Meta<typeof Description>;

--- a/app-libs/form-component/src/layout-components/common/HelpTextContainer/HelpTextContainer.stories.tsx
+++ b/app-libs/form-component/src/layout-components/common/HelpTextContainer/HelpTextContainer.stories.tsx
@@ -10,7 +10,7 @@ const meta = {
   },
   args: {
     id: 'example',
-    helpText: 'This is some helpful text that explains what to do.',
+    helpText: 'Dette er en hjelpetekst som forklarer hva du skal gjøre.',
   },
 } satisfies Meta<typeof HelpTextContainer>;
 
@@ -22,6 +22,6 @@ export const Preview: Story = {};
 
 export const WithTitle: Story = {
   args: {
-    title: 'Date of birth',
+    title: 'Fødselsdato',
   },
 };

--- a/app-libs/form-component/src/layout-components/common/LabelComponent/LabelComponent.stories.tsx
+++ b/app-libs/form-component/src/layout-components/common/LabelComponent/LabelComponent.stories.tsx
@@ -18,7 +18,7 @@ const meta = {
   ],
   args: {
     htmlFor: 'example',
-    title: 'First name',
+    title: 'Fornavn',
   },
 } satisfies Meta<typeof LabelComponent>;
 
@@ -42,7 +42,7 @@ export const Optional: Story = {
 
 export const WithHelpAndDescription: Story = {
   args: {
-    help: 'Enter the name exactly as written in your passport.',
-    description: 'We use this to address you.',
+    help: 'Skriv navnet nøyaktig slik det står i passet ditt.',
+    description: 'Vi bruker dette for å henvende oss til deg.',
   },
 };

--- a/app-libs/form-component/src/layout-components/common/storybook/LayoutComponentDocs.tsx
+++ b/app-libs/form-component/src/layout-components/common/storybook/LayoutComponentDocs.tsx
@@ -34,8 +34,8 @@ export function LayoutComponentDocs({ categories }: LayoutComponentDocsProps) {
       <Description />
       <Primary />
 
-      <h2>Studio configurable</h2>
-      <p>Props that are configurable in Altinn Studio.</p>
+      <h2>Konfigurerbart i Studio</h2>
+      <p>Egenskaper som kan konfigureres i Altinn Studio.</p>
       {STUDIO_CATEGORIES.map(({ category, label }) =>
         groups[category].length > 0 ? (
           <section key={category}>
@@ -48,11 +48,11 @@ export function LayoutComponentDocs({ categories }: LayoutComponentDocsProps) {
       {groups.runtime.length > 0 && (
         <details>
           <summary>
-            <h2 style={{ display: 'inline' }}>Runtime (injected)</h2>
+            <h2 style={{ display: 'inline' }}>Kjøretid (injisert)</h2>
           </summary>
           <p>
-            Internal wiring supplied by the runtime wrapper — data binding, display overrides,
-            validation state and event handlers. Not part of the Studio configuration.
+            Intern kobling levert av kjøretids-wrapperen — databinding, visningsoverstyringer,
+            valideringstilstand og hendelseshåndterere. Ikke en del av Studio-konfigurasjonen.
           </p>
           <Controls include={groups.runtime} />
         </details>


### PR DESCRIPTION
## Make Norwegian the default language in Storybook
Sets nb (Norsk bokmål) as the default locale for built-in application texts in the form-component Storybook, and aligns the hardcoded example texts in the LayoutComponents stories to match.

Changes

- .storybook/preview.tsx: default locale set to nb
- Translated the hardcoded example texts (titles, descriptions, help texts, HTML/Markdown content) to Norwegian bokmål in the layout-component stories.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated Storybook to default to Norwegian, with the locale selector reordered so Norwegian options appear first.
  * Refreshed demo and example content across several form component stories with Norwegian/Danish text, improving localisation coverage and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->