### PR TITLE
fix: correct app changelog order + validate any CHANGELOG.md on PRs

### DIFF
--- a/.github/workflows/app-backend-tests.yml
+++ b/.github/workflows/app-backend-tests.yml
@@ -15,50 +15,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  detect-changelog-change:
-    name: Detect changelog changes
-    if: github.event_name == 'pull_request' && github.event.action != 'closed' && !github.event.pull_request.draft && !contains(github.event.pull_request.labels.*.name, 'skip-changelog')
-    runs-on: self-hosted-single
-    timeout-minutes: 30
-    outputs:
-      changed: ${{ steps.changes.outputs.changed }}
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          fetch-depth: 0
-
-      - name: Detect changelog changes
-        id: changes
-        run: |
-          if git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" -- src/App/backend/CHANGELOG.md | grep -q .; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          fi
-
-  validate-changelog:
-    name: Validate changelog
-    if: (github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft)) && needs.detect-changelog-change.outputs.changed == 'true'
-    needs: detect-changelog-change
-    runs-on: self-hosted-single
-    timeout-minutes: 30
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          fetch-depth: 0
-
-      - name: Setup Go for changelog validation
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
-        with:
-          go-version-file: 'src/tools/releaser/go.mod'
-          cache-dependency-path: src/tools/releaser/go.sum
-
-      - name: Validate changelog
-        working-directory: src/tools/releaser
-        run: |
-          go run . validate-changelog -component app -base "${{ github.event.pull_request.base.sha }}" -head "${{ github.event.pull_request.head.sha }}"
-
   build-frontend:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     timeout-minutes: 10

--- a/.github/workflows/app-backend-tests.yml
+++ b/.github/workflows/app-backend-tests.yml
@@ -15,6 +15,50 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect-changelog-change:
+    name: Detect changelog changes
+    if: github.event_name == 'pull_request' && github.event.action != 'closed' && !github.event.pull_request.draft && !contains(github.event.pull_request.labels.*.name, 'skip-changelog')
+    runs-on: self-hosted-single
+    timeout-minutes: 30
+    outputs:
+      changed: ${{ steps.changes.outputs.changed }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Detect changelog changes
+        id: changes
+        run: |
+          if git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" -- src/App/backend/CHANGELOG.md | grep -q .; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  validate-changelog:
+    name: Validate changelog
+    if: (github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft)) && needs.detect-changelog-change.outputs.changed == 'true'
+    needs: detect-changelog-change
+    runs-on: self-hosted-single
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go for changelog validation
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: 'src/tools/releaser/go.mod'
+          cache-dependency-path: src/tools/releaser/go.sum
+
+      - name: Validate changelog
+        working-directory: src/tools/releaser
+        run: |
+          go run . validate-changelog -component app -base "${{ github.event.pull_request.base.sha }}" -head "${{ github.event.pull_request.head.sha }}"
+
   build-frontend:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     timeout-minutes: 10

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,50 @@
+name: Changelog - validate
+
+# Validates the Keep a Changelog structure of every changed CHANGELOG.md in the
+# repository, regardless of which project or component owns it. Driven entirely
+# by the releaser's `validate-changelogs` command, so any new project's
+# changelog is covered automatically with no changes to this workflow.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+    paths:
+      - '**/CHANGELOG.md'
+      - 'src/tools/releaser/**'
+      - '.github/workflows/changelog.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate-changelogs:
+    name: Validate changelogs
+    if: github.event_name != 'pull_request' || (!github.event.pull_request.draft && !contains(github.event.pull_request.labels.*.name, 'skip-changelog'))
+    runs-on: self-hosted-single
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: 'src/tools/releaser/go.mod'
+          cache-dependency-path: src/tools/releaser/go.sum
+
+      # On a pull request, validate only the changelogs changed in the PR.
+      # On workflow_dispatch the SHAs are empty, so the command falls back to
+      # validating every tracked CHANGELOG.md.
+      - name: Validate changelogs
+        working-directory: src/tools/releaser
+        run: |
+          go run . validate-changelogs \
+            -base "${{ github.event.pull_request.base.sha }}" \
+            -head "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6

--- a/.github/workflows/cli-build-test.yaml
+++ b/.github/workflows/cli-build-test.yaml
@@ -14,50 +14,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  detect-changelog-change:
-    name: Detect changelog changes
-    if: github.event_name == 'pull_request' && github.event.action != 'closed' && !github.event.pull_request.draft && !contains(github.event.pull_request.labels.*.name, 'skip-changelog')
-    runs-on: self-hosted-single
-    timeout-minutes: 30
-    outputs:
-      changed: ${{ steps.changes.outputs.changed }}
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          fetch-depth: 0
-
-      - name: Detect changelog changes
-        id: changes
-        run: |
-          if git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" -- src/cli/CHANGELOG.md | grep -q .; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          fi
-
-  validate-changelog:
-    name: Validate changelog
-    if: (github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft)) && needs.detect-changelog-change.outputs.changed == 'true'
-    needs: detect-changelog-change
-    runs-on: self-hosted-single
-    timeout-minutes: 30
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          fetch-depth: 0
-
-      - name: Setup Go for changelog validation
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
-        with:
-          go-version-file: 'src/tools/releaser/go.mod'
-          cache-dependency-path: src/tools/releaser/go.sum
-
-      - name: Validate changelog
-        working-directory: src/tools/releaser
-        run: |
-          go run . validate-changelog -component studioctl -base "${{ github.event.pull_request.base.sha }}" -head "${{ github.event.pull_request.head.sha }}"
-
   verify-release-artifacts:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Verify studioctl release artifacts

--- a/src/App/backend/CHANGELOG.md
+++ b/src/App/backend/CHANGELOG.md
@@ -21,13 +21,13 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 - Modify `IServiceTask` and `ServiceTaskResult` to support workflow engine integration.
 - Update `Microsoft.OpenApi` to version 2.
 
-### Removed
-
-- Breaking: remove `IProcessTaskStart`, `IProcessTaskEnd`, and `IProcessTaskAbandon` in favor of the new `IOnTaskStartingHandler`, `IOnTaskEndingHandler`, and `IOnTaskAbandonHandler` hooks.
-
 ### Fixed
 
 - Fix PDF generation to respect global page settings.
+
+### Removed
+
+- Breaking: remove `IProcessTaskStart`, `IProcessTaskEnd`, and `IProcessTaskAbandon` in favor of the new `IOnTaskStartingHandler`, `IOnTaskEndingHandler`, and `IOnTaskAbandonHandler` hooks.
 
 ## [9.0.0-preview.1] - 2026-06-08
 

--- a/src/tools/releaser/internal/validate.go
+++ b/src/tools/releaser/internal/validate.go
@@ -85,6 +85,137 @@ func RunValidationWithDeps(ctx context.Context, req ValidationRequest, git *GitC
 		return fmt.Errorf("%w: %s", ErrChangelogNotModified, clPath)
 	}
 
+	return parseAndValidateChangelog(ctx, git, root, clPath, req.Base)
+}
+
+// vendoredChangelogFragments are path fragments that mark a CHANGELOG.md as
+// third-party or generated, so it must not be structurally validated against
+// our Keep a Changelog conventions.
+//
+//nolint:gochecknoglobals // Read-only package constant.
+var vendoredChangelogFragments = []string{
+	"node_modules/",
+	"/.nuget/",
+	"/_testapps/",
+	".claude/",
+	"/obj/",
+	"/bin/",
+}
+
+// RunStructureValidation validates the Keep a Changelog structure of every
+// changed CHANGELOG.md between base and head (or, when base/head are empty,
+// every tracked CHANGELOG.md). It is component-agnostic: any project's
+// changelog is covered automatically, with no registry or workflow wiring.
+// Vendored and generated changelogs are skipped. Only structural errors
+// (category order, invalid categories, version ordering, duplicates) fail;
+// release-policy semantics are intentionally not enforced here.
+func RunStructureValidation(ctx context.Context, base, head string, log Logger) error {
+	if log == nil {
+		log = NopLogger{}
+	}
+	git := NewGitCLI(WithLogger(log))
+	return RunStructureValidationWithDeps(ctx, base, head, git, log)
+}
+
+// RunStructureValidationWithDeps validates changelog structure with an
+// injected git dependency.
+func RunStructureValidationWithDeps(ctx context.Context, base, head string, git *GitCLI, log Logger) error {
+	if ctx == nil {
+		return errContextRequired
+	}
+	if git == nil {
+		return errGitRequired
+	}
+	if log == nil {
+		log = NopLogger{}
+	}
+
+	root, err := git.RepoRoot(ctx)
+	if err != nil {
+		return fmt.Errorf("get repo root: %w", err)
+	}
+
+	paths, err := discoverChangelogPaths(ctx, git, base, head)
+	if err != nil {
+		return err
+	}
+	if len(paths) == 0 {
+		log.Info("no changelog changes to validate")
+		return nil
+	}
+
+	var errs []error
+	for _, clPath := range paths {
+		log.Info("validating changelog structure: %s", clPath)
+		if perr := validateChangelogStructure(root, clPath); perr != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", clPath, perr))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// discoverChangelogPaths returns the repo-relative CHANGELOG.md paths to
+// validate: those changed between base and head when both are provided,
+// otherwise all tracked changelogs. Vendored/generated paths are excluded.
+func discoverChangelogPaths(ctx context.Context, git *GitCLI, base, head string) ([]string, error) {
+	var raw string
+	var err error
+	if base != "" && head != "" {
+		// --diff-filter=d excludes deletions so we never read a removed file.
+		raw, err = git.Run(ctx, "diff", "--name-only", "--diff-filter=d", base, head, "--", "*CHANGELOG.md")
+		if err != nil {
+			return nil, fmt.Errorf("git diff: %w", err)
+		}
+	} else {
+		raw, err = git.Run(ctx, "ls-files", "*CHANGELOG.md")
+		if err != nil {
+			return nil, fmt.Errorf("git ls-files: %w", err)
+		}
+	}
+
+	var paths []string
+	for line := range strings.SplitSeq(raw, "\n") {
+		path := strings.TrimSpace(line)
+		if path == "" || filepath.Base(path) != "CHANGELOG.md" || isVendoredChangelog(path) {
+			continue
+		}
+		paths = append(paths, path)
+	}
+	return paths, nil
+}
+
+func isVendoredChangelog(path string) bool {
+	for _, fragment := range vendoredChangelogFragments {
+		if strings.Contains(path, fragment) {
+			return true
+		}
+	}
+	return false
+}
+
+// validateChangelogStructure reads and parses a single changelog on disk,
+// surfacing only structural (format) errors.
+func validateChangelogStructure(root, clPath string) error {
+	changelogFile := clPath
+	if !filepath.IsAbs(changelogFile) {
+		changelogFile = filepath.Join(root, changelogFile)
+	}
+
+	//nolint:gosec // G304: path derived from git-tracked changelog paths.
+	content, err := os.ReadFile(changelogFile)
+	if err != nil {
+		return fmt.Errorf("read changelog: %w", err)
+	}
+
+	if _, err := changelog.Parse(string(content)); err != nil {
+		return fmt.Errorf("parse changelog: %w", err)
+	}
+	return nil
+}
+
+// parseAndValidateChangelog reads, parses and validates a single component
+// changelog on disk (the head working tree) against its base revision.
+func parseAndValidateChangelog(ctx context.Context, git *GitCLI, root, clPath, base string) error {
 	changelogFile := clPath
 	if !filepath.IsAbs(changelogFile) {
 		changelogFile = filepath.Join(root, changelogFile)
@@ -101,7 +232,7 @@ func RunValidationWithDeps(ctx context.Context, req ValidationRequest, git *GitC
 		return fmt.Errorf("parse changelog: %w", err)
 	}
 
-	return ValidateUnreleasedOrReleasePromotion(ctx, git, cl, req.Base, clPath)
+	return ValidateUnreleasedOrReleasePromotion(ctx, git, cl, base, clPath)
 }
 
 // ChangelogWasModified reports whether changelogPath exists in git diff --name-only output.

--- a/src/tools/releaser/internal/validate_structure_test.go
+++ b/src/tools/releaser/internal/validate_structure_test.go
@@ -1,0 +1,161 @@
+package internal_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"altinn.studio/releaser/internal"
+	"altinn.studio/releaser/internal/changelog"
+)
+
+const validStructureChangelog = `# Changelog
+
+## [Unreleased]
+
+### Added
+
+- Existing
+`
+
+// outOfOrderChangelog places Fixed before Added, which violates the standard
+// category order and is exactly the class of bug that broke the release.
+const outOfOrderChangelog = `# Changelog
+
+## [Unreleased]
+
+### Fixed
+
+- A fix
+
+### Added
+
+- A feature
+`
+
+func TestRunStructureValidation(t *testing.T) {
+	t.Run("passes on valid changed changelog", testStructureValidPasses)
+	t.Run("fails on out-of-order categories", testStructureOutOfOrderFails)
+	t.Run("no-op when no changelog changed", testStructureNoChangelogChanged)
+	t.Run("skips vendored changelogs", testStructureSkipsVendored)
+	t.Run("validates all tracked changelogs when no range given", testStructureValidatesAllTracked)
+	t.Run("reports every broken changelog", testStructureReportsMultiple)
+}
+
+func testStructureValidPasses(t *testing.T) {
+	repo := createStudioctlWorkflowRepo(t, validStructureChangelog)
+	base := revParseHead(t, repo)
+	head := commitValidationFile(t, repo, "src/cli/CHANGELOG.md", `# Changelog
+
+## [Unreleased]
+
+### Added
+
+- Existing
+
+### Fixed
+
+- A new fix
+`, "add fix")
+
+	if err := runStructureValidation(t, repo, base, head); err != nil {
+		t.Fatalf("RunStructureValidation() error = %v, want nil", err)
+	}
+}
+
+func testStructureOutOfOrderFails(t *testing.T) {
+	repo := createStudioctlWorkflowRepo(t, validStructureChangelog)
+	base := revParseHead(t, repo)
+	head := commitValidationFile(t, repo, "src/cli/CHANGELOG.md", outOfOrderChangelog, "break order")
+
+	err := runStructureValidation(t, repo, base, head)
+	assertValidationError(t, err, changelog.ErrCategoryOrder)
+	if !strings.Contains(err.Error(), "src/cli/CHANGELOG.md") {
+		t.Fatalf("error = %v, want it to name the offending changelog", err)
+	}
+}
+
+func testStructureNoChangelogChanged(t *testing.T) {
+	repo := createStudioctlWorkflowRepo(t, validStructureChangelog)
+	base := revParseHead(t, repo)
+	head := commitValidationFile(t, repo, "README.md", "changed\n", "touch readme")
+
+	if err := runStructureValidation(t, repo, base, head); err != nil {
+		t.Fatalf("RunStructureValidation() error = %v, want nil (nothing to validate)", err)
+	}
+}
+
+func testStructureSkipsVendored(t *testing.T) {
+	repo := createStudioctlWorkflowRepo(t, validStructureChangelog)
+	base := revParseHead(t, repo)
+	// A broken changelog under node_modules must be ignored.
+	head := commitValidationFile(t, repo, "node_modules/pkg/CHANGELOG.md", outOfOrderChangelog, "vendored changelog")
+
+	if err := runStructureValidation(t, repo, base, head); err != nil {
+		t.Fatalf("RunStructureValidation() error = %v, want vendored changelog to be skipped", err)
+	}
+}
+
+func testStructureValidatesAllTracked(t *testing.T) {
+	repo := createStudioctlWorkflowRepo(t, outOfOrderChangelog)
+
+	// No base/head: every tracked changelog is validated, so the broken
+	// initial changelog must be caught.
+	err := runStructureValidation(t, repo, "", "")
+	assertValidationError(t, err, changelog.ErrCategoryOrder)
+}
+
+func testStructureReportsMultiple(t *testing.T) {
+	repo := createStudioctlWorkflowRepo(t, validStructureChangelog)
+	base := revParseHead(t, repo)
+	writeRepoFile(t, repo, "src/cli/CHANGELOG.md", outOfOrderChangelog)
+	writeRepoFile(t, repo, "src/App/backend/CHANGELOG.md", outOfOrderChangelog)
+	runGitCmd(t, repo, "add", ".")
+	runGitCmd(t, repo, "commit", "-m", "break two changelogs")
+	head := revParseHead(t, repo)
+
+	err := runStructureValidation(t, repo, base, head)
+	if err == nil {
+		t.Fatal("RunStructureValidation() expected error, got nil")
+	}
+	for _, want := range []string{"src/cli/CHANGELOG.md", "src/App/backend/CHANGELOG.md"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %v, want it to mention %q", err, want)
+		}
+	}
+}
+
+func runStructureValidation(t *testing.T, repo, base, head string) error {
+	t.Helper()
+	t.Chdir(repo)
+	if err := internal.RunStructureValidation(t.Context(), base, head, internal.NopLogger{}); err != nil {
+		return fmt.Errorf("run structure validation: %w", err)
+	}
+	return nil
+}
+
+func TestRunStructureValidationWithDeps_GuardErrors(t *testing.T) {
+	repo := createStudioctlWorkflowRepo(t, validStructureChangelog)
+	git := internal.NewGitCLI(internal.WithWorkdir(repo), internal.WithLogger(internal.NopLogger{}))
+
+	t.Run("nil context", func(t *testing.T) {
+		err := internal.RunStructureValidationWithDeps(nilContext(), "", "", git, internal.NopLogger{})
+		assertErrorContains(t, err, "context is required")
+	})
+
+	t.Run("nil git", func(t *testing.T) {
+		err := internal.RunStructureValidationWithDeps(context.Background(), "", "", nil, internal.NopLogger{})
+		assertErrorContains(t, err, "git client is required")
+	})
+}
+
+func assertErrorContains(t *testing.T, err error, want string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error containing %q, got nil", want)
+	}
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want message containing %q", err, want)
+	}
+}

--- a/src/tools/releaser/main.go
+++ b/src/tools/releaser/main.go
@@ -40,6 +40,8 @@ func main() {
 		err = runBackport(os.Args[2:])
 	case "validate-changelog":
 		err = runValidateChangelog(os.Args[2:])
+	case "validate-changelogs":
+		err = runValidateChangelogs(os.Args[2:])
 	case "resolve-version":
 		err = runResolveVersion(os.Args[2:])
 	case "help", "-h", "--help":
@@ -66,7 +68,8 @@ Commands:
   workflow            Run the complete release workflow (for CI)
   prepare             Create a changelog promotion PR for release
   backport            Cherry-pick a commit to a release branch with changelog handling
-  validate-changelog  Validate changelog was modified and release-ready
+  validate-changelog  Validate a component changelog was modified and release-ready
+  validate-changelogs Validate the structure of every changed CHANGELOG.md (any project)
   resolve-version     Print the release version resolved from a component changelog
 
 Notes:
@@ -352,6 +355,46 @@ Options:
 	}
 
 	fmt.Println("changelog validated")
+	return nil
+}
+
+func runValidateChangelogs(args []string) error {
+	fs := flag.NewFlagSet("validate-changelogs", flag.ExitOnError)
+	base := fs.String("base", "", "Base commit SHA (optional; validates all tracked changelogs if omitted)")
+	head := fs.String("head", "", "Head commit SHA (optional; validates all tracked changelogs if omitted)")
+	fs.Usage = func() {
+		fmt.Print(`Usage: releaser validate-changelogs [-base <sha> -head <sha>]
+
+Validates the Keep a Changelog structure of every changed CHANGELOG.md in the
+repository, regardless of component. Component-agnostic: any project's changelog
+is covered automatically with no registry or workflow wiring.
+
+When -base and -head are given, only changelogs changed in that range are
+validated. Otherwise every tracked CHANGELOG.md is validated. Vendored and
+generated changelogs (node_modules, .nuget, _testapps, etc.) are skipped.
+
+Only structural errors fail (category order, invalid categories, version
+ordering, duplicate versions). Release-policy semantics are not enforced here;
+use 'validate-changelog' for a specific component's release readiness.
+
+Options:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return fmt.Errorf("parse flags: %w", err)
+	}
+
+	if err := internal.RunStructureValidation(
+		context.Background(),
+		*base,
+		*head,
+		internal.NewConsoleLogger(),
+	); err != nil {
+		return fmt.Errorf("validate changelogs: %w", err)
+	}
+
+	fmt.Println("changelogs validated")
 	return nil
 }
 


### PR DESCRIPTION
## Context

The app release for `9.0.0-preview.2` ([#19393](https://github.com/Altinn/altinn-studio/pull/19393)) failed at publish time in the `Resolve release context` step:

> `error: resolve version: parse changelog: categories not in standard order: "Fixed" appears out of order (expected order: Added, Changed, Fixed, Removed, Security, Deprecated)`

## a) Fix the actual issue

`src/App/backend/CHANGELOG.md` listed the `9.0.0-preview.2` categories as **Added → Changed → Removed → Fixed**. The releaser enforces the Keep a Changelog order, so `Fixed` after `Removed` is rejected. This reorders `Fixed` before `Removed`.

## b) Validate changelogs on the PR — one standalone, project-agnostic gate

The failure was only caught after merge, at publish. This adds a pre-merge gate. Rather than wiring per-project `detect + validate` jobs into each pipeline (which would need re-adding for every future component), it's done once, globally:

- **New `validate-changelogs` releaser command** discovers every changed `CHANGELOG.md` between base/head (or all tracked changelogs when no range is given) and validates its Keep a Changelog **structure**. Vendored/generated changelogs (`node_modules`, `.nuget`, `_testapps`, …) are skipped.
- **New `.github/workflows/changelog.yml`** triggers on any `**/CHANGELOG.md` change and runs it. Any new project's changelog is covered automatically — no registry or workflow wiring.
- **Removed** the now-duplicated `detect-changelog-change` + `validate-changelog` jobs from `cli-build-test.yaml` and `app-backend-tests.yml`.

### Why structural-only

Validation was already path-driven, not component-driven — the component registry was only used to look up a path. The command discovers paths from the diff instead.

Only **structural** errors fail here (category order, invalid categories, version ordering, duplicate versions) — the exact bug class that broke the release. The release-policy semantic check (*"this PR must add an `[Unreleased]` entry"*) is intentionally **not** in this gate: it is release-prep specific and would mis-fire on legitimate changelog hotfixes (including the fix in this very PR, which edits a released section). The per-component `validate-changelog` command is kept for release readiness.

## Verification

- `releaser validate-changelogs` fails on the broken ordering with the exact CI error and passes on the fix.
- Vendored changelogs skipped; multiple broken changelogs each reported.
- Unit tests added; `make build/lint/fmt/test` all green.

## Note

Because [#19393](https://github.com/Altinn/altinn-studio/pull/19393) is already merged, the release itself must be re-triggered once this lands — via `workflow_dispatch` on `release-app.yaml` from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `validate-changelogs` CLI command to validate all tracked `CHANGELOG.md` files (optionally for a commit range).
  * Added a CI workflow to validate changelog structure on pull requests and manual runs.

* **Bug Fixes**
  * Reports changelog structure issues across multiple files in a single run.
  * Ignores vendored/generated changelog fragments (for example, under `node_modules`).

* **Documentation**
  * Updated changelog entry ordering for version `9.0.0-preview.2`.

* **Chores**
  * Simplified the existing CI workflow by removing redundant changelog-change validation jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->