### PR TITLE
chore(deps): update gateway dotnet image digests

### DIFF
--- a/src/Runtime/gateway/Dockerfile
+++ b/src/Runtime/gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0-noble@sha256:548d93f8a18a1acbe6cc127bc4f47281430d34a9e35c18afa80a8d6741c2adc3 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0-noble@sha256:ea8bde36c11b6e7eec2656d0e59101d4462f6bd630730f2c8201ed0572b295d5 AS build
 
 # Install native AOT build prerequisites
 RUN apt-get update && apt-get install -y clang zlib1g-dev && rm -rf /var/lib/apt/lists/*
@@ -23,7 +23,7 @@ COPY Runtime/gateway/src/Altinn.Studio.Gateway.Contracts/ Runtime/gateway/src/Al
 WORKDIR /build/Runtime/gateway/src/Altinn.Studio.Gateway.Api/
 RUN dotnet publish -c Release -o /app/publish /p:CSharpier_Bypass=true
 
-FROM mcr.microsoft.com/dotnet/runtime-deps:10.0-noble-chiseled@sha256:9cae0b131d058693c8d7496fed4a188380f05f27f34c98dd9a516b4d0331b0c4
+FROM mcr.microsoft.com/dotnet/runtime-deps:10.0-noble-chiseled@sha256:01bd3f3d617a16705f896962ce26f5c1e1588ea57c71c98908cadb7bdcd0cd4d
 WORKDIR /app
 COPY --from=build /app/publish .
 


### PR DESCRIPTION
## Summary

@martinothamar updates the Runtime gateway Docker base-image digests for the existing stable tags:

- `mcr.microsoft.com/dotnet/sdk:10.0-noble`
- `mcr.microsoft.com/dotnet/runtime-deps:10.0-noble-chiseled`

Both tags stay unchanged; this is digest-only.

## Safety

- No stable -> preview move.
- SDK image remains Ubuntu `24.04.4 LTS`, .NET SDK `10.0.301`, ASP.NET/.NET runtime `10.0.9`.
- Runtime-deps image config remains unchanged, including `USER 1654`, env, and no default command/cmd.
- SDK package diff is Ubuntu patch/security updates only: CA certificates, libgcrypt, GnuTLS, xz/lzma, Perl, systemd/udev.
- Final `runtime-deps` chiseled package diff is only `ca-certificates 20240203 -> 20260601~24.04.1`.

## Testing

- `make build` in `src/Runtime/gateway`
- `make lint` in `src/Runtime/gateway`
- `docker build -t altinn-gateway:pr-gateway-digests -f Runtime/gateway/Dockerfile .` from `src`
- Container smoke: started `altinn-gateway:pr-gateway-digests` and verified `GET /health/live` returned `Healthy`

Existing warning: `Microsoft.OpenApi 2.0.0` emits NU1903 during restore/build, but this PR does not change NuGet dependencies.

## Reviewer subagent

No findings. Reviewer confirmed this is a digest-only update for unchanged stable MCR tags, with current digests, same platform coverage, unchanged .NET versions, and only normal CA/Ubuntu patch churn. Residual risk is limited to normal CA trust-store churn from the `ca-certificates` update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pinned base image digests used by the gateway container build and runtime images.
  * No changes to build steps, runtime behaviour, or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->