### PR TITLE
test: wait for operator secret consistency

### DIFF
--- a/src/Runtime/operator/test/e2e/snapshot_helpers.go
+++ b/src/Runtime/operator/test/e2e/snapshot_helpers.go
@@ -68,29 +68,6 @@ func parseKeyIndex(keyId string) (int, error) {
 	return index, nil
 }
 
-// CaptureConsistency records initial values from the first successful reconciliation.
-func CaptureConsistency(client *resourcesv1alpha1.MaskinportenClient, secret *corev1.Secret) {
-	if consistencyState != nil || client == nil {
-		return // Already captured or no client
-	}
-	if client.Status.ClientId == "" {
-		return // Not yet reconciled
-	}
-
-	maxIdx := -1
-	for _, keyId := range client.Status.KeyIds {
-		if idx, err := parseKeyIndex(keyId); err == nil && idx > maxIdx {
-			maxIdx = idx
-		}
-	}
-
-	consistencyState = &ConsistencyState{
-		ClientID:    client.Status.ClientId,
-		KeyIDs:      client.Status.KeyIds,
-		MaxKeyIndex: maxIdx,
-	}
-}
-
 // AssertConsistency verifies key rotation invariants:
 // - ClientID never changes
 // - Max 2 keys (newest + previous)
@@ -102,27 +79,59 @@ func AssertConsistency(client *resourcesv1alpha1.MaskinportenClient, secret *cor
 }
 
 func CheckConsistency(client *resourcesv1alpha1.MaskinportenClient, secret *corev1.Secret) error {
-	if consistencyState == nil || client == nil {
+	if client == nil {
 		return nil // Nothing to verify
 	}
 
-	newMaxIdx, err := checkClientConsistency(client)
+	state := consistencyState
+	if state == nil {
+		candidate, ready, err := newConsistencyState(client)
+		if err != nil {
+			return err
+		}
+		if !ready {
+			return nil // Not yet reconciled
+		}
+		state = candidate
+	}
+
+	newMaxIdx, err := checkClientConsistency(state, client)
 	if err != nil {
 		return err
 	}
-	if err := checkSecretConsistency(client, secret); err != nil {
+	if err := checkSecretConsistency(state, client, secret); err != nil {
 		return err
 	}
 
+	if consistencyState == nil {
+		consistencyState = state
+	}
 	consistencyState.KeyIDs = client.Status.KeyIds
 	consistencyState.MaxKeyIndex = newMaxIdx
 	return nil
 }
 
-func checkClientConsistency(client *resourcesv1alpha1.MaskinportenClient) (int, error) {
-	if client.Status.ClientId != consistencyState.ClientID {
+func newConsistencyState(client *resourcesv1alpha1.MaskinportenClient) (*ConsistencyState, bool, error) {
+	if client.Status.ClientId == "" {
+		return nil, false, nil
+	}
+
+	indices, err := keyIndices(client.Status.KeyIds)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return &ConsistencyState{
+		ClientID:    client.Status.ClientId,
+		KeyIDs:      client.Status.KeyIds,
+		MaxKeyIndex: maxKeyIndex(indices),
+	}, true, nil
+}
+
+func checkClientConsistency(state *ConsistencyState, client *resourcesv1alpha1.MaskinportenClient) (int, error) {
+	if client.Status.ClientId != state.ClientID {
 		return 0, fmt.Errorf("%w: got %q want %q",
-			errConsistencyClientIDChanged, client.Status.ClientId, consistencyState.ClientID)
+			errConsistencyClientIDChanged, client.Status.ClientId, state.ClientID)
 	}
 	if len(client.Status.KeyIds) > 2 {
 		return 0, fmt.Errorf("%w: got %d", errConsistencyTooManyKeys, len(client.Status.KeyIds))
@@ -132,35 +141,35 @@ func checkClientConsistency(client *resourcesv1alpha1.MaskinportenClient) (int, 
 	if err != nil {
 		return 0, err
 	}
-	if err := checkKeyContinuity(client.Status.KeyIds, currentIndices); err != nil {
+	if err := checkKeyContinuity(state, client.Status.KeyIds, currentIndices); err != nil {
 		return 0, err
 	}
-	return updatedMaxKeyIndex(currentIndices), nil
+	return updatedMaxKeyIndex(state, currentIndices), nil
 }
 
-func checkKeyContinuity(keyIDs []string, indices []int) error {
-	if len(consistencyState.KeyIDs) == 0 {
+func checkKeyContinuity(state *ConsistencyState, keyIDs []string, indices []int) error {
+	if len(state.KeyIDs) == 0 {
 		return nil
 	}
 	if len(keyIDs) == 0 {
-		return fmt.Errorf("%w: got empty want to retain %v", errConsistencyKeyRetention, consistencyState.KeyIDs)
+		return fmt.Errorf("%w: got empty want to retain %v", errConsistencyKeyRetention, state.KeyIDs)
 	}
 
 	newestIndex := indices[0]
-	if newestIndex < consistencyState.MaxKeyIndex {
+	if newestIndex < state.MaxKeyIndex {
 		return fmt.Errorf("%w: got newest %d want at least %d",
-			errConsistencyKeyRegression, newestIndex, consistencyState.MaxKeyIndex)
+			errConsistencyKeyRegression, newestIndex, state.MaxKeyIndex)
 	}
-	if newestIndex == consistencyState.MaxKeyIndex {
-		if !sameStringSlice(keyIDs, consistencyState.KeyIDs) {
-			return fmt.Errorf("%w: got %v want %v", errConsistencyKeyRetention, keyIDs, consistencyState.KeyIDs)
+	if newestIndex == state.MaxKeyIndex {
+		if !sameStringSlice(keyIDs, state.KeyIDs) {
+			return fmt.Errorf("%w: got %v want %v", errConsistencyKeyRetention, keyIDs, state.KeyIDs)
 		}
 		return nil
 	}
 
-	if len(keyIDs) < 2 || keyIDs[1] != consistencyState.KeyIDs[0] {
+	if len(keyIDs) < 2 || keyIDs[1] != state.KeyIDs[0] {
 		return fmt.Errorf("%w: got %v want previous newest %q",
-			errConsistencyKeyRetention, keyIDs, consistencyState.KeyIDs[0])
+			errConsistencyKeyRetention, keyIDs, state.KeyIDs[0])
 	}
 	return nil
 }
@@ -183,17 +192,31 @@ func keyIndices(keyIDs []string) ([]int, error) {
 	return currentIndices, nil
 }
 
-func updatedMaxKeyIndex(currentIndices []int) int {
-	newMaxIdx := consistencyState.MaxKeyIndex
+func updatedMaxKeyIndex(state *ConsistencyState, currentIndices []int) int {
+	newMaxIdx := state.MaxKeyIndex
 	for _, idx := range currentIndices {
-		if idx > consistencyState.MaxKeyIndex && idx > newMaxIdx {
+		if idx > state.MaxKeyIndex && idx > newMaxIdx {
 			newMaxIdx = idx
 		}
 	}
 	return newMaxIdx
 }
 
-func checkSecretConsistency(client *resourcesv1alpha1.MaskinportenClient, secret *corev1.Secret) error {
+func maxKeyIndex(indices []int) int {
+	maxIdx := -1
+	for _, idx := range indices {
+		if idx > maxIdx {
+			maxIdx = idx
+		}
+	}
+	return maxIdx
+}
+
+func checkSecretConsistency(
+	state *ConsistencyState,
+	client *resourcesv1alpha1.MaskinportenClient,
+	secret *corev1.Secret,
+) error {
 	if secret == nil || secret.Data == nil {
 		return nil
 	}
@@ -209,7 +232,7 @@ func checkSecretConsistency(client *resourcesv1alpha1.MaskinportenClient, secret
 	}
 
 	settings = unwrapMaskinportenSettings(settings)
-	if err := checkSecretClientID(settings); err != nil {
+	if err := checkSecretClientID(state, settings); err != nil {
 		return err
 	}
 	return checkSecretKeyIDs(settings, client.Status.KeyIds)
@@ -222,16 +245,16 @@ func unwrapMaskinportenSettings(settings map[string]any) map[string]any {
 	return settings
 }
 
-func checkSecretClientID(settings map[string]any) error {
+func checkSecretClientID(state *ConsistencyState, settings map[string]any) error {
 	secretClientID, ok := settings["ClientId"].(string)
 	if !ok || secretClientID == "" {
 		return fmt.Errorf("%w: missing ClientId want %q",
-			errConsistencySecretClientID, consistencyState.ClientID)
+			errConsistencySecretClientID, state.ClientID)
 	}
 
-	if secretClientID != consistencyState.ClientID {
+	if secretClientID != state.ClientID {
 		return fmt.Errorf("%w: got %q want %q",
-			errConsistencySecretClientID, secretClientID, consistencyState.ClientID)
+			errConsistencySecretClientID, secretClientID, state.ClientID)
 	}
 	return nil
 }
@@ -239,17 +262,11 @@ func checkSecretClientID(settings map[string]any) error {
 func checkSecretKeyIDs(settings map[string]any, expected []string) error {
 	jwks, ok := settings["Jwks"].(map[string]any)
 	if !ok {
-		if len(expected) == 0 {
-			return nil
-		}
 		return fmt.Errorf("%w: missing Jwks.keys want %v", errConsistencySecretKeyIDs, expected)
 	}
 
 	keys, ok := jwks["keys"].([]any)
 	if !ok {
-		if len(expected) == 0 {
-			return nil
-		}
 		return fmt.Errorf("%w: missing Jwks.keys want %v", errConsistencySecretKeyIDs, expected)
 	}
 
@@ -769,11 +786,8 @@ func EventuallyWithSnapshot(
 		if err := condition(client, secret); err != nil {
 			return err
 		}
-		CaptureConsistency(lastClient, lastSecret)
 		return CheckConsistency(lastClient, lastSecret)
 	}, timeout, interval).Should(gomega.Succeed())
-
-	CaptureConsistency(lastClient, lastSecret)
 
 	AssertConsistency(lastClient, lastSecret)
 

--- a/src/Runtime/operator/test/e2e/snapshot_helpers.go
+++ b/src/Runtime/operator/test/e2e/snapshot_helpers.go
@@ -35,6 +35,8 @@ var errNoPodsFound = errors.New("no pods found for label")
 var errConsistencyClientIDChanged = errors.New("clientId changed unexpectedly - client may have been recreated")
 var errConsistencyTooManyKeys = errors.New("expected at most 2 keys")
 var errConsistencyKeyOrder = errors.New("keys not ordered from newest to oldest")
+var errConsistencyKeyRegression = errors.New("key index regressed")
+var errConsistencyKeyRetention = errors.New("previous key was not retained")
 var errConsistencySecretJSON = errors.New("decode secret maskinporten settings")
 var errConsistencySecretClientID = errors.New("secret clientId doesn't match CR clientId")
 var errConsistencySecretKeyIDs = errors.New("secret keyIds don't match CR keyIds")
@@ -130,7 +132,37 @@ func checkClientConsistency(client *resourcesv1alpha1.MaskinportenClient) (int, 
 	if err != nil {
 		return 0, err
 	}
+	if err := checkKeyContinuity(client.Status.KeyIds, currentIndices); err != nil {
+		return 0, err
+	}
 	return updatedMaxKeyIndex(currentIndices), nil
+}
+
+func checkKeyContinuity(keyIDs []string, indices []int) error {
+	if len(consistencyState.KeyIDs) == 0 {
+		return nil
+	}
+	if len(keyIDs) == 0 {
+		return fmt.Errorf("%w: got empty want to retain %v", errConsistencyKeyRetention, consistencyState.KeyIDs)
+	}
+
+	newestIndex := indices[0]
+	if newestIndex < consistencyState.MaxKeyIndex {
+		return fmt.Errorf("%w: got newest %d want at least %d",
+			errConsistencyKeyRegression, newestIndex, consistencyState.MaxKeyIndex)
+	}
+	if newestIndex == consistencyState.MaxKeyIndex {
+		if !sameStringSlice(keyIDs, consistencyState.KeyIDs) {
+			return fmt.Errorf("%w: got %v want %v", errConsistencyKeyRetention, keyIDs, consistencyState.KeyIDs)
+		}
+		return nil
+	}
+
+	if len(keyIDs) < 2 || keyIDs[1] != consistencyState.KeyIDs[0] {
+		return fmt.Errorf("%w: got %v want previous newest %q",
+			errConsistencyKeyRetention, keyIDs, consistencyState.KeyIDs[0])
+	}
+	return nil
 }
 
 func keyIndices(keyIDs []string) ([]int, error) {
@@ -192,8 +224,9 @@ func unwrapMaskinportenSettings(settings map[string]any) map[string]any {
 
 func checkSecretClientID(settings map[string]any) error {
 	secretClientID, ok := settings["ClientId"].(string)
-	if !ok {
-		return nil
+	if !ok || secretClientID == "" {
+		return fmt.Errorf("%w: missing ClientId want %q",
+			errConsistencySecretClientID, consistencyState.ClientID)
 	}
 
 	if secretClientID != consistencyState.ClientID {
@@ -206,12 +239,18 @@ func checkSecretClientID(settings map[string]any) error {
 func checkSecretKeyIDs(settings map[string]any, expected []string) error {
 	jwks, ok := settings["Jwks"].(map[string]any)
 	if !ok {
-		return nil
+		if len(expected) == 0 {
+			return nil
+		}
+		return fmt.Errorf("%w: missing Jwks.keys want %v", errConsistencySecretKeyIDs, expected)
 	}
 
 	keys, ok := jwks["keys"].([]any)
 	if !ok {
-		return nil
+		if len(expected) == 0 {
+			return nil
+		}
+		return fmt.Errorf("%w: missing Jwks.keys want %v", errConsistencySecretKeyIDs, expected)
 	}
 
 	secretKeyIDs := make([]string, 0, len(keys))
@@ -244,6 +283,18 @@ func sameStringMultiset(actual []string, expected []string) bool {
 	for _, value := range actual {
 		counts[value]--
 		if counts[value] < 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func sameStringSlice(actual []string, expected []string) bool {
+	if len(actual) != len(expected) {
+		return false
+	}
+	for i, value := range actual {
+		if value != expected[i] {
 			return false
 		}
 	}

--- a/src/Runtime/operator/test/e2e/snapshot_helpers.go
+++ b/src/Runtime/operator/test/e2e/snapshot_helpers.go
@@ -32,6 +32,12 @@ var errInvalidKeyIDFormat = errors.New("invalid key ID format")
 var errFakesDBStatus = errors.New("fakes db returned unexpected status")
 var errFakesResetStatus = errors.New("fakes reset returned unexpected status")
 var errNoPodsFound = errors.New("no pods found for label")
+var errConsistencyClientIDChanged = errors.New("clientId changed unexpectedly - client may have been recreated")
+var errConsistencyTooManyKeys = errors.New("expected at most 2 keys")
+var errConsistencyKeyOrder = errors.New("keys not ordered from newest to oldest")
+var errConsistencySecretJSON = errors.New("decode secret maskinporten settings")
+var errConsistencySecretClientID = errors.New("secret clientId doesn't match CR clientId")
+var errConsistencySecretKeyIDs = errors.New("secret keyIds don't match CR keyIds")
 
 // ConsistencyState tracks values that should remain consistent across test steps.
 type ConsistencyState struct {
@@ -90,40 +96,59 @@ func CaptureConsistency(client *resourcesv1alpha1.MaskinportenClient, secret *co
 // - New keys have higher index suffix than previous max
 // - Secret matches CR state.
 func AssertConsistency(client *resourcesv1alpha1.MaskinportenClient, secret *corev1.Secret) {
+	gomega.Expect(CheckConsistency(client, secret)).To(gomega.Succeed())
+}
+
+func CheckConsistency(client *resourcesv1alpha1.MaskinportenClient, secret *corev1.Secret) error {
 	if consistencyState == nil || client == nil {
-		return // Nothing to verify
+		return nil // Nothing to verify
 	}
 
-	assertClientConsistency(client)
-	currentIndices := keyIndices(client.Status.KeyIds)
-	newMaxIdx := updatedMaxKeyIndex(currentIndices)
+	newMaxIdx, err := checkClientConsistency(client)
+	if err != nil {
+		return err
+	}
+	if err := checkSecretConsistency(client, secret); err != nil {
+		return err
+	}
+
 	consistencyState.KeyIDs = client.Status.KeyIds
 	consistencyState.MaxKeyIndex = newMaxIdx
-
-	assertSecretConsistency(client, secret)
+	return nil
 }
 
-func assertClientConsistency(client *resourcesv1alpha1.MaskinportenClient) {
-	gomega.Expect(client.Status.ClientId).To(gomega.Equal(consistencyState.ClientID),
-		"clientId changed unexpectedly - client may have been recreated")
-	gomega.Expect(len(client.Status.KeyIds)).To(gomega.BeNumerically("<=", 2),
-		"expected at most 2 keys, got %d", len(client.Status.KeyIds))
+func checkClientConsistency(client *resourcesv1alpha1.MaskinportenClient) (int, error) {
+	if client.Status.ClientId != consistencyState.ClientID {
+		return 0, fmt.Errorf("%w: got %q want %q",
+			errConsistencyClientIDChanged, client.Status.ClientId, consistencyState.ClientID)
+	}
+	if len(client.Status.KeyIds) > 2 {
+		return 0, fmt.Errorf("%w: got %d", errConsistencyTooManyKeys, len(client.Status.KeyIds))
+	}
+
+	currentIndices, err := keyIndices(client.Status.KeyIds)
+	if err != nil {
+		return 0, err
+	}
+	return updatedMaxKeyIndex(currentIndices), nil
 }
 
-func keyIndices(keyIDs []string) []int {
+func keyIndices(keyIDs []string) ([]int, error) {
 	currentIndices := make([]int, 0, len(keyIDs))
 	for _, keyID := range keyIDs {
 		idx, err := parseKeyIndex(keyID)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
-			"failed to parse key index from "+keyID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse key index from %s: %w", keyID, err)
+		}
 		currentIndices = append(currentIndices, idx)
 	}
 	for i := 1; i < len(currentIndices); i++ {
-		gomega.Expect(currentIndices[i]).To(gomega.BeNumerically("<", currentIndices[i-1]),
-			"keys not ordered from newest to oldest: index %d should be < %d",
-			currentIndices[i], currentIndices[i-1])
+		if currentIndices[i] >= currentIndices[i-1] {
+			return nil, fmt.Errorf("%w: index %d should be < %d",
+				errConsistencyKeyOrder, currentIndices[i], currentIndices[i-1])
+		}
 	}
-	return currentIndices
+	return currentIndices, nil
 }
 
 func updatedMaxKeyIndex(currentIndices []int) int {
@@ -136,24 +161,26 @@ func updatedMaxKeyIndex(currentIndices []int) int {
 	return newMaxIdx
 }
 
-func assertSecretConsistency(client *resourcesv1alpha1.MaskinportenClient, secret *corev1.Secret) {
+func checkSecretConsistency(client *resourcesv1alpha1.MaskinportenClient, secret *corev1.Secret) error {
 	if secret == nil || secret.Data == nil {
-		return
+		return nil
 	}
 
 	settingsJSON, ok := secret.Data["maskinporten-settings.json"]
 	if !ok {
-		return
+		return nil
 	}
 
 	var settings map[string]any
-	if json.Unmarshal(settingsJSON, &settings) != nil {
-		return
+	if jsonErr := json.Unmarshal(settingsJSON, &settings); jsonErr != nil {
+		return fmt.Errorf("%w: %w", errConsistencySecretJSON, jsonErr)
 	}
 
 	settings = unwrapMaskinportenSettings(settings)
-	assertSecretClientID(settings)
-	assertSecretKeyIDs(settings, client.Status.KeyIds)
+	if err := checkSecretClientID(settings); err != nil {
+		return err
+	}
+	return checkSecretKeyIDs(settings, client.Status.KeyIds)
 }
 
 func unwrapMaskinportenSettings(settings map[string]any) map[string]any {
@@ -163,25 +190,28 @@ func unwrapMaskinportenSettings(settings map[string]any) map[string]any {
 	return settings
 }
 
-func assertSecretClientID(settings map[string]any) {
+func checkSecretClientID(settings map[string]any) error {
 	secretClientID, ok := settings["ClientId"].(string)
 	if !ok {
-		return
+		return nil
 	}
 
-	gomega.Expect(secretClientID).To(gomega.Equal(consistencyState.ClientID),
-		"Secret clientId doesn't match CR clientId")
+	if secretClientID != consistencyState.ClientID {
+		return fmt.Errorf("%w: got %q want %q",
+			errConsistencySecretClientID, secretClientID, consistencyState.ClientID)
+	}
+	return nil
 }
 
-func assertSecretKeyIDs(settings map[string]any, expected []string) {
+func checkSecretKeyIDs(settings map[string]any, expected []string) error {
 	jwks, ok := settings["Jwks"].(map[string]any)
 	if !ok {
-		return
+		return nil
 	}
 
 	keys, ok := jwks["keys"].([]any)
 	if !ok {
-		return
+		return nil
 	}
 
 	secretKeyIDs := make([]string, 0, len(keys))
@@ -196,8 +226,28 @@ func assertSecretKeyIDs(settings map[string]any, expected []string) {
 		}
 	}
 
-	gomega.Expect(secretKeyIDs).To(gomega.ConsistOf(expected),
-		"Secret keyIds don't match CR keyIds")
+	if !sameStringMultiset(secretKeyIDs, expected) {
+		return fmt.Errorf("%w: got %v want %v", errConsistencySecretKeyIDs, secretKeyIDs, expected)
+	}
+	return nil
+}
+
+func sameStringMultiset(actual []string, expected []string) bool {
+	if len(actual) != len(expected) {
+		return false
+	}
+
+	counts := make(map[string]int, len(expected))
+	for _, value := range expected {
+		counts[value]++
+	}
+	for _, value := range actual {
+		counts[value]--
+		if counts[value] < 0 {
+			return false
+		}
+	}
+	return true
 }
 
 // marshalJSONNoEscape marshals JSON without escaping HTML characters like < and >.
@@ -665,7 +715,11 @@ func EventuallyWithSnapshot(
 		}
 		lastClient = client
 		lastSecret = secret
-		return condition(client, secret)
+		if err := condition(client, secret); err != nil {
+			return err
+		}
+		CaptureConsistency(lastClient, lastSecret)
+		return CheckConsistency(lastClient, lastSecret)
 	}, timeout, interval).Should(gomega.Succeed())
 
 	CaptureConsistency(lastClient, lastSecret)


### PR DESCRIPTION
## What

Stabilizes the operator Maskinporten e2e snapshot helper so CR/Secret consistency checks participate in the existing `EventuallyWithSnapshot` retry loop.

The helper now:

- Converts the existing consistency assertions into an error-returning `CheckConsistency` path.
- Runs `CheckConsistency` after the normal poll condition succeeds.
- Keeps the final `AssertConsistency` after polling as a guard.
- Rejects key regressions, dropped retained keys, and non-rotation key-set changes before advancing `consistencyState`.
- Treats missing/empty `ClientId` and missing/wrongly typed `Jwks.keys` inside an existing `maskinporten-settings.json` as not-yet-consistent.
- Creates the initial consistency baseline locally and assigns the global baseline only after client and Secret consistency checks pass.

## Why

The Go x/tools dependency PR exposed a pre-existing e2e race in `controller Operator should handle manual JWK rotation via annotation`.

The failing run observed a transient state where the MaskinportenClient CR status had moved to the new key set while the Secret still contained the previous key set. Controller logs showed the next reconcile completed immediately after the assertion timestamp.

Before this change, the helper checked consistency only after `Eventually` had already succeeded, using immediate Gomega assertions. That made a transient convergence mismatch fail the spec before another poll could observe the final reconciled state.

This is split from the dependency PR so the test stabilization can merge first.

@martinothamar

## Testing

Commands run:

```bash
cd src/Runtime/operator && make lint test
cd src/Runtime/operator/test && go run ./cmd/tester test-e2e
git diff --check
```

Results:

- Operator main and test module lint passed with `0 issues`.
- Operator envtest-backed unit tests passed.
- Operator e2e passed: 21/21 specs, including the Maskinporten manual JWK rotation and second rotation specs.
- `git diff --check` passed.

Local note: the e2e kind fixture needs host port 80. I temporarily stopped the existing local `studio-loadbalancer`, ran the e2e suite, and restarted `studio-loadbalancer` afterward.

After CodeRabbit review, I pushed `bcd00de1fb` and reran the same verification successfully.

After follow-up subagent review, I pushed `5fd4303237` and reran the same verification successfully:

- `cd src/Runtime/operator && make lint test` passed.
- `cd src/Runtime/operator/test && go run ./cmd/tester test-e2e` passed 21/21.
- `git diff --check` passed.

## Reviewer subagent summary

Initial subagent review:

- No actionable findings.
- The race fix is correct: consistency now runs after the normal condition succeeds and returns mismatches as polling errors, so a stale Secret/updated CR pair keeps `Eventually` running instead of failing immediately.
- The change is appropriately scoped as a standalone test stabilization; it touches only `src/Runtime/operator/test/e2e/snapshot_helpers.go`.

CodeRabbit follow-up handled:

- Added key continuity checks so stale/subset/regressed key sets cannot overwrite the baseline.
- Made missing/empty `ClientId` and missing/wrongly typed `Jwks.keys` inside existing settings JSON retry instead of passing early.

Follow-up subagent review:

- Found and fixed that initial baseline capture still happened before full Secret consistency was proven.
- Found and fixed too-broad `len(expected) == 0` exemptions for existing settings JSON with missing/wrongly typed `Jwks.keys`.
- Final re-check found no actionable findings. The reviewer confirmed `CheckConsistency` now validates with a local candidate state and only mutates `consistencyState` after checks pass, and that existing settings JSON with missing inner fields returns errors.
- Residual risk: missing `maskinporten-settings.json` is still intentionally treated as “nothing to verify”, matching the existing initial-state behavior.
