### PR TITLE
chore: extend Go cluster dependency Renovate policy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,24 +35,26 @@
       "groupSlug": "{{manager}}-minor-patch"
     },
     {
-      "description": "Group Kubernetes and Flux runtime Go dependency patches so related release trains move together",
+      "description": "Group Kubernetes, Flux, and cluster tooling Go dependency patches so related release trains move together",
       "matchManagers": ["gomod"],
       "matchPackageNames": [
         "/^k8s\\.io\\//",
-        "/^sigs\\.k8s\\.io\\/(controller-runtime|gateway-api)$/",
-        "/^github\\.com\\/fluxcd\\/(flux2\\/v2|.*-controller\\/api)$/"
+        "/^sigs\\.k8s\\.io\\/(controller-runtime|gateway-api|kind)$/",
+        "/^sigs\\.k8s\\.io\\/(kustomize|structured-merge-diff)\\//",
+        "/^github\\.com\\/fluxcd\\/(flux2\\/v2|.*-controller\\/api|pkg\\/.*)$/"
       ],
       "matchUpdateTypes": ["patch"],
-      "groupName": "Kubernetes and Flux runtime Go dependency patches",
+      "groupName": "Kubernetes, Flux, and cluster tooling Go dependency patches",
       "groupSlug": "k8s-flux-runtime-go-patches"
     },
     {
-      "description": "Kubernetes and Flux runtime Go dependency minor/major updates are done manually after checking target cluster compatibility",
+      "description": "Kubernetes, Flux, and cluster tooling Go dependency minor/major updates are done manually after checking target cluster compatibility",
       "matchManagers": ["gomod"],
       "matchPackageNames": [
         "/^k8s\\.io\\//",
-        "/^sigs\\.k8s\\.io\\/(controller-runtime|gateway-api)$/",
-        "/^github\\.com\\/fluxcd\\/(flux2\\/v2|.*-controller\\/api)$/"
+        "/^sigs\\.k8s\\.io\\/(controller-runtime|gateway-api|kind)$/",
+        "/^sigs\\.k8s\\.io\\/(kustomize|structured-merge-diff)\\//",
+        "/^github\\.com\\/fluxcd\\/(flux2\\/v2|.*-controller\\/api|pkg\\/.*)$/"
       ],
       "matchUpdateTypes": ["minor", "major"],
       "enabled": false


### PR DESCRIPTION
## Description

@martinothamar extends the Renovate policy for Go cluster/runtime dependency updates.

The previous rules grouped Kubernetes and Flux patch updates and disabled Kubernetes/Flux minor/major updates, but they only matched:

- `k8s.io/*`
- `sigs.k8s.io/controller-runtime`
- `sigs.k8s.io/gateway-api`
- `github.com/fluxcd/flux2/v2`
- `github.com/fluxcd/*-controller/api`

This leaves several coordinated cluster-adjacent dependency families to the generic `gomod non-major dependencies` rule, including `github.com/fluxcd/pkg/*`, `sigs.k8s.io/kind`, `sigs.k8s.io/kustomize/*`, and `sigs.k8s.io/structured-merge-diff/*`.

This PR adds those families to the same policy:

- patch updates are grouped with the Kubernetes/Flux runtime Go dependency patch PR
- minor/major updates are disabled for Renovate and should be done manually after checking cluster compatibility

No Go module versions are changed in this PR.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (not applicable: Renovate config-only change)

Commands run:

```text
jq empty renovate.json
git diff --check
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded grouped update rules for Go dependencies so more Kubernetes, Flux, and cluster tooling packages are included together.
  * Improved naming and descriptions for patch updates, making dependency update groups clearer and more consistent.
  * Broadened the matching rules for manual review of non-patch updates across the same dependency families.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->