### PR TITLE
refactor: move Divider to layout-components libs

### DIFF
--- a/app-libs/form-component/src/layout-components/Divider/Divider.mdx
+++ b/app-libs/form-component/src/layout-components/Divider/Divider.mdx
@@ -1,0 +1,9 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+import { LayoutComponentDocs } from '../common/storybook';
+import * as DividerStories from './Divider.stories';
+import { DIVIDER_PROP_CATEGORIES } from './Divider.stories';
+
+<Meta of={DividerStories} />
+
+<LayoutComponentDocs categories={DIVIDER_PROP_CATEGORIES} />

--- a/app-libs/form-component/src/layout-components/Divider/Divider.stories.tsx
+++ b/app-libs/form-component/src/layout-components/Divider/Divider.stories.tsx
@@ -1,0 +1,40 @@
+import type { PropCategories } from '@app/form-component/layout-components/common/storybook';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Divider } from './Divider';
+import type { DividerProps } from './Divider';
+
+export const DIVIDER_PROP_CATEGORIES = {
+  componentId: 'content',
+  innerGrid: 'content',
+  validationGrid: 'content',
+  validationMessages: 'runtime',
+} satisfies PropCategories<DividerProps>;
+
+const meta = {
+  title: 'LayoutComponents/Divider',
+  component: Divider,
+  excludeStories: ['DIVIDER_PROP_CATEGORIES'],
+  parameters: {
+    layout: 'padded',
+  },
+  args: {
+    componentId: 'divider-preview',
+  },
+} satisfies Meta<typeof Divider>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Preview: Story = {};
+
+export const BetweenContent: Story = {
+  render: (args) => (
+    <div>
+      <p>Innhold over skillelinjen</p>
+      <Divider {...args} />
+      <p>Innhold under skillelinjen</p>
+    </div>
+  ),
+};

--- a/app-libs/form-component/src/layout-components/Divider/Divider.stories.tsx
+++ b/app-libs/form-component/src/layout-components/Divider/Divider.stories.tsx
@@ -7,8 +7,6 @@ import type { DividerProps } from './Divider';
 export const DIVIDER_PROP_CATEGORIES = {
   componentId: 'content',
   innerGrid: 'content',
-  validationGrid: 'content',
-  validationMessages: 'runtime',
 } satisfies PropCategories<DividerProps>;
 
 const meta = {

--- a/app-libs/form-component/src/layout-components/Divider/Divider.test.tsx
+++ b/app-libs/form-component/src/layout-components/Divider/Divider.test.tsx
@@ -1,5 +1,4 @@
 import { renderWithTranslations } from '@app/form-component/test/renderWithTranslations';
-import { screen } from '@testing-library/react';
 
 import { Divider } from './Divider';
 
@@ -12,19 +11,5 @@ describe('Divider', () => {
   it('renders the form-content wrapper for the given componentId', () => {
     renderWithTranslations(<Divider componentId='divider-1' />);
     expect(document.getElementById('form-content-divider-1')).toBeInTheDocument();
-  });
-
-  it('renders validation messages when provided', () => {
-    renderWithTranslations(
-      <Divider componentId='divider-1' validationMessages={<span>Feilmelding</span>} />,
-    );
-    expect(screen.getByText('Feilmelding')).toBeInTheDocument();
-  });
-
-  it('does not render a validation area when validationMessages is undefined', () => {
-    renderWithTranslations(<Divider componentId='divider-1' />);
-    const formContent = document.getElementById('form-content-divider-1');
-    expect(formContent).toBeInTheDocument();
-    expect(formContent?.children).toHaveLength(1);
   });
 });

--- a/app-libs/form-component/src/layout-components/Divider/Divider.test.tsx
+++ b/app-libs/form-component/src/layout-components/Divider/Divider.test.tsx
@@ -1,0 +1,30 @@
+import { renderWithTranslations } from '@app/form-component/test/renderWithTranslations';
+import { screen } from '@testing-library/react';
+
+import { Divider } from './Divider';
+
+describe('Divider', () => {
+  it('renders a divider separator', () => {
+    const { container } = renderWithTranslations(<Divider componentId='divider-1' />);
+    expect(container.querySelector('hr')).toBeInTheDocument();
+  });
+
+  it('renders the form-content wrapper for the given componentId', () => {
+    renderWithTranslations(<Divider componentId='divider-1' />);
+    expect(document.getElementById('form-content-divider-1')).toBeInTheDocument();
+  });
+
+  it('renders validation messages when provided', () => {
+    renderWithTranslations(
+      <Divider componentId='divider-1' validationMessages={<span>Feilmelding</span>} />,
+    );
+    expect(screen.getByText('Feilmelding')).toBeInTheDocument();
+  });
+
+  it('does not render a validation area when validationMessages is undefined', () => {
+    renderWithTranslations(<Divider componentId='divider-1' />);
+    const formContent = document.getElementById('form-content-divider-1');
+    expect(formContent).toBeInTheDocument();
+    expect(formContent?.children).toHaveLength(1);
+  });
+});

--- a/app-libs/form-component/src/layout-components/Divider/Divider.tsx
+++ b/app-libs/form-component/src/layout-components/Divider/Divider.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from 'react';
+
+import { ComponentStructure } from '@app/form-component/layout-components/common/ComponentStructure';
+import { Divider as DsDivider } from '@digdir/designsystemet-react';
+import type { IGridStyling } from '@app/form-component/app-components/Flex';
+
+export interface DividerProps {
+  componentId: string;
+  innerGrid?: IGridStyling;
+  validationGrid?: IGridStyling;
+  validationMessages?: ReactNode;
+}
+
+export function Divider({
+  componentId,
+  innerGrid,
+  validationGrid,
+  validationMessages,
+}: DividerProps) {
+  return (
+    <ComponentStructure
+      componentId={componentId}
+      innerGrid={innerGrid}
+      validationGrid={validationGrid}
+      validationMessages={validationMessages}
+    >
+      <DsDivider />
+    </ComponentStructure>
+  );
+}

--- a/app-libs/form-component/src/layout-components/Divider/Divider.tsx
+++ b/app-libs/form-component/src/layout-components/Divider/Divider.tsx
@@ -1,5 +1,3 @@
-import type { ReactNode } from 'react';
-
 import { ComponentStructure } from '@app/form-component/layout-components/common/ComponentStructure';
 import { Divider as DsDivider } from '@digdir/designsystemet-react';
 import type { IGridStyling } from '@app/form-component/app-components/Flex';
@@ -7,23 +5,11 @@ import type { IGridStyling } from '@app/form-component/app-components/Flex';
 export interface DividerProps {
   componentId: string;
   innerGrid?: IGridStyling;
-  validationGrid?: IGridStyling;
-  validationMessages?: ReactNode;
 }
 
-export function Divider({
-  componentId,
-  innerGrid,
-  validationGrid,
-  validationMessages,
-}: DividerProps) {
+export function Divider({ componentId, innerGrid }: DividerProps) {
   return (
-    <ComponentStructure
-      componentId={componentId}
-      innerGrid={innerGrid}
-      validationGrid={validationGrid}
-      validationMessages={validationMessages}
-    >
+    <ComponentStructure componentId={componentId} innerGrid={innerGrid}>
       <DsDivider />
     </ComponentStructure>
   );

--- a/app-libs/form-component/src/layout-components/Divider/index.ts
+++ b/app-libs/form-component/src/layout-components/Divider/index.ts
@@ -1,0 +1,2 @@
+export { Divider } from './Divider';
+export type { DividerProps } from './Divider';

--- a/app-libs/form-component/src/layout-components/index.ts
+++ b/app-libs/form-component/src/layout-components/index.ts
@@ -2,4 +2,5 @@ export * from './Accordion';
 export * from './Address';
 export * from './ButtonGroup';
 export * from './Datepicker';
+export * from './Divider';
 export * from './Paragraph';

--- a/src/App/frontend/src/layout/Divider/DividerComponent.tsx
+++ b/src/App/frontend/src/layout/Divider/DividerComponent.tsx
@@ -2,21 +2,16 @@ import React from 'react';
 
 import { Divider } from '@app/form-component';
 
-import { AllComponentValidations } from 'src/features/validation/ComponentValidations';
 import { useComponentStructureData } from 'src/utils/layout/useComponentStructureData';
 import type { PropsFromGenericComponent } from 'src/layout/index';
 
 export function DividerComponent({ baseComponentId }: PropsFromGenericComponent<'Divider'>) {
-  const { componentId, innerGrid, validationGrid, showValidationMessages } = useComponentStructureData(baseComponentId);
+  const { componentId, innerGrid } = useComponentStructureData(baseComponentId);
 
   return (
     <Divider
       componentId={componentId}
       innerGrid={innerGrid}
-      validationGrid={validationGrid}
-      validationMessages={
-        showValidationMessages ? <AllComponentValidations baseComponentId={baseComponentId} /> : undefined
-      }
     />
   );
 }

--- a/src/App/frontend/src/layout/Divider/DividerComponent.tsx
+++ b/src/App/frontend/src/layout/Divider/DividerComponent.tsx
@@ -1,14 +1,22 @@
 import React from 'react';
 
-import { Divider } from '@digdir/designsystemet-react';
+import { Divider } from '@app/form-component';
 
-import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
+import { AllComponentValidations } from 'src/features/validation/ComponentValidations';
+import { useComponentStructureData } from 'src/utils/layout/useComponentStructureData';
 import type { PropsFromGenericComponent } from 'src/layout/index';
 
 export function DividerComponent({ baseComponentId }: PropsFromGenericComponent<'Divider'>) {
+  const { componentId, innerGrid, validationGrid, showValidationMessages } = useComponentStructureData(baseComponentId);
+
   return (
-    <ComponentStructureWrapper baseComponentId={baseComponentId}>
-      <Divider />
-    </ComponentStructureWrapper>
+    <Divider
+      componentId={componentId}
+      innerGrid={innerGrid}
+      validationGrid={validationGrid}
+      validationMessages={
+        showValidationMessages ? <AllComponentValidations baseComponentId={baseComponentId} /> : undefined
+      }
+    />
   );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Moves the **Divider** layout component's presentational logic from app-frontend (`src/layout/Divider`) into the shared `@app/form-component` lib (`layout-components/Divider`), leaving a thin data/update wrapper behind — continuing the layout-component migration pattern (Paragraph, Datepicker, Accordion).

Divider is the purely-presentational baseline: a visual separator with no text-resource or data-model props, so this PR is mostly about establishing the wrapper/lib split and the shared structure wiring for a minimal component.

**Lib (`layout-components/Divider`) owns all presentation:**

- Renders the designsystemet divider (imported as `DsDivider` to avoid the name clash with our own `Divider`) inside the shared `ComponentStructure` (grid + validation layout).
- Fully controlled via structural props (`componentId`, `innerGrid`, `validationGrid`, `validationMessages`) that map 1:1 to the component's Studio-configurable grid options — no text/data props, since a divider is purely visual.
- Storybook stories, a `*.mdx` docs page driven by `DIVIDER_PROP_CATEGORIES`, and unit tests using the stub translation provider.

**Wrapper (`src/layout/Divider/DividerComponent.tsx`) only resolves runtime data and delegates rendering:**

- `useComponentStructureData(baseComponentId)` for the indexed `componentId`, grid sizing, and whether default validations should show.
- Passes the rendered `AllComponentValidations` as `validationMessages`; removes the `ComponentStructureWrapper` usage.

CLOSES: #19059 

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a reusable **Divider** component to the form component library and exposed it through the layout components package.
* **Documentation**
  * Added Storybook documentation, including a preview and an example showing content around the divider.
* **Tests**
  * Added tests to verify the divider renders correctly (including the expected wrapper).
* **Refactor**
  * Updated the app’s Divider layout to use the shared component-structure data when rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->