### PR TITLE
chore: update Go gRPC dependencies

### DIFF
--- a/src/Runtime/gateway/test/go.mod
+++ b/src/Runtime/gateway/test/go.mod
@@ -72,6 +72,7 @@ require (
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/go-containerregistry v0.20.7 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect

--- a/src/Runtime/gateway/test/go.sum
+++ b/src/Runtime/gateway/test/go.sum
@@ -188,8 +188,8 @@ github.com/gorilla/handlers v1.5.2 h1:cLTUSsNkgcwhgRqvCNmdbRWG0A3N4F+M2nWKdScwyE
 github.com/gorilla/handlers v1.5.2/go.mod h1:dX+xVpaxdSw+q0Qek8SSsl3dfMk3jNddUkMzo0GtH0w=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz+PMpZ14Jynv3O2Zs=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/golang-lru/arc/v2 v2.0.5 h1:l2zaLDubNhW4XO3LnliVj0GXO3+/CGNJAg1dcN2Fpfw=


### PR DESCRIPTION
## What

Updates the retained Go gRPC ecosystem dependency in the gateway test module:

- `github.com/grpc-ecosystem/grpc-gateway/v2` -> `v2.29.0`

Affected module:

- `src/Runtime/gateway/test`

## Why

Continuing the Go dependency update stack, one focused dependency family at a time. `grpc-gateway/v2 v2.29.0` is the latest stable tag reported by Go module metadata.

I also checked these gRPC ecosystem packages where they appeared in module graphs:

- `github.com/grpc-ecosystem/go-grpc-middleware`
- `github.com/grpc-ecosystem/go-grpc-middleware/v2`
- `github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus`

Those were not retained by `go mod tidy`; `go mod why -m` reports the gateway test module does not need them. I did not force direct/explicit requirements just to move non-package-needed build-list entries.

@martinothamar

## Safety notes

The cluster-sensitive packages stayed pinned during this update:

- `k8s.io/api`, `k8s.io/apimachinery`, `k8s.io/client-go` remain `v0.35.6`
- `sigs.k8s.io/controller-runtime` remains `v0.23.3`

No preview/alpha/beta/rc versions were selected.

## Testing

Commands run:

```bash
cd src/Runtime/gateway && make test lint && git diff --check
```

Results:

- Gateway has no unit tests yet.
- .NET lint/build passed with existing `Microsoft.OpenApi` NU1903 warnings.
- Go lint reported `0 issues`.
- `git diff --check` passed.

## Reviewer subagent summary

No blocking issues found.

Reviewer assessment:

- The retained diff only updates `github.com/grpc-ecosystem/grpc-gateway/v2` from `v2.28.0` to `v2.29.0` in `src/Runtime/gateway/test`.
- `v2.29.0` is a stable release, with no alpha/beta/rc tag involved.
- Not forcing `go-grpc-middleware`, `go-grpc-middleware/v2`, or `providers/prometheus` is appropriate because `go mod why -m` reports the gateway test module does not need them and `go mod tidy` does not retain explicit requirements.
- Kubernetes modules remain at `v0.35.6`, `sigs.k8s.io/controller-runtime` remains at `v0.23.3`, and checked Flux/Helm packages were not moved.

Non-blocking reviewer audit note: `grpc-gateway/v2@v2.29.0` brings two stable upstream build-list modules, `github.com/antihax/optional v1.0.0` and `github.com/rogpeppe/fastuuid v1.2.0`; `go mod why` says neither is package-needed by the main module.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the test environment’s dependency list to include a new indirect library version.
  * No changes to public features or user-facing behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->