### PR TITLE
fix: make content use 100% width in popover for studioiconcard

### DIFF
--- a/src/Designer/frontend/libs/studio-components/src/components/StudioIconCard/StudioIconCard.module.css
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioIconCard/StudioIconCard.module.css
@@ -102,3 +102,8 @@
 .title {
   letter-spacing: var(--ds-size-0);
 }
+
+.popoverContainer > * {
+  width: 100%;
+  justify-content: flex-start;
+}

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioIconCard/StudioIconCard.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioIconCard/StudioIconCard.tsx
@@ -38,7 +38,7 @@ function StudioIconCard(
               <MenuElipsisVerticalIcon />
             </StudioPopoverTrigger>
           </div>
-          <StudioPopover placement='bottom-end' data-size='sm'>
+          <StudioPopover placement='bottom-end' className={classes.popoverContainer}>
             {contextButtons}
           </StudioPopover>
         </StudioPopover.TriggerContext>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Before:
<img width="570" height="591" alt="image" src="https://github.com/user-attachments/assets/f84ec302-da4d-4979-b313-b0c6ad8fa6d3" />



After:
<img width="357" height="287" alt="image" src="https://github.com/user-attachments/assets/06dc3811-45db-479a-beac-fd95ce95ae7b" />



<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the layout of icon card popovers so their content now fills the available width and aligns more consistently to the left.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->