### PR TITLE
fix: restore textarea aria-label when rendered in tables

### DIFF
--- a/app-libs/form-component/src/layout-components/TextArea/TextAreaLayout.stories.tsx
+++ b/app-libs/form-component/src/layout-components/TextArea/TextAreaLayout.stories.tsx
@@ -27,6 +27,7 @@ export const TEXT_AREA_PROP_CATEGORIES = {
   onChange: 'runtime',
   onBlur: 'runtime',
   error: 'runtime',
+  ariaLabel: 'runtime',
   validationMessages: 'runtime',
 } satisfies PropCategories<TextAreaLayoutProps>;
 

--- a/app-libs/form-component/src/layout-components/TextArea/TextAreaLayout.test.tsx
+++ b/app-libs/form-component/src/layout-components/TextArea/TextAreaLayout.test.tsx
@@ -55,6 +55,11 @@ describe('TextAreaLayout', () => {
     expect(screen.queryByText('My Label')).not.toBeInTheDocument();
   });
 
+  it('uses ariaLabel as the accessible name when no visible label is rendered', () => {
+    render({ ariaLabel: 'My hidden label' });
+    expect(screen.getByRole('textbox', { name: 'My hidden label' })).toBeInTheDocument();
+  });
+
   it('renders a description when provided', () => {
     render(
       { title: 'my.label', description: 'my.desc' },

--- a/app-libs/form-component/src/layout-components/TextArea/TextAreaLayout.tsx
+++ b/app-libs/form-component/src/layout-components/TextArea/TextAreaLayout.tsx
@@ -29,6 +29,8 @@ export interface TextAreaLayoutProps {
   autoComplete?: string;
   /** Text-resource key for the label. */
   title?: string;
+  /** Accessible name for the textarea when no visible label is rendered (e.g. in tables). */
+  ariaLabel?: string;
   /** Text-resource key for the description. */
   description?: string;
   /** Text-resource key for the help text. */
@@ -56,6 +58,7 @@ export function TextAreaLayout({
   maxLength,
   autoComplete,
   title,
+  ariaLabel,
   description,
   help,
   showOptionalMarking,
@@ -105,6 +108,7 @@ export function TextAreaLayout({
           error={error}
           characterLimit={!readOnly ? characterLimit : undefined}
           dataTestId={componentId}
+          ariaLabel={ariaLabel}
           ariaDescribedBy={ariaDescribedBy}
           autoComplete={autoComplete}
           style={{ minHeight: '150px', height: '150px', width: '100%' }}

--- a/src/App/frontend/src/layout/TextArea/TextAreaComponent.tsx
+++ b/src/App/frontend/src/layout/TextArea/TextAreaComponent.tsx
@@ -4,6 +4,7 @@ import { TextAreaLayout } from '@app/form-component';
 
 import { FormStore } from 'src/features/form/FormContext';
 import { useDataModelBindings } from 'src/features/formData/useDataModelBindings';
+import { useLanguage } from 'src/features/language/useLanguage';
 import { AllComponentValidations } from 'src/features/validation/ComponentValidations';
 import { useIsValid } from 'src/features/validation/selectors/isValid';
 import { useComponentStructureData } from 'src/utils/layout/useComponentStructureData';
@@ -14,10 +15,9 @@ import type { PropsFromGenericComponent } from 'src/layout';
 export type ITextAreaProps = Readonly<PropsFromGenericComponent<'TextArea'>>;
 
 export function TextAreaComponent({ baseComponentId, overrideDisplay }: ITextAreaProps) {
-  const { readOnly, dataModelBindings, saveWhileTyping, autocomplete, maxLength, grid } = useItemWhenType(
-    baseComponentId,
-    'TextArea',
-  );
+  const { langAsString } = useLanguage();
+  const { readOnly, dataModelBindings, saveWhileTyping, autocomplete, maxLength, grid, textResourceBindings } =
+    useItemWhenType(baseComponentId, 'TextArea');
 
   const { setValue, formData } = useDataModelBindings(dataModelBindings, saveWhileTyping);
   const debounce = FormStore.data.useDebounceImmediately();
@@ -41,6 +41,11 @@ export function TextAreaComponent({ baseComponentId, overrideDisplay }: ITextAre
       maxLength={maxLength}
       autoComplete={autocomplete}
       title={title}
+      ariaLabel={
+        overrideDisplay?.renderedInTable === true && textResourceBindings?.title
+          ? langAsString(textResourceBindings.title)
+          : undefined
+      }
       help={help}
       description={description}
       showOptionalMarking={showOptionalMarking}


### PR DESCRIPTION
## Description

The TextArea lib migration (#19375) dropped the `renderedInTable` aria-label wiring. `useLabelData` (correctly) suppresses the visible label when a component renders inside a table/Grid, but nothing reinstates the title as an accessible name — leaving the `<textarea>` with no label at all.

This fails axe's critical `label` rule ("Form elements must have labels") and has been breaking the `component-library/grid.ts` Cypress spec (`Grid summary test — Shows Summary2 of Grid correctly`) on every merge-ref CI run since the refactor landed.

### Fix

- `TextAreaLayout` gains an `ariaLabel` prop, passed through to the inner `TextArea` app-component (which already supported it).
- `TextAreaComponent` restores the pre-refactor behavior: when `overrideDisplay.renderedInTable === true` and a title binding exists, the resolved title is passed as `aria-label`.
- Unit test added for the accessible-name passthrough.

### Verification

- `TextAreaLayout` vitest suite: 19/19 passing.
- `component-library/grid.ts` e2e against localtest: 2/2 passing with this fix (failed consistently without it).

Extracted from #19426 for visibility, since this affects every open PR's Cypress runs.

## Related Issue(s)

- Regression from #19375

## Verification

- [x] **Your code builds clean without any errors or warnings**
- [x] **Manual testing done (required)**
- [x] **Relevant automated test added (if you find this hard, leave it and we'll help out)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved textarea accessibility by allowing an accessible name to be set when no visible label is shown.
  * Textareas displayed in table contexts can now use a translated title as their accessible label.
* **Tests**
  * Added coverage to verify the textarea falls back to the provided accessible label when no visible label is rendered.
* **Documentation**
  * Updated Storybook prop categories to include `ariaLabel`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->