### PR TITLE
chore: allow Kubernetes and Flux patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,20 +28,34 @@
       "minimumReleaseAge": null
     },
     {
-      "description": "Kubernetes Go client/runtime dependencies are updated manually after checking target cluster compatibility",
-      "matchManagers": ["gomod"],
-      "matchPackageNames": [
-        "/^k8s\\.io\\//",
-        "/^sigs\\.k8s\\.io\\/(controller-runtime|gateway-api)$/"
-      ],
-      "enabled": false
-    },
-    {
       "matchManagers": ["gomod", "pep621"],
       "groupName": "{{manager}} non-major dependencies",
       "matchPackageNames": ["*"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupSlug": "{{manager}}-minor-patch"
+    },
+    {
+      "description": "Group Kubernetes and Flux runtime Go dependency patches so related release trains move together",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": [
+        "/^k8s\\.io\\//",
+        "/^sigs\\.k8s\\.io\\/(controller-runtime|gateway-api)$/",
+        "/^github\\.com\\/fluxcd\\/(flux2\\/v2|.*-controller\\/api)$/"
+      ],
+      "matchUpdateTypes": ["patch"],
+      "groupName": "Kubernetes and Flux runtime Go dependency patches",
+      "groupSlug": "k8s-flux-runtime-go-patches"
+    },
+    {
+      "description": "Kubernetes and Flux runtime Go dependency minor/major updates are done manually after checking target cluster compatibility",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": [
+        "/^k8s\\.io\\//",
+        "/^sigs\\.k8s\\.io\\/(controller-runtime|gateway-api)$/",
+        "/^github\\.com\\/fluxcd\\/(flux2\\/v2|.*-controller\\/api)$/"
+      ],
+      "matchUpdateTypes": ["minor", "major"],
+      "enabled": false
     },
     {
       "groupName": "LibGit2Sharp dependency",


### PR DESCRIPTION
## Summary

- @martinothamar replace the full Renovate disable for Kubernetes Go client/runtime dependencies with a more precise policy.
- Allow and group patch updates for Kubernetes and Flux runtime Go dependencies.
- Disable only minor/major updates for the same dependency set, so cluster/runtime compatibility decisions remain manual.

## Why

Patch updates within the same Kubernetes minor are not a cluster skew issue. For example, `k8s.io/client-go v0.35.5 -> v0.35.6` remains in the Kubernetes 1.35 client family.

The reason to group these packages is dependency graph consistency: Kubernetes Go modules are released on the same patch train and should move together. Flux controller API minor updates can also pull Kubernetes/client-runtime minor updates, so minor/major updates should still be manual.

Policy after this PR:

- `k8s.io/*`, `sigs.k8s.io/controller-runtime`, `sigs.k8s.io/gateway-api`: patch updates grouped, minor/major disabled.
- `github.com/fluxcd/flux2/v2` and `github.com/fluxcd/*-controller/api`: patch updates grouped, minor/major disabled.

## Testing

```text
npx --yes --package renovate -- renovate-config-validator --strict
git diff --check
```

Result:

```text
INFO: Validating renovate.json
INFO: Config validated successfully against 1 file(s)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update grouping so patch releases for Kubernetes and Flux-related packages can now be grouped separately.
  * Minor and major updates for those dependencies remain grouped and require manual handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->