### PR TITLE
fix: update layoutSet name 404 error

### DIFF
--- a/src/Designer/frontend/app-development/hooks/mutations/useUpdateLayoutSetIdMutation.ts
+++ b/src/Designer/frontend/app-development/hooks/mutations/useUpdateLayoutSetIdMutation.ts
@@ -14,8 +14,8 @@ export const useUpdateLayoutSetIdMutation = (org: string, app: string) => {
       layoutSetIdToUpdate: string;
       newLayoutSetId: string;
     }) => updateLayoutSetId(org, app, layoutSetIdToUpdate, newLayoutSetId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [QueryKey.LayoutSetsExtended, org, app] });
+    onSuccess: async () => {
+      await queryClient.refetchQueries({ queryKey: [QueryKey.LayoutSetsExtended, org, app] });
       queryClient.invalidateQueries({ queryKey: [QueryKey.LayoutSets, org, app] });
     },
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
fix error 404 when updating layoutSet name

<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Layout sets now refresh more reliably after updates, so changes are reflected sooner in the app.
  * Improved data refresh behaviour for layout set lists to reduce stale or outdated information being shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->