### PR TITLE
fix: bind localtest skip-cleanup header via [FromHeader] nullable bool

### DIFF
--- a/src/Runtime/localtest/src/Controllers/Storage/ProcessController.cs
+++ b/src/Runtime/localtest/src/Controllers/Storage/ProcessController.cs
@@ -37,7 +37,7 @@ public class ProcessController : ControllerBase
     /// <summary>
     /// Header set by callers that manage their own task-generated data cleanup (e.g. v9 apps, which
     /// prune elements generated from the entered task at task start). When present and true, this
-    /// service skips its own cleanup so it does not race the caller's writes.
+    /// controller skips its own cleanup so it does not race the caller's writes.
     /// </summary>
     private const string SkipTaskDataCleanupHeaderName = "Altinn-Storage-Skip-Task-Data-Cleanup";
 
@@ -133,6 +133,13 @@ public class ProcessController : ControllerBase
     /// <param name="instanceOwnerPartyId">The party id of the instance owner.</param>
     /// <param name="instanceGuid">The id of the instance that should have its process updated.</param>
     /// <param name="processStateUpdate">The new process state of the instance (including instance events).</param>
+    /// <param name="skipTaskDataCleanupHeader">
+    /// Value of the <c>Altinn-Storage-Skip-Task-Data-Cleanup</c> header, bound as a nullable boolean. When
+    /// <c>true</c> the caller is declaring it manages its own task-generated data and this controller skips
+    /// its cleanup; absent (<c>null</c>) or <c>false</c> cleans as normal. A non-boolean value is rejected
+    /// with <c>400 Bad Request</c> by model binding - a caller sending this deliberate header is expected
+    /// to encode a valid boolean.
+    /// </param>
     /// <param name="cancellationToken">CancellationToken</param>
     /// <returns></returns>
     [Authorize]
@@ -146,6 +153,7 @@ public class ProcessController : ControllerBase
         int instanceOwnerPartyId,
         Guid instanceGuid,
         [FromBody] ProcessStateUpdate processStateUpdate,
+        [FromHeader(Name = SkipTaskDataCleanupHeaderName)] bool? skipTaskDataCleanupHeader,
         CancellationToken cancellationToken
     )
     {
@@ -189,7 +197,8 @@ public class ProcessController : ControllerBase
         // visits to that same task (e.g. stale PDFs, signatures) - unless the caller manages its own
         // task-generated data cleanup and has opted out via header (see SkipTaskDataCleanupHeaderName).
         string? targetTaskId = processState.CurrentTask?.ElementId;
-        if (!string.IsNullOrWhiteSpace(targetTaskId) && !CallerManagesTaskDataCleanup())
+        bool callerManagesTaskDataCleanup = skipTaskDataCleanupHeader == true;
+        if (!string.IsNullOrWhiteSpace(targetTaskId) && !callerManagesTaskDataCleanup)
         {
             await _processDataCleanupService.CleanupGeneratedFromTask(
                 existingInstance,
@@ -294,11 +303,6 @@ public class ProcessController : ControllerBase
             $"Unable to find instance {instanceOwnerPartyId}/{instanceGuid}: {message}"
         );
     }
-
-    private bool CallerManagesTaskDataCleanup() =>
-        Request.Headers.TryGetValue(SkipTaskDataCleanupHeaderName, out var value)
-        && bool.TryParse(value.ToString(), out bool skip)
-        && skip;
 
     private void UpdateInstance(
         Instance existingInstance,


### PR DESCRIPTION
## Summary

Keeps localtest a faithful stand-in for real Storage by mirroring the header-binding change from Altinn/altinn-storage#1027.

localtest's `ProcessController` read the `Altinn-Storage-Skip-Task-Data-Cleanup` header off `Request.Headers` with a lenient `bool.TryParse`. Storage now binds it as a nullable boolean via `[FromHeader]` model binding (cleaner, self-documenting, surfaces in OpenAPI, and satisfies SonarCloud S6932). This change brings localtest in line so the two behave identically.

## What changed

- `PutInstanceAndEvents` gains a `[FromHeader(Name = "Altinn-Storage-Skip-Task-Data-Cleanup")] bool? skipTaskDataCleanupHeader` parameter; the cleanup is gated on `skipTaskDataCleanupHeader == true`.
- The `Request.Headers`-based `CallerManagesTaskDataCleanup()` helper is removed.

## Behavior

Identical to Storage on every value app-lib actually sends, and on malformed input:

| Header | Result |
| --- | --- |
| `true` | skip cleanup |
| `false` / absent | clean as normal |
| non-boolean | `400 Bad Request` (model binding, before the action runs) |

The only behavioral change from before is the non-boolean case: it used to fall through to a normal cleanup, and now returns 400. A caller sending this deliberate, verbose header is expected to encode a valid boolean, so a loud failure is preferable to a silent fall-through — and it matches Storage.

## Related

- Altinn/altinn-storage#1027 — the real Storage implementation this mirrors
- Altinn/altinn-studio#19487 — where the localtest header gate was originally added

## Verification

`LocalTest.csproj` builds clean (0 warnings / 0 errors). localtest has no unit tests for these Storage controllers; the header-binding behavior was verified against a minimal `[ApiController]` repro and is exercised end-to-end by the signering flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of the task data cleanup opt-out header when creating or updating instances.
  * Requests with invalid header values are now rejected automatically with `400 Bad Request`.
  * Cleanup is skipped only when the header is explicitly set to `true`.
* **Documentation**
  * Updated the header description to reflect the new validation and binding behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->