### PR TITLE
fix: paths for v4

### DIFF
--- a/src/Designer/frontend/packages/shared/src/api/mutations.ts
+++ b/src/Designer/frontend/packages/shared/src/api/mutations.ts
@@ -88,6 +88,7 @@ import {
   chatMessagePath,
   chatFeedbackPath,
   taskNavigationGroupPath,
+  layoutSetsV4Path,
 } from 'app-shared/api/paths';
 import type { AddLanguagePayload } from 'app-shared/types/api/AddLanguagePayload';
 import type { AddRepoParams } from 'app-shared/types/api';
@@ -204,8 +205,8 @@ export const convertToPageOrder = (org: string, app: string, layoutSetName: stri
 export const updateValidationOnNavigation = <TLevel extends ValidationOnNavigationLevel>(org: string, app: string, level: TLevel, config: ValidationOnNavigationByLevel[TLevel]) =>
   post<void, ValidationOnNavigationByLevel[TLevel]>(`${validationOnNavigationPath(org, app)}${buildQueryParams({ level })}`, config);
 
-export const updateValidationOnNavigationLayoutSets = (org: string, app: string, payload: IValidationOnNavigationLayoutSets) => post<IValidationOnNavigationLayoutSets>(`${layoutSetsPath(org, app)}/validation-on-navigation`, payload);
-export const deleteValidationOnNavigationLayoutSets = (org: string, app: string) => del(`${layoutSetsPath(org, app)}/validation-on-navigation`);
+export const updateValidationOnNavigationLayoutSets = (org: string, app: string, payload: IValidationOnNavigationLayoutSets) => post<IValidationOnNavigationLayoutSets>(`${layoutSetsV4Path(org, app)}/validation-on-navigation`, payload);
+export const deleteValidationOnNavigationLayoutSets = (org: string, app: string) => del(`${layoutSetsV4Path(org, app)}/validation-on-navigation`);
 
 // Resourceadm
 export const createResource = (org: string, payload: NewResource) => post(resourceCreatePath(org), payload);

--- a/src/Designer/frontend/packages/shared/src/api/mutations.ts
+++ b/src/Designer/frontend/packages/shared/src/api/mutations.ts
@@ -67,7 +67,6 @@ import {
   orgCodeListUpdateIdPath,
   orgLibraryUpdatePath,
   orgCodeListPublishPath,
-  layoutSetsPath,
   studioctlAuthRequestCancelPath,
   studioctlAuthRequestConfirmPath,
   userApiKeyPath,

--- a/src/Designer/frontend/packages/shared/src/api/paths.js
+++ b/src/Designer/frontend/packages/shared/src/api/paths.js
@@ -59,10 +59,11 @@ export const appMetadataModelIdsPath = (org, app, onlyUnReferenced) => `${apiBas
 export const dataModelMetadataPath = (org, app, layoutSetName, dataModelName) => `${apiBasePath}/${org}/${app}/app-development/model-metadata?${s({ layoutSetName })}&${s({ dataModelName })}`; // Get
 export const layoutNamesPath = (org, app) => `${apiBasePath}/${org}/${app}/app-development/layout-names`; // Get
 export const layoutSetsPath = (org, app) => `${apiBasePath}/${org}/${app}/ui-folders/layout-sets`; // Get
+export const layoutSetsV4Path = (org, app) => `${apiBasePath}/${org}/${app}/app-development/layout-sets`; // Get
 export const layoutSetsExtendedV4Path = (org, app) => `${apiBasePath}/${org}/${app}/app-development/layout-sets/extended`; // Get
 export const layoutSetPath = (org, app, layoutSetIdToUpdate) => `${apiBasePath}/${org}/${app}/app-development/layout-set/${layoutSetIdToUpdate}`; // Put, Delete
 export const layoutSettingsPath = (org, app, layoutSetName) => `${apiBasePath}/${org}/${app}/app-development/layout-settings?${s({ layoutSetName })}`; // Get, Post
-export const validationOnNavigationLayoutSetsPath = (org, app) => `${layoutSetsPath(org, app)}/validation-on-navigation`; // Get
+export const validationOnNavigationLayoutSetsPath = (org, app) => `${layoutSetsV4Path(org, app)}/validation-on-navigation`; // Get
 export const validateNavigationLayoutSettingsPath = (org, app) => `${apiBasePath}/${org}/${app}/app-development/layout-settings/validation-on-navigation`; // Get, Post
 export const validateNavigationPageSettingsPath = (org, app) => `${apiBasePath}/${org}/${app}/app-development/layout-settings/validation-on-navigation/pages`; // Get, Post
 export const formLayoutsPath = (org, app, layoutSetName) => `${apiBasePath}/${org}/${app}/app-development/form-layouts?${s({ layoutSetName })}`; // Get


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changes made while introducing a shared endpoint for layout sets inadvertently broke the validation endpoint paths for layout set navigation in v4. This PR fixes those paths.

<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated validation-on-navigation layout set requests to use the newer layout set route, improving compatibility with current app endpoints.
  * Kept request behaviour and responses unchanged while switching to the revised URL structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->