### PR TITLE
ci: schedule app frontend Percy baseline runs

### DIFF
--- a/.github/workflows/app-frontend-cypress.yml
+++ b/.github/workflows/app-frontend-cypress.yml
@@ -1,6 +1,8 @@
 name: App Frontend - Cypress
 
 on:
+  schedule:
+    - cron: '0 3 * * 1-5'
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:


### PR DESCRIPTION
## Description

Adds a weekday scheduled run for the App Frontend Cypress workflow.

The workflow already enables Percy when running on `refs/heads/main`, but it only ran automatically for pull requests. Scheduled runs execute on the default branch, so this gives Percy a regular `main` build that can refresh the visual baseline without running the full Cypress/Percy suite on every merge.

The schedule is Monday-Friday at 03:00 UTC.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated run schedule to execute on weekdays at 03:00, providing more consistent coverage during the working week.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->