### PR TITLE
ci: publish storybook to static web app

### DIFF
--- a/.github/workflows/apps-storybook-deploy.yaml
+++ b/.github/workflows/apps-storybook-deploy.yaml
@@ -1,0 +1,49 @@
+name: Build and deploy Apps Storybook Main
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'app-libs/form-component/**'
+      - '.github/workflows/apps-storybook-deploy.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    name: Build and deploy
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Use node LTS and yarn cache
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          cache: 'yarn'
+          node-version: '22'
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build Storybook
+        working-directory: app-libs/form-component
+        run: yarn build-storybook
+
+      - name: Deploy to Azure Static Web Apps
+        uses: Azure/static-web-apps-deploy@1a947af9992250f3bc2e68ad0754c0b0c11566c9 #v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.APPS_DEV_STORYBOOK }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          action: "upload"
+          app_location: "app-libs/form-component/storybook-static"
+          api_location: ""
+          output_location: ""
+          skip_app_build: true

--- a/.github/workflows/apps-storybook-deploy.yaml
+++ b/.github/workflows/apps-storybook-deploy.yaml
@@ -13,9 +13,6 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -23,6 +20,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Use node LTS and yarn cache
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/apps-storybook-preview.yaml
+++ b/.github/workflows/apps-storybook-preview.yaml
@@ -11,18 +11,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
   build-and-deploy:
     if: ${{ github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     name: Build and deploy preview
+    permissions:
+      pull-requests: write # Required for the Azure action to comment the preview URL on the PR
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Use node LTS and yarn cache
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/apps-storybook-preview.yaml
+++ b/.github/workflows/apps-storybook-preview.yaml
@@ -1,0 +1,60 @@
+name: Build and deploy Apps Storybook with preview
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+    paths:
+      - 'app-libs/form-component/**'
+      - '.github/workflows/apps-storybook-preview.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  build-and-deploy:
+    if: ${{ github.event.action != 'closed' }}
+    runs-on: ubuntu-latest
+    name: Build and deploy preview
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Use node LTS and yarn cache
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          cache: 'yarn'
+          node-version: '22'
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build Storybook
+        working-directory: app-libs/form-component
+        run: yarn build-storybook
+
+      - name: Deploy preview to Azure Static Web Apps
+        uses: Azure/static-web-apps-deploy@1a947af9992250f3bc2e68ad0754c0b0c11566c9 #v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.APPS_DEV_STORYBOOK }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          action: "upload"
+          app_location: "app-libs/form-component/storybook-static"
+          api_location: ""
+          output_location: ""
+          skip_app_build: true
+
+  close-preview:
+    if: ${{ github.event.action == 'closed' }}
+    runs-on: ubuntu-latest
+    name: Close preview
+    steps:
+      - name: Close preview environment in Azure Static Web Apps
+        uses: Azure/static-web-apps-deploy@1a947af9992250f3bc2e68ad0754c0b0c11566c9 #v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.APPS_DEV_STORYBOOK }}
+          action: "close"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Actions for å kunne publisere apps-storybook til et miljø med både støtte for preview og main release.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic preview deployments for the component Storybook on pull requests to simplify pre-merge review.
  * Preview environments now update with new PR activity and automatically close when the pull request is closed.
* **Chores**
  * Added automated build and deployment of the main Storybook to Azure Static Web Apps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->