### PR TITLE
feat(studioctl): notify when a newer release is available

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -10,7 +10,7 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ### Added
 
-- Notify when a newer `studioctl` release is available. The check runs at most once every 24 hours, caches its result under the studioctl home directory, and prints a hint to run `studioctl self update`. It is skipped in CI, for non-interactive output, and can be disabled with `STUDIOCTL_NO_UPDATE_CHECK=1`.
+- Notify when a newer `studioctl` release is available. The check runs at most once every few hours, caches its result under the studioctl home directory, and prints a hint to run `studioctl self update`. It is skipped in CI, for non-interactive output, and can be disabled with `STUDIOCTL_NO_UPDATE_CHECK=1`.
 
 ## [0.1.0-preview.16] - 2026-07-02
 

--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -8,6 +8,10 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+### Added
+
+- Notify when a newer `studioctl` release is available. The check runs at most once every 24 hours, caches its result under the studioctl home directory, and prints a hint to run `studioctl self update`. It is skipped in CI, for non-interactive output, and can be disabled with `STUDIOCTL_NO_UPDATE_CHECK=1`.
+
 ## [0.1.0-preview.16] - 2026-07-02
 
 ### Changed

--- a/src/cli/internal/cmd/root.go
+++ b/src/cli/internal/cmd/root.go
@@ -14,6 +14,7 @@ import (
 	"altinn.studio/studioctl/internal/config"
 	"altinn.studio/studioctl/internal/osutil"
 	"altinn.studio/studioctl/internal/ui"
+	"altinn.studio/studioctl/internal/updatecheck"
 )
 
 // version is set at build time via ldflags.
@@ -103,12 +104,27 @@ func (c *CLI) Run(ctx context.Context, args []string) int {
 		return 1
 	}
 
-	if err := cmd.Run(ctx, args[1:]); err != nil {
-		c.out.Error(err.Error())
-		return 1
+	runErr := cmd.Run(ctx, args[1:])
+	if runErr != nil {
+		c.out.Error(runErr.Error())
 	}
 
+	c.notifyUpdateAvailable(ctx, cmdName)
+
+	if runErr != nil {
+		return 1
+	}
 	return 0
+}
+
+// notifyUpdateAvailable prints a notice when a newer studioctl release exists.
+// It is skipped for the 'self' command so it does not interfere with a self
+// update or uninstall the user is already performing.
+func (c *CLI) notifyUpdateAvailable(ctx context.Context, cmdName string) {
+	if cmdName == "self" {
+		return
+	}
+	updatecheck.New(c.cfg, c.out).Run(ctx)
 }
 
 func (c *CLI) printUsage() {

--- a/src/cli/internal/config/config.go
+++ b/src/cli/internal/config/config.go
@@ -282,6 +282,11 @@ func (c *Config) CredentialsPath() string {
 	return filepath.Join(c.Home, "credentials.yaml")
 }
 
+// UpdateCheckCachePath returns the path to the passive update-check cache file.
+func (c *Config) UpdateCheckCachePath() string {
+	return filepath.Join(c.Home, "update-check.yaml")
+}
+
 // Validate checks that the configuration is valid.
 func (c *Config) Validate() error {
 	if c.Home == "" {

--- a/src/cli/internal/config/config_test.go
+++ b/src/cli/internal/config/config_test.go
@@ -98,6 +98,16 @@ func TestNew(t *testing.T) {
 	})
 }
 
+func TestUpdateCheckCachePath(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{Home: filepath.Join("some", "home")}
+	want := filepath.Join("some", "home", "update-check.yaml")
+	if got := cfg.UpdateCheckCachePath(); got != want {
+		t.Errorf("UpdateCheckCachePath() = %q, want %q", got, want)
+	}
+}
+
 func TestNewWithCustomHome(t *testing.T) {
 	t.Parallel()
 

--- a/src/cli/internal/install/update.go
+++ b/src/cli/internal/install/update.go
@@ -358,6 +358,15 @@ func IsNewerReleaseVersion(current, candidate string) bool {
 	return cand.preview > cur.preview
 }
 
+// IsReleaseVersion reports whether version parses as a studioctl release version
+// (for example "0.1.0-preview.15" or "studioctl/v0.1.0"). Development or unknown
+// builds such as "dev" return false, so callers can skip work that only makes
+// sense for a real release.
+func IsReleaseVersion(version string) bool {
+	_, ok := parseStudioctlTagVersion(toStudioctlTag(version))
+	return ok
+}
+
 // toStudioctlTag normalizes a bare or partially-prefixed version into the
 // "studioctl/vX.Y.Z" form expected by parseStudioctlTagVersion.
 func toStudioctlTag(version string) string {

--- a/src/cli/internal/install/update.go
+++ b/src/cli/internal/install/update.go
@@ -71,14 +71,16 @@ type resolvedUpdate struct {
 }
 
 type httpDownloader struct {
-	client  *http.Client
-	version config.Version
+	client   *http.Client
+	version  config.Version
+	maxPages int
 }
 
 func newHTTPDownloader(version config.Version) httpDownloader {
 	return httpDownloader{
-		version: version,
-		client:  &http.Client{Timeout: httpTimeout},
+		version:  version,
+		client:   &http.Client{Timeout: httpTimeout},
+		maxPages: releaseMaxPages,
 	}
 }
 
@@ -97,6 +99,35 @@ func (s *Service) ResolveUpdateVersion(ctx context.Context, opts UpdateOptions) 
 		if err != nil {
 			return "", err
 		}
+	}
+	return strings.TrimPrefix(version, "studioctl/"), nil
+}
+
+// LatestReleaseOptions tunes a newest-release lookup.
+type LatestReleaseOptions struct {
+	// Timeout bounds the total HTTP time for the lookup. Zero uses the default.
+	Timeout time.Duration
+	// MaxPages bounds how many GitHub release pages are scanned. Zero uses the default.
+	MaxPages int
+}
+
+// LatestStudioctlVersion resolves the newest available studioctl release version
+// from GitHub, returning it without the "studioctl/" prefix (for example
+// "v0.1.0-preview.15"). Unlike ResolveUpdateVersion it accepts tuning options so
+// lightweight callers such as the passive update notifier can keep the lookup
+// fast (fewer pages, a shorter timeout) instead of the full self-update scan.
+func (s *Service) LatestStudioctlVersion(ctx context.Context, opts LatestReleaseOptions) (string, error) {
+	downloads := newHTTPDownloader(s.cfg.Version)
+	if opts.Timeout > 0 {
+		downloads.client.Timeout = opts.Timeout
+	}
+	if opts.MaxPages > 0 {
+		downloads.maxPages = opts.MaxPages
+	}
+
+	version, err := downloads.resolveLatestStudioctlVersion(ctx, defaultUpdateRepo)
+	if err != nil {
+		return "", err
 	}
 	return strings.TrimPrefix(version, "studioctl/"), nil
 }
@@ -298,6 +329,46 @@ func comparePreviewVersion(a, b studioctlTagVersion) int {
 	return compareInt(a.preview, b.preview)
 }
 
+// IsNewerReleaseVersion reports whether candidate is a strictly newer studioctl
+// release than current. Both accept optional "studioctl/" and "v" prefixes (for
+// example "0.1.0-preview.0" or "v0.1.0-preview.15"). It returns false when either
+// version cannot be parsed, so unknown or development builds never trigger a
+// spurious "update available" signal.
+func IsNewerReleaseVersion(current, candidate string) bool {
+	cur, ok := parseStudioctlTagVersion(toStudioctlTag(current))
+	if !ok {
+		return false
+	}
+	cand, ok := parseStudioctlTagVersion(toStudioctlTag(candidate))
+	if !ok {
+		return false
+	}
+
+	if core := compareCoreVersion(cand, cur); core != 0 {
+		return core > 0
+	}
+	// Same core version: a stable release supersedes any preview of that core,
+	// and among previews the higher preview number wins.
+	if cand.isPreview != cur.isPreview {
+		return !cand.isPreview
+	}
+	if !cand.isPreview {
+		return false
+	}
+	return cand.preview > cur.preview
+}
+
+// toStudioctlTag normalizes a bare or partially-prefixed version into the
+// "studioctl/vX.Y.Z" form expected by parseStudioctlTagVersion.
+func toStudioctlTag(version string) string {
+	version = strings.TrimSpace(version)
+	version = strings.TrimPrefix(version, "studioctl/")
+	if !strings.HasPrefix(version, "v") {
+		version = "v" + version
+	}
+	return "studioctl/" + version
+}
+
 func compareInt(a, b int) int {
 	if a > b {
 		return 1
@@ -315,7 +386,7 @@ func (d httpDownloader) resolveLatestStudioctlVersionFromBase(
 ) (string, error) {
 	var candidates releaseCandidates
 
-	for page := 1; page <= releaseMaxPages; page++ {
+	for page := 1; page <= d.maxPages; page++ {
 		releases, err := d.fetchReleasesPage(ctx, repo, baseURL, page)
 		if err != nil {
 			return "", err

--- a/src/cli/internal/install/update_internal_test.go
+++ b/src/cli/internal/install/update_internal_test.go
@@ -182,3 +182,71 @@ func TestResolveLatestStudioctlVersion_Paginates(t *testing.T) {
 		t.Fatalf("expected at least 2 requests, got %d", requests)
 	}
 }
+
+func TestResolveLatestStudioctlVersion_MaxPagesBound(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			requests++
+			// Always return a full page so the scan never breaks early; the page
+			// budget is the only thing that stops pagination.
+			releases := make([]map[string]any, releasePageSize)
+			for i := range releases {
+				releases[i] = map[string]any{
+					"tag_name":   fmt.Sprintf("v2026.%d", i),
+					"draft":      false,
+					"prerelease": false,
+				}
+			}
+			if err := json.NewEncoder(w).Encode(releases); err != nil {
+				t.Fatalf("encode releases: %v", err)
+			}
+		}),
+	)
+	defer server.Close()
+
+	downloader := newHTTPDownloader(config.NewVersion("studioctl/v1.2.3"))
+	downloader.maxPages = 2
+	_, err := downloader.resolveLatestStudioctlVersionFromBase(
+		context.Background(),
+		"Altinn/altinn-studio",
+		server.URL+"/repos",
+	)
+	if !errors.Is(err, errStudioctlReleaseNotFound) {
+		t.Fatalf("resolveLatestStudioctlVersionFromBase() error = %v, want errStudioctlReleaseNotFound", err)
+	}
+	if requests != 2 {
+		t.Fatalf("expected exactly 2 requests with maxPages=2, got %d", requests)
+	}
+}
+
+func TestIsNewerReleaseVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		current   string
+		candidate string
+		want      bool
+	}{
+		{name: "newer patch", current: "v0.1.0", candidate: "v0.1.1", want: true},
+		{name: "newer preview", current: "v0.1.0-preview.14", candidate: "v0.1.0-preview.15", want: true},
+		{name: "stable over preview", current: "v0.1.0-preview.15", candidate: "v0.1.0", want: true},
+		{name: "bare current version", current: "0.1.0-preview.0", candidate: "v0.1.0-preview.15", want: true},
+		{name: "studioctl prefix accepted", current: "studioctl/v0.1.0", candidate: "studioctl/v0.2.0", want: true},
+		{name: "same version", current: "v0.1.0", candidate: "v0.1.0", want: false},
+		{name: "older candidate", current: "v0.2.0", candidate: "v0.1.0", want: false},
+		{name: "older preview candidate", current: "v0.1.0-preview.15", candidate: "v0.1.0-preview.14", want: false},
+		{name: "unparsable current", current: "dev", candidate: "v0.1.0", want: false},
+		{name: "unparsable candidate", current: "v0.1.0", candidate: "not-a-version", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsNewerReleaseVersion(tc.current, tc.candidate); got != tc.want {
+				t.Fatalf("IsNewerReleaseVersion(%q, %q) = %v, want %v", tc.current, tc.candidate, got, tc.want)
+			}
+		})
+	}
+}

--- a/src/cli/internal/install/update_internal_test.go
+++ b/src/cli/internal/install/update_internal_test.go
@@ -220,6 +220,31 @@ func TestResolveLatestStudioctlVersion_MaxPagesBound(t *testing.T) {
 	}
 }
 
+func TestIsReleaseVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		version string
+		want    bool
+	}{
+		{version: "0.1.0-preview.0", want: true},
+		{version: "v0.1.0", want: true},
+		{version: "studioctl/v0.1.0-preview.15", want: true},
+		{version: "dev", want: false},
+		{version: "", want: false},
+		{version: "not-a-version", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.version, func(t *testing.T) {
+			t.Parallel()
+			if got := IsReleaseVersion(tc.version); got != tc.want {
+				t.Fatalf("IsReleaseVersion(%q) = %v, want %v", tc.version, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestIsNewerReleaseVersion(t *testing.T) {
 	t.Parallel()
 

--- a/src/cli/internal/updatecheck/updatecheck.go
+++ b/src/cli/internal/updatecheck/updatecheck.go
@@ -23,8 +23,11 @@ const (
 	EnvDisable = "STUDIOCTL_NO_UPDATE_CHECK"
 
 	// defaultInterval is how long a cached result is trusted before the registry
-	// is queried again.
-	defaultInterval = 24 * time.Hour
+	// is queried again. It governs how quickly a new release is noticed, not how
+	// often the notice is shown (that happens on every command while a newer
+	// version is cached). A few hours picks up new releases same-day while
+	// staying far below GitHub's unauthenticated rate limit.
+	defaultInterval = 3 * time.Hour
 
 	// defaultTimeout bounds the registry lookup so a slow or unreachable network
 	// never noticeably delays the command that triggered the check.

--- a/src/cli/internal/updatecheck/updatecheck.go
+++ b/src/cli/internal/updatecheck/updatecheck.go
@@ -1,0 +1,193 @@
+// Package updatecheck implements a passive, cached check that notifies the user
+// when a newer studioctl release is available. It queries the release registry
+// at most once per interval and persists the result so ordinary invocations do
+// not pay any network cost.
+package updatecheck
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"altinn.studio/studioctl/internal/config"
+	"altinn.studio/studioctl/internal/install"
+	"altinn.studio/studioctl/internal/osutil"
+	"altinn.studio/studioctl/internal/ui"
+)
+
+const (
+	// EnvDisable disables the passive update check when set to a truthy value.
+	EnvDisable = "STUDIOCTL_NO_UPDATE_CHECK"
+
+	// defaultInterval is how long a cached result is trusted before the registry
+	// is queried again.
+	defaultInterval = 24 * time.Hour
+
+	// defaultTimeout bounds the registry lookup so a slow or unreachable network
+	// never noticeably delays the command that triggered the check.
+	defaultTimeout = 3 * time.Second
+
+	// defaultMaxPages keeps the release scan lightweight; the newest studioctl
+	// release is effectively always within the most recent releases page.
+	defaultMaxPages = 3
+)
+
+// versionResolver resolves the newest available studioctl release version.
+type versionResolver interface {
+	LatestStudioctlVersion(ctx context.Context, opts install.LatestReleaseOptions) (string, error)
+}
+
+// cache is the on-disk record of the last registry lookup.
+type cache struct {
+	LastCheck     time.Time `yaml:"lastCheck"`
+	LatestVersion string    `yaml:"latestVersion,omitempty"`
+}
+
+// Checker performs the cached update check and prints a notice when a newer
+// release is available.
+type Checker struct {
+	out        *ui.Output
+	resolver   versionResolver
+	now        func() time.Time
+	isTerminal func() bool
+	cachePath  string
+	current    string
+	interval   time.Duration
+	timeout    time.Duration
+	maxPages   int
+}
+
+// New builds a Checker from the resolved config and output writer.
+func New(cfg *config.Config, out *ui.Output) *Checker {
+	cachePath := ""
+	if cfg.Home != "" {
+		cachePath = cfg.UpdateCheckCachePath()
+	}
+
+	return &Checker{
+		out:        out,
+		resolver:   install.NewService(cfg),
+		now:        time.Now,
+		isTerminal: out.IsTerminal,
+		cachePath:  cachePath,
+		current:    cfg.Version.String(),
+		interval:   defaultInterval,
+		timeout:    defaultTimeout,
+		maxPages:   defaultMaxPages,
+	}
+}
+
+// Run performs the check and prints a notice when a newer release is available.
+// It is best-effort: any failure to reach the registry or persist the cache is
+// silent (surfaced only under verbose output) so it never disrupts the command
+// that triggered it.
+func (c *Checker) Run(ctx context.Context) {
+	if !c.enabled() || ctx.Err() != nil {
+		return
+	}
+
+	var current cache
+	loaded, err := c.load()
+	if err != nil {
+		c.out.Verbosef("update check: %v", err)
+	} else {
+		current = loaded
+	}
+
+	if c.due(current.LastCheck) {
+		current = c.refresh(ctx, current)
+	}
+
+	c.notify(current.LatestVersion)
+}
+
+// enabled reports whether the check should run in the current environment.
+func (c *Checker) enabled() bool {
+	switch {
+	case c.cachePath == "":
+		return false
+	case config.IsCI():
+		return false
+	case config.IsTruthyEnv(os.Getenv(EnvDisable)):
+		return false
+	case !c.isTerminal():
+		return false
+	default:
+		return true
+	}
+}
+
+// due reports whether the cached result is stale and should be refreshed.
+func (c *Checker) due(lastCheck time.Time) bool {
+	return c.now().Sub(lastCheck) >= c.interval
+}
+
+// refresh queries the registry and persists the result. On failure it still
+// records the attempt time (keeping the previously known version) so the check
+// does not query the registry again until the next interval.
+func (c *Checker) refresh(ctx context.Context, prior cache) cache {
+	fetchCtx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	latest, err := c.resolver.LatestStudioctlVersion(fetchCtx, install.LatestReleaseOptions{
+		Timeout:  c.timeout,
+		MaxPages: c.maxPages,
+	})
+
+	updated := prior
+	updated.LastCheck = c.now()
+	if err != nil {
+		c.out.Verbosef("update check: resolve latest version: %v", err)
+	} else if latest != "" {
+		updated.LatestVersion = latest
+	}
+
+	if saveErr := c.save(updated); saveErr != nil {
+		c.out.Verbosef("update check: %v", saveErr)
+	}
+	return updated
+}
+
+// notify prints the update notice when latest is a strictly newer release.
+func (c *Checker) notify(latest string) {
+	if latest == "" || !install.IsNewerReleaseVersion(c.current, latest) {
+		return
+	}
+
+	bin := osutil.CurrentBin()
+	c.out.Warning("")
+	c.out.Warninglnf("A new version of %s is available: %s -> %s", bin, c.current, latest)
+	c.out.Warninglnf("Run '%s self update' to upgrade.", bin)
+}
+
+// load reads the cache file, returning a zero cache when it does not exist.
+func (c *Checker) load() (cache, error) {
+	var cached cache
+
+	data, err := os.ReadFile(c.cachePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return cached, nil
+		}
+		return cached, fmt.Errorf("read update check cache: %w", err)
+	}
+	if err := yaml.Unmarshal(data, &cached); err != nil {
+		return cached, fmt.Errorf("parse update check cache: %w", err)
+	}
+	return cached, nil
+}
+
+// save writes the cache file.
+func (c *Checker) save(cached cache) error {
+	data, err := yaml.Marshal(cached)
+	if err != nil {
+		return fmt.Errorf("marshal update check cache: %w", err)
+	}
+	if err := os.WriteFile(c.cachePath, data, osutil.FilePermDefault); err != nil {
+		return fmt.Errorf("write update check cache: %w", err)
+	}
+	return nil
+}

--- a/src/cli/internal/updatecheck/updatecheck.go
+++ b/src/cli/internal/updatecheck/updatecheck.go
@@ -112,6 +112,10 @@ func (c *Checker) enabled() bool {
 	switch {
 	case c.cachePath == "":
 		return false
+	case !install.IsReleaseVersion(c.current):
+		// Development or unknown builds can never resolve to a newer release, so
+		// skip the registry lookup entirely rather than querying it for nothing.
+		return false
 	case config.IsCI():
 		return false
 	case config.IsTruthyEnv(os.Getenv(EnvDisable)):

--- a/src/cli/internal/updatecheck/updatecheck_internal_test.go
+++ b/src/cli/internal/updatecheck/updatecheck_internal_test.go
@@ -1,0 +1,271 @@
+package updatecheck
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"altinn.studio/studioctl/internal/config"
+	"altinn.studio/studioctl/internal/install"
+	"altinn.studio/studioctl/internal/ui"
+)
+
+var errFakeNetwork = errors.New("network down")
+
+type fakeResolver struct {
+	err     error
+	version string
+	calls   int
+}
+
+func (f *fakeResolver) LatestStudioctlVersion(
+	_ context.Context,
+	_ install.LatestReleaseOptions,
+) (string, error) {
+	f.calls++
+	return f.version, f.err
+}
+
+// enableEnv neutralizes ambient environment that would otherwise disable the
+// check (CI markers, an opt-out, or terminal color affecting output assertions).
+func enableEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv(config.EnvCI, "")
+	t.Setenv(EnvDisable, "")
+	t.Setenv("NO_COLOR", "1")
+}
+
+func newTestChecker(t *testing.T, resolver versionResolver, current string, now time.Time) (*Checker, *bytes.Buffer) {
+	t.Helper()
+	var errBuf bytes.Buffer
+	checker := &Checker{
+		out:        ui.NewOutput(io.Discard, &errBuf, false),
+		resolver:   resolver,
+		now:        func() time.Time { return now },
+		isTerminal: func() bool { return true },
+		cachePath:  filepath.Join(t.TempDir(), "update-check.yaml"),
+		current:    current,
+		interval:   defaultInterval,
+		timeout:    defaultTimeout,
+		maxPages:   defaultMaxPages,
+	}
+	return checker, &errBuf
+}
+
+func writeCache(t *testing.T, path string, cached cache) {
+	t.Helper()
+	data, err := yaml.Marshal(cached)
+	if err != nil {
+		t.Fatalf("marshal cache: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write cache: %v", err)
+	}
+}
+
+func readCache(t *testing.T, path string) cache {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read cache: %v", err)
+	}
+	var cached cache
+	if err := yaml.Unmarshal(data, &cached); err != nil {
+		t.Fatalf("unmarshal cache: %v", err)
+	}
+	return cached
+}
+
+func TestRun_StaleCacheNotifiesAndPersists(t *testing.T) {
+	enableEnv(t)
+	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	resolver := &fakeResolver{version: "v0.2.0"}
+	checker, errBuf := newTestChecker(t, resolver, "v0.1.0", now)
+
+	checker.Run(context.Background())
+
+	if resolver.calls != 1 {
+		t.Fatalf("resolver calls = %d, want 1", resolver.calls)
+	}
+	out := errBuf.String()
+	if !strings.Contains(out, "v0.2.0") || !strings.Contains(out, "self update") {
+		t.Fatalf("notice missing expected content: %q", out)
+	}
+
+	saved := readCache(t, checker.cachePath)
+	if saved.LatestVersion != "v0.2.0" {
+		t.Fatalf("saved LatestVersion = %q, want v0.2.0", saved.LatestVersion)
+	}
+	if !saved.LastCheck.Equal(now) {
+		t.Fatalf("saved LastCheck = %v, want %v", saved.LastCheck, now)
+	}
+}
+
+func TestRun_FreshCacheSkipsNetwork(t *testing.T) {
+	enableEnv(t)
+	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	resolver := &fakeResolver{version: "v9.9.9"}
+	checker, errBuf := newTestChecker(t, resolver, "v0.1.0", now)
+	writeCache(t, checker.cachePath, cache{LastCheck: now.Add(-time.Hour), LatestVersion: "v0.2.0"})
+
+	checker.Run(context.Background())
+
+	if resolver.calls != 0 {
+		t.Fatalf("resolver calls = %d, want 0 (cache still fresh)", resolver.calls)
+	}
+	if out := errBuf.String(); !strings.Contains(out, "v0.2.0") {
+		t.Fatalf("expected notice for cached version, got %q", out)
+	}
+}
+
+func TestRun_FreshCacheSameVersionNoNotice(t *testing.T) {
+	enableEnv(t)
+	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	resolver := &fakeResolver{}
+	checker, errBuf := newTestChecker(t, resolver, "v0.2.0", now)
+	writeCache(t, checker.cachePath, cache{LastCheck: now.Add(-time.Hour), LatestVersion: "v0.2.0"})
+
+	checker.Run(context.Background())
+
+	if resolver.calls != 0 {
+		t.Fatalf("resolver calls = %d, want 0", resolver.calls)
+	}
+	if out := errBuf.String(); out != "" {
+		t.Fatalf("expected no notice, got %q", out)
+	}
+}
+
+func TestRun_ResolverErrorKeepsPriorVersion(t *testing.T) {
+	enableEnv(t)
+	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	resolver := &fakeResolver{err: errFakeNetwork}
+	checker, errBuf := newTestChecker(t, resolver, "v0.1.0", now)
+	writeCache(t, checker.cachePath, cache{LastCheck: now.Add(-48 * time.Hour), LatestVersion: "v0.2.0"})
+
+	checker.Run(context.Background())
+
+	if resolver.calls != 1 {
+		t.Fatalf("resolver calls = %d, want 1", resolver.calls)
+	}
+	if out := errBuf.String(); !strings.Contains(out, "v0.2.0") {
+		t.Fatalf("expected notice using prior version, got %q", out)
+	}
+	saved := readCache(t, checker.cachePath)
+	if saved.LatestVersion != "v0.2.0" {
+		t.Fatalf("saved LatestVersion = %q, want prior v0.2.0 preserved", saved.LatestVersion)
+	}
+	if !saved.LastCheck.Equal(now) {
+		t.Fatalf("saved LastCheck = %v, want bumped to %v", saved.LastCheck, now)
+	}
+}
+
+func TestRun_Disabled(t *testing.T) {
+	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		prepare func(t *testing.T, c *Checker)
+		name    string
+	}{
+		{
+			name: "opt-out env",
+			prepare: func(t *testing.T, _ *Checker) {
+				t.Helper()
+				t.Setenv(config.EnvCI, "")
+				t.Setenv(EnvDisable, "1")
+			},
+		},
+		{
+			name: "ci",
+			prepare: func(t *testing.T, _ *Checker) {
+				t.Helper()
+				t.Setenv(EnvDisable, "")
+				t.Setenv(config.EnvCI, "true")
+			},
+		},
+		{
+			name: "not a terminal",
+			prepare: func(t *testing.T, c *Checker) {
+				t.Helper()
+				t.Setenv(config.EnvCI, "")
+				t.Setenv(EnvDisable, "")
+				c.isTerminal = func() bool { return false }
+			},
+		},
+		{
+			name: "no cache path",
+			prepare: func(t *testing.T, c *Checker) {
+				t.Helper()
+				t.Setenv(config.EnvCI, "")
+				t.Setenv(EnvDisable, "")
+				c.cachePath = ""
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resolver := &fakeResolver{version: "v0.2.0"}
+			checker, errBuf := newTestChecker(t, resolver, "v0.1.0", now)
+			tc.prepare(t, checker)
+
+			checker.Run(context.Background())
+
+			if resolver.calls != 0 {
+				t.Fatalf("resolver calls = %d, want 0", resolver.calls)
+			}
+			if out := errBuf.String(); out != "" {
+				t.Fatalf("expected no notice, got %q", out)
+			}
+		})
+	}
+}
+
+func TestRun_CancelledContext(t *testing.T) {
+	enableEnv(t)
+	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	resolver := &fakeResolver{version: "v0.2.0"}
+	checker, errBuf := newTestChecker(t, resolver, "v0.1.0", now)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	checker.Run(ctx)
+
+	if resolver.calls != 0 {
+		t.Fatalf("resolver calls = %d, want 0", resolver.calls)
+	}
+	if out := errBuf.String(); out != "" {
+		t.Fatalf("expected no notice, got %q", out)
+	}
+}
+
+func TestNew_EmptyHomeDisablesCache(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{Version: config.NewVersion("studioctl/v0.1.0")}
+	checker := New(cfg, ui.NewOutput(io.Discard, io.Discard, false))
+	if checker.cachePath != "" {
+		t.Fatalf("cachePath = %q, want empty for unset home", checker.cachePath)
+	}
+	if checker.enabled() {
+		t.Fatalf("expected checker to be disabled with empty cache path")
+	}
+}
+
+func TestNew_UsesConfigCachePath(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{
+		Home:    filepath.Join("some", "home"),
+		Version: config.NewVersion("studioctl/v0.1.0"),
+	}
+	checker := New(cfg, ui.NewOutput(io.Discard, io.Discard, false))
+	if want := cfg.UpdateCheckCachePath(); checker.cachePath != want {
+		t.Fatalf("cachePath = %q, want %q", checker.cachePath, want)
+	}
+}

--- a/src/cli/internal/updatecheck/updatecheck_internal_test.go
+++ b/src/cli/internal/updatecheck/updatecheck_internal_test.go
@@ -208,6 +208,15 @@ func TestRun_Disabled(t *testing.T) {
 				c.cachePath = ""
 			},
 		},
+		{
+			name: "development build",
+			prepare: func(t *testing.T, c *Checker) {
+				t.Helper()
+				t.Setenv(config.EnvCI, "")
+				t.Setenv(EnvDisable, "")
+				c.current = "dev"
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

Adds a passive **update notifier** to `studioctl`: after any command runs, it prints a hint when a newer release is available. The result is cached so the release registry is queried **at most once every few hours** — ordinary invocations pay no network cost.

```
A new version of studioctl is available: 0.1.0-preview.15 -> v0.1.0-preview.16
Run 'studioctl self update' to upgrade.
```

## How it works

- **Hook**: `(*CLI).Run` invokes the checker after the command (regardless of the command's outcome), skipping the `self` command so it doesn't interfere with a self update/uninstall.
- **Cache**: `~/<studioctl home>/update-check.yaml` stores `lastCheck` + `latestVersion`. When fresh the notice is served from cache with no network call; when stale it refreshes within the same invocation, bounded by a short timeout and a small page budget. The interval governs how quickly a new release is *noticed*, not how often the notice is *shown* (that happens on every command while a newer version is cached).
- **Registry**: reuses the existing GitHub-releases client in `internal/install`. A new `Service.LatestStudioctlVersion` exposes a lightweight, tunable lookup, and an exported `IsNewerReleaseVersion` performs correct version comparison (a stable release supersedes its own preview series).
- **Best-effort**: any registry or cache-write failure is silent (surfaced only under `-v`) and still records the attempt time, so a slow/offline network never disrupts the command or triggers repeated lookups. Comfortably within GitHub's unauthenticated rate limit.

## When it stays quiet

- In CI (`CI` env)
- Non-interactive output (stdout not a terminal — protects piped/JSON output)
- The `self` command
- `STUDIOCTL_NO_UPDATE_CHECK=1`
- Unknown/`dev` builds (never parse to a comparable version)

## Testing

- Unit tests for `updatecheck.Checker` (stale/fresh cache, resolver error preserving prior version, all disable paths, cancelled context, cache path wiring), `install.IsNewerReleaseVersion`, the page-budget bound, and `config.UpdateCheckCachePath`.
- `make build`, `make lint`, `make fmt`, `make test` all pass.
- Verified end-to-end against the real GitHub registry under a PTY: notice on stale + fresh cache, cache written correctly, and correctly silent for opt-out / already-current / non-TTY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `studioctl` now notifies you when a newer release is available during interactive runs, using a cached, rate-limited check (skipped in CI and when running `studioctl self`). You can disable it with `STUDIOCTL_NO_UPDATE_CHECK=1`, and the notice includes a hint to run `studioctl self update`.
* **Bug Fixes**
  * Improved release version detection across stable and preview builds, while bounding release lookups to avoid excessive searching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->