### PR TITLE
chore: update Flux health dependencies

### DIFF
--- a/src/tools/health/go.mod
+++ b/src/tools/health/go.mod
@@ -3,8 +3,8 @@ module altinn.studio/runtime-health
 go 1.26.4
 
 require (
-	github.com/fluxcd/helm-controller/api v1.5.3
-	github.com/fluxcd/kustomize-controller/api v1.8.2
+	github.com/fluxcd/helm-controller/api v1.5.5
+	github.com/fluxcd/kustomize-controller/api v1.8.5
 	k8s.io/api v0.35.6
 	k8s.io/apimachinery v0.35.6
 	k8s.io/client-go v0.35.6

--- a/src/tools/health/go.sum
+++ b/src/tools/health/go.sum
@@ -7,10 +7,10 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emicklei/go-restful/v3 v3.13.0 h1:C4Bl2xDndpU6nJ4bc1jXd+uTmYPVUwkD6bFY/oTyCes=
 github.com/emicklei/go-restful/v3 v3.13.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
-github.com/fluxcd/helm-controller/api v1.5.3 h1:ruLzuyTHjjE9A5B/U+Id2q7yHXXqSFTswdZ14xCS5So=
-github.com/fluxcd/helm-controller/api v1.5.3/go.mod h1:lTgeUmtVYExMKp7mRDncsr4JwHTz3LFtLjRJZeR98lI=
-github.com/fluxcd/kustomize-controller/api v1.8.2 h1:LcFUjJccwNrhCo7pQBBneLAlHfZZcb58bWB2LnyFwag=
-github.com/fluxcd/kustomize-controller/api v1.8.2/go.mod h1:c/mUPIffDDLg1EicXCJtX4N/rc+z5Zh0e/CXjhd7Dyc=
+github.com/fluxcd/helm-controller/api v1.5.5 h1:xQA/9gbifMvZPGhSNKHsrkq829dI/yTBASVdYp9/s4Y=
+github.com/fluxcd/helm-controller/api v1.5.5/go.mod h1:lTgeUmtVYExMKp7mRDncsr4JwHTz3LFtLjRJZeR98lI=
+github.com/fluxcd/kustomize-controller/api v1.8.5 h1:4fGPh6foGVKUUbt5OjVzbC5iTyX+Q+NS50atPboDC4w=
+github.com/fluxcd/kustomize-controller/api v1.8.5/go.mod h1:c/mUPIffDDLg1EicXCJtX4N/rc+z5Zh0e/CXjhd7Dyc=
 github.com/fluxcd/pkg/apis/kustomize v1.15.1 h1:t9QZh+3ZS8EKmlxrnnbcKZcGTrg8FDvMF1T8BHMCuqI=
 github.com/fluxcd/pkg/apis/kustomize v1.15.1/go.mod h1:IZOy4CCtR/hxMGb7erK1RfbGnczVv4/dRBoVD37AywI=
 github.com/fluxcd/pkg/apis/meta v1.25.1 h1:WG1GIC/SOz0GjxT0uVuO6AMicQ3yFsk6bDozCnq+fto=


### PR DESCRIPTION
## Summary

- @martinothamar update `src/tools/health` Flux API dependencies:
  - `github.com/fluxcd/helm-controller/api` `v1.5.3` -> `v1.5.5`
  - `github.com/fluxcd/kustomize-controller/api` `v1.8.2` -> `v1.8.5`

## Why

This brings the runtime health tool in sync with the Flux patch versions already used by the other Go modules in the repo.

I checked the latest available stable Flux API versions with `go list -m -u`. Newer Flux minor lines exist (`helm-controller/api v1.6.1`, `kustomize-controller/api v1.9.1`), but trying those locally pulls Kubernetes/client-runtime dependencies across minor lines (`k8s.io/* v0.36.2`, `sigs.k8s.io/controller-runtime v0.24.1`). Since we do not want automatic Kubernetes/client minor upgrades, this PR intentionally stays on the latest patch versions for the current Flux minor lines.

## Testing

```text
cd src/tools/health
make build lint && go test ./...
```

Result:

```text
Building packages...
✓ Build successful
0 issues.
?   	altinn.studio/runtime-health/cmd	[no test files]
?   	altinn.studio/runtime-health/internal/az	[no test files]
ok  	altinn.studio/runtime-health/internal/kubernetes	0.004s
?   	altinn.studio/runtime-health/internal/output	[no test files]
?   	altinn.studio/runtime-health/internal/runtimes	[no test files]
?   	altinn.studio/runtime-health/internal/runtimes/dis	[no test files]
```

Also ran:

```text
git diff --check upstream/main...HEAD
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bundled controller dependencies to newer patch versions, bringing in the latest fixes and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->