### PR TITLE
fix: grafana sa now requires expiry

### DIFF
--- a/.github/workflows/rotate-grafana-gateway-token-expiry.yaml
+++ b/.github/workflows/rotate-grafana-gateway-token-expiry.yaml
@@ -1,0 +1,71 @@
+name: Runtime - rotate Grafana gateway token expiry
+
+on:
+  schedule:
+    # Keep the Grafana service account token expiry comfortably below the one-year limit.
+    - cron: "13 3 1 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  rotate-expiry:
+    name: Rotate expiry
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Update token expiry
+        id: update
+        run: |
+          expiry="$(date -u -d "$(date -u +%Y-%m-01) +11 months" +%Y-%m-%dT00:00:00Z)"
+          sed -i -E "s/^([[:space:]]+expires: \").*(\")$/\1${expiry}\2/" "$EXPIRY_FILE"
+          grep -q "expires: \"${expiry}\"" "$EXPIRY_FILE"
+          echo "expiry=${expiry}" >> "$GITHUB_OUTPUT"
+
+          if git diff --quiet -- "$EXPIRY_FILE"; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          EXPIRY_FILE: infra/runtime/grafana-manifests/service-accounts/altinn-studio-gateway-sa.yaml
+
+      - name: Create or update pull request
+        if: steps.update.outputs.changed == 'true'
+        run: |
+          branch="chore/rotate-grafana-gateway-token-expiry"
+          title="chore: rotate Grafana gateway token expiry"
+
+          cat > pr-body.md <<EOF
+          Updates \`spec.tokens[].expires\` for \`external-grafana-altinn-studio-gateway-sa\` to \`${EXPIRY}\`.
+
+          Grafana enforces a one-year service account token expiration limit, so this workflow keeps the expiry around 11 months out.
+          EOF
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin "$branch" || true
+          git checkout -B "$branch"
+          git add "$EXPIRY_FILE"
+          git commit -m "$title"
+          git push --force-with-lease origin "$branch"
+
+          pr_number="$(gh pr list --head "$branch" --state open --json number --jq '.[0].number // empty')"
+          if [[ -n "$pr_number" ]]; then
+            gh pr edit "$pr_number" --title "$title" --body-file pr-body.md
+          else
+            gh pr create --base main --head "$branch" --title "$title" --body-file pr-body.md
+          fi
+        env:
+          EXPIRY: ${{ steps.update.outputs.expiry }}
+          EXPIRY_FILE: infra/runtime/grafana-manifests/service-accounts/altinn-studio-gateway-sa.yaml
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/infra/runtime/grafana-manifests/service-accounts/altinn-studio-gateway-sa.yaml
+++ b/infra/runtime/grafana-manifests/service-accounts/altinn-studio-gateway-sa.yaml
@@ -8,4 +8,7 @@ spec:
   role: Editor
   tokens:
     - name: gateway
+      # Rotated monthly by .github/workflows/rotate-grafana-gateway-token-expiry.yaml.
+      # Keep below Grafana's one-year service account token expiration limit.
+      expires: "2027-06-01T00:00:00Z"
       secretName: external-grafana-altinn-studio-gateway-token

--- a/src/Runtime/gateway/infra/kustomize/base/deployment.yaml
+++ b/src/Runtime/gateway/infra/kustomize/base/deployment.yaml
@@ -105,6 +105,8 @@ spec:
                 configMapKeyRef:
                   name: runtime-environment
                   key: environment
+            - name: DOTNET_USE_POLLING_FILE_WATCHER
+              value: "1"
             - name: Gateway__AzureSubscriptionId
               valueFrom:
                 configMapKeyRef:

--- a/src/Runtime/gateway/infra/kustomize/base/deployment.yaml
+++ b/src/Runtime/gateway/infra/kustomize/base/deployment.yaml
@@ -105,6 +105,8 @@ spec:
                 configMapKeyRef:
                   name: runtime-environment
                   key: environment
+            # Combination of .NET AddJsonFile (PhysicalFileProvider) and k8s volume mounts
+            # makes us miss updates if we dont poll, since k8s uses symlink shenanigans
             - name: DOTNET_USE_POLLING_FILE_WATCHER
               value: "1"
             - name: Gateway__AzureSubscriptionId


### PR DESCRIPTION
## Description

recent cluster upgrade/change led to behavior change in grafana operator, whereby tokens now require expiry

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated monthly process (with manual trigger) to keep the Grafana gateway service account token expiry up to date.
  * Enabled polling-based file watching for the gateway to improve reliability in environments with limited file notification support.
* **Bug Fixes**
  * Reduced the risk of interruptions by ensuring the service account token stays within the supported validity window.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->