### PR TITLE
feat: expose runtime app deployment status

### DIFF
--- a/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Application/Deploy/AppDeploymentMapping.cs
+++ b/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Application/Deploy/AppDeploymentMapping.cs
@@ -1,0 +1,42 @@
+using Altinn.Studio.Gateway.Api.Clients.K8s;
+using Altinn.Studio.Gateway.Contracts.Deploy;
+
+namespace Altinn.Studio.Gateway.Api.Application;
+
+internal static class AppDeploymentMapping
+{
+    public static AppDeployment FromRuntimeDeployment(
+        string org,
+        string targetEnvironment,
+        DeploymentClient.RuntimeDeployment runtimeDeployment
+    ) =>
+        new(
+            org,
+            targetEnvironment,
+            runtimeDeployment.App,
+            SourceEnvironment: null,
+            BuildId: null,
+            runtimeDeployment.ImageTag,
+            runtimeDeployment.CurrentVersion,
+            runtimeDeployment.UpdateInProgress,
+            IsGitOpsManaged: false
+        );
+
+    public static AppDeployment WithGitOpsMetadata(
+        AppDeployment deployment,
+        HelmReleaseMapping.DeploymentMetadata? metadata
+    )
+    {
+        if (metadata is null || metadata.Org != deployment.Org || metadata.App != deployment.App)
+        {
+            return deployment;
+        }
+
+        return deployment with
+        {
+            SourceEnvironment = metadata.SourceEnvironment,
+            BuildId = metadata.BuildId,
+            IsGitOpsManaged = true,
+        };
+    }
+}

--- a/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Application/Deploy/HandleGetAppDeployment.cs
+++ b/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Application/Deploy/HandleGetAppDeployment.cs
@@ -9,42 +9,85 @@ internal static class HandleGetAppDeployment
     internal static async Task<IResult> GetAppDeploymentHandler(
         string app,
         string originEnvironment,
+        bool? includeNonGitOps,
         IOptionsMonitor<GatewayContext> gatewayContext,
         HelmReleaseClient helmReleaseClient,
+        DeploymentClient deploymentClient,
         ILogger<Program> logger,
         CancellationToken cancellationToken
     )
     {
         var currentGatewayContext = gatewayContext.CurrentValue;
+        var runtimeDeployment = await deploymentClient.GetAppDeployment(
+            currentGatewayContext.ServiceOwner,
+            app,
+            cancellationToken
+        );
+        if (runtimeDeployment is null)
+        {
+            return Results.NotFound();
+        }
+
+        var deployment = AppDeploymentMapping.FromRuntimeDeployment(
+            currentGatewayContext.ServiceOwner,
+            currentGatewayContext.Environment,
+            runtimeDeployment
+        );
+
         var helmReleaseName = HelmReleaseNameHelper.Generate(
             currentGatewayContext.ServiceOwner,
             app,
             originEnvironment
         );
+        var helmReleaseMetadata = await GetHelmReleaseMetadata(
+            helmReleaseName,
+            helmReleaseClient,
+            logger,
+            cancellationToken
+        );
+        deployment = AppDeploymentMapping.WithGitOpsMetadata(deployment, helmReleaseMetadata);
 
-        var helmRelease = await helmReleaseClient.Get(helmReleaseName, "default", cancellationToken);
-
-        if (helmRelease is null)
-            return Results.NotFound();
-
-        if (
-            !HelmReleaseMapping.TryCreateAppDeployment(
-                helmRelease,
-                currentGatewayContext.Environment,
-                out var deployment,
-                out var error
-            )
-        )
+        if (includeNonGitOps != true && !deployment.IsGitOpsManaged)
         {
-            logger.LogError("Invalid HelmRelease state for {HelmReleaseName}: {Error}", helmReleaseName, error);
-
-            return Results.Problem(
-                title: $"Invalid HelmRelease state for {helmReleaseName}",
-                detail: error,
-                statusCode: StatusCodes.Status500InternalServerError
-            );
+            return Results.NotFound();
         }
 
         return Results.Ok(deployment);
+    }
+
+    private static async Task<HelmReleaseMapping.DeploymentMetadata?> GetHelmReleaseMetadata(
+        string helmReleaseName,
+        HelmReleaseClient helmReleaseClient,
+        ILogger logger,
+        CancellationToken cancellationToken
+    )
+    {
+        HelmRelease? helmRelease;
+        try
+        {
+            helmRelease = await helmReleaseClient.Get(helmReleaseName, "default", cancellationToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogWarning(
+                ex,
+                "Failed to get HelmRelease metadata for {HelmReleaseName}. Returning runtime deployment without GitOps metadata.",
+                helmReleaseName
+            );
+            return null;
+        }
+
+        if (helmRelease is null)
+        {
+            return null;
+        }
+
+        if (!HelmReleaseMapping.TryGetDeploymentMetadata(helmRelease, out var metadata, out var error))
+        {
+            logger.LogWarning("Invalid HelmRelease metadata for {HelmReleaseName}: {Error}", helmReleaseName, error);
+            return null;
+        }
+
+        return metadata;
     }
 }

--- a/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Application/Deploy/HandleGetAppDeployment.cs
+++ b/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Application/Deploy/HandleGetAppDeployment.cs
@@ -45,7 +45,15 @@ internal static class HandleGetAppDeployment
             logger,
             cancellationToken
         );
-        deployment = AppDeploymentMapping.WithGitOpsMetadata(deployment, helmReleaseMetadata);
+        if (helmReleaseMetadata.Failed && includeNonGitOps != true)
+        {
+            return Results.Problem(
+                title: "Failed to get GitOps deployment metadata.",
+                statusCode: StatusCodes.Status503ServiceUnavailable
+            );
+        }
+
+        deployment = AppDeploymentMapping.WithGitOpsMetadata(deployment, helmReleaseMetadata.Metadata);
 
         if (includeNonGitOps != true && !deployment.IsGitOpsManaged)
         {
@@ -55,7 +63,7 @@ internal static class HandleGetAppDeployment
         return Results.Ok(deployment);
     }
 
-    private static async Task<HelmReleaseMapping.DeploymentMetadata?> GetHelmReleaseMetadata(
+    private static async Task<HelmReleaseMetadataResult> GetHelmReleaseMetadata(
         string helmReleaseName,
         HelmReleaseClient helmReleaseClient,
         ILogger logger,
@@ -74,20 +82,28 @@ internal static class HandleGetAppDeployment
                 "Failed to get HelmRelease metadata for {HelmReleaseName}. Returning runtime deployment without GitOps metadata.",
                 helmReleaseName
             );
-            return null;
+            return HelmReleaseMetadataResult.Failure();
         }
 
         if (helmRelease is null)
         {
-            return null;
+            return HelmReleaseMetadataResult.Success(null);
         }
 
         if (!HelmReleaseMapping.TryGetDeploymentMetadata(helmRelease, out var metadata, out var error))
         {
             logger.LogWarning("Invalid HelmRelease metadata for {HelmReleaseName}: {Error}", helmReleaseName, error);
-            return null;
+            return HelmReleaseMetadataResult.Success(null);
         }
 
-        return metadata;
+        return HelmReleaseMetadataResult.Success(metadata);
+    }
+
+    private sealed record HelmReleaseMetadataResult(HelmReleaseMapping.DeploymentMetadata? Metadata, bool Failed)
+    {
+        public static HelmReleaseMetadataResult Success(HelmReleaseMapping.DeploymentMetadata? metadata) =>
+            new(metadata, Failed: false);
+
+        public static HelmReleaseMetadataResult Failure() => new(Metadata: null, Failed: true);
     }
 }

--- a/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Application/Deploy/HandleListAppDeployments.cs
+++ b/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Application/Deploy/HandleListAppDeployments.cs
@@ -9,42 +9,42 @@ internal static class HandleListAppDeployments
 {
     internal static async Task<IResult> ListAppDeploymentsHandler(
         string originEnvironment,
+        bool? includeNonGitOps,
         IOptionsMonitor<GatewayContext> gatewayContext,
         HelmReleaseClient helmReleaseClient,
+        DeploymentClient deploymentClient,
         ILogger<Program> logger,
         CancellationToken cancellationToken
     )
     {
         var currentGatewayContext = gatewayContext.CurrentValue;
-        var labelSelector = HelmReleaseLabelSelector.ForOrgAndSourceEnvironment(
+        var runtimeDeployments = await deploymentClient.ListAppDeployments(
             currentGatewayContext.ServiceOwner,
-            originEnvironment
+            cancellationToken
         );
 
-        var helmReleases = await helmReleaseClient.List(
-            "default",
-            labelSelector: labelSelector,
-            cancellationToken: cancellationToken
+        var helmReleaseMetadata = await GetHelmReleaseMetadata(
+            currentGatewayContext.ServiceOwner,
+            originEnvironment,
+            helmReleaseClient,
+            logger,
+            cancellationToken
         );
 
         var deployments = new List<AppDeployment>();
 
-        foreach (var helmRelease in helmReleases)
+        foreach (var runtimeDeployment in runtimeDeployments)
         {
-            if (
-                !HelmReleaseMapping.TryCreateAppDeployment(
-                    helmRelease,
-                    currentGatewayContext.Environment,
-                    out var deployment,
-                    out var error
-                )
-            )
+            var deployment = AppDeploymentMapping.FromRuntimeDeployment(
+                currentGatewayContext.ServiceOwner,
+                currentGatewayContext.Environment,
+                runtimeDeployment
+            );
+
+            helmReleaseMetadata.TryGetValue(runtimeDeployment.App, out var metadata);
+            deployment = AppDeploymentMapping.WithGitOpsMetadata(deployment, metadata);
+            if (includeNonGitOps != true && !deployment.IsGitOpsManaged)
             {
-                logger.LogError(
-                    "Invalid HelmRelease state for {HelmReleaseName}: {Error}",
-                    helmRelease.GetName(),
-                    error
-                );
                 continue;
             }
 
@@ -52,5 +52,61 @@ internal static class HandleListAppDeployments
         }
 
         return Results.Ok(deployments);
+    }
+
+    private static async Task<Dictionary<string, HelmReleaseMapping.DeploymentMetadata>> GetHelmReleaseMetadata(
+        string org,
+        string originEnvironment,
+        HelmReleaseClient helmReleaseClient,
+        ILogger logger,
+        CancellationToken cancellationToken
+    )
+    {
+        IReadOnlyList<HelmRelease> helmReleases;
+        try
+        {
+            var labelSelector = HelmReleaseLabelSelector.ForOrgAndSourceEnvironment(org, originEnvironment);
+            helmReleases = await helmReleaseClient.List(
+                "default",
+                labelSelector: labelSelector,
+                cancellationToken: cancellationToken
+            );
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogWarning(
+                ex,
+                "Failed to get HelmRelease metadata for {Org}/{OriginEnvironment}. Returning runtime deployments without GitOps metadata.",
+                org,
+                originEnvironment
+            );
+            return [];
+        }
+
+        var result = new Dictionary<string, HelmReleaseMapping.DeploymentMetadata>(StringComparer.Ordinal);
+
+        foreach (var helmRelease in helmReleases)
+        {
+            if (!HelmReleaseMapping.TryGetDeploymentMetadata(helmRelease, out var metadata, out var error))
+            {
+                logger.LogWarning(
+                    "Invalid HelmRelease metadata for {HelmReleaseName}: {Error}",
+                    helmRelease.GetName(),
+                    error
+                );
+                continue;
+            }
+
+            if (!result.TryAdd(metadata.App, metadata))
+            {
+                logger.LogWarning(
+                    "Duplicate HelmRelease metadata for {Org}/{App}. Keeping the first metadata.",
+                    org,
+                    metadata.App
+                );
+            }
+        }
+
+        return result;
     }
 }

--- a/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Application/Deploy/HandleListAppDeployments.cs
+++ b/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Application/Deploy/HandleListAppDeployments.cs
@@ -30,6 +30,13 @@ internal static class HandleListAppDeployments
             logger,
             cancellationToken
         );
+        if (helmReleaseMetadata.Failed && includeNonGitOps != true)
+        {
+            return Results.Problem(
+                title: "Failed to get GitOps deployment metadata.",
+                statusCode: StatusCodes.Status503ServiceUnavailable
+            );
+        }
 
         var deployments = new List<AppDeployment>();
 
@@ -41,7 +48,7 @@ internal static class HandleListAppDeployments
                 runtimeDeployment
             );
 
-            helmReleaseMetadata.TryGetValue(runtimeDeployment.App, out var metadata);
+            helmReleaseMetadata.Metadata.TryGetValue(runtimeDeployment.App, out var metadata);
             deployment = AppDeploymentMapping.WithGitOpsMetadata(deployment, metadata);
             if (includeNonGitOps != true && !deployment.IsGitOpsManaged)
             {
@@ -54,7 +61,7 @@ internal static class HandleListAppDeployments
         return Results.Ok(deployments);
     }
 
-    private static async Task<Dictionary<string, HelmReleaseMapping.DeploymentMetadata>> GetHelmReleaseMetadata(
+    private static async Task<HelmReleaseMetadataResult> GetHelmReleaseMetadata(
         string org,
         string originEnvironment,
         HelmReleaseClient helmReleaseClient,
@@ -80,7 +87,7 @@ internal static class HandleListAppDeployments
                 org,
                 originEnvironment
             );
-            return [];
+            return HelmReleaseMetadataResult.Failure();
         }
 
         var result = new Dictionary<string, HelmReleaseMapping.DeploymentMetadata>(StringComparer.Ordinal);
@@ -107,6 +114,18 @@ internal static class HandleListAppDeployments
             }
         }
 
-        return result;
+        return HelmReleaseMetadataResult.Success(result);
+    }
+
+    private sealed record HelmReleaseMetadataResult(
+        Dictionary<string, HelmReleaseMapping.DeploymentMetadata> Metadata,
+        bool Failed
+    )
+    {
+        public static HelmReleaseMetadataResult Success(
+            Dictionary<string, HelmReleaseMapping.DeploymentMetadata> metadata
+        ) => new(metadata, Failed: false);
+
+        public static HelmReleaseMetadataResult Failure() => new(Metadata: [], Failed: true);
     }
 }

--- a/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Application/Deploy/HelmReleaseMapping.cs
+++ b/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Application/Deploy/HelmReleaseMapping.cs
@@ -1,19 +1,17 @@
 using System.Diagnostics.CodeAnalysis;
 using Altinn.Studio.Gateway.Api.Clients.K8s;
-using Altinn.Studio.Gateway.Contracts.Deploy;
 
 namespace Altinn.Studio.Gateway.Api.Application;
 
 internal static class HelmReleaseMapping
 {
-    public static bool TryCreateAppDeployment(
+    public static bool TryGetDeploymentMetadata(
         HelmRelease helmRelease,
-        string targetEnvironment,
-        [NotNullWhen(true)] out AppDeployment? deployment,
+        [NotNullWhen(true)] out DeploymentMetadata? metadata,
         [NotNullWhen(false)] out string? error
     )
     {
-        deployment = null;
+        metadata = null;
         error = null;
 
         var labels = helmRelease.GetLabels();
@@ -29,14 +27,9 @@ internal static class HelmReleaseMapping
             return false;
         }
 
-        var imageTag = helmRelease.GetImageTag();
-        if (imageTag is null)
-        {
-            error = "HelmRelease is missing image tag.";
-            return false;
-        }
-
-        deployment = new AppDeployment(org, targetEnvironment, app, sourceEnv, buildId, imageTag);
+        metadata = new DeploymentMetadata(org, app, sourceEnv, buildId);
         return true;
     }
+
+    internal sealed record DeploymentMetadata(string Org, string App, string SourceEnvironment, string BuildId);
 }

--- a/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Clients/K8s/DeploymentClient.cs
+++ b/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Clients/K8s/DeploymentClient.cs
@@ -1,0 +1,127 @@
+using k8s;
+using k8s.Models;
+
+namespace Altinn.Studio.Gateway.Api.Clients.K8s;
+
+internal sealed class DeploymentClient(IKubernetes _kubernetes)
+{
+    private const string Namespace = "default";
+    private const string ReleaseLabel = "release";
+
+    public async Task<RuntimeDeployment?> GetAppDeployment(string org, string app, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var deployment = await _kubernetes.AppsV1.ReadNamespacedDeploymentAsync(
+                CreateDeploymentName(org, app),
+                Namespace,
+                cancellationToken: cancellationToken
+            );
+
+            var runtimeDeployment = TryMapDeployment(org, deployment);
+            return runtimeDeployment?.App == app ? runtimeDeployment : null;
+        }
+        catch (k8s.Autorest.HttpOperationException ex)
+            when (ex.Response.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    public async Task<IReadOnlyList<RuntimeDeployment>> ListAppDeployments(
+        string org,
+        CancellationToken cancellationToken
+    )
+    {
+        var deploymentList = await _kubernetes.AppsV1.ListNamespacedDeploymentAsync(
+            Namespace,
+            cancellationToken: cancellationToken
+        );
+
+        return deploymentList
+            .Items.Select(deployment => TryMapDeployment(org, deployment))
+            .OfType<RuntimeDeployment>()
+            .ToList();
+    }
+
+    private static RuntimeDeployment? TryMapDeployment(string org, V1Deployment deployment)
+    {
+        var app = TryGetAppName(org, deployment);
+        if (app is null)
+        {
+            return null;
+        }
+
+        return MapDeployment(app, deployment);
+    }
+
+    private static RuntimeDeployment MapDeployment(string app, V1Deployment deployment)
+    {
+        var updateInProgress = IsUpdateInProgress(deployment);
+        var imageTag = GetVersion(deployment);
+
+        return new RuntimeDeployment(app, imageTag, updateInProgress ? null : imageTag, updateInProgress);
+    }
+
+    private static string CreateDeploymentName(string org, string app) => $"{org}-{app}-deployment-v2";
+
+    private static string? GetRelease(V1Deployment deployment)
+    {
+        var labels = deployment.Metadata.Labels;
+        return labels is not null && labels.TryGetValue(ReleaseLabel, out var release) ? release : null;
+    }
+
+    private static string? TryGetAppName(string org, V1Deployment deployment)
+    {
+        var release = GetRelease(deployment);
+        var app = TryParseAppName(org, release);
+        if (app is null)
+        {
+            return null;
+        }
+
+        return deployment.Metadata.Name == CreateDeploymentName(org, app) ? app : null;
+    }
+
+    private static string? GetVersion(V1Deployment deployment)
+    {
+        var image = deployment.Spec.Template.Spec?.Containers.FirstOrDefault()?.Image;
+        if (image is null)
+        {
+            return null;
+        }
+
+        var lastColonIndex = image.LastIndexOf(':');
+        return lastColonIndex >= 0 && lastColonIndex < image.Length - 1 ? image[(lastColonIndex + 1)..] : null;
+    }
+
+    private static string? TryParseAppName(string org, string? release)
+    {
+        if (release is null || !release.StartsWith($"{org}-", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        return release[(org.Length + 1)..];
+    }
+
+    private static bool IsUpdateInProgress(V1Deployment deployment)
+    {
+        var desiredReplicas = deployment.Spec.Replicas ?? 0;
+        var status = deployment.Status;
+
+        return status.ObservedGeneration < deployment.Metadata.Generation
+            || (status.Replicas ?? 0) != (status.UpdatedReplicas ?? 0)
+            || (status.UpdatedReplicas ?? 0) < desiredReplicas
+            || (status.ReadyReplicas ?? 0) < desiredReplicas
+            || (status.AvailableReplicas ?? 0) < desiredReplicas
+            || (status.UnavailableReplicas ?? 0) > 0;
+    }
+
+    internal sealed record RuntimeDeployment(
+        string App,
+        string? ImageTag,
+        string? CurrentVersion,
+        bool UpdateInProgress
+    );
+}

--- a/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Clients/K8s/DeploymentClient.cs
+++ b/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Clients/K8s/DeploymentClient.cs
@@ -91,8 +91,12 @@ internal sealed class DeploymentClient(IKubernetes _kubernetes)
             return null;
         }
 
-        var lastColonIndex = image.LastIndexOf(':');
-        return lastColonIndex >= 0 && lastColonIndex < image.Length - 1 ? image[(lastColonIndex + 1)..] : null;
+        var imageWithoutDigest = image.Split('@', 2)[0];
+        var lastSlashIndex = imageWithoutDigest.LastIndexOf('/');
+        var lastColonIndex = imageWithoutDigest.LastIndexOf(':');
+        return lastColonIndex > lastSlashIndex && lastColonIndex < imageWithoutDigest.Length - 1
+            ? imageWithoutDigest[(lastColonIndex + 1)..]
+            : null;
     }
 
     private static string? TryParseAppName(string org, string? release)
@@ -107,15 +111,16 @@ internal sealed class DeploymentClient(IKubernetes _kubernetes)
 
     private static bool IsUpdateInProgress(V1Deployment deployment)
     {
-        var desiredReplicas = deployment.Spec.Replicas ?? 0;
+        var desiredReplicas = deployment.Spec?.Replicas ?? 0;
         var status = deployment.Status;
+        var generation = deployment.Metadata?.Generation ?? 0;
 
-        return status.ObservedGeneration < deployment.Metadata.Generation
-            || (status.Replicas ?? 0) != (status.UpdatedReplicas ?? 0)
-            || (status.UpdatedReplicas ?? 0) < desiredReplicas
-            || (status.ReadyReplicas ?? 0) < desiredReplicas
-            || (status.AvailableReplicas ?? 0) < desiredReplicas
-            || (status.UnavailableReplicas ?? 0) > 0;
+        return (status?.ObservedGeneration ?? 0) < generation
+            || (status?.Replicas ?? 0) != (status?.UpdatedReplicas ?? 0)
+            || (status?.UpdatedReplicas ?? 0) < desiredReplicas
+            || (status?.ReadyReplicas ?? 0) < desiredReplicas
+            || (status?.AvailableReplicas ?? 0) < desiredReplicas
+            || (status?.UnavailableReplicas ?? 0) > 0;
     }
 
     internal sealed record RuntimeDeployment(

--- a/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Clients/K8s/DeploymentClient.cs
+++ b/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Clients/K8s/DeploymentClient.cs
@@ -109,7 +109,7 @@ internal sealed class DeploymentClient(IKubernetes _kubernetes)
         return release[(org.Length + 1)..];
     }
 
-    private static bool IsUpdateInProgress(V1Deployment deployment)
+    internal static bool IsUpdateInProgress(V1Deployment deployment)
     {
         var desiredReplicas = deployment.Spec?.Replicas ?? 0;
         var status = deployment.Status;

--- a/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Clients/K8s/HelmRelease.cs
+++ b/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Clients/K8s/HelmRelease.cs
@@ -26,23 +26,6 @@ internal sealed class HelmRelease
         return null;
     }
 
-    public string? GetImageTag()
-    {
-        if (
-            _root.TryGetProperty("spec", out var spec)
-            && spec.TryGetProperty("values", out var values)
-            && values.TryGetProperty("image", out var image)
-            && image.TryGetProperty("tag", out var tag)
-            && tag.ValueKind == JsonValueKind.String
-            && tag.GetString() is { Length: > 0 } imageTag
-        )
-        {
-            return imageTag;
-        }
-
-        return null;
-    }
-
     public IReadOnlyDictionary<string, string> GetLabels() => GetMetadataMap("labels");
 
     public IReadOnlyDictionary<string, string> GetAnnotations() => GetMetadataMap("annotations");

--- a/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Clients/K8s/KubernetesServiceRegistration.cs
+++ b/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Clients/K8s/KubernetesServiceRegistration.cs
@@ -13,6 +13,7 @@ internal static class KubernetesServiceRegistration
         });
 
         services.AddSingleton<HelmReleaseClient>();
+        services.AddSingleton<DeploymentClient>();
         services.AddSingleton<PodsClient>();
         services.AddSingleton<OciRepositoryClient>();
         services.AddSingleton<KustomizationClient>();

--- a/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Endpoints/Public/DeployEndpoints.cs
+++ b/src/Runtime/gateway/src/Altinn.Studio.Gateway.Api/Endpoints/Public/DeployEndpoints.cs
@@ -12,13 +12,17 @@ internal static class DeployEndpoints
             .MapGet("/origin/{originEnvironment}/apps/", HandleListAppDeployments.ListAppDeploymentsHandler)
             .WithName("ListAppDeployments")
             .WithSummary("List all App deployments.")
-            .WithDescription("Endpoint to list all app deployments.");
+            .WithDescription(
+                "Endpoint to list GitOps-managed app deployments. Set includeNonGitOps=true to include all runtime deployments."
+            );
 
         deployApi
             .MapGet("/apps/{app}/{originEnvironment}", HandleGetAppDeployment.GetAppDeploymentHandler)
             .WithName("GetAppDeployment")
             .WithSummary("Get App deployment.")
-            .WithDescription("Endpoint to get a single app deployment.");
+            .WithDescription(
+                "Endpoint to get a GitOps-managed app deployment. Set includeNonGitOps=true to include a runtime deployment without GitOps metadata."
+            );
 
         deployApi
             .MapGet("/apps/{app}/{originEnvironment}/deployed", HandleIsAppDeployed.IsAppDeployedHandler)

--- a/src/Runtime/gateway/src/Altinn.Studio.Gateway.Contracts/Deploy/AppDeployment.cs
+++ b/src/Runtime/gateway/src/Altinn.Studio.Gateway.Contracts/Deploy/AppDeployment.cs
@@ -4,7 +4,10 @@ public record AppDeployment(
     string Org,
     string Env,
     string App,
-    string SourceEnvironment,
-    string BuildId,
-    string ImageTag
+    string? SourceEnvironment,
+    string? BuildId,
+    string? ImageTag,
+    string? CurrentVersion = null,
+    bool UpdateInProgress = false,
+    bool IsGitOpsManaged = false
 );

--- a/src/Runtime/gateway/tests/Altinn.Studio.Gateway.Api.Tests/AppDeploymentIntegrationTests.cs
+++ b/src/Runtime/gateway/tests/Altinn.Studio.Gateway.Api.Tests/AppDeploymentIntegrationTests.cs
@@ -1,0 +1,309 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization.Metadata;
+using Altinn.Studio.Gateway.Api.Tests.Models;
+using Altinn.Studio.Gateway.Contracts.Deploy;
+using k8s;
+using k8s.Models;
+
+namespace Altinn.Studio.Gateway.Api.Tests;
+
+[Trait("Category", "Kubernetes")]
+public sealed class AppDeploymentIntegrationTests : IAsyncLifetime
+{
+    private const string KindContextName = "kind-runtime-fixture-kind-minimal";
+    private const string TestNamespace = "default";
+    private const string Org = "ttd";
+    private const string OriginEnvironment = "staging";
+    private const string TargetEnvironment = "local";
+
+    private readonly IKubernetes _k8sClient;
+    private readonly HttpClient _httpClient;
+    private readonly List<string> _deploymentsToCleanup = [];
+    private readonly List<string> _helmReleasesToCleanup = [];
+
+    public AppDeploymentIntegrationTests()
+    {
+        KubernetesJson.AddJsonOptions(options =>
+        {
+#pragma warning disable NX0003
+            options.TypeInfoResolver = JsonTypeInfoResolver.Combine(TestJsonContext.Default, options.TypeInfoResolver!);
+#pragma warning restore NX0003
+        });
+
+        var config = KubernetesClientConfiguration.BuildConfigFromConfigFile(currentContext: KindContextName);
+        _k8sClient = new Kubernetes(config);
+        _httpClient = new HttpClient { BaseAddress = new Uri("http://localhost:8020") };
+        _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Bearer",
+            FakeMaskinportenTokenGenerator.GenerateValidToken()
+        );
+    }
+
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var name in _helmReleasesToCleanup)
+        {
+            await DeleteHelmReleaseSafeAsync(name);
+        }
+
+        foreach (var name in _deploymentsToCleanup)
+        {
+            await DeleteDeploymentSafeAsync(name);
+        }
+
+        _k8sClient.Dispose();
+        _httpClient.Dispose();
+    }
+
+    [Fact]
+    public async Task GetAppDeployment_WhenDeploymentIsNotGitOpsManaged_RequiresExplicitOptIn()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var app = CreateAppName();
+        const string imageTag = "1.2.3";
+        await CreateDeploymentAsync(app, imageTag, ct);
+
+        using var defaultResponse = await _httpClient.GetAsync(GetAppDeploymentUri(app), ct);
+        Assert.Equal(HttpStatusCode.NotFound, defaultResponse.StatusCode);
+
+        using var optInResponse = await _httpClient.GetAsync(GetAppDeploymentUri(app, includeNonGitOps: true), ct);
+        Assert.Equal(HttpStatusCode.OK, optInResponse.StatusCode);
+
+        var deployment = await optInResponse.Content.ReadFromJsonAsync<AppDeployment>(cancellationToken: ct);
+        Assert.NotNull(deployment);
+        Assert.Equal(Org, deployment.Org);
+        Assert.Equal(TargetEnvironment, deployment.Env);
+        Assert.Equal(app, deployment.App);
+        Assert.Null(deployment.SourceEnvironment);
+        Assert.Null(deployment.BuildId);
+        Assert.Equal(imageTag, deployment.ImageTag);
+        Assert.Null(deployment.CurrentVersion);
+        Assert.True(deployment.UpdateInProgress);
+        Assert.False(deployment.IsGitOpsManaged);
+    }
+
+    [Fact]
+    public async Task GetAndListAppDeployments_WhenGitOpsMetadataExists_ReturnEnrichedDeploymentByDefault()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var app = CreateAppName();
+        const string buildId = "12345";
+        const string imageTag = "2.3.4";
+
+        await CreateDeploymentAsync(app, imageTag, ct);
+        await CreateHelmReleaseAsync(app, buildId, ct);
+
+        using var getResponse = await _httpClient.GetAsync(GetAppDeploymentUri(app), ct);
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+
+        var deployment = await getResponse.Content.ReadFromJsonAsync<AppDeployment>(cancellationToken: ct);
+        Assert.NotNull(deployment);
+        Assert.Equal(Org, deployment.Org);
+        Assert.Equal(TargetEnvironment, deployment.Env);
+        Assert.Equal(app, deployment.App);
+        Assert.Equal(OriginEnvironment, deployment.SourceEnvironment);
+        Assert.Equal(buildId, deployment.BuildId);
+        Assert.Equal(imageTag, deployment.ImageTag);
+        Assert.True(deployment.IsGitOpsManaged);
+
+        using var listResponse = await _httpClient.GetAsync(ListAppDeploymentsUri(), ct);
+        Assert.Equal(HttpStatusCode.OK, listResponse.StatusCode);
+
+        var deployments = await listResponse.Content.ReadFromJsonAsync<List<AppDeployment>>(cancellationToken: ct);
+        Assert.NotNull(deployments);
+        var listedDeployment = Assert.Single(deployments, item => item.App == app);
+        Assert.Equal(buildId, listedDeployment.BuildId);
+        Assert.True(listedDeployment.IsGitOpsManaged);
+    }
+
+    [Fact]
+    public async Task ListAppDeployments_WithExplicitOptIn_IncludesOnlyCanonicalRuntimeDeployments()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var app = CreateAppName();
+        var nonCanonicalNameApp = CreateAppName();
+        var mismatchedLabelApp = CreateAppName();
+
+        await CreateDeploymentAsync(app, "3.4.5", ct);
+        await CreateDeploymentAsync(
+            nonCanonicalNameApp,
+            "4.5.6",
+            ct,
+            deploymentName: $"{Org}-{nonCanonicalNameApp}-copy"
+        );
+        await CreateDeploymentAsync(mismatchedLabelApp, "5.6.7", ct, release: $"{Org}-{CreateAppName()}");
+
+        using var defaultResponse = await _httpClient.GetAsync(ListAppDeploymentsUri(), ct);
+        Assert.Equal(HttpStatusCode.OK, defaultResponse.StatusCode);
+        var defaultDeployments = await defaultResponse.Content.ReadFromJsonAsync<List<AppDeployment>>(
+            cancellationToken: ct
+        );
+        Assert.NotNull(defaultDeployments);
+        Assert.DoesNotContain(defaultDeployments, item => item.App == app);
+
+        using var optInResponse = await _httpClient.GetAsync(ListAppDeploymentsUri(includeNonGitOps: true), ct);
+        Assert.Equal(HttpStatusCode.OK, optInResponse.StatusCode);
+
+        var deployments = await optInResponse.Content.ReadFromJsonAsync<List<AppDeployment>>(cancellationToken: ct);
+        Assert.NotNull(deployments);
+        var deployment = Assert.Single(deployments, item => item.App == app);
+        Assert.Equal("3.4.5", deployment.ImageTag);
+        Assert.DoesNotContain(deployments, item => item.App == nonCanonicalNameApp);
+        Assert.DoesNotContain(deployments, item => item.App == mismatchedLabelApp);
+    }
+
+    [Fact]
+    public async Task GetAppDeployment_WhenRuntimeDeploymentDoesNotExist_ReturnsNotFound()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        using var response = await _httpClient.GetAsync(
+            GetAppDeploymentUri(CreateAppName(), includeNonGitOps: true),
+            ct
+        );
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    private async Task CreateDeploymentAsync(
+        string app,
+        string imageTag,
+        CancellationToken ct,
+        string? deploymentName = null,
+        string? release = null
+    )
+    {
+        deploymentName ??= $"{Org}-{app}-deployment-v2";
+        release ??= $"{Org}-{app}";
+        _deploymentsToCleanup.Add(deploymentName);
+
+        var podLabel = $"{deploymentName}-pod";
+        var deployment = new V1Deployment
+        {
+            Metadata = new V1ObjectMeta
+            {
+                Name = deploymentName,
+                NamespaceProperty = TestNamespace,
+                Labels = new Dictionary<string, string> { ["release"] = release },
+            },
+            Spec = new V1DeploymentSpec
+            {
+                Replicas = 1,
+                Selector = new V1LabelSelector { MatchLabels = new Dictionary<string, string> { ["app"] = podLabel } },
+                Template = new V1PodTemplateSpec
+                {
+                    Metadata = new V1ObjectMeta { Labels = new Dictionary<string, string> { ["app"] = podLabel } },
+                    Spec = new V1PodSpec
+                    {
+                        Containers =
+                        [
+                            new V1Container
+                            {
+                                Name = "app",
+                                Image = $"registry.example:5000/{Org}-{app}:{imageTag}@sha256:{new string('a', 64)}",
+                            },
+                        ],
+                    },
+                },
+            },
+        };
+
+        await _k8sClient.AppsV1.CreateNamespacedDeploymentAsync(deployment, TestNamespace, cancellationToken: ct);
+    }
+
+    private async Task CreateHelmReleaseAsync(string app, string buildId, CancellationToken ct)
+    {
+        var helmReleaseName = $"{Org}-{app}-{OriginEnvironment}";
+        _helmReleasesToCleanup.Add(helmReleaseName);
+
+        var helmRelease = new HelmRelease
+        {
+            Metadata = new V1ObjectMeta
+            {
+                Name = helmReleaseName,
+                NamespaceProperty = TestNamespace,
+                Labels = new Dictionary<string, string>
+                {
+                    ["altinn.studio/managed-by"] = "altinn-studio",
+                    ["altinn.studio/build-id"] = buildId,
+                    ["altinn.studio/source-environment"] = OriginEnvironment,
+                    ["altinn.studio/org"] = Org,
+                    ["altinn.studio/app"] = app,
+                },
+            },
+            Spec = new HelmReleaseSpec
+            {
+                Chart = new HelmChartTemplate
+                {
+                    Spec = new HelmChartTemplateSpec
+                    {
+                        Chart = "not-used",
+                        SourceRef = new CrossNamespaceObjectReference
+                        {
+                            Kind = "HelmRepository",
+                            Name = "not-used",
+                            Namespace = FluxApi.FluxSystemNamespace,
+                        },
+                    },
+                },
+            },
+        };
+
+        await _k8sClient.CustomObjects.CreateNamespacedCustomObjectAsync(
+            body: helmRelease,
+            group: FluxApi.HelmReleaseGroup,
+            version: FluxApi.V2,
+            namespaceParameter: TestNamespace,
+            plural: FluxApi.HelmReleasePlural,
+            cancellationToken: ct
+        );
+    }
+
+    private async Task DeleteDeploymentSafeAsync(string name)
+    {
+        try
+        {
+            await _k8sClient.AppsV1.DeleteNamespacedDeploymentAsync(name, TestNamespace);
+        }
+        catch
+        {
+            // Best effort cleanup
+        }
+    }
+
+    private async Task DeleteHelmReleaseSafeAsync(string name)
+    {
+        try
+        {
+            await _k8sClient.CustomObjects.DeleteNamespacedCustomObjectAsync(
+                group: FluxApi.HelmReleaseGroup,
+                version: FluxApi.V2,
+                namespaceParameter: TestNamespace,
+                plural: FluxApi.HelmReleasePlural,
+                name: name
+            );
+        }
+        catch
+        {
+            // Best effort cleanup
+        }
+    }
+
+    private static string CreateAppName() => $"deployment-test-{Guid.NewGuid():N}"[..32];
+
+    private static Uri GetAppDeploymentUri(string app, bool includeNonGitOps = false)
+    {
+        var query = includeNonGitOps ? "?includeNonGitOps=true" : string.Empty;
+        return new Uri($"/runtime/gateway/api/v1/deploy/apps/{app}/{OriginEnvironment}{query}", UriKind.Relative);
+    }
+
+    private static Uri ListAppDeploymentsUri(bool includeNonGitOps = false)
+    {
+        var query = includeNonGitOps ? "?includeNonGitOps=true" : string.Empty;
+        return new Uri($"/runtime/gateway/api/v1/deploy/origin/{OriginEnvironment}/apps/{query}", UriKind.Relative);
+    }
+}

--- a/src/Runtime/gateway/tests/Altinn.Studio.Gateway.Api.Tests/DeploymentClientTests.cs
+++ b/src/Runtime/gateway/tests/Altinn.Studio.Gateway.Api.Tests/DeploymentClientTests.cs
@@ -1,0 +1,99 @@
+using Altinn.Studio.Gateway.Api.Clients.K8s;
+using k8s.Models;
+
+namespace Altinn.Studio.Gateway.Api.Tests;
+
+public sealed class DeploymentClientTests
+{
+    [Fact]
+    public void IsUpdateInProgress_WhenDeploymentRolloutStatusIsComplete_ReturnsFalse()
+    {
+        var deployment = CreateDeployment(
+            generation: 2,
+            desiredReplicas: 3,
+            status: new V1DeploymentStatus
+            {
+                ObservedGeneration = 2,
+                Replicas = 3,
+                UpdatedReplicas = 3,
+                ReadyReplicas = 3,
+                AvailableReplicas = 3,
+                UnavailableReplicas = 0,
+            }
+        );
+
+        var updateInProgress = DeploymentClient.IsUpdateInProgress(deployment);
+
+        Assert.False(updateInProgress);
+    }
+
+    // Kubernetes considers a Deployment rollout complete when all desired replicas are updated,
+    // available, and no old replicas are running:
+    // https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#complete-deployment
+    [Theory]
+    [InlineData(2, 1, 3, 3, 3, 3, 3, 0)]
+    [InlineData(2, 2, 3, 4, 3, 3, 3, 0)]
+    [InlineData(2, 2, 3, 3, 2, 2, 2, 1)]
+    [InlineData(2, 2, 3, 3, 3, 2, 2, 1)]
+    [InlineData(2, 2, 3, 3, 3, 3, 2, 1)]
+    [InlineData(2, 2, 3, 3, 3, 3, 3, 1)]
+    public void IsUpdateInProgress_WhenDeploymentRolloutStatusIsIncomplete_ReturnsTrue(
+        long generation,
+        long observedGeneration,
+        int desiredReplicas,
+        int replicas,
+        int updatedReplicas,
+        int readyReplicas,
+        int availableReplicas,
+        int unavailableReplicas
+    )
+    {
+        var deployment = CreateDeployment(
+            generation,
+            desiredReplicas,
+            new V1DeploymentStatus
+            {
+                ObservedGeneration = observedGeneration,
+                Replicas = replicas,
+                UpdatedReplicas = updatedReplicas,
+                ReadyReplicas = readyReplicas,
+                AvailableReplicas = availableReplicas,
+                UnavailableReplicas = unavailableReplicas,
+            }
+        );
+
+        var updateInProgress = DeploymentClient.IsUpdateInProgress(deployment);
+
+        Assert.True(updateInProgress);
+    }
+
+    [Fact]
+    public void IsUpdateInProgress_WhenDeploymentStatusIsMissingAndReplicasAreDesired_ReturnsTrue()
+    {
+        var deployment = CreateDeployment(generation: 1, desiredReplicas: 1, status: null);
+
+        var updateInProgress = DeploymentClient.IsUpdateInProgress(deployment);
+
+        Assert.True(updateInProgress);
+    }
+
+    private static V1Deployment CreateDeployment(long generation, int desiredReplicas, V1DeploymentStatus? status) =>
+        new()
+        {
+            Metadata = new V1ObjectMeta
+            {
+                Generation = generation,
+                Name = "ttd-test-app-deployment-v2",
+                Labels = new Dictionary<string, string> { ["release"] = "ttd-test-app" },
+            },
+            Spec = new V1DeploymentSpec
+            {
+                Replicas = desiredReplicas,
+                Template = new V1PodTemplateSpec
+                {
+                    Spec = new V1PodSpec { Containers = [new V1Container { Image = "repo/test-app:1.2.3" }] },
+                },
+            },
+            Status = status,
+        };
+}


### PR DESCRIPTION
## Description

Prepares Runtime Gateway to be the single source for app runtime deployment status before Designer is migrated off kubernetes-wrapper and before restart support is added.

Changes:
- Makes existing Runtime Gateway deploy endpoints read Kubernetes Deployments as the runtime source of truth.
- Keeps existing Designer-safe default behavior by returning GitOps-managed deployments only unless `includeNonGitOps=true` is passed.
- Enriches runtime deployments with GitOps metadata from HelmRelease labels when available.
- Adds runtime status fields to `AppDeployment`: `CurrentVersion`, `UpdateInProgress`, and `IsGitOpsManaged`.
- Keeps `ImageTag` as the runtime Deployment image tag, not HelmRelease desired image tag.
- Keeps `IsAppDeployed` HelmRelease-backed because Designer uses it as `IsAppDeployedWithGitOpsAsync`.

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

Commands run:

```bash
dotnet build src/Altinn.Studio.Gateway.Api/Altinn.Studio.Gateway.Api.csproj
make test-e2e
```

`make test-e2e` passed all gateway tests: 29 passed, 0 failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployment API now surfaces additional runtime details (source environment, build ID, image tag, current version) and status flags such as “update in progress” and “GitOps managed”.
  * Deployment results are now built from runtime data and enriched with GitOps Helm metadata when available.

* **Bug Fixes**
  * Improved not-found handling when runtime deployment data is missing.
  * Helm metadata errors now follow `includeNonGitOps` rules, including returning 503 for GitOps-only requests instead of failing the request.

* **Documentation**
  * Updated deploy endpoint descriptions to clarify `includeNonGitOps=true` and runtime responses without GitOps metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->