### PR TITLE
chore: disable Renovate for Kubernetes Go client deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,6 +28,15 @@
       "minimumReleaseAge": null
     },
     {
+      "description": "Kubernetes Go client/runtime dependencies are updated manually after checking target cluster compatibility",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": [
+        "/^k8s\\.io\\//",
+        "/^sigs\\.k8s\\.io\\/(controller-runtime|gateway-api)$/"
+      ],
+      "enabled": false
+    },
+    {
       "matchManagers": ["gomod", "pep621"],
       "groupName": "{{manager}} non-major dependencies",
       "matchPackageNames": ["*"],


### PR DESCRIPTION
## Description

Disables Renovate updates for Kubernetes Go client/runtime dependencies that should be updated manually after checking target cluster compatibility:

- `k8s.io/*`
- `sigs.k8s.io/controller-runtime`
- `sigs.k8s.io/gateway-api`

Patch updates inside an already selected Kubernetes minor line are usually low risk, but minor updates are coupled to the actual kube-apiserver/control-plane versions we support. Keeping these out of Renovate's broad gomod non-major grouping avoids accidental minor-line upgrades without environment compatibility checks.

This is a separate main-targeting PR from the dependency update stack.

## Verification

- [x] Related issues are connected (if applicable) - N/A
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out) - N/A, Renovate config only

Verification performed:

- `npx --yes --package renovate -- renovate-config-validator --strict`
- `git diff --check`

Reviewer: @martinothamar


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency automation to skip certain Kubernetes-related Go packages, so they will now be managed manually during compatibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->