### PR TITLE
feat(resource-adm): add link to documentation in resource type description

### DIFF
--- a/src/Designer/frontend/resourceadm/components/ResourcePageInputs/ResourceRadioGroup.tsx
+++ b/src/Designer/frontend/resourceadm/components/ResourcePageInputs/ResourceRadioGroup.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { type ReactNode } from 'react';
 import classes from './ResourcePageInputs.module.css';
 import {
   StudioRadio,
@@ -21,7 +21,7 @@ type ResourceRadioGroupProps = {
   /**
    * The description of the dropdown
    */
-  description?: string;
+  description?: ReactNode;
   /**
    * The value selected
    */
@@ -52,7 +52,7 @@ type ResourceRadioGroupProps = {
  *
  * @property {string}[id] - The field id, used by ErrorSummary
  * @property {string}[label] - The label of the dropdown
- * @property {string}[description] - The description of the dropdown
+ * @property {ReactNode}[description] - The description of the dropdown
  * @property {string}[value] - The value selected
  * @property {{value: string, lable: string}[]}[options] - List of the options in the dropdown
  * @property {function}[onChange] - Function to be executed on change

--- a/src/Designer/frontend/resourceadm/language/src/nb.json
+++ b/src/Designer/frontend/resourceadm/language/src/nb.json
@@ -74,7 +74,7 @@
   "resourceadm.about_resource_resource_type_consentresource": "Samtykkeressurs",
   "resourceadm.about_resource_resource_type_error": "Du må velge en ressurstype.",
   "resourceadm.about_resource_resource_type_generic_access_resource": "Generisk tilgangsressurs",
-  "resourceadm.about_resource_resource_type_label": "Velg en ressurstype fra listen under.",
+  "resourceadm.about_resource_resource_type_label": "Velg en ressurstype fra listen under. Er du usikker på hvilken du skal velge, se <a>beskrivelsen av de forskjellige ressurs­typene</a>.",
   "resourceadm.about_resource_resource_type_maskinporten": "Maskinporten-skjema",
   "resourceadm.about_resource_resource_type_system_resource": "Systemressurs",
   "resourceadm.about_resource_rights_description_label": "Delegeringstekst",

--- a/src/Designer/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.tsx
+++ b/src/Designer/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import classes from './AboutResourcePage.module.css';
-import { StudioAlert, StudioHeading, StudioErrorSummary } from '@studio/components';
+import { StudioAlert, StudioHeading, StudioErrorSummary, StudioLink } from '@studio/components';
 import type {
   Resource,
   ResourceTypeOption,
@@ -21,7 +21,7 @@ import {
   resourceTypeMap,
   convertMetadataStringToConsentMetadata,
 } from '../../utils/resourceUtils';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import {
   ResourceCheckboxGroup,
   ResourceLanguageTextField,
@@ -155,7 +155,22 @@ export const AboutResourcePage = ({
           <ResourceRadioGroup
             id='resourceType'
             label={t('resourceadm.about_resource_resource_type')}
-            description={t('resourceadm.about_resource_resource_type_label')}
+            description={
+              <Trans
+                i18nKey={'resourceadm.about_resource_resource_type_label'}
+                components={{
+                  a: (
+                    <StudioLink
+                      href='https://docs.altinn.studio/nb/authorization/what-do-you-get/resourceadministration/#ressurstypene'
+                      target='_blank'
+                      rel='noopener noreferrer'
+                    >
+                      {' '}
+                    </StudioLink>
+                  ),
+                }}
+              />
+            }
             value={resourceData.resourceType}
             options={resourceTypeOptions}
             onChange={(selected: ResourceTypeOption) =>

--- a/src/Designer/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.tsx
+++ b/src/Designer/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.tsx
@@ -35,6 +35,9 @@ import { AccessListEnvLinks } from '../../components/AccessListEnvLinks';
 import { ConsentPreview } from '../../components/ConsentPreview';
 import { useUrlParams } from '../../hooks/useUrlParams';
 
+const RESOURCE_TYPE_DOCUMENTATION_URL =
+  'https://docs.altinn.studio/nb/authorization/what-do-you-get/resourceadministration/#ressurstypene';
+
 export type AboutResourcePageProps = {
   resourceData: Resource;
   validationErrors: ResourceFormError[];
@@ -161,7 +164,7 @@ export const AboutResourcePage = ({
                 components={{
                   a: (
                     <StudioLink
-                      href='https://docs.altinn.studio/nb/authorization/what-do-you-get/resourceadministration/#ressurstypene'
+                      href={RESOURCE_TYPE_DOCUMENTATION_URL}
                       target='_blank'
                       rel='noopener noreferrer'
                     >


### PR DESCRIPTION
## Description
- Add link to documentation for resource types in resource type description
<img width="537" height="297" alt="image" src="https://github.com/user-attachments/assets/b8c509d6-9561-4df1-9e77-26036a6ad782" />


## Issue
- https://github.com/Altinn/altinn-resource-registry/issues/791

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resource option descriptions can now be richer and support formatted React content (e.g., links), not just plain text.
  * The “About Resource” page now includes an inline link within the resource type description to learn more.

* **Documentation**
  * Updated the Norwegian (Bokmål) help text with a clearer, longer explanation and direct reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->