### PR TITLE
fix: cascade workflow resume and self-heal stuck DependencyFailed workflows

### DIFF
--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/WorkflowEngineService.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/WorkflowEngineService.cs
@@ -268,7 +268,11 @@ internal sealed class WorkflowEngineService : IWorkflowEngineService
         CancellationToken ct = default
     )
     {
-        await _workflowEngineClient.ResumeWorkflow(GetNamespace(), workflowId, ct: ct);
+        // Resume with cascade so that auto-advance dependents left in DependencyFailed (because this
+        // workflow failed) are reset alongside the parent. Without it, resuming the failed parent
+        // would complete it while the dependent stays DependencyFailed, and waiting on the collection
+        // heads would keep reporting the dependency failure even after the parent succeeds.
+        await _workflowEngineClient.ResumeWorkflow(GetNamespace(), workflowId, cascade: true, ct: ct);
         return await WaitForWorkflowCollectionAndRefetchInstance(instance, collectionKey, ct);
     }
 

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/WorkflowEngineService.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/WorkflowEngineService.cs
@@ -268,10 +268,6 @@ internal sealed class WorkflowEngineService : IWorkflowEngineService
         CancellationToken ct = default
     )
     {
-        // Resume with cascade so that auto-advance dependents left in DependencyFailed (because this
-        // workflow failed) are reset alongside the parent. Without it, resuming the failed parent
-        // would complete it while the dependent stays DependencyFailed, and waiting on the collection
-        // heads would keep reporting the dependency failure even after the parent succeeds.
         await _workflowEngineClient.ResumeWorkflow(GetNamespace(), workflowId, cascade: true, ct: ct);
         return await WaitForWorkflowCollectionAndRefetchInstance(instance, collectionKey, ct);
     }

--- a/src/App/backend/test/Altinn.App.Core.Tests/Internal/WorkflowEngine/WorkflowEngineServiceTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Internal/WorkflowEngine/WorkflowEngineServiceTests.cs
@@ -1,0 +1,89 @@
+using Altinn.App.Core.Features;
+using Altinn.App.Core.Internal.Instances;
+using Altinn.App.Core.Internal.WorkflowEngine;
+using Altinn.App.Core.Internal.WorkflowEngine.Http;
+using Altinn.App.Core.Internal.WorkflowEngine.Models.Engine;
+using Altinn.App.Core.Models;
+using Altinn.Platform.Storage.Interface.Models;
+using Moq;
+
+namespace Altinn.App.Core.Tests.Internal.WorkflowEngine;
+
+public class WorkflowEngineServiceTests
+{
+    private const string Org = "ttd";
+    private const string App = "test-app";
+    private const string Namespace = $"{Org}/{App}";
+
+    [Fact]
+    public async Task ResumeAndWaitForWorkflow_ResumesWithCascade()
+    {
+        // Arrange
+        Guid workflowId = Guid.NewGuid();
+        const string collectionKey = "collection-key";
+        var instance = new Instance();
+
+        var client = new Mock<IWorkflowEngineClient>(MockBehavior.Strict);
+        client
+            .Setup(c => c.ResumeWorkflow(Namespace, workflowId, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ResumeWorkflowResponse(workflowId, DateTimeOffset.UtcNow, []));
+
+        // Collection head is already terminal (Completed) so the wait loop exits immediately.
+        client
+            .Setup(c => c.GetCollection(Namespace, collectionKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+                new WorkflowCollectionDetailResponse
+                {
+                    Key = collectionKey,
+                    Namespace = Namespace,
+                    Heads =
+                    [
+                        new CollectionHeadStatus { DatabaseId = workflowId, Status = PersistentItemStatus.Completed },
+                    ],
+                    CreatedAt = DateTimeOffset.UtcNow,
+                }
+            );
+        client
+            .Setup(c =>
+                c.ListWorkflows(
+                    Namespace,
+                    collectionKey,
+                    It.IsAny<Dictionary<string, string>?>(),
+                    It.IsAny<IReadOnlyList<PersistentItemStatus>?>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync([]);
+
+        var instanceClient = new Mock<IInstanceClient>(MockBehavior.Strict);
+        instanceClient
+            .Setup(c =>
+                c.GetInstance(instance, It.IsAny<StorageAuthenticationMethod?>(), It.IsAny<CancellationToken>())
+            )
+            .ReturnsAsync(instance);
+
+        // ProcessNextRequestFactory is not exercised on the resume path, so it can be left null here.
+        var service = new WorkflowEngineService(
+            processNextRequestFactory: null!,
+            client.Object,
+            instanceClient.Object,
+            new AppIdentifier(Org, App)
+        );
+
+        // Act
+        ProcessNextWorkflowResult result = await service.ResumeAndWaitForWorkflow(
+            instance,
+            workflowId,
+            collectionKey,
+            CancellationToken.None
+        );
+
+        // Assert
+        Assert.Null(result.WorkflowFailure);
+        client.Verify(
+            c => c.ResumeWorkflow(Namespace, workflowId, true, It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the resume path must cascade so dependency-failed auto-advance children are reset alongside the parent"
+        );
+    }
+}

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Core/Constants/Defaults.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Core/Constants/Defaults.cs
@@ -30,6 +30,7 @@ internal static class Defaults
         StaleWorkflowThreshold = TimeSpan.FromSeconds(30),
         MaxReclaimCount = 5,
         CancellationWatcherInterval = TimeSpan.FromSeconds(2),
+        MaintenanceInterval = TimeSpan.FromMinutes(1),
         Concurrency = new ConcurrencySettings()
         {
             MaxWorkers = 400,

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Core/Extensions/ServiceCollectionExtensions.cs
@@ -184,6 +184,9 @@ public static class OptionsBuilderExtensions
                 if (config.CancellationWatcherInterval <= TimeSpan.Zero)
                     config.CancellationWatcherInterval = Defaults.EngineSettings.CancellationWatcherInterval;
 
+                if (config.MaintenanceInterval <= TimeSpan.Zero)
+                    config.MaintenanceInterval = Defaults.EngineSettings.MaintenanceInterval;
+
                 if (config.MaxWorkflowsPerRequest <= 0)
                     config.MaxWorkflowsPerRequest = Defaults.EngineSettings.MaxWorkflowsPerRequest;
 

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Data/Services/DbMaintenanceService.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Data/Services/DbMaintenanceService.cs
@@ -19,7 +19,7 @@ internal sealed class DbMaintenanceService(
     IConcurrencyLimiter concurrencyLimiter
 ) : BackgroundService
 {
-    private static readonly TimeSpan _interval = TimeSpan.FromMinutes(1);
+    private static readonly TimeSpan _fallbackInterval = TimeSpan.FromMinutes(1);
 
     /// <summary>
     /// Backoff strategy used when database operations fail. Exponential from 1s up to 2min.
@@ -55,6 +55,7 @@ internal sealed class DbMaintenanceService(
 
                 await AbandonStaleWorkflows(now, settings, stoppingToken);
                 await ReclaimStaleWorkflows(now, settings, stoppingToken);
+                await RecoverDependencyResolvedWorkflows(now, stoppingToken);
 
                 consecutiveFailures = 0;
                 Metrics.SetMaintenanceConsecutiveFailures(0);
@@ -77,7 +78,8 @@ internal sealed class DbMaintenanceService(
                 continue;
             }
 
-            await Task.Delay(_interval, timeProvider, stoppingToken);
+            var interval = options.Value.MaintenanceInterval;
+            await Task.Delay(interval > TimeSpan.Zero ? interval : _fallbackInterval, timeProvider, stoppingToken);
         }
 
         logger.ShuttingDown();
@@ -373,6 +375,36 @@ internal sealed class DbMaintenanceService(
         }
     }
 
+    /// <summary>
+    /// Re-enqueues workflows stuck in <see cref="PersistentItemStatus.DependencyFailed"/> whose
+    /// dependencies have since all reached <see cref="PersistentItemStatus.Completed"/>. The status
+    /// is purely derived — a workflow lands there because a dependency was in a failed state when it
+    /// was evaluated — so once every dependency completes (typically after the upstream was resumed
+    /// without cascade) the original reason no longer holds and the workflow should run.
+    /// A still-Canceled or still-Failed dependency keeps the workflow parked, which preserves the
+    /// intent expressed by those terminal states. Deep chains heal one layer per sweep as each
+    /// intermediate completes. Idempotent: re-enqueued rows no longer match the predicate.
+    /// </summary>
+    internal async Task RecoverDependencyResolvedWorkflows(DateTimeOffset now, CancellationToken ct)
+    {
+        using var activity = Metrics.Source.StartActivity("DbMaintenanceService.RecoverDependencyResolvedWorkflows");
+
+        int recovered;
+        using (await concurrencyLimiter.AcquireDbSlot(cancellationToken: ct))
+        {
+            await using var cmd = dataSource.CreateCommand(Sql.RecoverDependencyResolvedWorkflows);
+            cmd.Parameters.AddWithValue("now", now);
+
+            recovered = await cmd.ExecuteNonQueryAsync(ct);
+        }
+
+        if (recovered > 0)
+        {
+            Metrics.WorkflowsDependencyRecovered.Add(recovered);
+            logger.RecoveredDependencyResolvedWorkflows(recovered);
+        }
+    }
+
     internal static class Sql
     {
         internal const string SelectExpiredWorkflowCandidatesCommand = """
@@ -498,6 +530,31 @@ internal sealed class DbMaintenanceService(
               AND heartbeat_at < @staleDeadline
               AND reclaim_count < @maxReclaimCount
             """;
+
+        // Reset matches the resume path's column set (LeaseToken cleared to preserve the
+        // "NOT NULL iff Processing" invariant). Steps are left untouched: a DependencyFailed
+        // workflow short-circuits before its steps run, so they remain pristine Enqueued.
+        internal static readonly string RecoverDependencyResolvedWorkflows = $"""
+            UPDATE engine.workflows w
+            SET status = {(int)PersistentItemStatus.Enqueued},
+                cancellation_requested_at = NULL,
+                backoff_until = NULL,
+                heartbeat_at = NULL,
+                lease_token = NULL,
+                reclaim_count = 0,
+                updated_at = @now
+            WHERE w.status = {(int)PersistentItemStatus.DependencyFailed}
+              AND EXISTS (
+                  SELECT 1 FROM engine.workflow_dependency wd
+                  WHERE wd.workflow_id = w.id
+              )
+              AND NOT EXISTS (
+                  SELECT 1 FROM engine.workflow_dependency wd
+                  JOIN engine.workflows dep ON dep.id = wd.depends_on_workflow_id
+                  WHERE wd.workflow_id = w.id
+                    AND dep.status <> {(int)PersistentItemStatus.Completed}
+              )
+            """;
     }
 }
 
@@ -529,6 +586,15 @@ internal static partial class DbMaintenanceServiceLogs
 
     [LoggerMessage(LogLevel.Warning, "Reclaimed {Count} stale workflows from crashed/unresponsive workers")]
     internal static partial void ReclaimedStaleWorkflows(this ILogger<DbMaintenanceService> logger, int count);
+
+    [LoggerMessage(
+        LogLevel.Information,
+        "Recovered {Count} dependency-failed workflow(s) whose dependencies have since completed"
+    )]
+    internal static partial void RecoveredDependencyResolvedWorkflows(
+        this ILogger<DbMaintenanceService> logger,
+        int count
+    );
 
     [LoggerMessage(
         LogLevel.Error,

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Models/EngineSettings.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Models/EngineSettings.cs
@@ -119,6 +119,13 @@ public sealed record EngineSettings
     public TimeSpan CancellationWatcherInterval { get; set; }
 
     /// <summary>
+    /// Interval at which the database maintenance sweeps run (stale reclaim, poison abandon,
+    /// and dependency-recovery of workflows whose dependencies have since completed).
+    /// </summary>
+    [JsonPropertyName("maintenanceInterval")]
+    public TimeSpan MaintenanceInterval { get; set; }
+
+    /// <summary>
     /// Concurrency settings.
     /// </summary>
     [JsonPropertyName("concurrency")]

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Telemetry/Metrics.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Telemetry/Metrics.cs
@@ -139,6 +139,14 @@ public static class Metrics
     );
 
     /// <summary>
+    /// Counter of DependencyFailed workflows re-enqueued because their dependencies have since completed.
+    /// </summary>
+    public static readonly Counter<long> WorkflowsDependencyRecovered = Meter.CreateCounter<long>(
+        "engine.workflows.execution.dependency_recovered",
+        description: "Number of DependencyFailed workflows re-enqueued because their dependencies have since completed"
+    );
+
+    /// <summary>
     /// Counter of in-flight workflows this host abandoned because their lease was reclaimed by another host.
     /// </summary>
     public static readonly Counter<long> WorkflowsLeaseLost = Meter.CreateCounter<long>(

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Integration.Tests/EngineResumeTests.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Integration.Tests/EngineResumeTests.cs
@@ -209,6 +209,93 @@ public sealed class EngineResumeTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Resume_WithoutCascade_DependentSelfHealsViaMaintenanceSweep()
+    {
+        // Even without cascade, a dependent left in DependencyFailed must recover on its own once the
+        // parent it depends on completes — the DbMaintenanceService dependency-recovery sweep re-enqueues it.
+        SetupWireMock();
+        _wireMock
+            .Given(Request.Create().WithPath("/fail-parent-heal").UsingAnyMethod())
+            .AtPriority(1)
+            .RespondWith(Response.Create().WithStatusCode(500));
+
+        // Run the maintenance sweep aggressively so the test does not wait a full minute.
+        await using var factory = new EngineWebApplicationFactory<Program>(
+            _postgres.GetConnectionString(),
+            builder =>
+            {
+                builder.UseSetting("EngineSettings:Concurrency:MaxWorkers", "5");
+                builder.UseSetting("EngineSettings:DefaultStepRetryStrategy:MaxRetries", "0");
+                builder.UseSetting("EngineSettings:MaintenanceInterval", "00:00:00.2500000");
+            }
+        );
+
+        using var client = factory.CreateClient();
+        var request = new WorkflowEnqueueRequest
+        {
+            Context = JsonSerializer.SerializeToElement(new { test = "self-heal" }),
+            Workflows =
+            [
+                new WorkflowRequest
+                {
+                    Ref = "parent",
+                    OperationId = "parent-op",
+                    Steps = [CreateWebhookStep("/fail-parent-heal")],
+                },
+                new WorkflowRequest
+                {
+                    Ref = "child",
+                    OperationId = "child-op",
+                    Steps = [CreateWebhookStep("/child-step")],
+                    DependsOn = ["parent"],
+                },
+            ],
+        };
+
+        using var enqueueMsg = new HttpRequestMessage(HttpMethod.Post, WorkflowsPath)
+        {
+            Content = JsonContent.Create(request),
+        };
+        enqueueMsg.Headers.Add(WorkflowMetadataConstants.Headers.IdempotencyKey, $"idem-{Guid.NewGuid()}");
+
+        var enqueueResponse = await client.SendAsync(enqueueMsg, TestContext.Current.CancellationToken);
+        enqueueResponse.EnsureSuccessStatusCode();
+
+        var enqueueBody = await enqueueResponse.Content.ReadFromJsonAsync<WorkflowEnqueueResponse.Accepted>(
+            TestContext.Current.CancellationToken
+        );
+        Assert.NotNull(enqueueBody);
+
+        var parentId = enqueueBody.Workflows.Single(w => w.Ref == "parent").DatabaseId;
+        var childId = enqueueBody.Workflows.Single(w => w.Ref == "child").DatabaseId;
+
+        await WaitForTerminalStatus(parentId, PersistentItemStatus.Failed);
+        await WaitForTerminalStatus(childId, PersistentItemStatus.DependencyFailed);
+
+        // Reconfigure WireMock to succeed, then resume the parent WITHOUT cascade.
+        _wireMock.Reset();
+        SetupWireMock();
+
+        using var resumeResponse = await client.PostAsync(
+            $"{WorkflowsPath}/{parentId}/resume?cascade=false",
+            content: null,
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+        Assert.Equal(HttpStatusCode.OK, resumeResponse.StatusCode);
+
+        var resumeBody = await resumeResponse.Content.ReadFromJsonAsync<ResumeWorkflowResponse>(
+            TestContext.Current.CancellationToken
+        );
+        Assert.NotNull(resumeBody);
+        Assert.Empty(resumeBody.CascadeResumed);
+
+        // Parent completes from the resume; the child recovers only because the maintenance sweep
+        // re-enqueues it once the parent dependency is Completed.
+        await WaitForTerminalStatus(parentId, PersistentItemStatus.Completed);
+        await WaitForTerminalStatus(childId, PersistentItemStatus.Completed, TimeSpan.FromSeconds(30));
+    }
+
+    [Fact]
     public async Task Resume_CompletedWorkflow_Returns409()
     {
         SetupWireMock();

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Repository.Tests/DependencyRecoverySweepTests.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Repository.Tests/DependencyRecoverySweepTests.cs
@@ -1,0 +1,185 @@
+using WorkflowEngine.Models;
+using WorkflowEngine.Repository.Tests.Fixtures;
+
+namespace WorkflowEngine.Repository.Tests;
+
+/// <summary>
+/// Covers the dependency-recovery sweep in <c>DbMaintenanceService</c>
+/// (<see cref="WorkflowEngine.Data.Services.DbMaintenanceService.RecoverDependencyResolvedWorkflows"/>):
+/// a workflow stuck in <see cref="PersistentItemStatus.DependencyFailed"/> is re-enqueued once all of
+/// its dependencies have completed, but stays parked while any dependency is still Failed or Canceled.
+/// </summary>
+[Collection(PostgresCollection.Name)]
+public sealed class DependencyRecoverySweepTests(PostgresFixture fixture) : IAsyncLifetime
+{
+    public async ValueTask InitializeAsync() => await fixture.Reset();
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    [Fact]
+    public async Task Recover_DependencyFailed_WithCompletedDependency_IsReEnqueued()
+    {
+        await using var context = fixture.CreateDbContext();
+        var repo = fixture.CreateRepository();
+        var maintenance = fixture.CreateMaintenanceService();
+        var ns = Guid.NewGuid().ToString("N");
+
+        var parent = await WorkflowTestHelper.InsertAndSetStatus(repo, context, PersistentItemStatus.Completed, ns: ns);
+        var child = await WorkflowTestHelper.InsertAndSetStatus(
+            repo,
+            context,
+            PersistentItemStatus.DependencyFailed,
+            ns: ns,
+            dependencies: [parent.DatabaseId]
+        );
+
+        await maintenance.RecoverDependencyResolvedWorkflows(
+            DateTimeOffset.UtcNow,
+            TestContext.Current.CancellationToken
+        );
+
+        var dbChild = await fixture.GetWorkflow(child.DatabaseId);
+        Assert.NotNull(dbChild);
+        Assert.Equal(PersistentItemStatus.Enqueued, dbChild.Status);
+        Assert.Null(dbChild.LeaseToken);
+    }
+
+    [Fact]
+    public async Task Recover_ReEnqueuedChild_SurfacesAsFetchable()
+    {
+        // End-to-end: the sweep re-enqueues the resolved child; the next fetch picks it up.
+        await using var context = fixture.CreateDbContext();
+        var repo = fixture.CreateRepository();
+        var maintenance = fixture.CreateMaintenanceService();
+        var ns = Guid.NewGuid().ToString("N");
+
+        var parent = await WorkflowTestHelper.InsertAndSetStatus(repo, context, PersistentItemStatus.Completed, ns: ns);
+        var child = await WorkflowTestHelper.InsertAndSetStatus(
+            repo,
+            context,
+            PersistentItemStatus.DependencyFailed,
+            ns: ns,
+            dependencies: [parent.DatabaseId]
+        );
+
+        await maintenance.RecoverDependencyResolvedWorkflows(
+            DateTimeOffset.UtcNow,
+            TestContext.Current.CancellationToken
+        );
+
+        var fetched = await repo.FetchAndLockWorkflows(10, TestContext.Current.CancellationToken);
+        Assert.Contains(fetched, w => w.DatabaseId == child.DatabaseId);
+    }
+
+    [Fact]
+    public async Task Recover_DependencyFailed_WithFailedDependency_IsNotTouched()
+    {
+        await using var context = fixture.CreateDbContext();
+        var repo = fixture.CreateRepository();
+        var maintenance = fixture.CreateMaintenanceService();
+        var ns = Guid.NewGuid().ToString("N");
+
+        var parent = await WorkflowTestHelper.InsertAndSetStatus(repo, context, PersistentItemStatus.Failed, ns: ns);
+        var child = await WorkflowTestHelper.InsertAndSetStatus(
+            repo,
+            context,
+            PersistentItemStatus.DependencyFailed,
+            ns: ns,
+            dependencies: [parent.DatabaseId]
+        );
+
+        await maintenance.RecoverDependencyResolvedWorkflows(
+            DateTimeOffset.UtcNow,
+            TestContext.Current.CancellationToken
+        );
+
+        var dbChild = await fixture.GetWorkflow(child.DatabaseId);
+        Assert.NotNull(dbChild);
+        Assert.Equal(PersistentItemStatus.DependencyFailed, dbChild.Status);
+    }
+
+    [Fact]
+    public async Task Recover_DependencyFailed_WithCanceledDependency_IsNotTouched()
+    {
+        // Cancellation is intentional and terminal — a canceled dependency must keep dependents parked.
+        await using var context = fixture.CreateDbContext();
+        var repo = fixture.CreateRepository();
+        var maintenance = fixture.CreateMaintenanceService();
+        var ns = Guid.NewGuid().ToString("N");
+
+        var parent = await WorkflowTestHelper.InsertAndSetStatus(repo, context, PersistentItemStatus.Canceled, ns: ns);
+        var child = await WorkflowTestHelper.InsertAndSetStatus(
+            repo,
+            context,
+            PersistentItemStatus.DependencyFailed,
+            ns: ns,
+            dependencies: [parent.DatabaseId]
+        );
+
+        await maintenance.RecoverDependencyResolvedWorkflows(
+            DateTimeOffset.UtcNow,
+            TestContext.Current.CancellationToken
+        );
+
+        var dbChild = await fixture.GetWorkflow(child.DatabaseId);
+        Assert.NotNull(dbChild);
+        Assert.Equal(PersistentItemStatus.DependencyFailed, dbChild.Status);
+    }
+
+    [Fact]
+    public async Task Recover_DependencyFailed_WithMixedDependencies_IsNotTouchedUntilAllComplete()
+    {
+        await using var context = fixture.CreateDbContext();
+        var repo = fixture.CreateRepository();
+        var maintenance = fixture.CreateMaintenanceService();
+        var ns = Guid.NewGuid().ToString("N");
+
+        var completedParent = await WorkflowTestHelper.InsertAndSetStatus(
+            repo,
+            context,
+            PersistentItemStatus.Completed,
+            ns: ns
+        );
+        var failedParent = await WorkflowTestHelper.InsertAndSetStatus(
+            repo,
+            context,
+            PersistentItemStatus.Failed,
+            ns: ns
+        );
+        var child = await WorkflowTestHelper.InsertAndSetStatus(
+            repo,
+            context,
+            PersistentItemStatus.DependencyFailed,
+            ns: ns,
+            dependencies: [completedParent.DatabaseId, failedParent.DatabaseId]
+        );
+
+        await maintenance.RecoverDependencyResolvedWorkflows(
+            DateTimeOffset.UtcNow,
+            TestContext.Current.CancellationToken
+        );
+
+        var dbChild = await fixture.GetWorkflow(child.DatabaseId);
+        Assert.NotNull(dbChild);
+        Assert.Equal(PersistentItemStatus.DependencyFailed, dbChild.Status);
+    }
+
+    [Fact]
+    public async Task Recover_DependencyFailed_WithNoDependencies_IsNotTouched()
+    {
+        await using var context = fixture.CreateDbContext();
+        var repo = fixture.CreateRepository();
+        var maintenance = fixture.CreateMaintenanceService();
+
+        var orphan = await WorkflowTestHelper.InsertAndSetStatus(repo, context, PersistentItemStatus.DependencyFailed);
+
+        await maintenance.RecoverDependencyResolvedWorkflows(
+            DateTimeOffset.UtcNow,
+            TestContext.Current.CancellationToken
+        );
+
+        var dbOrphan = await fixture.GetWorkflow(orphan.DatabaseId);
+        Assert.NotNull(dbOrphan);
+        Assert.Equal(PersistentItemStatus.DependencyFailed, dbOrphan.Status);
+    }
+}


### PR DESCRIPTION
Addresses the **P1 `ResumeCurrentTask`** finding from the [PR #18735 review](https://github.com/Altinn/altinn-studio/pull/18735#issuecomment-4808589014). Implements both the targeted fix (A) and the deeper engine-semantics fix (B) discussed with the workflow-engine owner.

## A — App resume now cascades

When a service task auto-advances, a dependent workflow is enqueued that depends on the current (parent) workflow. If the parent fails on a later step, the child transitions to `DependencyFailed`. The Runtime resume path called `ResumeWorkflow(...)` with the client default `cascade = false`, so resuming the failed parent completed it but left the child stuck in `DependencyFailed` — and `WaitForWorkflowCollectionAndRefetchInstance` kept reporting the dependency failure even after the parent succeeded.

`WorkflowEngineService.ResumeAndWaitForWorkflow` now passes `cascade: true`. The engine already supports cascading resume; this just uses it. Safe by construction: the cascade CTE only resets transitively-dependent workflows that are themselves `DependencyFailed`, and is a no-op when there are no dependents.

## B — Engine self-heals `DependencyFailed` (derived-state fix)

`DependencyFailed` is computed purely from *"a dependency was in a failed state when this workflow was evaluated"* (`WorkflowHandler`), and carries no independent intent — deliberate stops use `Canceled`. Recovery, however, was never automatic: nothing re-pulled a workflow out of `DependencyFailed` once its dependency later completed.

A new `DbMaintenanceService` sweep (`RecoverDependencyResolvedWorkflows`) re-enqueues `DependencyFailed` workflows once **all** their dependencies have reached `Completed`, while leaving them parked if any dependency is still `Failed` or `Canceled` (preserving cancellation intent). Deep chains heal one layer per sweep as each intermediate completes; the update is idempotent. This removes the "every resume caller must remember `cascade`" footgun and is the safety net behind (A).

Supporting changes:
- Configurable `EngineSettings.MaintenanceInterval` (default 1 min; mirrors the existing interval-normalization pattern) so the sweep cadence is tunable and testable.
- New `engine.workflows.execution.dependency_recovered` counter.

## Why both

A gives the synchronous resume path immediate, correct behaviour (it resets dependents inside the resume transaction, which the app's collection-head polling depends on). B makes `DependencyFailed` a properly self-maintaining derived state for any path — but a lazy sweep alone wouldn't satisfy the resume polling window, so both are kept.

## Tests
- **App:** `WorkflowEngineServiceTests` — asserts the resume path sends `cascade: true`.
- **Engine (repository):** `DependencyRecoverySweepTests` — recovers when deps Completed; leaves parked for Failed/Canceled/mixed/no-deps; re-enqueued row is fetchable.
- **Engine (integration):** `EngineResumeTests.Resume_WithoutCascade_DependentSelfHealsViaMaintenanceSweep` — end-to-end self-heal after a non-cascade resume.

All green locally: app Core WF suite (158), engine Core (157), repository sweep tests, and `EngineResumeTests` (6/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)