### PR TITLE
fix: repair workflow engine CI expectations

### DIFF
--- a/src/App/backend/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.cs
@@ -2125,7 +2125,7 @@ public sealed class ProcessEngineTest
                 ),
             ]);
         processEngineClientMock
-            .Setup(c => c.ResumeWorkflow(It.IsAny<string>(), workflowId, false, It.IsAny<CancellationToken>()))
+            .Setup(c => c.ResumeWorkflow(It.IsAny<string>(), workflowId, true, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ResumeWorkflowResponse(workflowId, DateTimeOffset.UtcNow, []));
 
         Mock<IInstanceClient> instanceClientMock = new(MockBehavior.Strict);
@@ -2164,7 +2164,7 @@ public sealed class ProcessEngineTest
         result.ProcessStateChange!.OldProcessState.Should().BeEquivalentTo(originalInstance.Process);
         result.ProcessStateChange.NewProcessState.Should().BeEquivalentTo(resumedInstance.Process);
         processEngineClientMock.Verify(
-            c => c.ResumeWorkflow(It.IsAny<string>(), workflowId, false, It.IsAny<CancellationToken>()),
+            c => c.ResumeWorkflow(It.IsAny<string>(), workflowId, true, It.IsAny<CancellationToken>()),
             Times.Once
         );
     }


### PR DESCRIPTION
## Description

Follow-up fix for the remaining app-backend CI failure on #18735 after `4a5ad09`.

- Updates `ProcessEngineTest.ResumeCurrentTask_resumes_failed_workflow_and_returns_updated_instance` to expect `ResumeWorkflow(..., cascade: true)`, matching the implementation change in `ResumeAndWaitForWorkflow`.

`4a5ad09` already fixed the `multiple-datamodels-test` hook API issue, so this branch is now intentionally scoped to the remaining unit-test expectation.

## Verification

```bash
dotnet test test/Altinn.App.Core.Tests/Altinn.App.Core.Tests.csproj -v m --filter "FullyQualifiedName=Altinn.App.Core.Tests.Internal.Process.ProcessEngineTest.ResumeCurrentTask_resumes_failed_workflow_and_returns_updated_instance"
dotnet csharpier check test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.cs
```
