### PR TITLE
test: add unit tests for the studioctl v8-to-v9 upgrade migrators

### DIFF
--- a/src/cli/Directory.Packages.props
+++ b/src/cli/Directory.Packages.props
@@ -21,5 +21,8 @@
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="18.4.0" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.4.0" />
     <PackageVersion Include="Microsoft.NET.StringTools" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 </Project>

--- a/src/cli/Makefile
+++ b/src/cli/Makefile
@@ -34,6 +34,7 @@ build: ## Build studioctl binary
 .PHONY: test
 test: ## Run unit tests
 	go test -race -count=1 ./...
+	dotnet test studioctl-server-tests -v m
 
 .PHONY: test-e2e
 test-e2e: ## Run e2e tests

--- a/src/cli/studioctl-server-tests/Studioctl.Tests.csproj
+++ b/src/cli/studioctl-server-tests/Studioctl.Tests.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Studioctl.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <!-- MSBuild assemblies must not be deployed next to the app (they are provided by
+       Microsoft.Build.Locator at run time); mirror the referencing pattern of the server project
+       to satisfy the MSBL001 guard on the transitive references. -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.StringTools" ExcludeAssets="runtime" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../studioctl-server/studioctl-server.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Upgrade/v8Tov9/TestData/**" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>

--- a/src/cli/studioctl-server-tests/Upgrade/v8Tov9/ApplicationMetadataPdfRewriterTests.cs
+++ b/src/cli/studioctl-server-tests/Upgrade/v8Tov9/ApplicationMetadataPdfRewriterTests.cs
@@ -90,6 +90,28 @@ public sealed class ApplicationMetadataPdfRewriterTests : IDisposable
     }
 
     [Fact]
+    public async Task FlagWithUnexpectedCasing_IsStripped()
+    {
+        // v8 binds the flag via Newtonsoft (case-insensitive), so an odd-cased "EnablePdfCreation"
+        // was live under v8 and must be removed, not left behind.
+        var json = """
+            {
+              "dataTypes": [
+                {
+                  "id": "model",
+                  "EnablePdfCreation": true
+                }
+              ]
+            }
+            """.ReplaceLineEndings("\n");
+
+        var (_, after) = await Strip(json);
+
+        Assert.DoesNotContain("EnablePdfCreation", after, StringComparison.OrdinalIgnoreCase);
+        using var _ = JsonDocument.Parse(after); // still valid JSON
+    }
+
+    [Fact]
     public async Task FileWithoutTheFlag_IsUntouched()
     {
         var json = """

--- a/src/cli/studioctl-server-tests/Upgrade/v8Tov9/ApplicationMetadataPdfRewriterTests.cs
+++ b/src/cli/studioctl-server-tests/Upgrade/v8Tov9/ApplicationMetadataPdfRewriterTests.cs
@@ -1,0 +1,139 @@
+using System.Text.Json;
+using Altinn.Studio.Cli.Upgrade.v8Tov9.PdfServiceTaskMigration;
+
+namespace Studioctl.Tests.Upgrade.v8Tov9;
+
+public sealed class ApplicationMetadataPdfRewriterTests : IDisposable
+{
+    private readonly TempAppFolder _app = new();
+
+    public void Dispose() => _app.Dispose();
+
+    private async Task<(ApplicationMetadataPdfRewriter Rewriter, string After)> Strip(string json)
+    {
+        var file = _app.Write("config/applicationmetadata.json", json);
+        var rewriter = new ApplicationMetadataPdfRewriter(file);
+        await rewriter.StripEnablePdfCreation();
+        return (rewriter, _app.Read("config/applicationmetadata.json"));
+    }
+
+    [Fact]
+    public async Task LastPropertyInObject_CommaOnPreviousLineIsRemoved()
+    {
+        // Raw string literals inherit the source file's line endings (CRLF on Windows checkouts),
+        // so normalize to LF to match the "\n" assertion below on every platform.
+        var json = """
+            {
+              "dataTypes": [
+                {
+                  "id": "model",
+                  "enablePdfCreation": true
+                }
+              ]
+            }
+            """.ReplaceLineEndings("\n");
+
+        var (_, after) = await Strip(json);
+
+        Assert.DoesNotContain("enablePdfCreation", after, StringComparison.Ordinal);
+        using var _ = JsonDocument.Parse(after); // still valid JSON
+        Assert.Contains("\"id\": \"model\"\n", after, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CrlfFile_CommaRemovalPreservesLineEndings()
+    {
+        var json = "{\r\n  \"id\": \"ttd/myapp\",\r\n  \"enablePdfCreation\": true\r\n}\r\n";
+
+        var (_, after) = await Strip(json);
+
+        Assert.DoesNotContain("enablePdfCreation", after, StringComparison.Ordinal);
+        Assert.Contains("\"id\": \"ttd/myapp\"\r\n", after, StringComparison.Ordinal);
+        using var _ = JsonDocument.Parse(after);
+    }
+
+    [Fact]
+    public async Task LineWithOtherContent_IsLeftInPlaceWithWarning()
+    {
+        // Compact formatting: removing the whole line would take "maxCount" with it, so the property
+        // must be left for manual removal.
+        var json = """
+            {
+              "dataTypes": [
+                { "id": "model", "enablePdfCreation": true, "maxCount": 1 }
+              ]
+            }
+            """;
+
+        var (rewriter, after) = await Strip(json);
+
+        Assert.Contains("enablePdfCreation", after, StringComparison.Ordinal);
+        Assert.Contains("maxCount", after, StringComparison.Ordinal);
+        Assert.Contains(rewriter.GetWarnings(), w => w.Contains("unexpected formatting", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task PropertyInsideStringValue_IsNotStripped()
+    {
+        var json = """
+            {
+              "title": { "nb": "\"enablePdfCreation\": true" },
+              "enablePdfCreation": false
+            }
+            """;
+
+        var (_, after) = await Strip(json);
+
+        Assert.Contains("\"nb\": \"\\\"enablePdfCreation\\\": true\"", after, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"enablePdfCreation\": false", after, StringComparison.Ordinal);
+        using var _ = JsonDocument.Parse(after);
+    }
+
+    [Fact]
+    public async Task FileWithoutTheFlag_IsUntouched()
+    {
+        var json = """
+            {
+              "id": "ttd/myapp"
+            }
+            """;
+
+        var (rewriter, after) = await Strip(json);
+
+        Assert.Equal(json, after);
+        Assert.Empty(rewriter.GetWarnings());
+    }
+
+    [Fact]
+    public async Task BomIsPreservedThroughStrip_AndAbsenceStaysAbsent()
+    {
+        var json = "{\n  \"id\": \"ttd/myapp\",\n  \"enablePdfCreation\": true\n}\n";
+        var file = _app.WriteBytes(
+            "config/applicationmetadata.json",
+            [0xEF, 0xBB, 0xBF, .. System.Text.Encoding.UTF8.GetBytes(json)]
+        );
+
+        await new ApplicationMetadataPdfRewriter(file).StripEnablePdfCreation();
+
+        Assert.True(
+            _app.ReadBytes("config/applicationmetadata.json") is [0xEF, 0xBB, 0xBF, ..],
+            "expected the UTF-8 BOM to be preserved"
+        );
+        Assert.DoesNotContain(
+            "enablePdfCreation",
+            _app.Read("config/applicationmetadata.json"),
+            StringComparison.Ordinal
+        );
+
+        // And the inverse: a BOM-less file must not gain one.
+        using var second = new TempAppFolder();
+        var secondFile = second.Write("config/applicationmetadata.json", json);
+
+        await new ApplicationMetadataPdfRewriter(secondFile).StripEnablePdfCreation();
+
+        Assert.False(
+            second.ReadBytes("config/applicationmetadata.json") is [0xEF, 0xBB, 0xBF, ..],
+            "expected no UTF-8 BOM to be introduced"
+        );
+    }
+}

--- a/src/cli/studioctl-server-tests/Upgrade/v8Tov9/BpmnBuilder.cs
+++ b/src/cli/studioctl-server-tests/Upgrade/v8Tov9/BpmnBuilder.cs
@@ -30,6 +30,18 @@ internal static class BpmnBuilder
                 </bpmn:task>
             """;
 
+    /// <summary>A pdf service task as the migrator emits it (serviceTask carrying taskType `pdf`).</summary>
+    public static string PdfServiceTask(string id) =>
+        $"""
+                <bpmn:serviceTask id="{id}" name="Generate PDF">
+                  <bpmn:extensionElements>
+                    <altinn:taskExtension>
+                      <altinn:taskType>pdf</altinn:taskType>
+                    </altinn:taskExtension>
+                  </bpmn:extensionElements>
+                </bpmn:serviceTask>
+            """;
+
     public static string StartEvent(string id) => $"    <bpmn:startEvent id=\"{id}\" />";
 
     public static string EndEvent(string id) => $"    <bpmn:endEvent id=\"{id}\" />";

--- a/src/cli/studioctl-server-tests/Upgrade/v8Tov9/BpmnBuilder.cs
+++ b/src/cli/studioctl-server-tests/Upgrade/v8Tov9/BpmnBuilder.cs
@@ -1,0 +1,84 @@
+namespace Studioctl.Tests.Upgrade.v8Tov9;
+
+/// <summary>
+/// Composable builders for process.bpmn fixtures matching the structure Altinn Studio generates.
+/// </summary>
+internal static class BpmnBuilder
+{
+    public static string Process(params string[] elements) =>
+        """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:altinn="http://altinn.no/process" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+              <bpmn:process id="Process_1" isExecutable="false">
+            """
+        + "\n"
+        + string.Join("\n", elements)
+        + "\n"
+        + """
+              </bpmn:process>
+            </bpmn:definitions>
+            """;
+
+    public static string Task(string id, string taskType) =>
+        $"""
+                <bpmn:task id="{id}" name="{id}">
+                  <bpmn:extensionElements>
+                    <altinn:taskExtension>
+                      <altinn:taskType>{taskType}</altinn:taskType>
+                    </altinn:taskExtension>
+                  </bpmn:extensionElements>
+                </bpmn:task>
+            """;
+
+    public static string StartEvent(string id) => $"    <bpmn:startEvent id=\"{id}\" />";
+
+    public static string EndEvent(string id) => $"    <bpmn:endEvent id=\"{id}\" />";
+
+    public static string Gateway(string id) => $"    <bpmn:exclusiveGateway id=\"{id}\" />";
+
+    public static string Flow(string id, string sourceRef, string targetRef) =>
+        $"    <bpmn:sequenceFlow id=\"{id}\" sourceRef=\"{sourceRef}\" targetRef=\"{targetRef}\" />";
+
+    public static string ConditionalFlow(string id, string sourceRef, string targetRef, string expression) =>
+        $"""
+                <bpmn:sequenceFlow id="{id}" sourceRef="{sourceRef}" targetRef="{targetRef}">
+                  <bpmn:conditionExpression>{expression}</bpmn:conditionExpression>
+                </bpmn:sequenceFlow>
+            """;
+
+    public static string Metadata(params string[] dataTypes) =>
+        """
+            {
+              "id": "ttd/myapp",
+              "org": "ttd",
+              "dataTypes": [
+            """
+        + "\n"
+        + string.Join(",\n", dataTypes)
+        + "\n"
+        + """
+              ]
+            }
+            """;
+
+    public static string FormDataType(string id, string taskId, bool enablePdfCreation) =>
+        $$"""
+                {
+                  "id": "{{id}}",
+                  "taskId": "{{taskId}}",
+                  "enablePdfCreation": {{(enablePdfCreation ? "true" : "false")}},
+                  "appLogic": {
+                    "classRef": "Altinn.App.Models.{{id}}"
+                  }
+                }
+            """;
+
+    public static string AttachmentDataType(string id, bool enablePdfCreation) =>
+        $$"""
+                {
+                  "id": "{{id}}",
+                  "enablePdfCreation": {{(enablePdfCreation ? "true" : "false")}},
+                  "maxCount": 1
+                }
+            """;
+}

--- a/src/cli/studioctl-server-tests/Upgrade/v8Tov9/PdfServiceTaskMigratorTests.cs
+++ b/src/cli/studioctl-server-tests/Upgrade/v8Tov9/PdfServiceTaskMigratorTests.cs
@@ -465,4 +465,102 @@ public sealed class PdfServiceTaskMigratorTests : IDisposable
             StringComparison.Ordinal
         );
     }
+
+    [Fact]
+    public async Task TaskIdRefersToNonTaskElement_IsSkippedAndFlagKept()
+    {
+        // A stale/colliding taskId that names a gateway (or event) rather than a task must not have a
+        // pdf service task spliced after it - that would move PDF generation to a wrong point. The
+        // gateway has a single outgoing flow, so without the type guard it would have been rewritten.
+        _app.Write(
+            "config/applicationmetadata.json",
+            Metadata(FormDataType("model", "Gateway_1", enablePdfCreation: true))
+        );
+        var bpmn = Process(
+            Task("Task_1", "data"),
+            Gateway("Gateway_1"),
+            Flow("Flow_to_gw", "Task_1", "Gateway_1"),
+            Flow("Flow_end", "Gateway_1", "EndEvent_1"),
+            EndEvent("EndEvent_1")
+        );
+        _app.Write("config/process/process.bpmn", bpmn);
+
+        var warnings = await Migrate();
+
+        Assert.Null(ElementById(ProcessAfter(), "PdfTask_Gateway_1"));
+        Assert.Equal(bpmn, _app.Read("config/process/process.bpmn"));
+        Assert.Contains(warnings, w => w.Contains("not a task", StringComparison.Ordinal));
+        Assert.Contains("enablePdfCreation", _app.Read("config/applicationmetadata.json"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MalformedMetadataJson_IsRefused_NothingTouched()
+    {
+        // Invalid JSON must produce an actionable warning, not an unhandled exception (which would
+        // abort the whole upgrade run).
+        var metadata = "{ \"dataTypes\": [ }";
+        _app.Write("config/applicationmetadata.json", metadata);
+        _app.Write(
+            "config/process/process.bpmn",
+            Process(Task("Task_1", "data"), Flow("Flow_end", "Task_1", "EndEvent_1"), EndEvent("EndEvent_1"))
+        );
+
+        var warnings = await Migrate();
+
+        Assert.Contains(warnings, w => w.Contains("not valid JSON", StringComparison.Ordinal));
+        Assert.Equal(metadata, _app.Read("config/applicationmetadata.json"));
+    }
+
+    [Fact]
+    public async Task MalformedProcessXml_IsRefused_FlagKept()
+    {
+        // Invalid BPMN XML must produce an actionable warning and leave the flag in place, not throw.
+        _app.Write(
+            "config/applicationmetadata.json",
+            Metadata(FormDataType("model", "Task_1", enablePdfCreation: true))
+        );
+        var bpmn = "<root><child></root>";
+        _app.Write("config/process/process.bpmn", bpmn);
+
+        var warnings = await Migrate();
+
+        Assert.Contains(warnings, w => w.Contains("not valid XML", StringComparison.Ordinal));
+        Assert.Equal(bpmn, _app.Read("config/process/process.bpmn"));
+        Assert.Contains("enablePdfCreation", _app.Read("config/applicationmetadata.json"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task FlagWithUnexpectedCasing_IsDetectedAndMigrated()
+    {
+        // v8 binds applicationmetadata.json with Newtonsoft (case-insensitive), so a hand-edited
+        // "EnablePdfCreation" generated PDFs under v8 and must be migrated, not silently ignored.
+        _app.Write(
+            "config/applicationmetadata.json",
+            Metadata(
+                """
+                    {
+                      "id": "model",
+                      "taskId": "Task_1",
+                      "EnablePdfCreation": true,
+                      "appLogic": {
+                        "classRef": "Altinn.App.Models.model"
+                      }
+                    }
+                """
+            )
+        );
+        _app.Write(
+            "config/process/process.bpmn",
+            Process(Task("Task_1", "data"), Flow("Flow_end", "Task_1", "EndEvent_1"), EndEvent("EndEvent_1"))
+        );
+
+        await Migrate();
+
+        Assert.NotNull(ElementById(ProcessAfter(), "PdfTask_Task_1"));
+        Assert.DoesNotContain(
+            "enablePdfCreation",
+            _app.Read("config/applicationmetadata.json"),
+            StringComparison.OrdinalIgnoreCase
+        );
+    }
 }

--- a/src/cli/studioctl-server-tests/Upgrade/v8Tov9/PdfServiceTaskMigratorTests.cs
+++ b/src/cli/studioctl-server-tests/Upgrade/v8Tov9/PdfServiceTaskMigratorTests.cs
@@ -635,6 +635,26 @@ public sealed class PdfServiceTaskMigratorTests : IDisposable
     }
 
     [Fact]
+    public async Task DefaultTemplateMetadata_NeedsNoPdfMigration()
+    {
+        // A freshly-scaffolded app's applicationmetadata.json has no enablePdfCreation, so the
+        // migrator must do nothing and leave the file byte-for-byte untouched. The fixture is a
+        // verbatim copy of src/App/template/src/App/config/applicationmetadata.json; its [ORG]/[APP]
+        // placeholders are valid JSON string values and irrelevant to this migrator.
+        var metadata = await File.ReadAllTextAsync(
+            Path.Combine(AppContext.BaseDirectory, "Upgrade/v8Tov9/TestData/template-appmetadata.json"),
+            TestContext.Current.CancellationToken
+        );
+        _app.Write("config/applicationmetadata.json", metadata);
+
+        var result = await MigrateResult();
+
+        Assert.Empty(result.Warnings);
+        Assert.False(result.ManualActionRequired);
+        Assert.Equal(metadata, _app.Read("config/applicationmetadata.json"));
+    }
+
+    [Fact]
     public async Task FlagWithUnexpectedCasing_IsDetectedAndMigrated()
     {
         // v8 binds applicationmetadata.json with Newtonsoft (case-insensitive), so a hand-edited

--- a/src/cli/studioctl-server-tests/Upgrade/v8Tov9/PdfServiceTaskMigratorTests.cs
+++ b/src/cli/studioctl-server-tests/Upgrade/v8Tov9/PdfServiceTaskMigratorTests.cs
@@ -1,0 +1,468 @@
+using System.Xml.Linq;
+using Altinn.Studio.Cli.Upgrade.v8Tov9.PdfServiceTaskMigration;
+using static Studioctl.Tests.Upgrade.v8Tov9.BpmnBuilder;
+
+namespace Studioctl.Tests.Upgrade.v8Tov9;
+
+public sealed class PdfServiceTaskMigratorTests : IDisposable
+{
+    private readonly TempAppFolder _app = new();
+
+    public void Dispose() => _app.Dispose();
+
+    private async Task<IReadOnlyList<string>> Migrate() => await new PdfServiceTaskMigrator(_app.Root).Migrate();
+
+    private XElement ProcessAfter()
+    {
+        var doc = XDocument.Parse(_app.Read("config/process/process.bpmn"));
+        var root = doc.Root ?? throw new InvalidOperationException("process.bpmn has no root element");
+        return root.Elements().Single(e => e.Name.LocalName == "process");
+    }
+
+    private static XElement? ElementById(XElement process, string id) =>
+        process.Elements().FirstOrDefault(e => e.Attribute("id")?.Value == id);
+
+    [Fact]
+    public async Task PdfEnabledFormData_GetsPdfServiceTaskAndFlagStripped()
+    {
+        _app.Write(
+            "config/applicationmetadata.json",
+            Metadata(FormDataType("model", "Task_1", enablePdfCreation: true), AttachmentDataType("file", false))
+        );
+        _app.Write(
+            "config/process/process.bpmn",
+            Process(
+                StartEvent("StartEvent_1"),
+                Task("Task_1", "data"),
+                EndEvent("EndEvent_1"),
+                Flow("Flow_start", "StartEvent_1", "Task_1"),
+                Flow("Flow_end", "Task_1", "EndEvent_1")
+            )
+        );
+
+        await Migrate();
+
+        var process = ProcessAfter();
+
+        // T --flow--> PdfTask_T --newFlow--> X
+        var pdfTask = ElementById(process, "PdfTask_Task_1");
+        Assert.NotNull(pdfTask);
+        Assert.Equal("serviceTask", pdfTask.Name.LocalName);
+        Assert.Equal("pdf", pdfTask.Descendants().Single(e => e.Name.LocalName == "taskType").Value);
+        Assert.Equal("Task_1", pdfTask.Descendants().Single(e => e.Name.LocalName == "taskId").Value);
+
+        Assert.Equal("PdfTask_Task_1", ElementById(process, "Flow_end")?.Attribute("targetRef")?.Value);
+        var newFlow = ElementById(process, "Flow_PdfTask_Task_1_to_EndEvent_1");
+        Assert.Equal("EndEvent_1", newFlow?.Attribute("targetRef")?.Value);
+
+        Assert.DoesNotContain(
+            "enablePdfCreation",
+            _app.Read("config/applicationmetadata.json"),
+            StringComparison.Ordinal
+        );
+    }
+
+    [Fact]
+    public async Task AttachmentAndTaskLessDataTypes_WereLegacyNoOps_GetNoPdfTask()
+    {
+        // enablePdfCreation on an attachment (no classRef) or without a taskId never produced a PDF
+        // in v8, so no service task is added - but the deprecated flag is still stripped.
+        _app.Write(
+            "config/applicationmetadata.json",
+            Metadata(
+                AttachmentDataType("file", enablePdfCreation: true),
+                """
+                    {
+                      "id": "stateless-model",
+                      "enablePdfCreation": true,
+                      "appLogic": {
+                        "classRef": "Altinn.App.Models.Stateless"
+                      }
+                    }
+                """
+            )
+        );
+        _app.Write(
+            "config/process/process.bpmn",
+            Process(Task("Task_1", "data"), Flow("Flow_end", "Task_1", "EndEvent_1"), EndEvent("EndEvent_1"))
+        );
+        var processBefore = _app.Read("config/process/process.bpmn");
+
+        var warnings = await Migrate();
+
+        Assert.Equal(processBefore, _app.Read("config/process/process.bpmn"));
+        Assert.DoesNotContain(
+            "enablePdfCreation",
+            _app.Read("config/applicationmetadata.json"),
+            StringComparison.Ordinal
+        );
+        Assert.Contains(warnings, w => w.Contains("no taskId", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task TaskNotFoundInProcess_FlagIsKeptAndWarned()
+    {
+        // Stripping the flag when the service task could not be inserted would leave the app with
+        // neither the v8 flag nor the v9 task, silently dropping PDF generation.
+        _app.Write(
+            "config/applicationmetadata.json",
+            Metadata(FormDataType("model", "Task_Ghost", enablePdfCreation: true))
+        );
+        _app.Write(
+            "config/process/process.bpmn",
+            Process(Task("Task_1", "data"), Flow("Flow_end", "Task_1", "EndEvent_1"), EndEvent("EndEvent_1"))
+        );
+
+        var warnings = await Migrate();
+
+        Assert.Contains("enablePdfCreation", _app.Read("config/applicationmetadata.json"), StringComparison.Ordinal);
+        Assert.Contains(warnings, w => w.Contains("Task_Ghost", StringComparison.Ordinal));
+        Assert.Contains(warnings, w => w.Contains("Left enablePdfCreation", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task AmbiguousOutgoingFlows_FlagIsKeptAndWarned()
+    {
+        _app.Write(
+            "config/applicationmetadata.json",
+            Metadata(FormDataType("model", "Task_1", enablePdfCreation: true))
+        );
+        _app.Write(
+            "config/process/process.bpmn",
+            Process(
+                Task("Task_1", "data"),
+                Flow("Flow_a", "Task_1", "EndEvent_1"),
+                Flow("Flow_b", "Task_1", "EndEvent_2"),
+                EndEvent("EndEvent_1"),
+                EndEvent("EndEvent_2")
+            )
+        );
+
+        var warnings = await Migrate();
+
+        Assert.Contains("enablePdfCreation", _app.Read("config/applicationmetadata.json"), StringComparison.Ordinal);
+        Assert.Contains(warnings, w => w.Contains("2 outgoing sequence flows", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task AlreadyMigratedTask_CountsAsSatisfied_FlagIsStripped()
+    {
+        // A PdfTask left by a previous (partial) run counts as migrated, so a re-run can finish the
+        // job and strip the flag.
+        _app.Write(
+            "config/applicationmetadata.json",
+            Metadata(FormDataType("model", "Task_1", enablePdfCreation: true))
+        );
+        _app.Write(
+            "config/process/process.bpmn",
+            Process(
+                Task("Task_1", "data"),
+                "    <bpmn:serviceTask id=\"PdfTask_Task_1\" name=\"Generate PDF\" />",
+                Flow("Flow_end", "Task_1", "PdfTask_Task_1"),
+                Flow("Flow_pdf", "PdfTask_Task_1", "EndEvent_1"),
+                EndEvent("EndEvent_1")
+            )
+        );
+
+        var warnings = await Migrate();
+
+        Assert.Contains(warnings, w => w.Contains("already migrated", StringComparison.Ordinal));
+        Assert.DoesNotContain(
+            "enablePdfCreation",
+            _app.Read("config/applicationmetadata.json"),
+            StringComparison.Ordinal
+        );
+    }
+
+    [Fact]
+    public async Task DownstreamGatewayWithConditions_GetsConnectedDataTypeIdPinned()
+    {
+        // Gateways used to infer their data model from the current task; with the pdf task inserted
+        // in front, the data task's form model must be pinned explicitly.
+        _app.Write(
+            "config/applicationmetadata.json",
+            Metadata(FormDataType("model", "Task_1", enablePdfCreation: true))
+        );
+        _app.Write(
+            "config/process/process.bpmn",
+            Process(
+                Task("Task_1", "data"),
+                Gateway("Gateway_1"),
+                Flow("Flow_to_gw", "Task_1", "Gateway_1"),
+                ConditionalFlow(
+                    "Flow_yes",
+                    "Gateway_1",
+                    "EndEvent_1",
+                    "[\"equals\", [\"dataModel\", \"model.done\"], true]"
+                ),
+                ConditionalFlow(
+                    "Flow_no",
+                    "Gateway_1",
+                    "EndEvent_2",
+                    "[\"equals\", [\"dataModel\", \"model.done\"], false]"
+                ),
+                EndEvent("EndEvent_1"),
+                EndEvent("EndEvent_2")
+            )
+        );
+
+        var warnings = await Migrate();
+
+        var gateway = ElementById(ProcessAfter(), "Gateway_1");
+        Assert.Equal("model", gateway?.Descendants().Single(e => e.Name.LocalName == "connectedDataTypeId").Value);
+        Assert.Contains(warnings, w => w.Contains("connectedDataTypeId", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task GatewayWithExplicitDataType_IsLeftUntouched()
+    {
+        _app.Write(
+            "config/applicationmetadata.json",
+            Metadata(FormDataType("model", "Task_1", enablePdfCreation: true))
+        );
+        _app.Write(
+            "config/process/process.bpmn",
+            Process(
+                Task("Task_1", "data"),
+                """
+                    <bpmn:exclusiveGateway id="Gateway_1">
+                      <bpmn:extensionElements>
+                        <altinn:gatewayExtension>
+                          <altinn:connectedDataTypeId>other-model</altinn:connectedDataTypeId>
+                        </altinn:gatewayExtension>
+                      </bpmn:extensionElements>
+                    </bpmn:exclusiveGateway>
+                """,
+                Flow("Flow_to_gw", "Task_1", "Gateway_1"),
+                ConditionalFlow("Flow_yes", "Gateway_1", "EndEvent_1", "[\"equals\", true, true]"),
+                ConditionalFlow("Flow_no", "Gateway_1", "EndEvent_2", "[\"equals\", true, false]"),
+                EndEvent("EndEvent_1"),
+                EndEvent("EndEvent_2")
+            )
+        );
+
+        await Migrate();
+
+        var gateway = ElementById(ProcessAfter(), "Gateway_1");
+        Assert.NotNull(gateway);
+        var dataTypeIds = gateway.Descendants().Where(e => e.Name.LocalName == "connectedDataTypeId").ToList();
+        Assert.Single(dataTypeIds);
+        Assert.Equal("other-model", dataTypeIds[0].Value);
+    }
+
+    [Fact]
+    public async Task ProcessFileBom_IsPreserved_AndAbsenceStaysAbsent()
+    {
+        _app.Write(
+            "config/applicationmetadata.json",
+            Metadata(FormDataType("model", "Task_1", enablePdfCreation: true))
+        );
+        var bpmn = Process(Task("Task_1", "data"), Flow("Flow_end", "Task_1", "EndEvent_1"), EndEvent("EndEvent_1"));
+        _app.WriteBytes("config/process/process.bpmn", [0xEF, 0xBB, 0xBF, .. System.Text.Encoding.UTF8.GetBytes(bpmn)]);
+
+        await Migrate();
+        Assert.True(
+            _app.ReadBytes("config/process/process.bpmn") is [0xEF, 0xBB, 0xBF, ..],
+            "expected the UTF-8 BOM to be preserved"
+        );
+
+        // And the inverse: a BOM-less file must not gain one.
+        using var second = new TempAppFolder();
+        second.Write(
+            "config/applicationmetadata.json",
+            Metadata(FormDataType("model", "Task_1", enablePdfCreation: true))
+        );
+        second.Write("config/process/process.bpmn", bpmn);
+
+        await new PdfServiceTaskMigrator(second.Root).Migrate();
+        Assert.False(
+            second.ReadBytes("config/process/process.bpmn") is [0xEF, 0xBB, 0xBF, ..],
+            "expected no UTF-8 BOM to be introduced"
+        );
+    }
+
+    [Fact]
+    public async Task SecondRun_IsIdempotent()
+    {
+        _app.Write(
+            "config/applicationmetadata.json",
+            Metadata(FormDataType("model", "Task_1", enablePdfCreation: true))
+        );
+        _app.Write(
+            "config/process/process.bpmn",
+            Process(Task("Task_1", "data"), Flow("Flow_end", "Task_1", "EndEvent_1"), EndEvent("EndEvent_1"))
+        );
+
+        await Migrate();
+        var processAfterFirst = _app.Read("config/process/process.bpmn");
+        var metadataAfterFirst = _app.Read("config/applicationmetadata.json");
+
+        await Migrate();
+
+        Assert.Equal(processAfterFirst, _app.Read("config/process/process.bpmn"));
+        Assert.Equal(metadataAfterFirst, _app.Read("config/applicationmetadata.json"));
+    }
+
+    [Fact]
+    public async Task NonUtf8ProcessFile_IsRefused_NothingTouched()
+    {
+        // A legacy-encoded file must not be decoded lossily and rewritten: that would permanently
+        // replace the non-ASCII content with U+FFFD.
+        _app.Write(
+            "config/applicationmetadata.json",
+            Metadata(FormDataType("model", "Task_1", enablePdfCreation: true))
+        );
+        var bpmn = Process(
+            Task("Task_1", "data"),
+            "    <!-- norsk: blæh -->",
+            Flow("Flow_end", "Task_1", "EndEvent_1"),
+            EndEvent("EndEvent_1")
+        );
+        _app.WriteBytes("config/process/process.bpmn", System.Text.Encoding.Latin1.GetBytes(bpmn));
+        var processBytesBefore = _app.ReadBytes("config/process/process.bpmn");
+
+        var warnings = await Migrate();
+
+        Assert.Contains(warnings, w => w.Contains("not valid UTF-8", StringComparison.Ordinal));
+        Assert.Equal(processBytesBefore, _app.ReadBytes("config/process/process.bpmn"));
+        Assert.Contains("enablePdfCreation", _app.Read("config/applicationmetadata.json"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task NonUtf8Metadata_IsRefused_NothingTouched()
+    {
+        var metadata = Metadata(FormDataType("modæl", "Task_1", enablePdfCreation: true));
+        _app.WriteBytes("config/applicationmetadata.json", System.Text.Encoding.Latin1.GetBytes(metadata));
+        _app.Write(
+            "config/process/process.bpmn",
+            Process(Task("Task_1", "data"), Flow("Flow_end", "Task_1", "EndEvent_1"), EndEvent("EndEvent_1"))
+        );
+        var metadataBytesBefore = _app.ReadBytes("config/applicationmetadata.json");
+        var processBefore = _app.Read("config/process/process.bpmn");
+
+        var warnings = await Migrate();
+
+        Assert.Contains(warnings, w => w.Contains("not valid UTF-8", StringComparison.Ordinal));
+        Assert.Equal(metadataBytesBefore, _app.ReadBytes("config/applicationmetadata.json"));
+        Assert.Equal(processBefore, _app.Read("config/process/process.bpmn"));
+    }
+
+    [Fact]
+    public async Task MultipleProcessElements_WarnsAndKeepsFlag_ProcessUntouched()
+    {
+        // Multiple <process> elements form a legal BPMN collaboration; the migrator cannot know
+        // which one to rewrite and must skip with an actionable message instead of throwing.
+        _app.Write(
+            "config/applicationmetadata.json",
+            Metadata(FormDataType("model", "Task_1", enablePdfCreation: true))
+        );
+        var bpmn = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:altinn="http://altinn.no/process" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+              <bpmn:process id="Process_1">
+                <bpmn:task id="Task_1" />
+                <bpmn:endEvent id="EndEvent_1" />
+                <bpmn:sequenceFlow id="Flow_end" sourceRef="Task_1" targetRef="EndEvent_1" />
+              </bpmn:process>
+              <bpmn:process id="Process_2" />
+            </bpmn:definitions>
+            """;
+        _app.Write("config/process/process.bpmn", bpmn);
+
+        var warnings = await Migrate();
+
+        Assert.Contains(warnings, w => w.Contains("2 <process> element(s)", StringComparison.Ordinal));
+        Assert.Equal(bpmn, _app.Read("config/process/process.bpmn"));
+        Assert.Contains("enablePdfCreation", _app.Read("config/applicationmetadata.json"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task DuplicateTaskIds_WarnsAndKeepsFlag_ProcessUntouched()
+    {
+        _app.Write(
+            "config/applicationmetadata.json",
+            Metadata(FormDataType("model", "Task_1", enablePdfCreation: true))
+        );
+        var bpmn = Process(
+            Task("Task_1", "data"),
+            Task("Task_1", "data"),
+            Flow("Flow_end", "Task_1", "EndEvent_1"),
+            EndEvent("EndEvent_1")
+        );
+        _app.Write("config/process/process.bpmn", bpmn);
+
+        var warnings = await Migrate();
+
+        Assert.Contains(warnings, w => w.Contains("occurs 2 times", StringComparison.Ordinal));
+        Assert.Equal(bpmn, _app.Read("config/process/process.bpmn"));
+        Assert.Contains("enablePdfCreation", _app.Read("config/applicationmetadata.json"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CrlfProcessFileWithoutTrailingNewline_KeepsBothTraits()
+    {
+        _app.Write(
+            "config/applicationmetadata.json",
+            Metadata(FormDataType("model", "Task_1", enablePdfCreation: true))
+        );
+        var bpmn = Process(Task("Task_1", "data"), Flow("Flow_end", "Task_1", "EndEvent_1"), EndEvent("EndEvent_1"))
+            .ReplaceLineEndings("\r\n");
+        Assert.False(bpmn.EndsWith('\n')); // fixture sanity: the builder emits no trailing newline
+        _app.Write("config/process/process.bpmn", bpmn);
+
+        await Migrate();
+
+        var after = _app.Read("config/process/process.bpmn");
+        Assert.Contains("PdfTask_Task_1", after, StringComparison.Ordinal);
+        Assert.DoesNotContain('\n', after.Replace("\r\n", string.Empty)); // every newline is CRLF
+        Assert.False(after.EndsWith('\n'), "expected no trailing newline to be introduced");
+    }
+
+    [Fact]
+    public async Task LfProcessFileWithTrailingNewline_KeepsBothTraits()
+    {
+        _app.Write(
+            "config/applicationmetadata.json",
+            Metadata(FormDataType("model", "Task_1", enablePdfCreation: true))
+        );
+        var bpmn =
+            Process(Task("Task_1", "data"), Flow("Flow_end", "Task_1", "EndEvent_1"), EndEvent("EndEvent_1"))
+                .ReplaceLineEndings("\n") + "\n";
+        _app.Write("config/process/process.bpmn", bpmn);
+
+        await Migrate();
+
+        var after = _app.Read("config/process/process.bpmn");
+        Assert.Contains("PdfTask_Task_1", after, StringComparison.Ordinal);
+        Assert.DoesNotContain('\r', after);
+        Assert.EndsWith("\n", after, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task RunThatChangesNothing_DoesNotRewriteTheProcessFile()
+    {
+        // Already-migrated task: the run strips the flag but must not reformat the process file.
+        _app.Write(
+            "config/applicationmetadata.json",
+            Metadata(FormDataType("model", "Task_1", enablePdfCreation: true))
+        );
+        var bpmn = Process(
+            Task("Task_1", "data"),
+            "    <bpmn:serviceTask id=\"PdfTask_Task_1\" name=\"Generate PDF\" />",
+            Flow("Flow_end", "Task_1", "PdfTask_Task_1"),
+            Flow("Flow_pdf", "PdfTask_Task_1", "EndEvent_1"),
+            EndEvent("EndEvent_1")
+        );
+        _app.Write("config/process/process.bpmn", bpmn);
+        var processBytesBefore = _app.ReadBytes("config/process/process.bpmn");
+
+        await Migrate();
+
+        Assert.Equal(processBytesBefore, _app.ReadBytes("config/process/process.bpmn"));
+        Assert.DoesNotContain(
+            "enablePdfCreation",
+            _app.Read("config/applicationmetadata.json"),
+            StringComparison.Ordinal
+        );
+    }
+}

--- a/src/cli/studioctl-server-tests/Upgrade/v8Tov9/PdfServiceTaskMigratorTests.cs
+++ b/src/cli/studioctl-server-tests/Upgrade/v8Tov9/PdfServiceTaskMigratorTests.cs
@@ -157,7 +157,7 @@ public sealed class PdfServiceTaskMigratorTests : IDisposable
             "config/process/process.bpmn",
             Process(
                 Task("Task_1", "data"),
-                "    <bpmn:serviceTask id=\"PdfTask_Task_1\" name=\"Generate PDF\" />",
+                PdfServiceTask("PdfTask_Task_1"),
                 Flow("Flow_end", "Task_1", "PdfTask_Task_1"),
                 Flow("Flow_pdf", "PdfTask_Task_1", "EndEvent_1"),
                 EndEvent("EndEvent_1")
@@ -448,7 +448,7 @@ public sealed class PdfServiceTaskMigratorTests : IDisposable
         );
         var bpmn = Process(
             Task("Task_1", "data"),
-            "    <bpmn:serviceTask id=\"PdfTask_Task_1\" name=\"Generate PDF\" />",
+            PdfServiceTask("PdfTask_Task_1"),
             Flow("Flow_end", "Task_1", "PdfTask_Task_1"),
             Flow("Flow_pdf", "PdfTask_Task_1", "EndEvent_1"),
             EndEvent("EndEvent_1")
@@ -526,6 +526,56 @@ public sealed class PdfServiceTaskMigratorTests : IDisposable
 
         Assert.Contains(warnings, w => w.Contains("not valid XML", StringComparison.Ordinal));
         Assert.Equal(bpmn, _app.Read("config/process/process.bpmn"));
+        Assert.Contains("enablePdfCreation", _app.Read("config/applicationmetadata.json"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ExistingPdfTaskIdCollidesWithNonPdfElement_IsSkippedAndFlagKept()
+    {
+        // The "already migrated" short-circuit must not fire for an unrelated element that merely
+        // shares the id - stripping the flag then would drop PDF generation with no task to replace it.
+        _app.Write(
+            "config/applicationmetadata.json",
+            Metadata(FormDataType("model", "Task_1", enablePdfCreation: true))
+        );
+        var bpmn = Process(
+            Task("Task_1", "data"),
+            Task("PdfTask_Task_1", "data"), // collides with the id the migrator would generate
+            Flow("Flow_end", "Task_1", "EndEvent_1"),
+            EndEvent("EndEvent_1")
+        );
+        _app.Write("config/process/process.bpmn", bpmn);
+
+        var warnings = await Migrate();
+
+        Assert.Equal(bpmn, _app.Read("config/process/process.bpmn"));
+        Assert.Contains(warnings, w => w.Contains("not a PDF service task", StringComparison.Ordinal));
+        Assert.Contains("enablePdfCreation", _app.Read("config/applicationmetadata.json"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ExistingNewFlowIdCollision_IsSkippedAndFlagKept()
+    {
+        // The generated flow id (Flow_PdfTask_{taskId}_to_{target}) must not duplicate an existing id,
+        // which would produce invalid BPMN.
+        _app.Write(
+            "config/applicationmetadata.json",
+            Metadata(FormDataType("model", "Task_1", enablePdfCreation: true))
+        );
+        var bpmn = Process(
+            StartEvent("StartEvent_1"),
+            Task("Task_1", "data"),
+            EndEvent("EndEvent_1"),
+            Flow("Flow_start", "StartEvent_1", "Task_1"),
+            Flow("Flow_end", "Task_1", "EndEvent_1"),
+            Flow("Flow_PdfTask_Task_1_to_EndEvent_1", "StartEvent_1", "EndEvent_1") // collides with newFlowId
+        );
+        _app.Write("config/process/process.bpmn", bpmn);
+
+        var warnings = await Migrate();
+
+        Assert.Equal(bpmn, _app.Read("config/process/process.bpmn"));
+        Assert.Contains(warnings, w => w.Contains("already exists", StringComparison.Ordinal));
         Assert.Contains("enablePdfCreation", _app.Read("config/applicationmetadata.json"), StringComparison.Ordinal);
     }
 

--- a/src/cli/studioctl-server-tests/Upgrade/v8Tov9/PdfServiceTaskMigratorTests.cs
+++ b/src/cli/studioctl-server-tests/Upgrade/v8Tov9/PdfServiceTaskMigratorTests.cs
@@ -1,4 +1,5 @@
 using System.Xml.Linq;
+using Altinn.Studio.Cli.Upgrade.v8Tov9;
 using Altinn.Studio.Cli.Upgrade.v8Tov9.PdfServiceTaskMigration;
 using static Studioctl.Tests.Upgrade.v8Tov9.BpmnBuilder;
 
@@ -10,7 +11,9 @@ public sealed class PdfServiceTaskMigratorTests : IDisposable
 
     public void Dispose() => _app.Dispose();
 
-    private async Task<IReadOnlyList<string>> Migrate() => await new PdfServiceTaskMigrator(_app.Root).Migrate();
+    private async Task<MigrationResult> MigrateResult() => await new PdfServiceTaskMigrator(_app.Root).Migrate();
+
+    private async Task<IReadOnlyList<string>> Migrate() => (await MigrateResult()).Warnings;
 
     private XElement ProcessAfter()
     {
@@ -527,6 +530,58 @@ public sealed class PdfServiceTaskMigratorTests : IDisposable
         Assert.Contains(warnings, w => w.Contains("not valid XML", StringComparison.Ordinal));
         Assert.Equal(bpmn, _app.Read("config/process/process.bpmn"));
         Assert.Contains("enablePdfCreation", _app.Read("config/applicationmetadata.json"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CleanMigration_DoesNotRequireManualAction()
+    {
+        _app.Write(
+            "config/applicationmetadata.json",
+            Metadata(FormDataType("model", "Task_1", enablePdfCreation: true))
+        );
+        _app.Write(
+            "config/process/process.bpmn",
+            Process(Task("Task_1", "data"), Flow("Flow_end", "Task_1", "EndEvent_1"), EndEvent("EndEvent_1"))
+        );
+
+        var result = await MigrateResult();
+
+        Assert.False(result.ManualActionRequired);
+        Assert.Empty(result.Warnings);
+    }
+
+    [Fact]
+    public async Task SkippedTask_RequiresManualAction()
+    {
+        // The task can't be found, so the flag is kept - the developer must finish the migration.
+        _app.Write(
+            "config/applicationmetadata.json",
+            Metadata(FormDataType("model", "Task_Ghost", enablePdfCreation: true))
+        );
+        _app.Write(
+            "config/process/process.bpmn",
+            Process(Task("Task_1", "data"), Flow("Flow_end", "Task_1", "EndEvent_1"), EndEvent("EndEvent_1"))
+        );
+
+        var result = await MigrateResult();
+
+        Assert.True(result.ManualActionRequired);
+    }
+
+    [Fact]
+    public async Task LegacyNoOp_DoesNotRequireManualAction()
+    {
+        // enablePdfCreation on an attachment was a no-op in v8; stripping it is a clean outcome, not
+        // something needing manual follow-up.
+        _app.Write("config/applicationmetadata.json", Metadata(AttachmentDataType("file", enablePdfCreation: true)));
+        _app.Write(
+            "config/process/process.bpmn",
+            Process(Task("Task_1", "data"), Flow("Flow_end", "Task_1", "EndEvent_1"), EndEvent("EndEvent_1"))
+        );
+
+        var result = await MigrateResult();
+
+        Assert.False(result.ManualActionRequired);
     }
 
     [Fact]

--- a/src/cli/studioctl-server-tests/Upgrade/v8Tov9/PolicyXmlBuilder.cs
+++ b/src/cli/studioctl-server-tests/Upgrade/v8Tov9/PolicyXmlBuilder.cs
@@ -1,0 +1,62 @@
+namespace Studioctl.Tests.Upgrade.v8Tov9;
+
+/// <summary>
+/// Composable builders for XACML policy fixtures, mirroring the shapes Studio and hand-edited
+/// policies use. Kept intentionally textual: the migrator under test does textual insertion, so the
+/// fixtures should look like real files.
+/// </summary>
+internal static class PolicyXmlBuilder
+{
+    private const string Header = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <xacml:Policy xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" PolicyId="urn:altinn:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides">
+          <xacml:Target />
+        """;
+
+    public const string EqualFunction = "urn:oasis:names:tc:xacml:1.0:function:string-equal";
+    public const string EqualIgnoreCaseFunction = "urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case";
+    public const string SubjectCategory = "urn:oasis:names:tc:xacml:1.0:subject-category:access-subject";
+    public const string ResourceCategory = "urn:oasis:names:tc:xacml:3.0:attribute-category:resource";
+    public const string ActionCategory = "urn:oasis:names:tc:xacml:3.0:attribute-category:action";
+    public const string ActionAttributeId = "urn:oasis:names:tc:xacml:1.0:action:action-id";
+
+    public static string Policy(params string[] rules) =>
+        Header + "\n" + string.Join("\n", rules) + "\n</xacml:Policy>";
+
+    public static string Rule(string id, params string[] anyOfs) =>
+        $"  <xacml:Rule RuleId=\"urn:altinn:example:ruleid:{id}\" Effect=\"Permit\">\n"
+        + "    <xacml:Target>\n"
+        + string.Join("\n", anyOfs)
+        + "\n    </xacml:Target>\n"
+        + "  </xacml:Rule>";
+
+    public static string AnyOf(params string[] allOfs) =>
+        "      <xacml:AnyOf>\n" + string.Join("\n", allOfs) + "\n      </xacml:AnyOf>";
+
+    public static string AllOf(params string[] matches) =>
+        "        <xacml:AllOf>\n" + string.Join("\n", matches) + "\n        </xacml:AllOf>";
+
+    public static string Match(string matchFunction, string value, string attributeId, string category) =>
+        $"          <xacml:Match MatchId=\"{matchFunction}\">\n"
+        + $"            <xacml:AttributeValue DataType=\"http://www.w3.org/2001/XMLSchema#string\">{value}</xacml:AttributeValue>\n"
+        + $"            <xacml:AttributeDesignator AttributeId=\"{attributeId}\" Category=\"{category}\" DataType=\"http://www.w3.org/2001/XMLSchema#string\" MustBePresent=\"false\" />\n"
+        + "          </xacml:Match>";
+
+    public static string SubjectOrg(string org) =>
+        Match(EqualIgnoreCaseFunction, org, "urn:altinn:org", SubjectCategory);
+
+    public static string SubjectRole(string role) =>
+        Match(EqualIgnoreCaseFunction, role, "urn:altinn:rolecode", SubjectCategory);
+
+    public static string ResourceOrg(string org) => Match(EqualFunction, org, "urn:altinn:org", ResourceCategory);
+
+    public static string ResourceApp(string app) => Match(EqualFunction, app, "urn:altinn:app", ResourceCategory);
+
+    public static string ResourceTask(string task) => Match(EqualFunction, task, "urn:altinn:task", ResourceCategory);
+
+    public static string ResourceEndEvent(string endEvent) =>
+        Match(EqualFunction, endEvent, "urn:altinn:end-event", ResourceCategory);
+
+    public static string Action(string action) =>
+        Match(EqualIgnoreCaseFunction, action, ActionAttributeId, ActionCategory);
+}

--- a/src/cli/studioctl-server-tests/Upgrade/v8Tov9/ServiceOwnerPolicyMigratorTests.cs
+++ b/src/cli/studioctl-server-tests/Upgrade/v8Tov9/ServiceOwnerPolicyMigratorTests.cs
@@ -1,3 +1,4 @@
+using Altinn.Studio.Cli.Upgrade.v8Tov9;
 using Altinn.Studio.Cli.Upgrade.v8Tov9.PolicyMigration;
 using static Studioctl.Tests.Upgrade.v8Tov9.PolicyXmlBuilder;
 
@@ -11,7 +12,7 @@ public sealed class ServiceOwnerPolicyMigratorTests : IDisposable
 
     public void Dispose() => _app.Dispose();
 
-    private async Task<IReadOnlyList<string>> Migrate(string policy, string? metadata = Metadata)
+    private async Task<MigrationResult> MigrateResult(string policy, string? metadata = Metadata)
     {
         _app.Write("config/authorization/policy.xml", policy);
         if (metadata is not null)
@@ -20,6 +21,9 @@ public sealed class ServiceOwnerPolicyMigratorTests : IDisposable
         var migrator = new ServiceOwnerPolicyMigrator(_app.Root);
         return await migrator.Migrate();
     }
+
+    private async Task<IReadOnlyList<string>> Migrate(string policy, string? metadata = Metadata) =>
+        (await MigrateResult(policy, metadata)).Warnings;
 
     private string PolicyAfter() => _app.Read("config/authorization/policy.xml");
 
@@ -58,9 +62,10 @@ public sealed class ServiceOwnerPolicyMigratorTests : IDisposable
             )
         );
 
-        var warnings = await Migrate(policy);
+        var result = await MigrateResult(policy);
 
-        Assert.Empty(warnings);
+        Assert.Empty(result.Warnings);
+        Assert.False(result.ManualActionRequired);
         Assert.Equal(policy, PolicyAfter());
     }
 
@@ -243,7 +248,7 @@ public sealed class ServiceOwnerPolicyMigratorTests : IDisposable
         var firstWarnings = await Migrate(policy);
         var afterFirst = PolicyAfter();
 
-        var secondWarnings = await new ServiceOwnerPolicyMigrator(_app.Root).Migrate();
+        var secondWarnings = (await new ServiceOwnerPolicyMigrator(_app.Root).Migrate()).Warnings;
 
         Assert.Contains(firstWarnings, w => w.Contains("Added a policy rule", StringComparison.Ordinal));
         Assert.DoesNotContain(secondWarnings, w => w.Contains("Added a policy rule", StringComparison.Ordinal));
@@ -338,7 +343,7 @@ public sealed class ServiceOwnerPolicyMigratorTests : IDisposable
         _app.Write("config/applicationmetadata.json", Metadata);
         var bytesBefore = _app.ReadBytes("config/authorization/policy.xml");
 
-        var warnings = await new ServiceOwnerPolicyMigrator(_app.Root).Migrate();
+        var warnings = (await new ServiceOwnerPolicyMigrator(_app.Root).Migrate()).Warnings;
 
         Assert.Contains(warnings, w => w.Contains("not valid UTF-8", StringComparison.Ordinal));
         Assert.Equal(bytesBefore, _app.ReadBytes("config/authorization/policy.xml"));
@@ -390,16 +395,17 @@ public sealed class ServiceOwnerPolicyMigratorTests : IDisposable
             denyRule
         );
 
-        var warnings = await Migrate(policy);
+        var result = await MigrateResult(policy);
 
+        Assert.True(result.ManualActionRequired);
         Assert.Contains(
-            warnings,
+            result.Warnings,
             w =>
                 w.Contains("Deny rule", StringComparison.Ordinal)
                 && w.Contains("inconclusive", StringComparison.Ordinal)
                 && w.Contains("[read, write, complete]", StringComparison.Ordinal)
         );
-        Assert.DoesNotContain(warnings, w => w.Contains("Added a policy rule", StringComparison.Ordinal));
+        Assert.DoesNotContain(result.Warnings, w => w.Contains("Added a policy rule", StringComparison.Ordinal));
         Assert.Equal(policy, PolicyAfter());
     }
 

--- a/src/cli/studioctl-server-tests/Upgrade/v8Tov9/ServiceOwnerPolicyMigratorTests.cs
+++ b/src/cli/studioctl-server-tests/Upgrade/v8Tov9/ServiceOwnerPolicyMigratorTests.cs
@@ -1,0 +1,533 @@
+using Altinn.Studio.Cli.Upgrade.v8Tov9.PolicyMigration;
+using static Studioctl.Tests.Upgrade.v8Tov9.PolicyXmlBuilder;
+
+namespace Studioctl.Tests.Upgrade.v8Tov9;
+
+public sealed class ServiceOwnerPolicyMigratorTests : IDisposable
+{
+    private const string Metadata = """{"id":"ttd/myapp","org":"ttd"}""";
+
+    private readonly TempAppFolder _app = new();
+
+    public void Dispose() => _app.Dispose();
+
+    private async Task<IReadOnlyList<string>> Migrate(string policy, string? metadata = Metadata)
+    {
+        _app.Write("config/authorization/policy.xml", policy);
+        if (metadata is not null)
+            _app.Write("config/applicationmetadata.json", metadata);
+
+        var migrator = new ServiceOwnerPolicyMigrator(_app.Root);
+        return await migrator.Migrate();
+    }
+
+    private string PolicyAfter() => _app.Read("config/authorization/policy.xml");
+
+    [Fact]
+    public async Task StandardTemplateShape_NothingMissing_InsertsNothing()
+    {
+        // Org has instantiate+read (rule 1), write in any state (rule 4), complete at the end event
+        // (rule 5) - the standard Studio template shape. The end-event-scoped complete grant only
+        // counts because the process actually has that end event.
+        var policy = Policy(
+            Rule(
+                "1",
+                AnyOf(AllOf(SubjectRole("dagl")), AllOf(SubjectOrg("ttd"))),
+                AnyOf(AllOf(ResourceOrg("ttd"), ResourceApp("myapp"))),
+                AnyOf(AllOf(Action("instantiate")), AllOf(Action("read")))
+            ),
+            Rule(
+                "4",
+                AnyOf(AllOf(SubjectOrg("ttd"))),
+                AnyOf(AllOf(ResourceOrg("ttd"), ResourceApp("myapp"))),
+                AnyOf(AllOf(Action("write")))
+            ),
+            Rule(
+                "5",
+                AnyOf(AllOf(SubjectOrg("ttd"))),
+                AnyOf(AllOf(ResourceOrg("ttd"), ResourceApp("myapp"), ResourceEndEvent("EndEvent_1"))),
+                AnyOf(AllOf(Action("complete")))
+            )
+        );
+        _app.Write(
+            "config/process/process.bpmn",
+            BpmnBuilder.Process(
+                BpmnBuilder.Task("Task_1", "data"),
+                BpmnBuilder.Flow("Flow_end", "Task_1", "EndEvent_1"),
+                BpmnBuilder.EndEvent("EndEvent_1")
+            )
+        );
+
+        var warnings = await Migrate(policy);
+
+        Assert.Empty(warnings);
+        Assert.Equal(policy, PolicyAfter());
+    }
+
+    [Fact]
+    public async Task RealStudioTemplatePolicy_InsertsNothing()
+    {
+        var policy = await File.ReadAllTextAsync(
+            Path.Combine(AppContext.BaseDirectory, "Upgrade/v8Tov9/TestData/template-policy.xml"),
+            TestContext.Current.CancellationToken
+        );
+        var metadata = await File.ReadAllTextAsync(
+            Path.Combine(AppContext.BaseDirectory, "Upgrade/v8Tov9/TestData/template-appmetadata.json"),
+            TestContext.Current.CancellationToken
+        );
+        // The template's complete grant is scoped to EndEvent_1; scoped grants only count when the
+        // process really has the element they name.
+        _app.Write(
+            "config/process/process.bpmn",
+            BpmnBuilder.Process(
+                BpmnBuilder.Task("Task_1", "data"),
+                BpmnBuilder.Flow("Flow_end", "Task_1", "EndEvent_1"),
+                BpmnBuilder.EndEvent("EndEvent_1")
+            )
+        );
+
+        var warnings = await Migrate(policy, metadata);
+
+        Assert.DoesNotContain(warnings, w => w.Contains("Added a policy rule", StringComparison.Ordinal));
+        Assert.Equal(policy, PolicyAfter());
+    }
+
+    [Fact]
+    public async Task ActionsSplitAcrossAllOfsInOneAnyOf_AreNotMisreadAsOrgGrants()
+    {
+        // XACML semantics: within one AnyOf, subject and action pair up per AllOf. The org only has
+        // 'instantiate' here; read/write/complete belong to a role. A matcher that flattens the rule
+        // would wrongly conclude the org already has them.
+        var policy = Policy(
+            Rule(
+                "1",
+                AnyOf(
+                    AllOf(SubjectOrg("ttd"), Action("instantiate")),
+                    AllOf(SubjectRole("dagl"), Action("read")),
+                    AllOf(SubjectRole("dagl"), Action("write")),
+                    AllOf(SubjectRole("dagl"), Action("complete"))
+                ),
+                AnyOf(AllOf(ResourceOrg("ttd"), ResourceApp("myapp")))
+            )
+        );
+
+        var warnings = await Migrate(policy);
+
+        Assert.Contains(warnings, w => w.Contains("[read, write, complete]", StringComparison.Ordinal));
+        Assert.Contains("v8 to v9 upgrade", PolicyAfter(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PolicyLeadingWithForeignOrgRule_InsertedRuleNamesTheAppOwner()
+    {
+        // The first urn:altinn:org resource match in document order belongs to another org; the
+        // inserted rule must name the app's own org (from applicationmetadata.json), not that one.
+        var policy = Policy(
+            Rule(
+                "1",
+                AnyOf(AllOf(SubjectOrg("brg"))),
+                AnyOf(AllOf(ResourceOrg("brg"), ResourceApp("their-app"))),
+                AnyOf(AllOf(Action("read")))
+            ),
+            Rule(
+                "2",
+                AnyOf(AllOf(SubjectRole("dagl"))),
+                AnyOf(AllOf(ResourceOrg("ttd"), ResourceApp("myapp"))),
+                AnyOf(AllOf(Action("read")), AllOf(Action("write")))
+            )
+        );
+
+        var warnings = await Migrate(policy);
+
+        Assert.Contains(
+            warnings,
+            w => w.Contains("'ttd'", StringComparison.Ordinal) && w.Contains("ttd/myapp", StringComparison.Ordinal)
+        );
+        Assert.Contains("gives the app owner ttd", PolicyAfter(), StringComparison.Ordinal);
+        Assert.DoesNotContain("gives the app owner brg", PolicyAfter(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PlaceholderPolicy_InsertedRuleUsesPlaceholders()
+    {
+        // Studio templates use [ORG]/[APP], substituted at deploy time. The inserted rule must follow
+        // the file's convention even when applicationmetadata.json has concrete values.
+        var policy = Policy(
+            Rule(
+                "1",
+                AnyOf(AllOf(SubjectOrg("[ORG]"))),
+                AnyOf(AllOf(ResourceOrg("[ORG]"), ResourceApp("[APP]"))),
+                AnyOf(AllOf(Action("instantiate")), AllOf(Action("read")))
+            )
+        );
+
+        var warnings = await Migrate(policy);
+
+        Assert.Contains(warnings, w => w.Contains("[write, complete]", StringComparison.Ordinal));
+        Assert.Contains("gives the app owner [ORG]", PolicyAfter(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task TaskScopedGrant_DoesNotCountAsStateIndependentBaseline()
+    {
+        var policy = Policy(
+            Rule(
+                "1",
+                AnyOf(AllOf(SubjectOrg("ttd"))),
+                AnyOf(AllOf(ResourceOrg("ttd"), ResourceApp("myapp"), ResourceTask("Task_1"))),
+                AnyOf(AllOf(Action("read")), AllOf(Action("write")), AllOf(Action("complete")))
+            )
+        );
+
+        var warnings = await Migrate(policy);
+
+        Assert.Contains(warnings, w => w.Contains("[read, write, complete]", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task RuleWithCondition_IsNotTrustedAsAGrant()
+    {
+        var policy = Policy(
+            "  <xacml:Rule RuleId=\"urn:altinn:example:ruleid:1\" Effect=\"Permit\">\n"
+                + "    <xacml:Target>\n"
+                + AnyOf(AllOf(SubjectOrg("ttd")))
+                + "\n"
+                + AnyOf(AllOf(ResourceOrg("ttd"), ResourceApp("myapp")))
+                + "\n"
+                + AnyOf(AllOf(Action("read")), AllOf(Action("write")), AllOf(Action("complete")))
+                + "\n    </xacml:Target>\n"
+                + "    <xacml:Condition>\n"
+                + "      <xacml:Apply FunctionId=\"urn:oasis:names:tc:xacml:1.0:function:string-equal\">\n"
+                + "        <xacml:AttributeValue DataType=\"http://www.w3.org/2001/XMLSchema#string\">x</xacml:AttributeValue>\n"
+                + "        <xacml:AttributeValue DataType=\"http://www.w3.org/2001/XMLSchema#string\">y</xacml:AttributeValue>\n"
+                + "      </xacml:Apply>\n"
+                + "    </xacml:Condition>\n"
+                + "  </xacml:Rule>"
+        );
+
+        var warnings = await Migrate(policy);
+
+        Assert.Contains(warnings, w => w.Contains("[read, write, complete]", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task WithoutApplicationMetadata_FallsBackToPolicyValues()
+    {
+        var policy = Policy(
+            Rule(
+                "1",
+                AnyOf(AllOf(SubjectOrg("ttd"))),
+                AnyOf(AllOf(ResourceOrg("ttd"), ResourceApp("myapp"))),
+                AnyOf(AllOf(Action("instantiate")))
+            )
+        );
+
+        var warnings = await Migrate(policy, metadata: null);
+
+        Assert.Contains(warnings, w => w.Contains("'ttd'", StringComparison.Ordinal));
+        Assert.Contains("gives the app owner ttd", PolicyAfter(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task SecondRun_IsIdempotent()
+    {
+        var policy = Policy(
+            Rule(
+                "1",
+                AnyOf(AllOf(SubjectOrg("ttd"))),
+                AnyOf(AllOf(ResourceOrg("ttd"), ResourceApp("myapp"))),
+                AnyOf(AllOf(Action("instantiate")))
+            )
+        );
+
+        var firstWarnings = await Migrate(policy);
+        var afterFirst = PolicyAfter();
+
+        var secondWarnings = await new ServiceOwnerPolicyMigrator(_app.Root).Migrate();
+
+        Assert.Contains(firstWarnings, w => w.Contains("Added a policy rule", StringComparison.Ordinal));
+        Assert.DoesNotContain(secondWarnings, w => w.Contains("Added a policy rule", StringComparison.Ordinal));
+        Assert.Equal(afterFirst, PolicyAfter());
+    }
+
+    [Fact]
+    public async Task InsertedRuleContinuesTheRuleIdSequence()
+    {
+        var policy = Policy(
+            Rule(
+                "7",
+                AnyOf(AllOf(SubjectOrg("ttd"))),
+                AnyOf(AllOf(ResourceOrg("ttd"), ResourceApp("myapp"))),
+                AnyOf(AllOf(Action("instantiate")))
+            )
+        );
+
+        await Migrate(policy);
+
+        Assert.Contains("urn:altinn:example:ruleid:8", PolicyAfter(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task BomIsPreserved()
+    {
+        var policy = Policy(
+            Rule(
+                "1",
+                AnyOf(AllOf(SubjectOrg("ttd"))),
+                AnyOf(AllOf(ResourceOrg("ttd"), ResourceApp("myapp"))),
+                AnyOf(AllOf(Action("instantiate")))
+            )
+        );
+        _app.WriteBytes(
+            "config/authorization/policy.xml",
+            [0xEF, 0xBB, 0xBF, .. System.Text.Encoding.UTF8.GetBytes(policy)]
+        );
+        _app.Write("config/applicationmetadata.json", Metadata);
+
+        await new ServiceOwnerPolicyMigrator(_app.Root).Migrate();
+
+        var bytes = _app.ReadBytes("config/authorization/policy.xml");
+        Assert.True(bytes is [0xEF, 0xBB, 0xBF, ..], "expected the UTF-8 BOM to be preserved");
+        Assert.Contains("v8 to v9 upgrade", PolicyAfter(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task TaskSpecificActions_MissingGrantsAreWarnedAbout()
+    {
+        // Org has the baseline (unscoped read/write/complete) but the process contains a signing
+        // task, whose transitions replay with sign/reject.
+        var policy = Policy(
+            Rule(
+                "1",
+                AnyOf(AllOf(SubjectOrg("ttd"))),
+                AnyOf(AllOf(ResourceOrg("ttd"), ResourceApp("myapp"))),
+                AnyOf(AllOf(Action("read")), AllOf(Action("write")), AllOf(Action("complete")))
+            )
+        );
+        _app.Write(
+            "config/process/process.bpmn",
+            BpmnBuilder.Process(
+                BpmnBuilder.Task("Task_1", "data"),
+                BpmnBuilder.Task("Task_2", "signing"),
+                BpmnBuilder.Flow("Flow_1", "Task_1", "Task_2")
+            )
+        );
+
+        var warnings = await Migrate(policy);
+
+        Assert.Contains(
+            warnings,
+            w => w.Contains("'sign'", StringComparison.Ordinal) && w.Contains("'reject'", StringComparison.Ordinal)
+        );
+    }
+
+    [Fact]
+    public async Task NonUtf8Policy_IsRefusedAndLeftByteIdentical()
+    {
+        // A legacy-encoded policy must not be decoded lossily and rewritten: that would permanently
+        // replace the non-ASCII content with U+FFFD.
+        var policy = Policy(
+            Rule(
+                "1",
+                AnyOf(AllOf(SubjectRole("dæglig"))),
+                AnyOf(AllOf(ResourceOrg("ttd"), ResourceApp("myapp"))),
+                AnyOf(AllOf(Action("read")))
+            )
+        );
+        _app.WriteBytes("config/authorization/policy.xml", System.Text.Encoding.Latin1.GetBytes(policy));
+        _app.Write("config/applicationmetadata.json", Metadata);
+        var bytesBefore = _app.ReadBytes("config/authorization/policy.xml");
+
+        var warnings = await new ServiceOwnerPolicyMigrator(_app.Root).Migrate();
+
+        Assert.Contains(warnings, w => w.Contains("not valid UTF-8", StringComparison.Ordinal));
+        Assert.Equal(bytesBefore, _app.ReadBytes("config/authorization/policy.xml"));
+    }
+
+    [Fact]
+    public async Task InsertionPointInsideComment_IsCaughtAndFileLeftUnchanged()
+    {
+        // The line-based insertion point matcher can land inside a commented-out block (valid XML,
+        // dead rule); the migrator must detect that the rule did not become a real element and bail.
+        var policy = Policy(
+            Rule(
+                "1",
+                AnyOf(AllOf(SubjectRole("dagl"))),
+                AnyOf(AllOf(ResourceOrg("ttd"), ResourceApp("myapp"))),
+                AnyOf(AllOf(Action("read")))
+            ),
+            "  <!-- disabled while testing:\n"
+                + "  <xacml:ObligationExpressions>\n"
+                + "  </xacml:ObligationExpressions>\n"
+                + "  -->"
+        );
+
+        var warnings = await Migrate(policy);
+
+        Assert.Contains(warnings, w => w.Contains("inside a comment", StringComparison.Ordinal));
+        Assert.DoesNotContain(warnings, w => w.Contains("Added a policy rule", StringComparison.Ordinal));
+        Assert.Equal(policy, PolicyAfter());
+    }
+
+    [Fact]
+    public async Task DenyRulePresent_AnalysisIsInconclusive_NoRuleInserted()
+    {
+        // With Deny rules (and a deny-overrides combining algorithm) a Permit we find may still be
+        // overridden, so "already granted" conclusions are unreliable in both directions.
+        var denyRule =
+            "  <xacml:Rule RuleId=\"urn:altinn:example:ruleid:2\" Effect=\"Deny\">\n"
+            + "    <xacml:Target>\n"
+            + AnyOf(AllOf(Action("write")))
+            + "\n    </xacml:Target>\n"
+            + "  </xacml:Rule>";
+        var policy = Policy(
+            Rule(
+                "1",
+                AnyOf(AllOf(SubjectOrg("ttd"))),
+                AnyOf(AllOf(ResourceOrg("ttd"), ResourceApp("myapp"))),
+                AnyOf(AllOf(Action("read")), AllOf(Action("write")), AllOf(Action("complete")))
+            ),
+            denyRule
+        );
+
+        var warnings = await Migrate(policy);
+
+        Assert.Contains(
+            warnings,
+            w =>
+                w.Contains("Deny rule", StringComparison.Ordinal)
+                && w.Contains("inconclusive", StringComparison.Ordinal)
+                && w.Contains("[read, write, complete]", StringComparison.Ordinal)
+        );
+        Assert.DoesNotContain(warnings, w => w.Contains("Added a policy rule", StringComparison.Ordinal));
+        Assert.Equal(policy, PolicyAfter());
+    }
+
+    [Fact]
+    public async Task EndEventScopedComplete_NamingAnUnknownEndEvent_DoesNotCount()
+    {
+        // A complete grant scoped to an end event the process does not have (e.g. renamed) can never
+        // match a real request, so complete is still missing.
+        var policy = Policy(
+            Rule(
+                "1",
+                AnyOf(AllOf(SubjectOrg("ttd"))),
+                AnyOf(AllOf(ResourceOrg("ttd"), ResourceApp("myapp"))),
+                AnyOf(AllOf(Action("read")), AllOf(Action("write")))
+            ),
+            Rule(
+                "2",
+                AnyOf(AllOf(SubjectOrg("ttd"))),
+                AnyOf(AllOf(ResourceOrg("ttd"), ResourceApp("myapp"), ResourceEndEvent("EndEvent_99"))),
+                AnyOf(AllOf(Action("complete")))
+            )
+        );
+        _app.Write(
+            "config/process/process.bpmn",
+            BpmnBuilder.Process(
+                BpmnBuilder.Task("Task_1", "data"),
+                BpmnBuilder.Flow("Flow_end", "Task_1", "EndEvent_1"),
+                BpmnBuilder.EndEvent("EndEvent_1")
+            )
+        );
+
+        var warnings = await Migrate(policy);
+
+        Assert.Contains(
+            warnings,
+            w =>
+                w.Contains("Added a policy rule", StringComparison.Ordinal)
+                && w.Contains("[complete]", StringComparison.Ordinal)
+        );
+    }
+
+    [Fact]
+    public async Task SignGrantScopedToANonSigningTask_DoesNotSatisfyTheSigningTask()
+    {
+        var policy = Policy(
+            Rule(
+                "1",
+                AnyOf(AllOf(SubjectOrg("ttd"))),
+                AnyOf(AllOf(ResourceOrg("ttd"), ResourceApp("myapp"))),
+                AnyOf(AllOf(Action("read")), AllOf(Action("write")), AllOf(Action("complete")))
+            ),
+            Rule(
+                "2",
+                AnyOf(AllOf(SubjectOrg("ttd"))),
+                AnyOf(AllOf(ResourceOrg("ttd"), ResourceApp("myapp"), ResourceTask("Task_1"))),
+                AnyOf(AllOf(Action("sign")), AllOf(Action("reject")))
+            )
+        );
+        _app.Write(
+            "config/process/process.bpmn",
+            BpmnBuilder.Process(
+                BpmnBuilder.Task("Task_1", "data"),
+                BpmnBuilder.Task("Task_2", "signing"),
+                BpmnBuilder.Flow("Flow_1", "Task_1", "Task_2")
+            )
+        );
+
+        var warnings = await Migrate(policy);
+
+        Assert.Contains(warnings, w => w.Contains("'sign'", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task SignGrantScopedToTheSigningTask_Satisfies()
+    {
+        var policy = Policy(
+            Rule(
+                "1",
+                AnyOf(AllOf(SubjectOrg("ttd"))),
+                AnyOf(AllOf(ResourceOrg("ttd"), ResourceApp("myapp"))),
+                AnyOf(AllOf(Action("read")), AllOf(Action("write")), AllOf(Action("complete")))
+            ),
+            Rule(
+                "2",
+                AnyOf(AllOf(SubjectOrg("ttd"))),
+                AnyOf(AllOf(ResourceOrg("ttd"), ResourceApp("myapp"), ResourceTask("Task_2"))),
+                AnyOf(AllOf(Action("sign")), AllOf(Action("reject")))
+            )
+        );
+        _app.Write(
+            "config/process/process.bpmn",
+            BpmnBuilder.Process(
+                BpmnBuilder.Task("Task_1", "data"),
+                BpmnBuilder.Task("Task_2", "signing"),
+                BpmnBuilder.Flow("Flow_1", "Task_1", "Task_2")
+            )
+        );
+
+        var warnings = await Migrate(policy);
+
+        Assert.Empty(warnings);
+    }
+
+    [Fact]
+    public async Task ConfirmationTask_WarnsOnlyAboutConfirm()
+    {
+        // Confirmation tasks advance with 'confirm' only (see ProcessEngineAuthorizer); warning
+        // about 'reject' for them would be noise.
+        var policy = Policy(
+            Rule(
+                "1",
+                AnyOf(AllOf(SubjectOrg("ttd"))),
+                AnyOf(AllOf(ResourceOrg("ttd"), ResourceApp("myapp"))),
+                AnyOf(AllOf(Action("read")), AllOf(Action("write")), AllOf(Action("complete")))
+            )
+        );
+        _app.Write(
+            "config/process/process.bpmn",
+            BpmnBuilder.Process(
+                BpmnBuilder.Task("Task_1", "data"),
+                BpmnBuilder.Task("Task_2", "confirmation"),
+                BpmnBuilder.Flow("Flow_1", "Task_1", "Task_2")
+            )
+        );
+
+        var warnings = await Migrate(policy);
+
+        Assert.Contains(warnings, w => w.Contains("'confirm'", StringComparison.Ordinal));
+        Assert.DoesNotContain(warnings, w => w.Contains("'reject'", StringComparison.Ordinal));
+    }
+}

--- a/src/cli/studioctl-server-tests/Upgrade/v8Tov9/ServiceOwnerPolicyMigratorTests.cs
+++ b/src/cli/studioctl-server-tests/Upgrade/v8Tov9/ServiceOwnerPolicyMigratorTests.cs
@@ -70,30 +70,21 @@ public sealed class ServiceOwnerPolicyMigratorTests : IDisposable
     }
 
     [Fact]
-    public async Task RealStudioTemplatePolicy_InsertsNothing()
+    public async Task DefaultStudioTemplatePolicy_NeedsNoMigration()
     {
+        // A freshly-scaffolded app ships with the default Studio template, whose org rule already
+        // grants read/write/complete (via the [ORG]/[APP] placeholders). The migrator must recognise
+        // that and leave the file completely untouched. The fixture is a verbatim copy of
+        // src/App/template/src/App/config/authorization/policy.xml.
         var policy = await File.ReadAllTextAsync(
             Path.Combine(AppContext.BaseDirectory, "Upgrade/v8Tov9/TestData/template-policy.xml"),
             TestContext.Current.CancellationToken
         );
-        var metadata = await File.ReadAllTextAsync(
-            Path.Combine(AppContext.BaseDirectory, "Upgrade/v8Tov9/TestData/template-appmetadata.json"),
-            TestContext.Current.CancellationToken
-        );
-        // The template's complete grant is scoped to EndEvent_1; scoped grants only count when the
-        // process really has the element they name.
-        _app.Write(
-            "config/process/process.bpmn",
-            BpmnBuilder.Process(
-                BpmnBuilder.Task("Task_1", "data"),
-                BpmnBuilder.Flow("Flow_end", "Task_1", "EndEvent_1"),
-                BpmnBuilder.EndEvent("EndEvent_1")
-            )
-        );
 
-        var warnings = await Migrate(policy, metadata);
+        var result = await MigrateResult(policy, metadata: null);
 
-        Assert.DoesNotContain(warnings, w => w.Contains("Added a policy rule", StringComparison.Ordinal));
+        Assert.Empty(result.Warnings);
+        Assert.False(result.ManualActionRequired);
         Assert.Equal(policy, PolicyAfter());
     }
 

--- a/src/cli/studioctl-server-tests/Upgrade/v8Tov9/TempAppFolder.cs
+++ b/src/cli/studioctl-server-tests/Upgrade/v8Tov9/TempAppFolder.cs
@@ -46,9 +46,10 @@ internal sealed class TempAppFolder : IDisposable
         {
             Directory.Delete(Root, recursive: true);
         }
-        catch (IOException)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
-            // Best-effort cleanup of temp state; leftovers are harmless.
+            // Best-effort cleanup of temp state; leftovers are harmless. A recursive delete can also
+            // hit UnauthorizedAccessException (e.g. a read-only file), which must not fail the run.
         }
     }
 }

--- a/src/cli/studioctl-server-tests/Upgrade/v8Tov9/TempAppFolder.cs
+++ b/src/cli/studioctl-server-tests/Upgrade/v8Tov9/TempAppFolder.cs
@@ -1,0 +1,54 @@
+namespace Studioctl.Tests.Upgrade.v8Tov9;
+
+/// <summary>
+/// A disposable app folder (repo-root layout with an <c>App/</c> subfolder) in the system temp
+/// directory, for running the v8-to-v9 migrators against synthetic fixtures.
+/// </summary>
+internal sealed class TempAppFolder : IDisposable
+{
+    public string Root { get; }
+
+    public TempAppFolder()
+    {
+        Root = Path.Combine(Path.GetTempPath(), "studioctl-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Root);
+    }
+
+    public string Write(string relativePath, string content)
+    {
+        var path = PreparePath(relativePath);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    public string WriteBytes(string relativePath, byte[] content)
+    {
+        var path = PreparePath(relativePath);
+        File.WriteAllBytes(path, content);
+        return path;
+    }
+
+    private string PreparePath(string relativePath)
+    {
+        var path = Path.Combine(Root, "App", relativePath);
+        if (Path.GetDirectoryName(path) is { } directory)
+            Directory.CreateDirectory(directory);
+        return path;
+    }
+
+    public string Read(string relativePath) => File.ReadAllText(Path.Combine(Root, "App", relativePath));
+
+    public byte[] ReadBytes(string relativePath) => File.ReadAllBytes(Path.Combine(Root, "App", relativePath));
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(Root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup of temp state; leftovers are harmless.
+        }
+    }
+}

--- a/src/cli/studioctl-server-tests/Upgrade/v8Tov9/TestData/template-appmetadata.json
+++ b/src/cli/studioctl-server-tests/Upgrade/v8Tov9/TestData/template-appmetadata.json
@@ -1,4 +1,51 @@
 {
-  "id": "ttd/frontend-test",
-  "org": "ttd"
+  "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/application/application-metadata.schema.v1.json",
+  "id": "[ORG]/[APP]",
+  "org": "[ORG]",
+  "title": { "nb": "[APP]" },
+  "dataTypes": [
+    {
+      "id": "ref-data-as-pdf",
+      "allowedContentTypes": ["application/pdf"],
+      "maxCount": 0,
+      "minCount": 0,
+      "enableFileScan": false,
+      "validationErrorOnPendingFileScan": false,
+      "enabledFileAnalysers": [],
+      "enabledFileValidators": []
+    },
+    {
+      "id": "model",
+      "allowedContentTypes": ["application/xml"],
+      "appLogic": {
+        "autoCreate": true,
+        "classRef": "Altinn.App.Models.model.model",
+        "allowAnonymousOnStateless": false,
+        "autoDeleteOnProcessEnd": false
+      },
+      "taskId": "Task_1",
+      "maxCount": 1,
+      "minCount": 1,
+      "enableFileScan": false,
+      "validationErrorOnPendingFileScan": false,
+      "enabledFileAnalysers": [],
+      "enabledFileValidators": []
+    }
+  ],
+  "partyTypesAllowed": {
+    "bankruptcyEstate": true,
+    "organisation": true,
+    "person": true,
+    "subUnit": true
+  },
+  "access": {
+    "delegable": true,
+    "visible": true,
+    "rightDescription": {
+      "nb": "Ved å gi tilgang til denne tjenesten gir du en annen person fullmakt til å bruke den på dine vegne. Les beskrivelsen av tjenesten for mer informasjon om hva tilgangen innebærer.",
+      "nn": "Når du gir tilgang til denne tenesta, gir du ein annan person fullmakt til å bruka ho på dine vegner. Les skildringa av tenesta for meir informasjon om kva tilgangen inneber.",
+      "en": "By granting access to this service, you are authorising another person to use it on your behalf. Please read the service description for more information about what this access entails."
+    }
+  },
+  "autoDeleteOnProcessEnd": false
 }

--- a/src/cli/studioctl-server-tests/Upgrade/v8Tov9/TestData/template-appmetadata.json
+++ b/src/cli/studioctl-server-tests/Upgrade/v8Tov9/TestData/template-appmetadata.json
@@ -1,0 +1,4 @@
+{
+  "id": "ttd/frontend-test",
+  "org": "ttd"
+}

--- a/src/cli/studioctl-server-tests/Upgrade/v8Tov9/TestData/template-policy.xml
+++ b/src/cli/studioctl-server-tests/Upgrade/v8Tov9/TestData/template-policy.xml
@@ -1,13 +1,13 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<xacml:Policy PolicyId="urn:altinn:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17">
+<?xml version="1.0" encoding="utf-8"?>
+<xacml:Policy PolicyId="urn:altinn:resource:app_[ORG]_[APP]:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17">
   <xacml:Target />
-  <xacml:Rule RuleId="urn:altinn:example:ruleid:1" Effect="Permit">
-    <xacml:Description>A rule giving user with role REGNA, DAGL or SELN and the app owner ttd the right to instantiate a instance of a given app of ttd/frontend-test</xacml:Description>
+  <xacml:Rule RuleId="urn:altinn:resource:app_[ORG]_[APP]:policyid:1:ruleid:1" Effect="Permit">
+    <xacml:Description>Regel for sluttbruker: Gir rettighetene Les, Skriv, Slett og Start til brukere med rollene Privatperson (PRIV) og Daglig leder (DAGL), for hele tjenesten. </xacml:Description>
     <xacml:Target>
       <xacml:AnyOf>
         <xacml:AllOf>
           <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">regna</xacml:AttributeValue>
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">priv</xacml:AttributeValue>
             <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
           </xacml:Match>
         </xacml:AllOf>
@@ -17,189 +17,16 @@
             <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
           </xacml:Match>
         </xacml:AllOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">seln</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
       </xacml:AnyOf>
       <xacml:AnyOf>
         <xacml:AllOf>
           <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">[ORG]</xacml:AttributeValue>
             <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
           </xacml:Match>
           <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">[APP]</xacml:AttributeValue>
             <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-      </xacml:AnyOf>
-      <xacml:AnyOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">instantiate</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">read</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-        <xacml:AllOf>
-          <!-- Allows process next through the custom 'pdfIfRequested' service tasks (unknown task
-               types are authorized against an action of the same name; see ProcessEngineAuthorizer). -->
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">pdfIfRequested</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-      </xacml:AnyOf>
-    </xacml:Target>
-  </xacml:Rule>
-  <xacml:Rule RuleId="urn:altinn:example:ruleid:2" Effect="Permit">
-    <xacml:Description>Rule that defines that user with role REGNA, DAGL or SELN can read and write for ttd/frontend-test when it is in Task_1</xacml:Description>
-    <xacml:Target>
-      <xacml:AnyOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">regna</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">dagl</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">seln</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-      </xacml:AnyOf>
-      <xacml:AnyOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Task_1</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:task" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Task_2</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:task" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Task_3</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:task" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Task_4</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:task" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Task_5</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:task" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Task_Custom_Confirm</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:task" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Task_Default_Confirm</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:task" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">EndEvent_1</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:end-event" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
           </xacml:Match>
         </xacml:AllOf>
       </xacml:AnyOf>
@@ -216,228 +43,28 @@
             <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
           </xacml:Match>
         </xacml:AllOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">confirm</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">reject</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-      </xacml:AnyOf>
-    </xacml:Target>
-  </xacml:Rule>
-  <xacml:Rule RuleId="urn:altinn:example:ruleid:2b" Effect="Permit">
-    <xacml:Description>Rule that defines that user with role REGNA, DAGL or SELN can fill, conflictingOptionsReset, shiftingOptionsAdd, shiftingOptionsRemoveAll for ttd/frontend-test when it is in Task_2</xacml:Description>
-    <xacml:Target>
-      <xacml:AnyOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">regna</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">dagl</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">seln</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-      </xacml:AnyOf>
-      <xacml:AnyOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Task_2</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:task" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-      </xacml:AnyOf>
-      <xacml:AnyOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">fill</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">conflictingOptionsReset</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">shiftingOptionsAdd</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">shiftingOptionsRemoveAll</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-      </xacml:AnyOf>
-    </xacml:Target>
-  </xacml:Rule>
-  <xacml:Rule RuleId="urn:altinn:example:ruleid:2c" Effect="Permit">
-    <xacml:Description>Rule that defines that user with role REGNA, DAGL or SELN can sortPets and generatePets for ttd/frontend-test when it is in Task_3</xacml:Description>
-    <xacml:Target>
-      <xacml:AnyOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">regna</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">dagl</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">seln</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-      </xacml:AnyOf>
-      <xacml:AnyOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Task_3</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:task" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-      </xacml:AnyOf>
-      <xacml:AnyOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">sortPets</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">generatePets</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-      </xacml:AnyOf>
-    </xacml:Target>
-  </xacml:Rule>
-  <xacml:Rule RuleId="urn:altinn:example:ruleid:3" Effect="Permit">
-    <xacml:Description>Rule that defines that user with role REGNA, DAGL or SELN can delete instances of ttd/frontend-test</xacml:Description>
-    <xacml:Target>
-      <xacml:AnyOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">regna</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">dagl</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">seln</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-      </xacml:AnyOf>
-      <xacml:AnyOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-      </xacml:AnyOf>
-      <xacml:AnyOf>
         <xacml:AllOf>
           <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
             <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">delete</xacml:AttributeValue>
             <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
           </xacml:Match>
         </xacml:AllOf>
-      </xacml:AnyOf>
-    </xacml:Target>
-  </xacml:Rule>
-  <xacml:Rule RuleId="urn:altinn:example:ruleid:4" Effect="Permit">
-    <xacml:Description>Rule that defines that org can write to instances of ttd/frontend-test for any states</xacml:Description>
-    <xacml:Target>
-      <xacml:AnyOf>
         <xacml:AllOf>
           <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-      </xacml:AnyOf>
-      <xacml:AnyOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-      </xacml:AnyOf>
-      <xacml:AnyOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">write</xacml:AttributeValue>
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">instantiate</xacml:AttributeValue>
             <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
           </xacml:Match>
         </xacml:AllOf>
       </xacml:AnyOf>
     </xacml:Target>
   </xacml:Rule>
-  <xacml:Rule RuleId="urn:altinn:example:ruleid:5" Effect="Permit">
-    <xacml:Description>Rule that defines that org can complete an instance of ttd/frontend-test which state is at the end event.</xacml:Description>
+  <xacml:Rule RuleId="urn:altinn:resource:app_[ORG]_[APP]:policyid:1:ruleid:2" Effect="Permit">
+    <xacml:Description>Regel for tjenesteeier: Gir rettighetene Les, Skriv, Start, Bekreft mottatt tjenesteeier til organisasjonen som eier tjenesten ([org]).</xacml:Description>
     <xacml:Target>
       <xacml:AnyOf>
         <xacml:AllOf>
           <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">[org]</xacml:AttributeValue>
             <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
           </xacml:Match>
         </xacml:AllOf>
@@ -445,20 +72,34 @@
       <xacml:AnyOf>
         <xacml:AllOf>
           <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">[ORG]</xacml:AttributeValue>
             <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
           </xacml:Match>
           <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">[APP]</xacml:AttributeValue>
             <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">EndEvent_1</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:end-event" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
           </xacml:Match>
         </xacml:AllOf>
       </xacml:AnyOf>
       <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">read</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">write</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">instantiate</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
         <xacml:AllOf>
           <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
             <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">complete</xacml:AttributeValue>
@@ -468,107 +109,10 @@
       </xacml:AnyOf>
     </xacml:Target>
   </xacml:Rule>
-  <xacml:Rule RuleId="urn:altinn:example:ruleid:6" Effect="Permit">
-    <xacml:Description>A rule giving user with role REGNA, DAGL or SELN and the app owner ttd the right to read the appresource events of a given app of ttd/frontend-test</xacml:Description>
-    <xacml:Target>
-      <xacml:AnyOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">regna</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">dagl</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">seln</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-      </xacml:AnyOf>
-      <xacml:AnyOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">events</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:appresource" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-      </xacml:AnyOf>
-      <xacml:AnyOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">read</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-      </xacml:AnyOf>
-    </xacml:Target>
-  </xacml:Rule>
-  <xacml:Rule RuleId="urn:altinn:example:ruleid:7" Effect="Permit">
-    <xacml:Description>Grants the service owner (ttd) the confirm/reject process-transition action(s) the v9 workflow engine replays out-of-band for ttd/frontend-test. Only the actions the standard org rules do not already cover are granted here: read, write (any state) and complete (end event) come from the regular org rules in this policy.</xacml:Description>
-    <xacml:Target>
-      <xacml:AnyOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-      </xacml:AnyOf>
-      <xacml:AnyOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-      </xacml:AnyOf>
-      <xacml:AnyOf>
-        <xacml:AllOf>
-          <!-- The v9 workflow engine persists each process transition to Storage out-of-band as the
-               service owner, replaying the action the user performed. The confirmation task transitions
-               with 'confirm' (or 'reject'), so the org must be permitted those actions too. -->
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">confirm</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">reject</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
-          </xacml:Match>
-        </xacml:AllOf>
-      </xacml:AnyOf>
-    </xacml:Target>
-  </xacml:Rule>
   <xacml:ObligationExpressions>
     <xacml:ObligationExpression ObligationId="urn:altinn:obligation:authenticationLevel1" FulfillOn="Permit">
       <xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation1-assignment1" Category="urn:altinn:minimum-authenticationlevel">
-        <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">0</xacml:AttributeValue>
+        <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">2</xacml:AttributeValue>
       </xacml:AttributeAssignmentExpression>
     </xacml:ObligationExpression>
     <xacml:ObligationExpression ObligationId="urn:altinn:obligation:authenticationLevel2" FulfillOn="Permit">

--- a/src/cli/studioctl-server-tests/Upgrade/v8Tov9/TestData/template-policy.xml
+++ b/src/cli/studioctl-server-tests/Upgrade/v8Tov9/TestData/template-policy.xml
@@ -1,0 +1,580 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xacml:Policy PolicyId="urn:altinn:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17">
+  <xacml:Target />
+  <xacml:Rule RuleId="urn:altinn:example:ruleid:1" Effect="Permit">
+    <xacml:Description>A rule giving user with role REGNA, DAGL or SELN and the app owner ttd the right to instantiate a instance of a given app of ttd/frontend-test</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">regna</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">dagl</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">seln</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">instantiate</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">read</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <!-- Allows process next through the custom 'pdfIfRequested' service tasks (unknown task
+               types are authorized against an action of the same name; see ProcessEngineAuthorizer). -->
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">pdfIfRequested</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+  <xacml:Rule RuleId="urn:altinn:example:ruleid:2" Effect="Permit">
+    <xacml:Description>Rule that defines that user with role REGNA, DAGL or SELN can read and write for ttd/frontend-test when it is in Task_1</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">regna</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">dagl</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">seln</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Task_1</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:task" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Task_2</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:task" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Task_3</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:task" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Task_4</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:task" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Task_5</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:task" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Task_Custom_Confirm</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:task" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Task_Default_Confirm</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:task" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">EndEvent_1</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:end-event" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">read</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">write</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">confirm</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">reject</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+  <xacml:Rule RuleId="urn:altinn:example:ruleid:2b" Effect="Permit">
+    <xacml:Description>Rule that defines that user with role REGNA, DAGL or SELN can fill, conflictingOptionsReset, shiftingOptionsAdd, shiftingOptionsRemoveAll for ttd/frontend-test when it is in Task_2</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">regna</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">dagl</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">seln</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Task_2</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:task" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">fill</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">conflictingOptionsReset</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">shiftingOptionsAdd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">shiftingOptionsRemoveAll</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+  <xacml:Rule RuleId="urn:altinn:example:ruleid:2c" Effect="Permit">
+    <xacml:Description>Rule that defines that user with role REGNA, DAGL or SELN can sortPets and generatePets for ttd/frontend-test when it is in Task_3</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">regna</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">dagl</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">seln</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Task_3</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:task" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">sortPets</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">generatePets</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+  <xacml:Rule RuleId="urn:altinn:example:ruleid:3" Effect="Permit">
+    <xacml:Description>Rule that defines that user with role REGNA, DAGL or SELN can delete instances of ttd/frontend-test</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">regna</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">dagl</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">seln</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">delete</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+  <xacml:Rule RuleId="urn:altinn:example:ruleid:4" Effect="Permit">
+    <xacml:Description>Rule that defines that org can write to instances of ttd/frontend-test for any states</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">write</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+  <xacml:Rule RuleId="urn:altinn:example:ruleid:5" Effect="Permit">
+    <xacml:Description>Rule that defines that org can complete an instance of ttd/frontend-test which state is at the end event.</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">EndEvent_1</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:end-event" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">complete</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+  <xacml:Rule RuleId="urn:altinn:example:ruleid:6" Effect="Permit">
+    <xacml:Description>A rule giving user with role REGNA, DAGL or SELN and the app owner ttd the right to read the appresource events of a given app of ttd/frontend-test</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">regna</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">dagl</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">seln</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">events</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:appresource" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">read</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+  <xacml:Rule RuleId="urn:altinn:example:ruleid:7" Effect="Permit">
+    <xacml:Description>Grants the service owner (ttd) the confirm/reject process-transition action(s) the v9 workflow engine replays out-of-band for ttd/frontend-test. Only the actions the standard org rules do not already cover are granted here: read, write (any state) and complete (end event) come from the regular org rules in this policy.</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <!-- The v9 workflow engine persists each process transition to Storage out-of-band as the
+               service owner, replaying the action the user performed. The confirmation task transitions
+               with 'confirm' (or 'reject'), so the org must be permitted those actions too. -->
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">confirm</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">reject</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+  <xacml:ObligationExpressions>
+    <xacml:ObligationExpression ObligationId="urn:altinn:obligation:authenticationLevel1" FulfillOn="Permit">
+      <xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation1-assignment1" Category="urn:altinn:minimum-authenticationlevel">
+        <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">0</xacml:AttributeValue>
+      </xacml:AttributeAssignmentExpression>
+    </xacml:ObligationExpression>
+    <xacml:ObligationExpression ObligationId="urn:altinn:obligation:authenticationLevel2" FulfillOn="Permit">
+      <xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation2-assignment2" Category="urn:altinn:minimum-authenticationlevel-org">
+        <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">3</xacml:AttributeValue>
+      </xacml:AttributeAssignmentExpression>
+    </xacml:ObligationExpression>
+  </xacml:ObligationExpressions>
+</xacml:Policy>

--- a/src/cli/studioctl-server/studioctl-server.csproj
+++ b/src/cli/studioctl-server/studioctl-server.csproj
@@ -12,6 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Studioctl.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="../../Shared/HostBridge/**/*.cs" LinkBase="HostBridge" />
     <Compile Include="../../Shared/EnvTopology/**/*.cs" LinkBase="EnvTopology" />
   </ItemGroup>


### PR DESCRIPTION
## Description

`studioctl-server` had no test project, so the v8→v9 upgrade migrators from #19426 — `PdfServiceTaskMigrator` (Job 8) and `ServiceOwnerPolicyMigrator` (Job 9) — were only exercised end-to-end against the in-repo test apps. These jobs do textual surgery on real service-owner repos, where a silent mis-migration surfaces as a production app that cannot advance its process, so they deserve durable regression coverage.

This adds **`Studioctl.Tests`** (xunit.v3, matching the workflow-engine test conventions) with **52 tests** across three suites. The migrators run against synthetic fixtures built by small composable helpers (`BpmnBuilder`, `PolicyXmlBuilder`) in a throwaway temp app folder, so the tests assert on the real rewrite output — not a mock.

**`ServiceOwnerPolicyMigratorTests` (19) — Job 9, service-owner policy migration**
- XACML target evaluation semantics: subject/action pairing per `AllOf` (a rule is not misread as an org grant when the action belongs to a different subject), task- and end-event scoping, rules carrying a `Condition`
- org/app anchoring: `applicationmetadata.json` as the source of truth, the `[ORG]`/`[APP]` placeholder convention, foreign-org-first policies, no-metadata fallback
- insertion mechanics: rule-id sequencing, BOM preservation, idempotency
- inconclusive/unsafe inputs: Deny rules (deny-overrides ⇒ no silent insertion), a rule inserted into a commented-out region detected and rolled back, non-UTF-8 policy refused and left byte-identical
- task-specific actions warned about (sign/reject, confirm-only for `confirmation`), verified against real `process.bpmn` task ids and end-event ids
- regression check that the unmodified default Studio template policy needs no migration (fixture is a verbatim copy of `src/App/template/.../policy.xml`)

**`PdfServiceTaskMigratorTests` (26) — Job 8, PDF service-task migration**
- service-task insertion and flow rewiring (`T → PdfTask_T → X`), flag stripped on success
- legacy no-op semantics (attachment dataTypes, missing `taskId`) — no task added, flag still stripped
- flag-kept-on-skip contract (task not found, ambiguous outgoing flows, `taskId` naming a non-task element, `PdfTask_*`/flow-id collisions) vs. already-migrated detection
- gateway `connectedDataTypeId` pinning (and leaving explicit ones alone)
- BOM / newline-style / trailing-newline preservation both ways, idempotency, no rewrite on a no-op run
- malformed/non-UTF-8 metadata and BPMN produce actionable warnings instead of throwing
- `MigrationResult.ManualActionRequired` contract: clean migration and legacy no-op are clean; a skipped task is not
- case-insensitive flag detection (`EnablePdfCreation`), matching v8's Newtonsoft binding
- regression check that the unmodified default Studio template `applicationmetadata.json` (no `enablePdfCreation`) needs no migration (fixture is a verbatim copy of `src/App/template/.../applicationmetadata.json`)

**`ApplicationMetadataPdfRewriterTests` (7) — metadata line-level strip**
- trailing-comma repair, CRLF preservation, refusal on compact formatting, no false match inside a string value, odd-cased flag stripped, BOM preserved, no-op when the flag is absent

### Wiring

- `make test` in `src/cli` now runs the dotnet tests after the Go tests, so the existing `CLI - Build and test` workflow picks them up on all three OS legs (ubuntu/macos/windows) with no workflow changes.
- The test project lives in a sibling folder (`studioctl-server-tests`) because the server csproj's default compile glob would otherwise pull the test sources into the server build.
- MSBuild package references mirror the server project's `ExcludeAssets="runtime"` pattern to satisfy the Locator's MSBL001 guard on transitive references.

## Verification

- [x] **Your code builds clean without any errors or warnings**
- [x] **Manual testing done (required)**
- [x] **Relevant automated test added (if you find this hard, leave it and we'll help out)**

## Related PRs

Part of the v9 workflow-engine / PDF service-task rollout — all prerequisites now merged:

1. ✅ #19487 — out-of-band callback auth, service-owner policies, localtest transition guard
2. ✅ #19486 — workflow engine: Abandoned workflow status with idempotency-key release
3. ✅ #19426 — deprecate `enablePdfCreation`: PDF service tasks + v8→v9 migrations (Jobs 8/9)
4. #19449 — eFormidling migration (Job 10) and #19468 — studioctl migrator unit tests (either order) — **now based directly on `main`**

Related: #19410 (surfacing service-task failure on the read path; independent) · Altinn/altinn-storage#1027 (the same transition guard in real Storage — must be deployed before the app-lib release containing this rollout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new .NET test coverage for v8→v9 upgrade behaviour, including `enablePdfCreation` handling, warnings/manual-action paths, idempotency, and robust refusal when inputs are malformed.
  * Introduced focused suites for PDF service-task migration and service-owner policy migration, with checks for UTF-8 BOM and CRLF/LF preservation.
* **Chores**
  * Centralised test package versions and expanded shared test fixtures/builders for upgrade scenarios.
  * Updated the `test` command to run the new .NET test suite alongside existing checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
