### PR TITLE
feat(studioctl): show target version on self update and skip when already current

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -8,6 +8,10 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+### Changed
+
+- Show the resolved target version during `studioctl self update` and skip the update when already on the newest version, instead of reinstalling and restarting the local environment.
+
 ## [0.1.0-preview.15] - 2026-07-01
 
 ### Changed

--- a/src/cli/internal/cmd/self.go
+++ b/src/cli/internal/cmd/self.go
@@ -330,14 +330,23 @@ func (c *SelfCommand) runUpdate(ctx context.Context, args []string) error {
 		return fmt.Errorf("parsing flags: %w", err)
 	}
 
-	c.out.Printlnf("Current version: %s", c.cfg.Version)
-	resolved, err := c.service.ResolveUpdateBundle(
-		ctx,
-		installpkg.UpdateOptions{
-			Version:      version,
-			SkipChecksum: skipChecksum,
-		},
-	)
+	opts := installpkg.UpdateOptions{
+		Version:      version,
+		SkipChecksum: skipChecksum,
+	}
+
+	target, proceed, err := c.resolveUpdateTarget(ctx, opts)
+	if err != nil {
+		return err
+	}
+	if !proceed {
+		return nil
+	}
+
+	// Pin the download to the resolved version so we do not resolve the latest
+	// release a second time.
+	opts.Version = target
+	resolved, err := c.service.ResolveUpdateBundle(ctx, opts)
 	if err != nil {
 		return fmt.Errorf("resolve update bundle: %w", err)
 	}
@@ -348,7 +357,11 @@ func (c *SelfCommand) runUpdate(ctx context.Context, args []string) error {
 			}
 			return err
 		}
-		c.out.Successf("%s update started. The replacement will finish after this process exits.", osutil.CurrentBin())
+		c.out.Successf(
+			"%s update to %s started. The replacement will finish after this process exits.",
+			osutil.CurrentBin(),
+			target,
+		)
 		return nil
 	}
 	if resolved.Cleanup != nil {
@@ -367,8 +380,52 @@ func (c *SelfCommand) runUpdate(ctx context.Context, args []string) error {
 		return fmt.Errorf("apply update bundle: %w", err)
 	}
 
-	c.out.Successf("%s updated successfully.", osutil.CurrentBin())
+	c.out.Successf("%s updated successfully to %s.", osutil.CurrentBin(), target)
 	return nil
+}
+
+// resolveUpdateTarget resolves and reports the release version an update would
+// install. It returns proceed=false when the running build is already on the
+// target version, in which case no update is needed.
+func (c *SelfCommand) resolveUpdateTarget(
+	ctx context.Context,
+	opts installpkg.UpdateOptions,
+) (target string, proceed bool, err error) {
+	c.out.Printlnf("Current version: %s", c.cfg.Version)
+
+	target, err = c.service.ResolveUpdateVersion(ctx, opts)
+	if err != nil {
+		return "", false, fmt.Errorf("resolve update version: %w", err)
+	}
+
+	versionLabel := "Latest version"
+	if opts.Version != "" {
+		versionLabel = "Target version"
+	}
+	c.out.Printlnf("%s: %s", versionLabel, target)
+
+	if isSameReleaseVersion(c.cfg.Version.String(), target) {
+		c.out.Successf("%s is already up to date.", osutil.CurrentBin())
+		return target, false, nil
+	}
+
+	c.out.Printlnf("Updating to %s...", target)
+	return target, true, nil
+}
+
+// isSameReleaseVersion reports whether the running build and the resolved
+// release target refer to the same version, tolerating "studioctl/" and "v"
+// prefix differences. An empty current version (unknown/dev build) never
+// matches, so those builds always proceed with the update.
+func isSameReleaseVersion(current, target string) bool {
+	current = normalizeCompareVersion(current)
+	target = normalizeCompareVersion(target)
+	return current != "" && current == target
+}
+
+func normalizeCompareVersion(v string) string {
+	v = strings.TrimPrefix(strings.TrimSpace(v), "studioctl/")
+	return strings.TrimPrefix(v, "v")
 }
 
 func (c *SelfCommand) runInstalledCompleteInstall(ctx context.Context, studioctlPath string) error {

--- a/src/cli/internal/cmd/self_internal_test.go
+++ b/src/cli/internal/cmd/self_internal_test.go
@@ -38,6 +38,38 @@ func TestSelfUninstallConfirmationRequiresYesWithoutTerminal(t *testing.T) {
 	}
 }
 
+func TestIsSameReleaseVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		current string
+		target  string
+		want    bool
+	}{
+		{name: "identical", current: "v0.1.0-preview.15", target: "v0.1.0-preview.15", want: true},
+		{
+			name:    "tolerates studioctl prefix",
+			current: "studioctl/v0.1.0-preview.15",
+			target:  "v0.1.0-preview.15",
+			want:    true,
+		},
+		{name: "tolerates missing v prefix", current: "0.1.0-preview.15", target: "v0.1.0-preview.15", want: true},
+		{name: "different version", current: "v0.1.0-preview.14", target: "v0.1.0-preview.15", want: false},
+		{name: "empty current never matches", current: "", target: "v0.1.0-preview.15", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isSameReleaseVersion(tc.current, tc.target); got != tc.want {
+				t.Fatalf("isSameReleaseVersion(%q, %q) = %v, want %v", tc.current, tc.target, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestSelfUsageHidesInternalSubcommands(t *testing.T) {
 	t.Parallel()
 

--- a/src/cli/internal/install/update.go
+++ b/src/cli/internal/install/update.go
@@ -82,6 +82,25 @@ func newHTTPDownloader(version config.Version) httpDownloader {
 	}
 }
 
+// ResolveUpdateVersion resolves the release version an update would install
+// without downloading any assets. It returns the version tag without the
+// "studioctl/" prefix (for example "v0.1.0-preview.15"). When opts.Version is
+// empty the newest available release is resolved from GitHub.
+func (s *Service) ResolveUpdateVersion(ctx context.Context, opts UpdateOptions) (string, error) {
+	version, err := normalizeReleaseVersion(opts.Version)
+	if err != nil {
+		return "", err
+	}
+	if version == "" {
+		downloads := newHTTPDownloader(s.cfg.Version)
+		version, err = downloads.resolveLatestStudioctlVersion(ctx, defaultUpdateRepo)
+		if err != nil {
+			return "", err
+		}
+	}
+	return strings.TrimPrefix(version, "studioctl/"), nil
+}
+
 // ResolveUpdateBundle downloads an update bundle and returns the current install target.
 func (s *Service) ResolveUpdateBundle(
 	ctx context.Context,

--- a/src/cli/internal/install/update_internal_test.go
+++ b/src/cli/internal/install/update_internal_test.go
@@ -3,6 +3,7 @@ package install
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -84,6 +85,35 @@ func TestResolveLatestStudioctlVersion(t *testing.T) {
 				t.Fatalf("resolveLatestStudioctlVersion() = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestResolveUpdateVersionExplicitVersionSkipsNetwork(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{Version: config.NewVersion("studioctl/v1.2.3")}
+	got, err := NewService(cfg).ResolveUpdateVersion(
+		context.Background(),
+		UpdateOptions{Version: "v1.5.0"},
+	)
+	if err != nil {
+		t.Fatalf("ResolveUpdateVersion() error = %v", err)
+	}
+	if got != "v1.5.0" {
+		t.Fatalf("ResolveUpdateVersion() = %q, want %q", got, "v1.5.0")
+	}
+}
+
+func TestResolveUpdateVersionRejectsInvalidVersion(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{Version: config.NewVersion("studioctl/v1.2.3")}
+	_, err := NewService(cfg).ResolveUpdateVersion(
+		context.Background(),
+		UpdateOptions{Version: "1.5.0"},
+	)
+	if !errors.Is(err, errInvalidReleaseVersion) {
+		t.Fatalf("ResolveUpdateVersion() error = %v, want errInvalidReleaseVersion", err)
 	}
 }
 


### PR DESCRIPTION
## Description

Improves the `studioctl self update` UX so end users can see which version is the newest and avoid a redundant, disruptive reinstall.

Previously `self update` printed only the *current* version and then always reinstalled — tearing down and restarting the local environment (localtest containers, network) even when already on the newest release.

### Now

- Resolves and shows the target version **before** downloading:
  - `Latest version: <v>` when auto-resolving
  - `Target version: <v>` when `--version` is passed
- Short-circuits with `✓ studioctl is already up to date.` when the running build already matches the target — **no download, no env teardown**.
- Includes the version in the "Updating to …", Windows "update started", and success messages.

### Notes

- New `Service.ResolveUpdateVersion` resolves the version without downloading; the resolved version is then pinned for the bundle download, so there is still only a **single** GitHub releases lookup.
- Empty/dev build versions never match, so local `make user-install` builds always proceed with an update.
- Added tests for `ResolveUpdateVersion` (explicit + invalid version) and `isSameReleaseVersion`.

### Example

```
Current version: v0.1.0-preview.15
Latest version: v0.1.0-preview.15
✓ studioctl is already up to date.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `studioctl self update` now shows the target version it will install.
  * If you’re already on the latest version, it now skips the reinstall and restart steps.
* **Bug Fixes**
  * Update checks are now more reliable across version formats, helping prevent unnecessary updates.
  * Success and start messages now include the resolved version for clearer feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->