### PR TITLE
feat: order layoutsets based on bpmn to be send by api call

### DIFF
--- a/src/Designer/backend/src/Designer/Helpers/Extensions/ProcessExtensions.cs
+++ b/src/Designer/backend/src/Designer/Helpers/Extensions/ProcessExtensions.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using System.Linq;
+using Altinn.App.Core.Internal.Process.Elements;
+
+namespace Altinn.Studio.Designer.Helpers.Extensions;
+
+/// <summary>
+/// Extensions for the BPMN process definition.
+/// </summary>
+public static class ProcessExtensions
+{
+    /// <summary>
+    /// Returns the process task ids in the order they are first reached when walking the sequence flows from
+    /// the start event, so the order stays stable regardless of element order in the BPMN file. Tasks not
+    /// reachable from a start event are appended last, in their declared order.
+    /// </summary>
+    public static List<string> OrderTaskIdsByFlow(this Process process)
+    {
+        List<ProcessTask> tasks = process.Tasks ?? [];
+        HashSet<string> taskIds = [.. tasks.Select(task => task.Id)];
+
+        ILookup<string, string> outgoingTargets = (process.SequenceFlow ?? [])
+            .Where(flow => flow.SourceRef is not null && flow.TargetRef is not null)
+            .ToLookup(flow => flow.SourceRef, flow => flow.TargetRef);
+
+        List<string> orderedTaskIds = [];
+        HashSet<string> visited = [];
+        Queue<string> toVisit = new((process.StartEvents ?? []).Select(startEvent => startEvent.Id));
+
+        while (toVisit.Count > 0)
+        {
+            string elementId = toVisit.Dequeue();
+            if (!visited.Add(elementId))
+            {
+                continue;
+            }
+            if (taskIds.Contains(elementId))
+            {
+                orderedTaskIds.Add(elementId);
+            }
+            foreach (string target in outgoingTargets[elementId])
+            {
+                toVisit.Enqueue(target);
+            }
+        }
+
+        orderedTaskIds.AddRange(tasks.Select(task => task.Id).Where(taskId => !visited.Contains(taskId)));
+
+        return orderedTaskIds;
+    }
+}

--- a/src/Designer/backend/src/Designer/Helpers/Extensions/ProcessExtensions.cs
+++ b/src/Designer/backend/src/Designer/Helpers/Extensions/ProcessExtensions.cs
@@ -16,16 +16,31 @@ public static class ProcessExtensions
     /// </summary>
     public static List<string> OrderTaskIdsByFlow(this Process process)
     {
-        List<ProcessTask> tasks = process.Tasks ?? [];
-        HashSet<string> taskIds = [.. tasks.Select(task => task.Id)];
+        List<string> taskIds = (process.Tasks ?? []).Select(task => task.Id).ToList();
 
         ILookup<string, string> outgoingTargets = (process.SequenceFlow ?? [])
             .Where(flow => flow.SourceRef is not null && flow.TargetRef is not null)
             .ToLookup(flow => flow.SourceRef, flow => flow.TargetRef);
 
+        IEnumerable<string> startIds = (process.StartEvents ?? []).Select(startEvent => startEvent.Id);
+        List<string> orderedTaskIds = TraverseTaskIdsFromStart(startIds, outgoingTargets, [.. taskIds]);
+
+        // Tasks not reachable from a start event still need a defined position, appended in declared order.
+        HashSet<string> reachedTaskIds = [.. orderedTaskIds];
+        orderedTaskIds.AddRange(taskIds.Where(taskId => !reachedTaskIds.Contains(taskId)));
+
+        return orderedTaskIds;
+    }
+
+    private static List<string> TraverseTaskIdsFromStart(
+        IEnumerable<string> startIds,
+        ILookup<string, string> outgoingTargets,
+        HashSet<string> taskIds
+    )
+    {
         List<string> orderedTaskIds = [];
         HashSet<string> visited = [];
-        Queue<string> toVisit = new((process.StartEvents ?? []).Select(startEvent => startEvent.Id));
+        Queue<string> toVisit = new(startIds);
 
         while (toVisit.Count > 0)
         {
@@ -43,8 +58,6 @@ public static class ProcessExtensions
                 toVisit.Enqueue(target);
             }
         }
-
-        orderedTaskIds.AddRange(tasks.Select(task => task.Id).Where(taskId => !visited.Contains(taskId)));
 
         return orderedTaskIds;
     }

--- a/src/Designer/backend/src/Designer/Services/Implementation/UiFoldersService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/UiFoldersService.cs
@@ -488,6 +488,15 @@ public class UiFoldersService : IUiFoldersService
         IEnumerable<string> uiFolders = await altinnAppGitRepository.GetUiFolders(cancellationToken);
         Definitions definitions = altinnAppGitRepository.GetProcessDefinitions();
 
+        // The position of each task in the process definition determines the display order of its layout set.
+        // Folder enumeration alone is alphabetical, which does not reflect the order tasks were added to the
+        // process, so we sort by task position and place subforms (which have no task) after the task-connected
+        // layout sets. This is displayed i.e. in the task cards bar of the form designer, where subforms are always last.
+        List<ProcessTask> tasks = definitions.Process.Tasks;
+        Dictionary<string, int> taskOrderById = tasks
+            .Select((task, index) => (task.Id, index))
+            .ToDictionary(entry => entry.Id, entry => entry.index);
+
         List<LayoutSetInfo> layoutSets = [];
 
         foreach (string layoutSetName in uiFolders)
@@ -504,7 +513,7 @@ public class UiFoldersService : IUiFoldersService
             }
 
             bool isSubform = layoutSettings.Type == "subform";
-            bool hasMatchingTask = definitions.Process.Tasks.Any(task => task.Id == layoutSetName);
+            bool hasMatchingTask = taskOrderById.ContainsKey(layoutSetName);
 
             if (!isSubform && !hasMatchingTask)
             {
@@ -516,7 +525,12 @@ public class UiFoldersService : IUiFoldersService
             layoutSets.Add(new LayoutSetInfo(layoutSetName, layoutSettings, taskType));
         }
 
-        return layoutSets;
+        return
+        [
+            .. layoutSets.OrderBy(layoutSet =>
+                taskOrderById.TryGetValue(layoutSet.LayoutSetName, out int order) ? order : int.MaxValue
+            ),
+        ];
     }
 
     private sealed record LayoutSetInfo(string LayoutSetName, LayoutSettings LayoutSettings, string? TaskType);

--- a/src/Designer/backend/src/Designer/Services/Implementation/UiFoldersService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/UiFoldersService.cs
@@ -12,6 +12,7 @@ using Altinn.Platform.Storage.Interface.Models;
 using Altinn.Studio.Designer.Enums;
 using Altinn.Studio.Designer.Events;
 using Altinn.Studio.Designer.Exceptions.AppDevelopment;
+using Altinn.Studio.Designer.Helpers.Extensions;
 using Altinn.Studio.Designer.Infrastructure.GitRepository;
 using Altinn.Studio.Designer.Mappers;
 using Altinn.Studio.Designer.Models;
@@ -488,14 +489,11 @@ public class UiFoldersService : IUiFoldersService
         IEnumerable<string> uiFolders = await altinnAppGitRepository.GetUiFolders(cancellationToken);
         Definitions definitions = altinnAppGitRepository.GetProcessDefinitions();
 
-        // The position of each task in the process definition determines the display order of its layout set.
-        // Folder enumeration alone is alphabetical, which does not reflect the order tasks were added to the
-        // process, so we sort by task position and place subforms (which have no task) after the task-connected
-        // layout sets. This is displayed i.e. in the task cards bar of the form designer, where subforms are always last.
-        List<ProcessTask> tasks = definitions.Process.Tasks;
-        Dictionary<string, int> taskOrderById = tasks
-            .Select((task, index) => (task.Id, index))
-            .ToDictionary(entry => entry.Id, entry => entry.index);
+        // Order layout sets by their task's position in the process flow, with subforms (no task) last.
+        List<string> orderedTaskIds = definitions.Process.OrderTaskIdsByFlow();
+        Dictionary<string, int> taskOrderById = orderedTaskIds
+            .Select((taskId, index) => (taskId, index))
+            .ToDictionary(entry => entry.taskId, entry => entry.index);
 
         List<LayoutSetInfo> layoutSets = [];
 

--- a/src/Designer/backend/tests/Designer.Tests/Services/UiFoldersServiceTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/UiFoldersServiceTests.cs
@@ -76,10 +76,11 @@ public class UiFoldersServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task GetLayoutSetsExtended_OrdersByProcessTaskAndPlacesSubformsLast()
+    public async Task GetLayoutSetsExtended_OrdersByProcessFlowAndPlacesSubformsLast()
     {
-        // Arrange: the process defines Task_2 before Task_1, so the result must follow that order rather
-        // than the alphabetical folder order, and the subform (which has no task) must come last.
+        // Arrange: the process flows StartEvent -> Task_2 -> Task_1 -> EndEvent, while the BPMN file lists
+        // the Task_1 element before Task_2. The result must follow the flow order (Task_2, Task_1), not the
+        // element/alphabetical order, and the subform (which has no task) must come last.
         (AltinnRepoEditingContext editingContext, UiFoldersService service) = await CreateTestContext(OrderedRepo);
 
         // Act

--- a/src/Designer/backend/tests/Designer.Tests/Services/UiFoldersServiceTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/UiFoldersServiceTests.cs
@@ -21,6 +21,7 @@ public class UiFoldersServiceTests : IDisposable
     private const string Org = "ttd";
     private const string Developer = "testUser";
     private const string Repo = "app-with-ui-folders";
+    private const string OrderedRepo = "app-with-ordered-ui-folders";
     private string _testRepoPath;
 
     [Fact]
@@ -74,10 +75,29 @@ public class UiFoldersServiceTests : IDisposable
         Assert.Equal(2, layoutSet.PageCount);
     }
 
-    private async Task<(AltinnRepoEditingContext editingContext, UiFoldersService service)> CreateTestContext()
+    [Fact]
+    public async Task GetLayoutSetsExtended_OrdersByProcessTaskAndPlacesSubformsLast()
+    {
+        // Arrange: the process defines Task_2 before Task_1, so the result must follow that order rather
+        // than the alphabetical folder order, and the subform (which has no task) must come last.
+        (AltinnRepoEditingContext editingContext, UiFoldersService service) = await CreateTestContext(OrderedRepo);
+
+        // Act
+        IEnumerable<UiFolderLayoutSetDto> result = await service.GetLayoutSetsExtended(
+            editingContext,
+            CancellationToken.None
+        );
+
+        // Assert
+        Assert.Equal(["Task_2", "Task_1", "subformSet"], result.Select(dto => dto.Id));
+    }
+
+    private async Task<(AltinnRepoEditingContext editingContext, UiFoldersService service)> CreateTestContext(
+        string repo = Repo
+    )
     {
         string targetRepository = TestDataHelper.GenerateTestRepoName();
-        _testRepoPath = await TestDataHelper.CopyRepositoryForTest(Org, Repo, Developer, targetRepository);
+        _testRepoPath = await TestDataHelper.CopyRepositoryForTest(Org, repo, Developer, targetRepository);
         AltinnRepoEditingContext editingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(
             Org,
             targetRepository,

--- a/src/Designer/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-ordered-ui-folders/App/config/applicationmetadata.json
+++ b/src/Designer/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-ordered-ui-folders/App/config/applicationmetadata.json
@@ -1,0 +1,42 @@
+{
+  "id": "ttd/app-with-ordered-ui-folders",
+  "org": "ttd",
+  "title": {
+    "nb": "app-with-ordered-ui-folders"
+  },
+  "dataTypes": [
+    {
+      "id": "modelTaskOne",
+      "allowedContentTypes": ["application/xml"],
+      "appLogic": {
+        "autoCreate": true,
+        "classRef": "Altinn.App.Models.modelTaskOne"
+      },
+      "taskId": "Task_1",
+      "maxCount": 1,
+      "minCount": 1
+    },
+    {
+      "id": "modelTaskTwo",
+      "allowedContentTypes": ["application/xml"],
+      "appLogic": {
+        "autoCreate": true,
+        "classRef": "Altinn.App.Models.modelTaskTwo"
+      },
+      "taskId": "Task_2",
+      "maxCount": 1,
+      "minCount": 1
+    }
+  ],
+  "partyTypesAllowed": {
+    "bankruptcyEstate": false,
+    "organisation": false,
+    "person": true,
+    "subUnit": false
+  },
+  "autoDeleteOnProcessEnd": false,
+  "created": "2024-01-01T00:00:00Z",
+  "createdBy": "testUser",
+  "lastChanged": "2024-01-01T00:00:00Z",
+  "lastChangedBy": "testUser"
+}

--- a/src/Designer/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-ordered-ui-folders/App/config/process/process.bpmn
+++ b/src/Designer/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-ordered-ui-folders/App/config/process/process.bpmn
@@ -4,16 +4,7 @@
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_1</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:task id="Task_2" name="Andre steg">
-      <bpmn:extensionElements>
-        <altinn:taskExtension>
-          <altinn:taskType>data</altinn:taskType>
-        </altinn:taskExtension>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_1</bpmn:incoming>
-      <bpmn:outgoing>Flow_2</bpmn:outgoing>
-    </bpmn:task>
-    <bpmn:task id="Task_1" name="Fyrste steg">
+    <bpmn:task id="Task_1" name="Andre steg">
       <bpmn:extensionElements>
         <altinn:taskExtension>
           <altinn:taskType>data</altinn:taskType>
@@ -21,6 +12,15 @@
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_2</bpmn:incoming>
       <bpmn:outgoing>Flow_3</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:task id="Task_2" name="Fyrste steg">
+      <bpmn:extensionElements>
+        <altinn:taskExtension>
+          <altinn:taskType>data</altinn:taskType>
+        </altinn:taskExtension>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
     </bpmn:task>
     <bpmn:endEvent id="EndEvent_1">
       <bpmn:incoming>Flow_3</bpmn:incoming>

--- a/src/Designer/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-ordered-ui-folders/App/config/process/process.bpmn
+++ b/src/Designer/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-ordered-ui-folders/App/config/process/process.bpmn
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:altinn="http://altinn.no/process" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Altinn_Process_Definition" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="TwoDataTasks" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_2" name="Andre steg">
+      <bpmn:extensionElements>
+        <altinn:taskExtension>
+          <altinn:taskType>data</altinn:taskType>
+        </altinn:taskExtension>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:task id="Task_1" name="Fyrste steg">
+      <bpmn:extensionElements>
+        <altinn:taskExtension>
+          <altinn:taskType>data</altinn:taskType>
+        </altinn:taskExtension>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+      <bpmn:outgoing>Flow_3</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_3</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="Task_2" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="Task_2" targetRef="Task_1" />
+    <bpmn:sequenceFlow id="Flow_3" sourceRef="Task_1" targetRef="EndEvent_1" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/src/Designer/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-ordered-ui-folders/App/ui/Task_1/Settings.json
+++ b/src/Designer/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-ordered-ui-folders/App/ui/Task_1/Settings.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://altinncdn.no/schemas/json/layout/layoutSettings.schema.v1.json",
+  "pages": {
+    "order": ["page1"]
+  },
+  "defaultDataType": "modelTaskOne"
+}

--- a/src/Designer/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-ordered-ui-folders/App/ui/Task_1/layouts/page1.json
+++ b/src/Designer/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-ordered-ui-folders/App/ui/Task_1/layouts/page1.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+  "data": {
+    "layout": []
+  }
+}

--- a/src/Designer/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-ordered-ui-folders/App/ui/Task_2/Settings.json
+++ b/src/Designer/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-ordered-ui-folders/App/ui/Task_2/Settings.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://altinncdn.no/schemas/json/layout/layoutSettings.schema.v1.json",
+  "pages": {
+    "order": ["page1"]
+  },
+  "defaultDataType": "modelTaskTwo"
+}

--- a/src/Designer/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-ordered-ui-folders/App/ui/Task_2/layouts/page1.json
+++ b/src/Designer/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-ordered-ui-folders/App/ui/Task_2/layouts/page1.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+  "data": {
+    "layout": []
+  }
+}

--- a/src/Designer/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-ordered-ui-folders/App/ui/subformSet/Settings.json
+++ b/src/Designer/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-ordered-ui-folders/App/ui/subformSet/Settings.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://altinncdn.no/schemas/json/layout/layoutSettings.schema.v1.json",
+  "pages": {
+    "order": ["page1"]
+  },
+  "type": "subform"
+}

--- a/src/Designer/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-ordered-ui-folders/App/ui/subformSet/layouts/page1.json
+++ b/src/Designer/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-ordered-ui-folders/App/ui/subformSet/layouts/page1.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+  "data": {
+    "layout": []
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

For v9 apps, the task card bar on the main "Utforming" page listed layout sets alphabetically, because v9 reads them from the folders under `App/ui/` instead of from `layout-sets.json`. This is confusing when a user adds a new layout set or subform.

This PR orders layout sets by the order flow their tasks appear in the BPMN process, with subforms always placed last (since they are not directly part of the flow). It's purely an ordering change on the API response, no files on disk are modified. This also improves on the legacy behavior by tying the order to the actual process flow.



Added `GetLayoutSetsExtended_OrdersByProcessTaskAndPlacesSubformsLast` test, using a new test app where the process defines Task_2 before Task_1 plus a subform, asserting the order Task_2, Task_1, subformSet.

<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Layout sets are now shown in the same order as the process task sequence, with task-linked items first and subforms or unmatched folders placed last.
* **Bug Fixes**
  * Improved layout set matching so task-connected folders are identified more reliably.
* **Tests**
  * Expanded test data and unit tests to cover ordered task layouts and subform placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->