### PR TITLE
fix: remove read-only server params from workflow-engine DatabaseServer

### DIFF
--- a/infra/admin/workflow-engine-db/base/database-server.yaml
+++ b/infra/admin/workflow-engine-db/base/database-server.yaml
@@ -25,8 +25,6 @@ spec:
       value: "0"
     - name: random_page_cost
       value: "1.1"
-    - name: default_toast_compression
-      value: "lz4"
     - name: wal_compression
       value: "lz4"
     - name: checkpoint_completion_target
@@ -36,8 +34,6 @@ spec:
     - name: autovacuum_vacuum_cost_limit
       value: "2400"
     - name: effective_io_concurrency
-      value: "200"
-    - name: maintenance_io_concurrency
       value: "200"
     - name: tcp_keepalives_idle
       value: "120"


### PR DESCRIPTION
`default_toast_compression` and `maintenance_io_concurrency` are read-only on Azure Database for PostgreSQL flexible server, so they can never be applied — their parameter resources stay in `ApplyFailed`, which keeps the `DatabaseServer` from reaching `Ready` and blocks all downstream provisioning (databases, role grants) on the server. This is what currently blocks the workflow-engine database from provisioning on at23.

Removing both lets reconciliation complete; Azure manages these values itself.

Source — read-only parameters and how to list them (portal **Read-Only** tab / `isReadOnly`): https://learn.microsoft.com/en-us/azure/postgresql/parameters/how-to-parameters-list-read-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated database server tuning settings to improve compression behaviour and simplify the configuration set.
  * Removed two legacy performance parameters so the server now uses a cleaner, more consistent default configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->