### PR TITLE
chore: release app v9.0.0-preview.2

### DIFF
--- a/src/App/backend/CHANGELOG.md
+++ b/src/App/backend/CHANGELOG.md
@@ -12,13 +12,13 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ### Added
 
-- Add workflow engine integration that runs process tasks and service tasks as idempotent, retryable commands.
-- Add process hook interfaces `IOnTaskStartingHandler`, `IOnTaskEndingHandler`, `IOnTaskAbandonHandler`, and `IOnProcessEndingHandler`, returning a `HookResult` (`Success`, `FailedRetryable`, or `FailedPermanent`).
-- Add `IServiceTask` with `ServiceTaskContext` and `ServiceTaskResult` for implementing custom BPMN service tasks.
+- Add workflow engine integration. Process transitions and service tasks now run as idempotent, retryable commands.
+- Add process hook interfaces `IOnTaskStartingHandler`, `IOnTaskEndingHandler`, `IOnTaskAbandonHandler`, and `IOnProcessEndingHandler`.
 - Add `GlobalPageSettings` model and `IAppResources.GetGlobalUiSettings()` for reading global UI settings in backend code.
 
 ### Changed
 
+- Modify `IServiceTask` and `ServiceTaskResult` to support workflow engine integration.
 - Update `Microsoft.OpenApi` to version 2.
 
 ### Removed

--- a/src/App/backend/CHANGELOG.md
+++ b/src/App/backend/CHANGELOG.md
@@ -8,6 +8,27 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+## [9.0.0-preview.2] - 2026-07-01
+
+### Added
+
+- Add workflow engine integration that runs process tasks and service tasks as idempotent, retryable commands.
+- Add process hook interfaces `IOnTaskStartingHandler`, `IOnTaskEndingHandler`, `IOnTaskAbandonHandler`, and `IOnProcessEndingHandler`, returning a `HookResult` (`Success`, `FailedRetryable`, or `FailedPermanent`).
+- Add `IServiceTask` with `ServiceTaskContext` and `ServiceTaskResult` for implementing custom BPMN service tasks.
+- Add `GlobalPageSettings` model and `IAppResources.GetGlobalUiSettings()` for reading global UI settings in backend code.
+
+### Changed
+
+- Update `Microsoft.OpenApi` to version 2.
+
+### Removed
+
+- Breaking: remove `IProcessTaskStart`, `IProcessTaskEnd`, and `IProcessTaskAbandon` in favor of the new `IOnTaskStartingHandler`, `IOnTaskEndingHandler`, and `IOnTaskAbandonHandler` hooks.
+
+### Fixed
+
+- Fix PDF generation to respect global page settings.
+
 ## [9.0.0-preview.1] - 2026-06-08
 
 ### Added


### PR DESCRIPTION
Promotes the app backend changelog to **9.0.0-preview.2** (dated 2026-07-01).

Merging this PR (it carries the `release/app` label and touches `src/App/backend/CHANGELOG.md`) triggers `release-app.yaml`, which builds the packages, creates the GitHub release + tag `app/v9.0.0-preview.2`, and publishes the NuGet packages. As a `-preview.` version it resolves to the **dev** environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated the workflow engine with improved idempotent and retryable command execution.
  * Added new hooks for process/task lifecycle events, including support for BPMN service tasks.
  * Introduced global UI settings that can be read from backend code.
* **Bug Fixes**
  * PDF generation now respects global page settings.
* **Breaking Changes**
  * Removed older process task start/end/abandon interfaces in favor of the new hook-based approach.
* **Chores**
  * Updated the OpenAPI tooling version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->