### PR TITLE
refactor: split LspServer into focused components

### DIFF
--- a/.github/workflows/cli-dotnet-build-test.yaml
+++ b/.github/workflows/cli-dotnet-build-test.yaml
@@ -31,6 +31,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
+      - name: Enable long paths for git on Windows
+        if: matrix.os == 'windows-latest'
+        run: git config --system core.longpaths true
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup .NET

--- a/.github/workflows/libs-dotnet-build-test.yaml
+++ b/.github/workflows/libs-dotnet-build-test.yaml
@@ -23,6 +23,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
+      - name: Enable long paths for git on Windows
+        if: matrix.os == 'windows-latest'
+        run: git config --system core.longpaths true
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup .NET

--- a/src/cli/Directory.Packages.props
+++ b/src/cli/Directory.Packages.props
@@ -26,6 +26,7 @@
     <!-- Test packages -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>

--- a/src/cli/studioctl-lsp.Tests/LspServerTests.cs
+++ b/src/cli/studioctl-lsp.Tests/LspServerTests.cs
@@ -459,7 +459,7 @@ public sealed class LspServerTests
     public void UnchangedDiagnostics_AreNotRepublished()
     {
         var publishes = RunDiagnosticsSession(SettingsJson + "\n"); // trailing newline: no semantic/position change
-        Assert.Equal(1, publishes.Count());
+        Assert.Single(publishes);
     }
 
     // A burst of changes validates once (debounced; the synchronous harness flushes on exit), and a
@@ -471,7 +471,7 @@ public sealed class LspServerTests
         var v3 = SettingsJson.Replace("MissingPage", "FinalMissing");
         var publishes = RunDiagnosticsSession(v2, v3);
 
-        Assert.Equal(2, publishes.Count()); // the initial set + ONE update for the two-change burst
+        Assert.Equal(2, publishes.Count); // the initial set + ONE update for the two-change burst
         var last = publishes[^1].GetProperty("diagnostics").EnumerateArray().ToList();
         Assert.Contains(last, d => (d.GetProperty("message").GetString() ?? "").Contains("FinalMissing"));
         Assert.DoesNotContain(last, d => (d.GetProperty("message").GetString() ?? "").Contains("OtherMissing"));
@@ -655,7 +655,7 @@ public sealed class LspServerTests
             )
             .ToList();
 
-        Assert.Equal(1, publishes.Count()); // the no-op change re-published nothing new
+        Assert.Single(publishes); // the no-op change re-published nothing new
         Assert.Contains(
             publishes[0].GetProperty("diagnostics").EnumerateArray(),
             d => d.GetProperty("code").GetString() == "REF-PAGE-FILE"

--- a/src/cli/studioctl-lsp.Tests/WorkspaceStateTests.cs
+++ b/src/cli/studioctl-lsp.Tests/WorkspaceStateTests.cs
@@ -4,16 +4,16 @@ namespace Altinn.Studio.AppConfigLsp.Tests;
 
 public sealed class WorkspaceStateTests
 {
+    private static string? NormalizedLocalPath(string? uri) => WorkspaceState.LocalPath(uri)?.Replace('\\', '/');
+
     [Fact]
     public void LocalPath_PercentEncodedDriveColonUri_HasNoLeadingSeparator()
     {
-        var path = WorkspaceState.LocalPath("file:///c%3A/Erling/Kode/apper/saksbehandling-konsept");
-
         Assert.Equal(
             OperatingSystem.IsWindows()
-                ? @"c:\Erling\Kode\apper\saksbehandling-konsept"
+                ? "c:/Erling/Kode/apper/saksbehandling-konsept"
                 : "/c:/Erling/Kode/apper/saksbehandling-konsept",
-            path
+            NormalizedLocalPath("file:///c%3A/Erling/Kode/apper/saksbehandling-konsept")
         );
     }
 
@@ -21,18 +21,15 @@ public sealed class WorkspaceStateTests
     public void LocalPath_LiteralDriveColonUri_IsDrivePath()
     {
         Assert.Equal(
-            @"c:\Erling\Kode\apper\saksbehandling-konsept",
-            WorkspaceState.LocalPath("file:///c:/Erling/Kode/apper/saksbehandling-konsept")
+            "c:/Erling/Kode/apper/saksbehandling-konsept",
+            NormalizedLocalPath("file:///c:/Erling/Kode/apper/saksbehandling-konsept")
         );
     }
 
     [Fact]
     public void LocalPath_UnixPathUri_IsUnchanged()
     {
-        Assert.Equal(
-            OperatingSystem.IsWindows() ? @"\home\erling\app" : "/home/erling/app",
-            WorkspaceState.LocalPath("file:///home/erling/app")
-        );
+        Assert.Equal("/home/erling/app", NormalizedLocalPath("file:///home/erling/app"));
     }
 
     [Fact]

--- a/src/cli/studioctl-lsp.Tests/WorkspaceStateTests.cs
+++ b/src/cli/studioctl-lsp.Tests/WorkspaceStateTests.cs
@@ -1,0 +1,45 @@
+using Xunit;
+
+namespace Altinn.Studio.AppConfigLsp.Tests;
+
+public sealed class WorkspaceStateTests
+{
+    [Fact]
+    public void LocalPath_PercentEncodedDriveColonUri_HasNoLeadingSeparator()
+    {
+        var path = WorkspaceState.LocalPath("file:///c%3A/Erling/Kode/apper/saksbehandling-konsept");
+
+        Assert.Equal(
+            OperatingSystem.IsWindows()
+                ? @"c:\Erling\Kode\apper\saksbehandling-konsept"
+                : "/c:/Erling/Kode/apper/saksbehandling-konsept",
+            path
+        );
+    }
+
+    [Fact]
+    public void LocalPath_LiteralDriveColonUri_IsDrivePath()
+    {
+        Assert.Equal(
+            @"c:\Erling\Kode\apper\saksbehandling-konsept",
+            WorkspaceState.LocalPath("file:///c:/Erling/Kode/apper/saksbehandling-konsept")
+        );
+    }
+
+    [Fact]
+    public void LocalPath_UnixPathUri_IsUnchanged()
+    {
+        Assert.Equal(
+            OperatingSystem.IsWindows() ? @"\home\erling\app" : "/home/erling/app",
+            WorkspaceState.LocalPath("file:///home/erling/app")
+        );
+    }
+
+    [Fact]
+    public void LocalPath_MalformedUri_ReturnsNull()
+    {
+        Assert.Null(WorkspaceState.LocalPath("not a uri"));
+        Assert.Null(WorkspaceState.LocalPath(""));
+        Assert.Null(WorkspaceState.LocalPath(null));
+    }
+}

--- a/src/cli/studioctl-lsp/DiagnosticsPublisher.cs
+++ b/src/cli/studioctl-lsp/DiagnosticsPublisher.cs
@@ -14,7 +14,7 @@ internal sealed class DiagnosticsPublisher(
     LspConversions convert,
     LspTransport transport,
     Logger log
-) : IDisposable
+)
 {
     private const int DebounceMs = 150;
 
@@ -39,7 +39,7 @@ internal sealed class DiagnosticsPublisher(
         Validate();
     }
 
-    public void Dispose() => _timer?.Dispose();
+    public void Stop() => _timer?.Dispose();
 
     private void Debounced()
     {

--- a/src/cli/studioctl-lsp/DiagnosticsPublisher.cs
+++ b/src/cli/studioctl-lsp/DiagnosticsPublisher.cs
@@ -1,0 +1,114 @@
+using System.Text.Json;
+using Altinn.Studio.AppConfig.Validation;
+
+namespace Altinn.Studio.AppConfigLsp;
+
+/// <summary>
+/// Debounced validation of the workspace and publishing of the resulting diagnostics,
+/// deduplicated per URI so unchanged sets aren't re-sent. <paramref name="sync"/> is the
+/// server's handler lock; the debounce timer takes it before validating.
+/// </summary>
+internal sealed class DiagnosticsPublisher(
+    object sync,
+    WorkspaceState workspace,
+    LspConversions convert,
+    LspTransport transport,
+    Logger log
+) : IDisposable
+{
+    private const int DebounceMs = 150;
+
+    private readonly Dictionary<string, string> _published = new(StringComparer.Ordinal);
+    private Timer? _timer;
+    private bool _pending;
+
+    // Called with the handler lock held (all callers run inside a handler).
+    public void Schedule()
+    {
+        _pending = true;
+        _timer ??= new Timer(_ => Debounced(), null, Timeout.Infinite, Timeout.Infinite);
+        _timer.Change(DebounceMs, Timeout.Infinite);
+    }
+
+    // Called with the handler lock held.
+    public void Flush()
+    {
+        if (!_pending)
+            return;
+        _pending = false;
+        Validate();
+    }
+
+    public void Dispose() => _timer?.Dispose();
+
+    private void Debounced()
+    {
+        try
+        {
+            lock (sync)
+                Flush();
+        }
+        catch (Exception ex)
+        {
+            log.Log(LogLevel.Error, $"debounced validation failed: {ex}");
+        }
+    }
+
+    private void Validate()
+    {
+        if (!workspace.HasWorkspace)
+            return;
+
+        var engine = workspace.EnsureEngine();
+        if (engine is null)
+            return;
+
+        IReadOnlyList<Finding> findings;
+        try
+        {
+            findings = ValidationEngine.Run(engine.Build()).Findings;
+        }
+        catch (Exception ex)
+        {
+            log.Log(LogLevel.Error, $"validation failed: {ex}");
+            return;
+        }
+
+        var byUri = new Dictionary<string, List<Diagnostic>>(StringComparer.Ordinal);
+        foreach (var f in findings)
+        {
+            var pos = engine.ResolvePosition(f.Position);
+            if (string.IsNullOrEmpty(pos.File))
+                continue;
+            var uri = workspace.ToUri(pos.File);
+            if (!byUri.TryGetValue(uri, out var list))
+                byUri[uri] = list = new List<Diagnostic>();
+            list.Add(convert.ToDiagnostic(f, pos));
+        }
+
+        log.Log(LogLevel.Debug, $"validated: {findings.Count} finding(s) across {byUri.Count} file(s)");
+        foreach (var (uri, diagnostics) in byUri)
+            Publish(uri, diagnostics);
+        // Clear files that went clean (the publish mutates _published, hence the snapshot).
+        foreach (var uri in _published.Keys.Where(u => !byUri.ContainsKey(u)).ToList())
+            Publish(uri, Array.Empty<Diagnostic>());
+    }
+
+    // A publish replaces the URI's whole state, so the wire format is the identity to dedupe on.
+    private void Publish(string uri, IReadOnlyList<Diagnostic> diagnostics)
+    {
+        var payload = JsonSerializer.Serialize(diagnostics, LspJson.Options);
+        if (diagnostics.Count == 0)
+        {
+            if (!_published.Remove(uri))
+                return;
+        }
+        else
+        {
+            if (_published.TryGetValue(uri, out var prev) && string.Equals(prev, payload, StringComparison.Ordinal))
+                return;
+            _published[uri] = payload;
+        }
+        transport.Notify("textDocument/publishDiagnostics", new PublishDiagnosticsParams(uri, diagnostics));
+    }
+}

--- a/src/cli/studioctl-lsp/LanguageFeatures.cs
+++ b/src/cli/studioctl-lsp/LanguageFeatures.cs
@@ -1,0 +1,226 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using System.Text.Json;
+using Altinn.Studio.AppConfig;
+using Altinn.Studio.AppConfig.Documents.Text;
+
+namespace Altinn.Studio.AppConfigLsp;
+
+/// <summary>
+/// The symbol-backed requests: hover, definition/references, completion, rename,
+/// code actions, and code lenses. Callers hold the server's handler lock.
+/// </summary>
+internal sealed class LanguageFeatures(
+    WorkspaceState workspace,
+    LspConversions convert,
+    DiagnosticsPublisher diagnostics
+)
+{
+    // Shared prologue of every engine-reading request: flush pending validation (answer against
+    // the latest buffer, not the debounce-pending state), ensure the engine, and resolve the
+    // request's document. False when the engine isn't ready or the URI is outside the app.
+    private bool TryResolveRequest(
+        TextDocumentIdentifier? textDocument,
+        [NotNullWhen(true)] out string? rel,
+        [NotNullWhen(true)] out AppSymbols? symbols
+    )
+    {
+        diagnostics.Flush();
+        workspace.EnsureEngine();
+        rel = workspace.ToRelative(textDocument?.Uri);
+        symbols = workspace.Symbols;
+        return rel is not null && symbols is not null;
+    }
+
+    public IReadOnlyList<SourceSpan> Navigate(
+        TextDocumentPositionParams p,
+        Func<AppSymbols, string, int, int, IReadOnlyList<SourceSpan>> query
+    )
+    {
+        if (!TryResolveRequest(p.TextDocument, out var rel, out var symbols))
+            return Array.Empty<SourceSpan>();
+        var (line1, byteCol) = convert.CursorOf(p.Position, rel);
+        return query(symbols, rel, line1, byteCol);
+    }
+
+    public CompletionList OnCompletion(TextDocumentPositionParams p)
+    {
+        var items = new List<CompletionItem>();
+        if (TryResolveRequest(p.TextDocument, out var rel, out var symbols))
+        {
+            var (line1, byteCol) = convert.CursorOf(p.Position, rel);
+            foreach (var s in symbols.Completions(rel, line1, byteCol))
+            {
+                items.Add(
+                    new CompletionItem(
+                        s.Label,
+                        s.Detail,
+                        // LSP CompletionItemKind: Field=5, Class=7, File=17, Reference=18, EnumMember=20, Constant=21.
+                        s.Kind switch
+                        {
+                            SuggestionKind.DataModelPath => 5,
+                            SuggestionKind.DataType => 7,
+                            SuggestionKind.Component => 18,
+                            SuggestionKind.Page => 17,
+                            SuggestionKind.Task => 20,
+                            SuggestionKind.OptionsId => 17,
+                            _ => 21,
+                        }
+                    )
+                );
+            }
+        }
+        return new CompletionList(IsIncomplete: false, items);
+    }
+
+    // Rename the symbol under the cursor everywhere: a WorkspaceEdit replacing each
+    // token with its (JSON-quoted) new value. Null when nothing renameable.
+    public WorkspaceEdit? OnRename(RenameParams p)
+    {
+        if (!TryResolveRequest(p.TextDocument, out var rel, out var symbols))
+            return null;
+        var newName = p.NewName ?? "";
+        if (newName.Length == 0)
+            return null;
+
+        var (line1, byteCol) = convert.CursorOf(p.Position, rel);
+        var edits = symbols.ProposeRename(rel, line1, byteCol, newName);
+        if (edits.Count == 0)
+            return null;
+
+        // A rename that also moves files needs the documentChanges form: text edits first
+        // (on the pre-rename URIs), then the RenameFile operations.
+        var textByUri = new Dictionary<string, List<TextEdit>>(StringComparer.Ordinal);
+        var renames = new List<object>();
+        foreach (var e in edits)
+        {
+            switch (e)
+            {
+                case ReplaceEdit re:
+                    var uri = workspace.ToUri(re.Span.File);
+                    if (!textByUri.TryGetValue(uri, out var list))
+                        textByUri[uri] = list = new List<TextEdit>();
+                    // ReplaceEdit.NewValue is the literal splice text (already JSON-quoted for a string token).
+                    list.Add(new TextEdit(convert.LspRange(re.Span), re.NewValue));
+                    break;
+                case RenameFileEdit mv:
+                    renames.Add(
+                        new RenameFile(
+                            workspace.ToUri(mv.OldPath),
+                            workspace.ToUri(mv.NewPath),
+                            new RenameFileOptions(Overwrite: false, IgnoreIfExists: false)
+                        )
+                    );
+                    break;
+            }
+        }
+        if (renames.Count == 0)
+            return new WorkspaceEdit(Changes: textByUri);
+        var documentChanges = new List<object>();
+        foreach (var kv in textByUri)
+            documentChanges.Add(
+                new TextDocumentEdit(new OptionalVersionedTextDocumentIdentifier(kv.Key, Version: null), kv.Value)
+            );
+        documentChanges.AddRange(renames);
+        return new WorkspaceEdit(DocumentChanges: documentChanges);
+    }
+
+    // The command is registered client-side by the VS Code extension.
+    public List<CodeLens> OnCodeLenses(CodeLensParams p)
+    {
+        var lenses = new List<CodeLens>();
+        if (!TryResolveRequest(p.TextDocument, out var rel, out var symbols))
+            return lenses;
+        var uri = workspace.ToUri(rel);
+        foreach (var lens in symbols.CodeLenses(rel))
+        {
+            lenses.Add(
+                new CodeLens(
+                    convert.LspRange(lens.Range),
+                    new Command(
+                        lens.Title,
+                        "altinnAppConfig.showReferences",
+                        [
+                            uri,
+                            convert.LspStart(lens.Range),
+                            lens
+                                .Locations.Select(l => new Location(workspace.ToUri(l.File), convert.LspRange(l)))
+                                .ToList(),
+                        ]
+                    )
+                )
+            );
+        }
+        return lenses;
+    }
+
+    public List<CodeAction> OnCodeActions(CodeActionParams p)
+    {
+        var actions = new List<CodeAction>();
+        if (!TryResolveRequest(p.TextDocument, out var rel, out var symbols))
+            return actions;
+        var uri = p.TextDocument.Uri;
+        if (uri is null || p.Context?.Diagnostics is not { } diags)
+            return actions;
+
+        foreach (var d in diags)
+        {
+            if (d.Source != "altinn-appconfig" || d.Range is null)
+                continue;
+            var start = d.Range.Start;
+            // `start` is UTF-16 (from our own publish); convert back to a byte column.
+            var suggestion = symbols.SuggestCorrection(rel, start.Line + 1, convert.InputByteColumn(rel, start));
+            if (suggestion is null)
+                continue;
+            actions.Add(
+                new CodeAction(
+                    $"Change to \"{suggestion}\"",
+                    "quickfix",
+                    [d],
+                    IsPreferred: true,
+                    new WorkspaceEdit(
+                        Changes: new Dictionary<string, List<TextEdit>>
+                        {
+                            [uri] = [new TextEdit(d.Range, JsonSerializer.Serialize(suggestion))],
+                        }
+                    )
+                )
+            );
+        }
+        return actions;
+    }
+
+    public PrepareRenameResult? OnPrepareRename(TextDocumentPositionParams p)
+    {
+        if (!TryResolveRequest(p.TextDocument, out var rel, out var symbols))
+            return null;
+        var (line1, byteCol) = convert.CursorOf(p.Position, rel);
+        if (symbols.PrepareRename(rel, line1, byteCol) is not { } pr)
+            return null;
+        return new PrepareRenameResult(convert.LspRange(pr.Range), pr.Placeholder);
+    }
+
+    public Hover? OnHover(TextDocumentPositionParams p)
+    {
+        diagnostics.Flush(); // answer against the latest buffer, not the debounce-pending state
+        var rel = workspace.ToRelative(p.TextDocument.Uri);
+        if (rel is null || workspace.Engine is not { } engine)
+            return null;
+        var byteCol = convert.InputByteColumn(rel, p.Position);
+        if (engine.ResolveNodeAt(rel, p.Position.Line + 1, byteCol) is not { } node)
+            return null;
+
+        var sb = new StringBuilder();
+        if (workspace.Symbols?.SymbolHover(rel, p.Position.Line + 1, byteCol) is { } symbolCard)
+        {
+            sb.Append(symbolCard);
+        }
+        else
+        {
+            sb.Append('`').Append(string.IsNullOrEmpty(node.Pointer) ? "/" : node.Pointer).Append('`');
+            if (node.Key)
+                sb.Append(" _(property name)_");
+        }
+        return new Hover(new MarkupContent("markdown", sb.ToString()), convert.LspRange(node));
+    }
+}

--- a/src/cli/studioctl-lsp/Logger.cs
+++ b/src/cli/studioctl-lsp/Logger.cs
@@ -1,0 +1,35 @@
+namespace Altinn.Studio.AppConfigLsp;
+
+public enum LogLevel
+{
+    Error,
+    Warning,
+    Info,
+    Debug,
+    Trace,
+}
+
+/// <summary>Leveled logging to stderr (stdout carries the protocol).</summary>
+internal sealed class Logger(LogLevel level)
+{
+    public LogLevel Level { get; } = level;
+
+    public void Log(LogLevel level, string message)
+    {
+        if (level > Level)
+            return;
+        Console.Error.WriteLine(
+            $"[{DateTime.Now:HH:mm:ss.fff}] studioctl-lsp {level.ToString().ToLowerInvariant()}: {message}"
+        );
+    }
+
+    public static LogLevel ParseLevel(string? value) =>
+        value?.Trim().ToLowerInvariant() switch
+        {
+            "error" => LogLevel.Error,
+            "warn" or "warning" => LogLevel.Warning,
+            "debug" => LogLevel.Debug,
+            "trace" => LogLevel.Trace,
+            _ => LogLevel.Info,
+        };
+}

--- a/src/cli/studioctl-lsp/LspConversions.cs
+++ b/src/cli/studioctl-lsp/LspConversions.cs
@@ -1,0 +1,66 @@
+using Altinn.Studio.AppConfig.Documents.Text;
+using Altinn.Studio.AppConfig.Validation;
+
+namespace Altinn.Studio.AppConfigLsp;
+
+/// <summary>
+/// Converts between the engine's coordinates (1-based lines, 1-based UTF-8 byte columns,
+/// workspace-relative paths) and the LSP's (0-based lines, 0-based UTF-16 characters, URIs).
+/// </summary>
+internal sealed class LspConversions(WorkspaceState workspace)
+{
+    // An LSP request's 0-based (line, character[UTF-16]) → the engine's 1-based (line, byte column).
+    public int InputByteColumn(string? rel, Position position) =>
+        workspace.MapperFor(rel)?.ToByteColumn(position.Line, position.Character) ?? position.Character + 1;
+
+    // The request's 0-based cursor as the engine's 1-based line + byte column.
+    public (int Line1, int ByteCol) CursorOf(Position position, string rel) =>
+        (position.Line + 1, InputByteColumn(rel, position));
+
+    // Engine columns are 1-based UTF-8 bytes (end exclusive); LSP characters are 0-based UTF-16.
+    public Range LspRange(SourceSpan pos)
+    {
+        var map = workspace.MapperFor(pos.File);
+        var start = LspStart(pos);
+        var endLine = pos.EndLine > 0 ? pos.EndLine - 1 : start.Line;
+        var endCh = ToUtf16Column(map, pos.EndLine, pos.EndColumn, fallback: start.Character + 1);
+        return new Range(start, new Position(endLine, endCh));
+    }
+
+    public Position LspStart(SourceSpan pos)
+    {
+        var map = workspace.MapperFor(pos.File);
+        var line = pos.Line > 0 ? pos.Line - 1 : 0;
+        var ch = ToUtf16Column(map, pos.Line, pos.Column, fallback: 0);
+        return new Position(line, ch);
+    }
+
+    private static int ToUtf16Column(Utf16Mapper? map, int line, int column, int fallback)
+    {
+        if (map is not null && line > 0 && column > 0)
+            return map.ToUtf16Character(line, column);
+        return column > 0 ? column - 1 : fallback;
+    }
+
+    public Diagnostic ToDiagnostic(Finding f, SourceSpan pos) =>
+        new(
+            LspRange(pos),
+            f.Severity switch
+            {
+                Severity.Error => 1,
+                Severity.Warning => 2,
+                _ => 3,
+            },
+            "altinn-appconfig",
+            f.RuleId,
+            f.Message
+        );
+
+    public List<Location> Locations(IReadOnlyList<SourceSpan> spans)
+    {
+        var list = new List<Location>(spans.Count);
+        foreach (var s in spans)
+            list.Add(new Location(workspace.ToUri(s.File), LspRange(s)));
+        return list;
+    }
+}

--- a/src/cli/studioctl-lsp/LspServer.cs
+++ b/src/cli/studioctl-lsp/LspServer.cs
@@ -1,67 +1,39 @@
-using System.Buffers;
-using System.Diagnostics.CodeAnalysis;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Altinn.Studio.AppConfig;
-using Altinn.Studio.AppConfig.Documents;
-using Altinn.Studio.AppConfig.Documents.Text;
-using Altinn.Studio.AppConfig.Models;
-using Altinn.Studio.AppConfig.Validation;
 using StreamJsonRpc;
-using StreamJsonRpc.Protocol;
 
 namespace Altinn.Studio.AppConfigLsp;
 
-public enum LogLevel
-{
-    Error,
-    Warning,
-    Info,
-    Debug,
-    Trace,
-}
-
+/// <summary>
+/// Wires the JSON-RPC endpoint to the components: <see cref="LspTransport"/> (framing),
+/// <see cref="WorkspaceState"/> (root + document overlay), <see cref="DiagnosticsPublisher"/>
+/// (validation), and <see cref="LanguageFeatures"/> (symbol-backed requests). Owns the
+/// lifecycle (initialize/shutdown/exit) and the handler lock everything runs under.
+/// </summary>
 public sealed class LspServer
 {
-    private static readonly JsonSerializerOptions _jsonOpts = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-    };
-
     private const int InvalidRequestCode = -32600;
     private const int InternalErrorCode = -32603;
 
-    private readonly Stream _in;
-    private readonly Stream _out;
-
-    private string _root = "";
-    private bool _shutdownRequested;
-    private bool _engineOpenFailureShown;
-    private OverlayAppDirectory? _workspace;
-    private AppConfigEngine? _engine;
-    private AppSymbols? _symbols;
-
-    private readonly Dictionary<string, string> _published = new(StringComparer.Ordinal);
-
-    private readonly Dictionary<string, string> _openDocuments = new(StringComparer.Ordinal);
-
     private readonly object _sync = new();
-    private readonly object _outLock = new();
     private readonly TaskCompletionSource _exited = new(TaskCreationOptions.RunContinuationsAsynchronously);
-    private Timer? _validateTimer;
-    private bool _validatePending;
-    private const int ValidateDebounceMs = 150;
+    private readonly Logger _log;
+    private readonly LspTransport _transport;
+    private readonly WorkspaceState _workspace;
+    private readonly LspConversions _convert;
+    private readonly DiagnosticsPublisher _diagnostics;
+    private readonly LanguageFeatures _features;
 
-    private readonly Dictionary<string, Utf16Mapper> _mappers = new(StringComparer.Ordinal);
-    private readonly LogLevel _logLevel;
+    private bool _shutdownRequested;
 
     public LspServer(Stream input, Stream output)
     {
-        _in = input;
-        _out = output;
-        _logLevel = ParseLogLevel(Environment.GetEnvironmentVariable("STUDIOCTL_LSP_LOG"));
+        _log = new Logger(Logger.ParseLevel(Environment.GetEnvironmentVariable("STUDIOCTL_LSP_LOG")));
+        _transport = new LspTransport(input, output, _log);
+        _workspace = new WorkspaceState(_transport, _log);
+        _convert = new LspConversions(_workspace);
+        _diagnostics = new DiagnosticsPublisher(_sync, _workspace, _convert, _transport, _log);
+        _features = new LanguageFeatures(_workspace, _convert, _diagnostics);
     }
 
     /// <summary>
@@ -70,11 +42,14 @@ public sealed class LspServer
     /// </summary>
     public int Run()
     {
-        Log(LogLevel.Info, $"started (log level {_logLevel.ToString().ToLowerInvariant()}); waiting for initialize");
+        _log.Log(
+            LogLevel.Info,
+            $"started (log level {_log.Level.ToString().ToLowerInvariant()}); waiting for initialize"
+        );
         var formatter = new SystemTextJsonFormatter();
         formatter.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
         formatter.JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
-        var rpc = new JsonRpc(new FrameHandler(this, formatter));
+        var rpc = new JsonRpc(new FrameHandler(_transport, _log, formatter));
         rpc.AddLocalRpcTarget(new Target(this), null);
         rpc.StartListening();
         try
@@ -86,40 +61,21 @@ public sealed class LspServer
         {
             rpc.Dispose();
             if (rpc.Completion.Exception?.GetBaseException() is { } reason)
-                Log(LogLevel.Error, $"connection terminated: {reason.Message}");
+                _log.Log(LogLevel.Error, $"connection terminated: {reason.Message}");
             try
             {
                 lock (_sync)
-                    FlushValidate();
+                    _diagnostics.Flush();
             }
             catch (Exception ex)
             {
-                Log(LogLevel.Error, $"final validation flush failed: {ex}");
+                _log.Log(LogLevel.Error, $"final validation flush failed: {ex}");
             }
-            _validateTimer?.Dispose();
+            _diagnostics.Dispose();
         }
-        Log(LogLevel.Info, "exiting");
+        _log.Log(LogLevel.Info, "exiting");
         return _shutdownRequested ? 0 : 1;
     }
-
-    private void Log(LogLevel level, string message)
-    {
-        if (level > _logLevel)
-            return;
-        Console.Error.WriteLine(
-            $"[{DateTime.Now:HH:mm:ss.fff}] studioctl-lsp {level.ToString().ToLowerInvariant()}: {message}"
-        );
-    }
-
-    private static LogLevel ParseLogLevel(string? value) =>
-        value?.Trim().ToLowerInvariant() switch
-        {
-            "error" => LogLevel.Error,
-            "warn" or "warning" => LogLevel.Warning,
-            "debug" => LogLevel.Debug,
-            "trace" => LogLevel.Trace,
-            _ => LogLevel.Info,
-        };
 
     // Handlers are synchronous, so StreamJsonRpc dispatches messages strictly in arrival order.
     private sealed class Target(LspServer s)
@@ -158,19 +114,21 @@ public sealed class LspServer
             s.Notification(() => s.OnDidChangeWorkspaceFolders(p));
 
         [JsonRpcMethod("textDocument/hover", UseSingleObjectParameterDeserialization = true)]
-        public Hover? Hover(TextDocumentPositionParams? p = null) => s.Request(() => s.OnHover(Required(p)));
+        public Hover? Hover(TextDocumentPositionParams? p = null) => s.Request(() => s._features.OnHover(Required(p)));
 
         [JsonRpcMethod("textDocument/definition", UseSingleObjectParameterDeserialization = true)]
         public List<Location> Definition(TextDocumentPositionParams? p = null) =>
-            s.Request(() => s.Locations(s.Navigate(Required(p), (e, f, l, c) => e.Definition(f, l, c))));
+            s.Request(() =>
+                s._convert.Locations(s._features.Navigate(Required(p), (e, f, l, c) => e.Definition(f, l, c)))
+            );
 
         [JsonRpcMethod("textDocument/references", UseSingleObjectParameterDeserialization = true)]
         public List<Location> References(ReferenceParams? p = null) =>
             s.Request(() =>
             {
                 var r = Required(p);
-                return s.Locations(
-                    s.Navigate(
+                return s._convert.Locations(
+                    s._features.Navigate(
                         new TextDocumentPositionParams(r.TextDocument, r.Position),
                         (e, f, l, c) => e.References(f, l, c, r.Context?.IncludeDeclaration ?? false)
                     )
@@ -179,20 +137,22 @@ public sealed class LspServer
 
         [JsonRpcMethod("textDocument/completion", UseSingleObjectParameterDeserialization = true)]
         public CompletionList Completion(TextDocumentPositionParams? p = null) =>
-            s.Request(() => s.OnCompletion(Required(p)));
+            s.Request(() => s._features.OnCompletion(Required(p)));
 
         [JsonRpcMethod("textDocument/codeAction", UseSingleObjectParameterDeserialization = true)]
-        public List<CodeAction> CodeAction(CodeActionParams? p = null) => s.Request(() => s.OnCodeActions(Required(p)));
+        public List<CodeAction> CodeAction(CodeActionParams? p = null) =>
+            s.Request(() => s._features.OnCodeActions(Required(p)));
 
         [JsonRpcMethod("textDocument/codeLens", UseSingleObjectParameterDeserialization = true)]
-        public List<CodeLens> CodeLens(CodeLensParams? p = null) => s.Request(() => s.OnCodeLenses(Required(p)));
+        public List<CodeLens> CodeLens(CodeLensParams? p = null) =>
+            s.Request(() => s._features.OnCodeLenses(Required(p)));
 
         [JsonRpcMethod("textDocument/prepareRename", UseSingleObjectParameterDeserialization = true)]
         public PrepareRenameResult? PrepareRename(TextDocumentPositionParams? p = null) =>
-            s.Request(() => s.OnPrepareRename(Required(p)));
+            s.Request(() => s._features.OnPrepareRename(Required(p)));
 
         [JsonRpcMethod("textDocument/rename", UseSingleObjectParameterDeserialization = true)]
-        public WorkspaceEdit? Rename(RenameParams? p = null) => s.Request(() => s.OnRename(Required(p)));
+        public WorkspaceEdit? Rename(RenameParams? p = null) => s.Request(() => s._features.OnRename(Required(p)));
 
         private static T Required<T>(T? value)
             where T : class => value ?? throw new InvalidOperationException("missing request params");
@@ -210,7 +170,7 @@ public sealed class LspServer
             }
             catch (Exception ex)
             {
-                Log(LogLevel.Error, $"request failed: {ex}");
+                _log.Log(LogLevel.Error, $"request failed: {ex}");
                 throw new LocalRpcException(ex.Message, ex) { ErrorCode = InternalErrorCode };
             }
         }
@@ -228,14 +188,14 @@ public sealed class LspServer
             }
             catch (Exception ex)
             {
-                Log(LogLevel.Error, $"notification failed: {ex}");
+                _log.Log(LogLevel.Error, $"notification failed: {ex}");
             }
         }
     }
 
     private InitializeResult OnInitialize(InitializeParams? p)
     {
-        SetRoot(ResolveRoot(p));
+        _workspace.SetRoot(ResolveRoot(p));
         return new InitializeResult(
             new ServerCapabilities(
                 TextDocumentSync: 1,
@@ -254,35 +214,31 @@ public sealed class LspServer
         );
     }
 
-    private void SetRoot(string root)
+    private static string ResolveRoot(InitializeParams? p)
     {
-        _root = root;
-        _workspace = new OverlayAppDirectory(new FileSystemAppDirectory(root));
-        _engine = null;
-        _symbols = null;
-        _engineOpenFailureShown = false;
-        _mappers.Clear();
-        foreach (var (path, text) in _openDocuments)
-            if (Relativize(path) is { } rel)
-                _workspace.Set(rel, text);
-        Log(LogLevel.Info, $"workspace root = {root}");
+        var folders = (p?.WorkspaceFolders ?? [])
+            .Select(f => WorkspaceState.LocalPath(f.Uri))
+            .OfType<string>()
+            .ToList();
+        if (folders.Count > 0)
+            return folders.FirstOrDefault(WorkspaceState.IsAppDirectory) ?? folders[0];
+        if (WorkspaceState.LocalPath(p?.RootUri) is { } fromUri)
+            return fromUri;
+        return p?.RootPath ?? Directory.GetCurrentDirectory();
     }
 
     private void OnDidChangeWorkspaceFolders(DidChangeWorkspaceFoldersParams? p)
     {
         var added = p?.Event?.Added ?? [];
-        if (added.Length == 0 || IsAppDirectory(_root))
+        if (added.Length == 0 || WorkspaceState.IsAppDirectory(_workspace.Root))
             return;
-        var candidates = added.Select(f => LocalPath(f.Uri)).OfType<string>().ToList();
-        var next = candidates.FirstOrDefault(IsAppDirectory) ?? candidates.FirstOrDefault();
-        if (next is null || string.Equals(next, _root, StringComparison.Ordinal))
+        var candidates = added.Select(f => WorkspaceState.LocalPath(f.Uri)).OfType<string>().ToList();
+        var next = candidates.FirstOrDefault(WorkspaceState.IsAppDirectory) ?? candidates.FirstOrDefault();
+        if (next is null || string.Equals(next, _workspace.Root, StringComparison.Ordinal))
             return;
-        SetRoot(next);
-        ScheduleValidate();
+        _workspace.SetRoot(next);
+        _diagnostics.Schedule();
     }
-
-    private static bool IsAppDirectory(string? path) =>
-        !string.IsNullOrEmpty(path) && Directory.Exists(Path.Combine(path, "App", "config"));
 
     private void OnDidChange(DidChangeTextDocumentParams? p)
     {
@@ -291,601 +247,21 @@ public sealed class LspServer
             SetDocument(p.TextDocument?.Uri, changes[^1].Text);
     }
 
+    private void SetDocument(string? uri, string? text)
+    {
+        if (_workspace.SetDocument(uri, text))
+            _diagnostics.Schedule();
+    }
+
     private void OnDidClose(string? uri)
     {
-        var path = LocalPath(uri);
-        if (path is not null)
-        {
-            _openDocuments.Remove(path);
-            if (Relativize(path) is { } rel)
-            {
-                _workspace?.Clear(rel);
-                _mappers.Remove(rel); // reverted to disk content → drop its cached position map
-            }
-        }
-        ScheduleValidate();
+        _workspace.CloseDocument(uri);
+        _diagnostics.Schedule();
     }
 
     private void OnDidChangeWatchedFiles()
     {
-        _mappers.Clear();
-        ScheduleValidate();
-    }
-
-    private void SetDocument(string? uri, string? text)
-    {
-        var path = LocalPath(uri);
-        if (path is null || _workspace is null)
-            return;
-        _openDocuments[path] = text ?? "";
-        if (Relativize(path) is { } rel)
-        {
-            _workspace.Set(rel, text ?? "");
-            _mappers.Remove(rel); // document content changed → drop its cached position map
-            ScheduleValidate();
-        }
-    }
-
-    // Called with _sync held (all callers run inside a handler).
-    private void ScheduleValidate()
-    {
-        _validatePending = true;
-        _validateTimer ??= new Timer(_ => DebouncedValidate(), null, Timeout.Infinite, Timeout.Infinite);
-        _validateTimer.Change(ValidateDebounceMs, Timeout.Infinite);
-    }
-
-    private void DebouncedValidate()
-    {
-        try
-        {
-            lock (_sync)
-                FlushValidate();
-        }
-        catch (Exception ex)
-        {
-            Log(LogLevel.Error, $"debounced validation failed: {ex}");
-        }
-    }
-
-    // Called with _sync held.
-    private void FlushValidate()
-    {
-        if (!_validatePending)
-            return;
-        _validatePending = false;
-        Validate();
-    }
-
-    private Utf16Mapper? MapperFor(string? rel)
-    {
-        if (rel is null || _workspace is null)
-            return null;
-        if (_mappers.TryGetValue(rel, out var cached))
-            return cached;
-        var bytes = _workspace.ReadAllBytes(rel);
-        if (bytes is null)
-            return null;
-        var mapper = new Utf16Mapper(bytes);
-        _mappers[rel] = mapper;
-        return mapper;
-    }
-
-    // An LSP request's 0-based (line, character[UTF-16]) → the engine's 1-based (line, byte column).
-    private int InputByteColumn(string? rel, Position position) =>
-        MapperFor(rel)?.ToByteColumn(position.Line, position.Character) ?? position.Character + 1;
-
-    private void Validate()
-    {
-        if (_workspace is null)
-            return;
-
-        var engine = EnsureEngine();
-        if (engine is null)
-            return;
-
-        IReadOnlyList<Finding> findings;
-        try
-        {
-            findings = ValidationEngine.Run(engine.Build()).Findings;
-        }
-        catch (Exception ex)
-        {
-            Log(LogLevel.Error, $"validation failed: {ex}");
-            return;
-        }
-
-        var byUri = new Dictionary<string, List<Diagnostic>>(StringComparer.Ordinal);
-        foreach (var f in findings)
-        {
-            var pos = engine.ResolvePosition(f.Position);
-            if (string.IsNullOrEmpty(pos.File))
-                continue;
-            var uri = ToUri(pos.File);
-            if (!byUri.TryGetValue(uri, out var list))
-                byUri[uri] = list = new List<Diagnostic>();
-            list.Add(ToDiagnostic(f, pos));
-        }
-
-        Log(LogLevel.Debug, $"validated: {findings.Count} finding(s) across {byUri.Count} file(s)");
-        foreach (var (uri, diagnostics) in byUri)
-            PublishDiagnostics(uri, diagnostics);
-        // Clear files that went clean (the publish mutates _published, hence the snapshot).
-        foreach (var uri in _published.Keys.Where(u => !byUri.ContainsKey(u)).ToList())
-            PublishDiagnostics(uri, Array.Empty<Diagnostic>());
-    }
-
-    private Diagnostic ToDiagnostic(Finding f, SourceSpan pos) =>
-        new(
-            LspRange(pos),
-            f.Severity switch
-            {
-                Severity.Error => 1,
-                Severity.Warning => 2,
-                _ => 3,
-            },
-            "altinn-appconfig",
-            f.RuleId,
-            f.Message
-        );
-
-    // Engine columns are 1-based UTF-8 bytes (end exclusive); LSP characters are 0-based UTF-16.
-    private Range LspRange(SourceSpan pos)
-    {
-        var map = MapperFor(pos.File);
-        var start = LspStart(pos);
-        var endLine = pos.EndLine > 0 ? pos.EndLine - 1 : start.Line;
-        var endCh = ToUtf16Column(map, pos.EndLine, pos.EndColumn, fallback: start.Character + 1);
-        return new Range(start, new Position(endLine, endCh));
-    }
-
-    private Position LspStart(SourceSpan pos)
-    {
-        var map = MapperFor(pos.File);
-        var line = pos.Line > 0 ? pos.Line - 1 : 0;
-        var ch = ToUtf16Column(map, pos.Line, pos.Column, fallback: 0);
-        return new Position(line, ch);
-    }
-
-    private static int ToUtf16Column(Utf16Mapper? map, int line, int column, int fallback)
-    {
-        if (map is not null && line > 0 && column > 0)
-            return map.ToUtf16Character(line, column);
-        return column > 0 ? column - 1 : fallback;
-    }
-
-    private AppConfigEngine? EnsureEngine()
-    {
-        if (_engine is not null)
-            return _engine;
-        if (_workspace is null)
-            return null;
-        try
-        {
-            _engine = AppConfigEngine.Open(_workspace);
-            _symbols = new AppSymbols(_engine);
-            return _engine;
-        }
-        catch (Exception ex)
-        {
-            Log(LogLevel.Error, $"engine open failed: {ex}");
-            if (!_engineOpenFailureShown)
-            {
-                _engineOpenFailureShown = true;
-                Notify(
-                    "window/showMessage",
-                    new ShowMessageParams(Type: 1, $"studioctl-lsp: cannot analyze this app: {ex.Message}")
-                );
-            }
-            return null;
-        }
-    }
-
-    // Shared prologue of every engine-reading request: flush pending validation (answer against
-    // the latest buffer, not the debounce-pending state), ensure the engine, and resolve the
-    // request's document. False when the engine isn't ready or the URI is outside the app.
-    private bool TryResolveRequest(
-        TextDocumentIdentifier? textDocument,
-        [NotNullWhen(true)] out string? rel,
-        [NotNullWhen(true)] out AppSymbols? symbols
-    )
-    {
-        FlushValidate();
-        EnsureEngine();
-        rel = ToRelative(textDocument?.Uri);
-        symbols = _symbols;
-        return rel is not null && symbols is not null;
-    }
-
-    // The request's 0-based cursor as the engine's 1-based line + byte column.
-    private (int Line1, int ByteCol) CursorOf(Position position, string rel) =>
-        (position.Line + 1, InputByteColumn(rel, position));
-
-    private IReadOnlyList<SourceSpan> Navigate(
-        TextDocumentPositionParams p,
-        Func<AppSymbols, string, int, int, IReadOnlyList<SourceSpan>> query
-    )
-    {
-        if (!TryResolveRequest(p.TextDocument, out var rel, out var symbols))
-            return Array.Empty<SourceSpan>();
-        var (line1, byteCol) = CursorOf(p.Position, rel);
-        return query(symbols, rel, line1, byteCol);
-    }
-
-    private List<Location> Locations(IReadOnlyList<SourceSpan> spans)
-    {
-        var list = new List<Location>(spans.Count);
-        foreach (var s in spans)
-            list.Add(new Location(ToUri(s.File), LspRange(s)));
-        return list;
-    }
-
-    private CompletionList OnCompletion(TextDocumentPositionParams p)
-    {
-        var items = new List<CompletionItem>();
-        if (TryResolveRequest(p.TextDocument, out var rel, out var symbols))
-        {
-            var (line1, byteCol) = CursorOf(p.Position, rel);
-            foreach (var s in symbols.Completions(rel, line1, byteCol))
-            {
-                items.Add(
-                    new CompletionItem(
-                        s.Label,
-                        s.Detail,
-                        // LSP CompletionItemKind: Field=5, Class=7, File=17, Reference=18, EnumMember=20, Constant=21.
-                        s.Kind switch
-                        {
-                            SuggestionKind.DataModelPath => 5,
-                            SuggestionKind.DataType => 7,
-                            SuggestionKind.Component => 18,
-                            SuggestionKind.Page => 17,
-                            SuggestionKind.Task => 20,
-                            SuggestionKind.OptionsId => 17,
-                            _ => 21,
-                        }
-                    )
-                );
-            }
-        }
-        return new CompletionList(IsIncomplete: false, items);
-    }
-
-    // Rename the symbol under the cursor everywhere: a WorkspaceEdit replacing each
-    // token with its (JSON-quoted) new value. Null when nothing renameable.
-    private WorkspaceEdit? OnRename(RenameParams p)
-    {
-        if (!TryResolveRequest(p.TextDocument, out var rel, out var symbols))
-            return null;
-        var newName = p.NewName ?? "";
-        if (newName.Length == 0)
-            return null;
-
-        var (line1, byteCol) = CursorOf(p.Position, rel);
-        var edits = symbols.ProposeRename(rel, line1, byteCol, newName);
-        if (edits.Count == 0)
-            return null;
-
-        // A rename that also moves files needs the documentChanges form: text edits first
-        // (on the pre-rename URIs), then the RenameFile operations.
-        var textByUri = new Dictionary<string, List<TextEdit>>(StringComparer.Ordinal);
-        var renames = new List<object>();
-        foreach (var e in edits)
-        {
-            switch (e)
-            {
-                case ReplaceEdit re:
-                    var uri = ToUri(re.Span.File);
-                    if (!textByUri.TryGetValue(uri, out var list))
-                        textByUri[uri] = list = new List<TextEdit>();
-                    // ReplaceEdit.NewValue is the literal splice text (already JSON-quoted for a string token).
-                    list.Add(new TextEdit(LspRange(re.Span), re.NewValue));
-                    break;
-                case RenameFileEdit mv:
-                    renames.Add(
-                        new RenameFile(
-                            ToUri(mv.OldPath),
-                            ToUri(mv.NewPath),
-                            new RenameFileOptions(Overwrite: false, IgnoreIfExists: false)
-                        )
-                    );
-                    break;
-            }
-        }
-        if (renames.Count == 0)
-            return new WorkspaceEdit(Changes: textByUri);
-        var documentChanges = new List<object>();
-        foreach (var kv in textByUri)
-            documentChanges.Add(
-                new TextDocumentEdit(new OptionalVersionedTextDocumentIdentifier(kv.Key, Version: null), kv.Value)
-            );
-        documentChanges.AddRange(renames);
-        return new WorkspaceEdit(DocumentChanges: documentChanges);
-    }
-
-    // The command is registered client-side by the VS Code extension.
-    private List<CodeLens> OnCodeLenses(CodeLensParams p)
-    {
-        var lenses = new List<CodeLens>();
-        if (!TryResolveRequest(p.TextDocument, out var rel, out var symbols))
-            return lenses;
-        var uri = ToUri(rel);
-        foreach (var lens in symbols.CodeLenses(rel))
-        {
-            lenses.Add(
-                new CodeLens(
-                    LspRange(lens.Range),
-                    new Command(
-                        lens.Title,
-                        "altinnAppConfig.showReferences",
-                        [
-                            uri,
-                            LspStart(lens.Range),
-                            lens.Locations.Select(l => new Location(ToUri(l.File), LspRange(l))).ToList(),
-                        ]
-                    )
-                )
-            );
-        }
-        return lenses;
-    }
-
-    private List<CodeAction> OnCodeActions(CodeActionParams p)
-    {
-        var actions = new List<CodeAction>();
-        if (!TryResolveRequest(p.TextDocument, out var rel, out var symbols))
-            return actions;
-        var uri = p.TextDocument.Uri;
-        if (uri is null || p.Context?.Diagnostics is not { } diagnostics)
-            return actions;
-
-        foreach (var d in diagnostics)
-        {
-            if (d.Source != "altinn-appconfig" || d.Range is null)
-                continue;
-            var start = d.Range.Start;
-            // `start` is UTF-16 (from our own publish); convert back to a byte column.
-            var suggestion = symbols.SuggestCorrection(rel, start.Line + 1, InputByteColumn(rel, start));
-            if (suggestion is null)
-                continue;
-            actions.Add(
-                new CodeAction(
-                    $"Change to \"{suggestion}\"",
-                    "quickfix",
-                    [d],
-                    IsPreferred: true,
-                    new WorkspaceEdit(
-                        Changes: new Dictionary<string, List<TextEdit>>
-                        {
-                            [uri] = [new TextEdit(d.Range, JsonSerializer.Serialize(suggestion))],
-                        }
-                    )
-                )
-            );
-        }
-        return actions;
-    }
-
-    private PrepareRenameResult? OnPrepareRename(TextDocumentPositionParams p)
-    {
-        if (!TryResolveRequest(p.TextDocument, out var rel, out var symbols))
-            return null;
-        var (line1, byteCol) = CursorOf(p.Position, rel);
-        if (symbols.PrepareRename(rel, line1, byteCol) is not { } pr)
-            return null;
-        return new PrepareRenameResult(LspRange(pr.Range), pr.Placeholder);
-    }
-
-    private Hover? OnHover(TextDocumentPositionParams p)
-    {
-        FlushValidate(); // answer against the latest buffer, not the debounce-pending state
-        var rel = ToRelative(p.TextDocument.Uri);
-        if (rel is null || _engine is null)
-            return null;
-        var byteCol = InputByteColumn(rel, p.Position);
-        if (_engine.ResolveNodeAt(rel, p.Position.Line + 1, byteCol) is not { } node)
-            return null;
-
-        var sb = new StringBuilder();
-        if (_symbols?.SymbolHover(rel, p.Position.Line + 1, byteCol) is { } symbolCard)
-        {
-            sb.Append(symbolCard);
-        }
-        else
-        {
-            sb.Append('`').Append(string.IsNullOrEmpty(node.Pointer) ? "/" : node.Pointer).Append('`');
-            if (node.Key)
-                sb.Append(" _(property name)_");
-        }
-        return new Hover(new MarkupContent("markdown", sb.ToString()), LspRange(node));
-    }
-
-    // A publish replaces the URI's whole state, so the wire format is the identity to dedupe on.
-    private void PublishDiagnostics(string uri, IReadOnlyList<Diagnostic> diagnostics)
-    {
-        var payload = JsonSerializer.Serialize(diagnostics, _jsonOpts);
-        if (diagnostics.Count == 0)
-        {
-            if (!_published.Remove(uri))
-                return;
-        }
-        else
-        {
-            if (_published.TryGetValue(uri, out var prev) && string.Equals(prev, payload, StringComparison.Ordinal))
-                return;
-            _published[uri] = payload;
-        }
-        Notify("textDocument/publishDiagnostics", new PublishDiagnosticsParams(uri, diagnostics));
-    }
-
-    private static string ResolveRoot(InitializeParams? p)
-    {
-        var folders = (p?.WorkspaceFolders ?? []).Select(f => LocalPath(f.Uri)).OfType<string>().ToList();
-        if (folders.Count > 0)
-            return folders.FirstOrDefault(IsAppDirectory) ?? folders[0];
-        if (LocalPath(p?.RootUri) is { } fromUri)
-            return fromUri;
-        return p?.RootPath ?? Directory.GetCurrentDirectory();
-    }
-
-    private static string? LocalPath(string? uri)
-    {
-        if (string.IsNullOrEmpty(uri))
-            return null;
-        try
-        {
-            return new Uri(uri).LocalPath;
-        }
-        catch (UriFormatException)
-        {
-            return null;
-        }
-    }
-
-    private string? ToRelative(string? uri) => Relativize(LocalPath(uri));
-
-    private string? Relativize(string? path)
-    {
-        if (path is null)
-            return null;
-        var rel = Path.GetRelativePath(_root, path).Replace('\\', '/');
-        return rel.StartsWith("..", StringComparison.Ordinal) ? null : rel;
-    }
-
-    private string ToUri(string relativeFile) => new Uri(Path.Combine(_root, relativeFile)).AbsoluteUri;
-
-    private sealed record NotificationEnvelope(string Jsonrpc, string Method, object Params);
-
-    private sealed record ErrorEnvelope(
-        string Jsonrpc,
-        [property: JsonIgnore(Condition = JsonIgnoreCondition.Never)] object? Id,
-        ErrorDetail Error
-    );
-
-    private sealed record ErrorDetail(int Code, string Message);
-
-    private void Notify(string method, object parameters)
-    {
-        Log(LogLevel.Trace, $"send {method}");
-        WriteFrame(JsonSerializer.SerializeToUtf8Bytes(new NotificationEnvelope("2.0", method, parameters), _jsonOpts));
-    }
-
-    private void WriteParseError()
-    {
-        var envelope = new ErrorEnvelope("2.0", null, new ErrorDetail(-32700, "Parse error"));
-        WriteFrame(JsonSerializer.SerializeToUtf8Bytes(envelope, _jsonOpts));
-    }
-
-    private void WriteFrame(ReadOnlySpan<byte> body)
-    {
-        var header = Encoding.ASCII.GetBytes($"Content-Length: {body.Length}\r\n\r\n");
-        lock (_outLock)
-        {
-            _out.Write(header);
-            _out.Write(body);
-            _out.Flush();
-        }
-    }
-
-    private byte[]? ReadFrame()
-    {
-        var contentLength = -1;
-        for (var line = ReadLine(); !string.IsNullOrEmpty(line); line = ReadLine())
-        {
-            var colon = line.IndexOf(':');
-            if (
-                colon > 0
-                && line[..colon].Trim().Equals("Content-Length", StringComparison.OrdinalIgnoreCase)
-                && int.TryParse(line[(colon + 1)..].Trim(), out var parsed)
-            )
-                contentLength = parsed;
-        }
-        if (contentLength < 0)
-            return null;
-
-        var buffer = new byte[contentLength];
-        var read = 0;
-        while (read < contentLength)
-        {
-            var n = _in.Read(buffer, read, contentLength - read);
-            if (n <= 0)
-                return null;
-            read += n;
-        }
-        return buffer;
-    }
-
-    private string? ReadLine()
-    {
-        var sb = new StringBuilder();
-        while (true)
-        {
-            var b = _in.ReadByte();
-            if (b < 0)
-                return sb.Length == 0 ? null : sb.ToString();
-            if (b == '\n')
-            {
-                if (sb.Length > 0 && sb[^1] == '\r')
-                    sb.Length--;
-                return sb.ToString();
-            }
-            sb.Append((char)b);
-        }
-    }
-
-    // JsonRpc treats end-of-input as loss of the whole connection and stops responding to
-    // requests it has already received, so EOF is held back until every read request has had
-    // its response written.
-    private sealed class FrameHandler(LspServer server, SystemTextJsonFormatter formatter) : IJsonRpcMessageHandler
-    {
-        private readonly object _gate = new();
-        private int _pendingResponses;
-
-        public bool CanRead => true;
-        public bool CanWrite => true;
-        public IJsonRpcMessageFormatter Formatter => formatter;
-
-        public ValueTask<JsonRpcMessage?> ReadAsync(CancellationToken cancellationToken)
-        {
-            while (true)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                var body = server.ReadFrame();
-                if (body is null)
-                {
-                    lock (_gate)
-                    {
-                        while (_pendingResponses > 0)
-                            Monitor.Wait(_gate);
-                    }
-                    return ValueTask.FromResult<JsonRpcMessage?>(null);
-                }
-                try
-                {
-                    var message = formatter.Deserialize(new ReadOnlySequence<byte>(body));
-                    if (message is JsonRpcRequest { IsResponseExpected: true })
-                        lock (_gate)
-                            _pendingResponses++;
-                    return ValueTask.FromResult<JsonRpcMessage?>(message);
-                }
-                catch (JsonException ex)
-                {
-                    server.Log(LogLevel.Error, $"malformed frame: {ex.Message}");
-                    server.WriteParseError();
-                }
-            }
-        }
-
-        public ValueTask WriteAsync(JsonRpcMessage jsonRpcMessage, CancellationToken cancellationToken)
-        {
-            var buffer = new ArrayBufferWriter<byte>();
-            formatter.Serialize(buffer, jsonRpcMessage);
-            server.WriteFrame(buffer.WrittenSpan);
-            if (jsonRpcMessage is JsonRpcResult or JsonRpcError)
-                lock (_gate)
-                {
-                    _pendingResponses--;
-                    Monitor.PulseAll(_gate);
-                }
-            return ValueTask.CompletedTask;
-        }
+        _workspace.InvalidateMappers();
+        _diagnostics.Schedule();
     }
 }

--- a/src/cli/studioctl-lsp/LspServer.cs
+++ b/src/cli/studioctl-lsp/LspServer.cs
@@ -71,7 +71,7 @@ public sealed class LspServer
             {
                 _log.Log(LogLevel.Error, $"final validation flush failed: {ex}");
             }
-            _diagnostics.Dispose();
+            _diagnostics.Stop();
         }
         _log.Log(LogLevel.Info, "exiting");
         return _shutdownRequested ? 0 : 1;

--- a/src/cli/studioctl-lsp/LspTransport.cs
+++ b/src/cli/studioctl-lsp/LspTransport.cs
@@ -1,0 +1,166 @@
+using System.Buffers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using StreamJsonRpc;
+using StreamJsonRpc.Protocol;
+
+namespace Altinn.Studio.AppConfigLsp;
+
+internal static class LspJson
+{
+    public static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+}
+
+/// <summary>
+/// Content-Length framed reads and writes over the raw streams, plus server-initiated
+/// notifications and protocol-level error replies.
+/// </summary>
+internal sealed class LspTransport(Stream input, Stream output, Logger log)
+{
+    private readonly object _outLock = new();
+
+    private sealed record NotificationEnvelope(string Jsonrpc, string Method, object Params);
+
+    private sealed record ErrorEnvelope(
+        string Jsonrpc,
+        [property: JsonIgnore(Condition = JsonIgnoreCondition.Never)] object? Id,
+        ErrorDetail Error
+    );
+
+    private sealed record ErrorDetail(int Code, string Message);
+
+    public void Notify(string method, object parameters)
+    {
+        log.Log(LogLevel.Trace, $"send {method}");
+        WriteFrame(
+            JsonSerializer.SerializeToUtf8Bytes(new NotificationEnvelope("2.0", method, parameters), LspJson.Options)
+        );
+    }
+
+    public void WriteParseError()
+    {
+        var envelope = new ErrorEnvelope("2.0", null, new ErrorDetail(-32700, "Parse error"));
+        WriteFrame(JsonSerializer.SerializeToUtf8Bytes(envelope, LspJson.Options));
+    }
+
+    public void WriteFrame(ReadOnlySpan<byte> body)
+    {
+        var header = Encoding.ASCII.GetBytes($"Content-Length: {body.Length}\r\n\r\n");
+        lock (_outLock)
+        {
+            output.Write(header);
+            output.Write(body);
+            output.Flush();
+        }
+    }
+
+    public byte[]? ReadFrame()
+    {
+        var contentLength = -1;
+        for (var line = ReadLine(); !string.IsNullOrEmpty(line); line = ReadLine())
+        {
+            var colon = line.IndexOf(':');
+            if (
+                colon > 0
+                && line[..colon].Trim().Equals("Content-Length", StringComparison.OrdinalIgnoreCase)
+                && int.TryParse(line[(colon + 1)..].Trim(), out var parsed)
+            )
+                contentLength = parsed;
+        }
+        if (contentLength < 0)
+            return null;
+
+        var buffer = new byte[contentLength];
+        var read = 0;
+        while (read < contentLength)
+        {
+            var n = input.Read(buffer, read, contentLength - read);
+            if (n <= 0)
+                return null;
+            read += n;
+        }
+        return buffer;
+    }
+
+    private string? ReadLine()
+    {
+        var sb = new StringBuilder();
+        while (true)
+        {
+            var b = input.ReadByte();
+            if (b < 0)
+                return sb.Length == 0 ? null : sb.ToString();
+            if (b == '\n')
+            {
+                if (sb.Length > 0 && sb[^1] == '\r')
+                    sb.Length--;
+                return sb.ToString();
+            }
+            sb.Append((char)b);
+        }
+    }
+}
+
+// JsonRpc treats end-of-input as loss of the whole connection and stops responding to
+// requests it has already received, so EOF is held back until every read request has had
+// its response written.
+internal sealed class FrameHandler(LspTransport transport, Logger log, SystemTextJsonFormatter formatter)
+    : IJsonRpcMessageHandler
+{
+    private readonly object _gate = new();
+    private int _pendingResponses;
+
+    public bool CanRead => true;
+    public bool CanWrite => true;
+    public IJsonRpcMessageFormatter Formatter => formatter;
+
+    public ValueTask<JsonRpcMessage?> ReadAsync(CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var body = transport.ReadFrame();
+            if (body is null)
+            {
+                lock (_gate)
+                {
+                    while (_pendingResponses > 0)
+                        Monitor.Wait(_gate);
+                }
+                return ValueTask.FromResult<JsonRpcMessage?>(null);
+            }
+            try
+            {
+                var message = formatter.Deserialize(new ReadOnlySequence<byte>(body));
+                if (message is JsonRpcRequest { IsResponseExpected: true })
+                    lock (_gate)
+                        _pendingResponses++;
+                return ValueTask.FromResult<JsonRpcMessage?>(message);
+            }
+            catch (JsonException ex)
+            {
+                log.Log(LogLevel.Error, $"malformed frame: {ex.Message}");
+                transport.WriteParseError();
+            }
+        }
+    }
+
+    public ValueTask WriteAsync(JsonRpcMessage jsonRpcMessage, CancellationToken cancellationToken)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        formatter.Serialize(buffer, jsonRpcMessage);
+        transport.WriteFrame(buffer.WrittenSpan);
+        if (jsonRpcMessage is JsonRpcResult or JsonRpcError)
+            lock (_gate)
+            {
+                _pendingResponses--;
+                Monitor.PulseAll(_gate);
+            }
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/cli/studioctl-lsp/WorkspaceState.cs
+++ b/src/cli/studioctl-lsp/WorkspaceState.cs
@@ -1,0 +1,140 @@
+using Altinn.Studio.AppConfig;
+using Altinn.Studio.AppConfig.Documents;
+using Altinn.Studio.AppConfig.Documents.Text;
+
+namespace Altinn.Studio.AppConfigLsp;
+
+/// <summary>
+/// The workspace root, the open-document overlay on top of it, and the engine/symbol index
+/// derived from both — including the per-document UTF-16 position maps, which cache the same
+/// overlay content. Callers hold the server's handler lock.
+/// </summary>
+internal sealed class WorkspaceState(LspTransport transport, Logger log)
+{
+    private string _root = "";
+    private bool _engineOpenFailureShown;
+    private OverlayAppDirectory? _workspace;
+    private AppConfigEngine? _engine;
+    private AppSymbols? _symbols;
+
+    private readonly Dictionary<string, string> _openDocuments = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Utf16Mapper> _mappers = new(StringComparer.Ordinal);
+
+    public string Root => _root;
+    public bool HasWorkspace => _workspace is not null;
+    public AppConfigEngine? Engine => _engine;
+    public AppSymbols? Symbols => _symbols;
+
+    public void SetRoot(string root)
+    {
+        _root = root;
+        _workspace = new OverlayAppDirectory(new FileSystemAppDirectory(root));
+        _engine = null;
+        _symbols = null;
+        _engineOpenFailureShown = false;
+        _mappers.Clear();
+        foreach (var (path, text) in _openDocuments)
+            if (Relativize(path) is { } rel)
+                _workspace.Set(rel, text);
+        log.Log(LogLevel.Info, $"workspace root = {root}");
+    }
+
+    /// <summary>True when the document is inside the app, so diagnostics need refreshing.</summary>
+    public bool SetDocument(string? uri, string? text)
+    {
+        var path = LocalPath(uri);
+        if (path is null || _workspace is null)
+            return false;
+        _openDocuments[path] = text ?? "";
+        if (Relativize(path) is not { } rel)
+            return false;
+        _workspace.Set(rel, text ?? "");
+        _mappers.Remove(rel); // document content changed → drop its cached position map
+        return true;
+    }
+
+    public void CloseDocument(string? uri)
+    {
+        var path = LocalPath(uri);
+        if (path is null)
+            return;
+        _openDocuments.Remove(path);
+        if (Relativize(path) is { } rel)
+        {
+            _workspace?.Clear(rel);
+            _mappers.Remove(rel); // reverted to disk content → drop its cached position map
+        }
+    }
+
+    public void InvalidateMappers() => _mappers.Clear();
+
+    public AppConfigEngine? EnsureEngine()
+    {
+        if (_engine is not null)
+            return _engine;
+        if (_workspace is null)
+            return null;
+        try
+        {
+            _engine = AppConfigEngine.Open(_workspace);
+            _symbols = new AppSymbols(_engine);
+            return _engine;
+        }
+        catch (Exception ex)
+        {
+            log.Log(LogLevel.Error, $"engine open failed: {ex}");
+            if (!_engineOpenFailureShown)
+            {
+                _engineOpenFailureShown = true;
+                transport.Notify(
+                    "window/showMessage",
+                    new ShowMessageParams(Type: 1, $"studioctl-lsp: cannot analyze this app: {ex.Message}")
+                );
+            }
+            return null;
+        }
+    }
+
+    public Utf16Mapper? MapperFor(string? rel)
+    {
+        if (rel is null || _workspace is null)
+            return null;
+        if (_mappers.TryGetValue(rel, out var cached))
+            return cached;
+        var bytes = _workspace.ReadAllBytes(rel);
+        if (bytes is null)
+            return null;
+        var mapper = new Utf16Mapper(bytes);
+        _mappers[rel] = mapper;
+        return mapper;
+    }
+
+    public static bool IsAppDirectory(string? path) =>
+        !string.IsNullOrEmpty(path) && Directory.Exists(Path.Combine(path, "App", "config"));
+
+    public static string? LocalPath(string? uri)
+    {
+        if (string.IsNullOrEmpty(uri))
+            return null;
+        try
+        {
+            return new Uri(uri).LocalPath;
+        }
+        catch (UriFormatException)
+        {
+            return null;
+        }
+    }
+
+    public string? ToRelative(string? uri) => Relativize(LocalPath(uri));
+
+    public string? Relativize(string? path)
+    {
+        if (path is null)
+            return null;
+        var rel = Path.GetRelativePath(_root, path).Replace('\\', '/');
+        return rel.StartsWith("..", StringComparison.Ordinal) ? null : rel;
+    }
+
+    public string ToUri(string relativeFile) => new Uri(Path.Combine(_root, relativeFile)).AbsoluteUri;
+}

--- a/src/cli/studioctl-lsp/WorkspaceState.cs
+++ b/src/cli/studioctl-lsp/WorkspaceState.cs
@@ -118,13 +118,18 @@ internal sealed class WorkspaceState(LspTransport transport, Logger log)
             return null;
         try
         {
-            return new Uri(uri).LocalPath;
+            return TrimSeparatorBeforeWindowsDrive(new Uri(uri).LocalPath);
         }
         catch (UriFormatException)
         {
             return null;
         }
     }
+
+    private static string TrimSeparatorBeforeWindowsDrive(string path) =>
+        OperatingSystem.IsWindows() && path is ['/' or '\\', var drive, ':', ..] && char.IsAsciiLetter(drive)
+            ? path[1..]
+            : path;
 
     public string? ToRelative(string? uri) => Relativize(LocalPath(uri));
 

--- a/src/cli/studioctl-lsp/studioctl-lsp.csproj
+++ b/src/cli/studioctl-lsp/studioctl-lsp.csproj
@@ -14,4 +14,8 @@
   <ItemGroup>
     <PackageReference Include="StreamJsonRpc" />
   </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="studioctl-lsp.Tests" />
+  </ItemGroup>
 </Project>

--- a/src/libs/dotnet/.editorconfig
+++ b/src/libs/dotnet/.editorconfig
@@ -176,6 +176,9 @@ dotnet_diagnostic.S125.severity = suggestion
 [studioctl-server/Studioctl/AppUpgradeService.cs]
 dotnet_diagnostic.S1135.severity = none
 
+[BuiltinTextKeys.cs]
+dotnet_diagnostic.S1135.severity = none
+
 [Program.cs]
 dotnet_diagnostic.CA1050.severity = none
 dotnet_diagnostic.S1118.severity = none

--- a/src/libs/dotnet/Altinn.Studio.AppConfig.Tests/Validation/AppConfigTests.cs
+++ b/src/libs/dotnet/Altinn.Studio.AppConfig.Tests/Validation/AppConfigTests.cs
@@ -15,6 +15,8 @@ public sealed class AppConfigTests
         "layoutsets",
         "layout::App/ui/Task_1/layouts/P1.json",
     };
+    private static readonly string[] _reparsedLayoutOnly = ["layout::App/ui/Task_1/layouts/P1.json"];
+    private static readonly string[] _reparsedMetadataAndModel = ["metadata", "datamodel"];
 
     private static Dictionary<string, string> SampleApp() =>
         new()
@@ -77,14 +79,11 @@ public sealed class AppConfigTests
             """{"data":{"layout":[{"id":"a","type":"Input","dataModelBindings":{"simpleBinding":"project.good"}}]}}"""
         );
         engine.Build();
-        Assert.Equal(
-            new[] { "layout::App/ui/Task_1/layouts/P1.json" }.OrderBy(s => s),
-            engine.LastReparsed.OrderBy(s => s)
-        );
+        Assert.Equal(_reparsedLayoutOnly.OrderBy(s => s), engine.LastReparsed.OrderBy(s => s));
 
         dir.Set("App/config/applicationmetadata.json", TestMeta.Json("ttd/inc2", "model"));
         engine.Build();
-        Assert.Equal(new[] { "metadata", "datamodel" }.OrderBy(s => s), engine.LastReparsed.OrderBy(s => s));
+        Assert.Equal(_reparsedMetadataAndModel.OrderBy(s => s), engine.LastReparsed.OrderBy(s => s));
 
         engine.Build();
         Assert.Empty(engine.LastReparsed);

--- a/src/libs/dotnet/Altinn.Studio.AppConfig.Tests/Validation/AppSymbolsTests.cs
+++ b/src/libs/dotnet/Altinn.Studio.AppConfig.Tests/Validation/AppSymbolsTests.cs
@@ -106,7 +106,7 @@ public sealed class AppSymbolsTests
         Assert.Single(refs);
         Assert.Equal("/data/layout/1/children/0", refs[0].Pointer);
 
-        Assert.Equal(2, symbols.References(p1, l, c, includeDeclaration: true).Count());
+        Assert.Equal(2, symbols.References(p1, l, c, includeDeclaration: true).Count);
     }
 
     private const string Summary2NavLayout = """
@@ -169,10 +169,7 @@ public sealed class AppSymbolsTests
 
         var (l, c) = At(Summary2NavLayout, "\"target-comp\"", 1);
         var refs = symbols.References(p1, l, c, includeDeclaration: false);
-        Assert.Equal(
-            new[] { "/data/layout/1/target/id", "/data/layout/1/overrides/0/componentId" }.OrderBy(s => s),
-            refs.Select(r => r.Pointer).OrderBy(s => s)
-        );
+        Assert.Equal(_summary2ComponentRefPointers.OrderBy(s => s), refs.Select(r => r.Pointer).OrderBy(s => s));
     }
 
     [Fact]
@@ -196,9 +193,7 @@ public sealed class AppSymbolsTests
         var (l, c) = At(Summary2NavLayout, "\"target-comp\"", 1);
         var edits = symbols.ProposeRename(p1, l, c, "renamed").Cast<ReplaceEdit>().ToList();
         Assert.Equal(
-            new[] { "/data/layout/0/id", "/data/layout/1/target/id", "/data/layout/1/overrides/0/componentId" }.OrderBy(
-                s => s
-            ),
+            _summary2ComponentRenamePointers.OrderBy(s => s),
             edits.Select(e => e.Span.Pointer).OrderBy(s => s)
         );
         Assert.All(edits, e => Assert.True(e.NewValue == "\"renamed\""));
@@ -362,7 +357,7 @@ public sealed class AppSymbolsTests
         var edits = symbols.ProposeRename(p1, l, c, "Task_Renamed").Cast<ReplaceEdit>().ToList();
 
         Assert.All(edits, e => Assert.True(e.NewValue == "\"Task_Renamed\"" && e.OldValue == "\"Task_A\""));
-        Assert.Equal(2, edits.Where(e => e.Span.File == "App/config/process/process.bpmn").Count());
+        Assert.Equal(2, edits.Count(e => e.Span.File == "App/config/process/process.bpmn"));
         Assert.Contains(edits, e => e.Span.File == p1 && e.Span.Pointer == "/data/layout/0/target/taskId");
     }
 
@@ -436,10 +431,7 @@ public sealed class AppSymbolsTests
 
         var (cl, cc) = At(NavLayout, "\"field-a\"", 1);
         var comp = symbols.ProposeRename(p1, cl, cc, "renamed").Cast<ReplaceEdit>().ToList();
-        Assert.Equal(
-            new[] { "/data/layout/0/id", "/data/layout/1/children/0" }.OrderBy(s => s),
-            comp.Select(e => e.Span.Pointer).OrderBy(s => s)
-        );
+        Assert.Equal(_componentRenamePointers.OrderBy(s => s), comp.Select(e => e.Span.Pointer).OrderBy(s => s));
         Assert.All(comp, e => Assert.True(e.NewValue == "\"renamed\""));
         Assert.All(comp, e => Assert.True(e.OldValue == "\"field-a\""));
 
@@ -478,7 +470,7 @@ public sealed class AppSymbolsTests
 
         var (dl, dc) = At(layout, "\"model\"", 1);
         var dataTypes = symbols.Completions(p1, dl, dc);
-        Assert.Equal(new[] { "model", "attachment" }.OrderBy(s => s), dataTypes.Select(s => s.Label).OrderBy(s => s));
+        Assert.Equal(_declaredDataTypes.OrderBy(s => s), dataTypes.Select(s => s.Label).OrderBy(s => s));
         Assert.All(dataTypes, s => Assert.True(s.Kind == SuggestionKind.DataType));
 
         var (fl, fc) = At(layout, "\"project.x\"", 1);
@@ -992,7 +984,7 @@ public sealed class AppSymbolsTests
         var edits = symbols.ProposeRename(settings, l, c, "Front");
 
         var replaces = edits.OfType<ReplaceEdit>().ToList();
-        Assert.Equal(4, replaces.Count());
+        Assert.Equal(4, replaces.Count);
         Assert.All(replaces, r => Assert.True(r.NewValue == "\"Front\""));
         Assert.Equal(
             new[]
@@ -1010,7 +1002,10 @@ public sealed class AppSymbolsTests
         Assert.Equal("App/ui/Task_1/layouts/P1.json", moves[0].OldPath);
         Assert.Equal("App/ui/Task_1/layouts/Front.json", moves[0].NewPath);
 
-        Assert.DoesNotContain(edits.OfType<ReplaceEdit>(), r => r.Span.File.StartsWith("App/ui/Task_2/"));
+        Assert.DoesNotContain(
+            edits.OfType<ReplaceEdit>(),
+            r => r.Span.File.StartsWith("App/ui/Task_2/", StringComparison.Ordinal)
+        );
     }
 
     [Fact]
@@ -1109,7 +1104,7 @@ public sealed class AppSymbolsTests
         var symbols = OpenSymbols(NavApp());
         var lenses = symbols.CodeLenses("App/ui/Task_1/layouts/P1.json");
 
-        Assert.Equal(2, lenses.Count());
+        Assert.Equal(2, lenses.Count);
 
         var page = lenses.Single(l => l.Range.Line == 1);
         Assert.Equal("1 reference", page.Title);
@@ -1130,7 +1125,7 @@ public sealed class AppSymbolsTests
         Assert.Equal("1 reference", resourceLens.Title);
 
         var schema = symbols.CodeLenses("App/models/model.schema.json");
-        Assert.Equal(2, schema.Count());
+        Assert.Equal(2, schema.Count);
         Assert.All(schema, l => Assert.True(l.Title == "1 reference"));
     }
 
@@ -1140,7 +1135,7 @@ public sealed class AppSymbolsTests
         var symbols = OpenCSharpModelApp();
         var lenses = symbols.CodeLenses("App/models/Root.cs");
 
-        Assert.Equal(3, lenses.Count());
+        Assert.Equal(3, lenses.Count);
         var (classLine, _) = At(CSharpModelSource, "public class Root", 1);
         var classLens = lenses.Single(l => l.Range.Line == classLine);
         Assert.Equal("1 reference", classLens.Title);
@@ -1172,6 +1167,22 @@ public sealed class AppSymbolsTests
           }
         }
         """;
+    private static readonly string[] _summary2ComponentRefPointers =
+    [
+        "/data/layout/1/target/id",
+        "/data/layout/1/overrides/0/componentId",
+    ];
+
+    private static readonly string[] _summary2ComponentRenamePointers =
+    [
+        "/data/layout/0/id",
+        "/data/layout/1/target/id",
+        "/data/layout/1/overrides/0/componentId",
+    ];
+
+    private static readonly string[] _componentRenamePointers = ["/data/layout/0/id", "/data/layout/1/children/0"];
+
+    private static readonly string[] _declaredDataTypes = ["model", "attachment"];
 
     private static AppSymbols OpenExprCompletionApp() =>
         OpenSymbols(

--- a/src/libs/dotnet/Altinn.Studio.AppConfig.Tests/Validation/BuildOutputExclusionTests.cs
+++ b/src/libs/dotnet/Altinn.Studio.AppConfig.Tests/Validation/BuildOutputExclusionTests.cs
@@ -27,6 +27,8 @@ public sealed class BuildOutputExclusionTests
         Assert.False(model.CSharpClasses.ContainsKey("App.Generated.CopiedNoise"));
     }
 
+    private static readonly string[] expected = new[] { "App/models/a.cs" };
+
     [Fact]
     public void InMemoryEnumeration_SkipsBinAndObj()
     {
@@ -39,7 +41,7 @@ public sealed class BuildOutputExclusionTests
             }
         );
 
-        Assert.Equal(new[] { "App/models/a.cs" }, dir.EnumerateFiles("App", "*.cs", recursive: true));
+        Assert.Equal(expected, dir.EnumerateFiles("App", "*.cs", recursive: true));
         Assert.NotNull(dir.ReadAllBytes("App/obj/g.cs"));
     }
 
@@ -54,7 +56,7 @@ public sealed class BuildOutputExclusionTests
             dir.WriteAllBytes("App/obj/Debug/g.cs", new byte[] { 1 });
             dir.WriteAllBytes("App/bin/Debug/b.cs", new byte[] { 1 });
 
-            Assert.Equal(new[] { "App/models/a.cs" }, dir.EnumerateFiles("App", "*.cs", recursive: true));
+            Assert.Equal(expected, dir.EnumerateFiles("App", "*.cs", recursive: true));
         }
         finally
         {

--- a/src/libs/dotnet/Altinn.Studio.AppConfig.Tests/Validation/InMemoryAppDirectoryTests.cs
+++ b/src/libs/dotnet/Altinn.Studio.AppConfig.Tests/Validation/InMemoryAppDirectoryTests.cs
@@ -113,11 +113,11 @@ public sealed class InMemoryAppDirectoryTests
 
         var report = ValidationEngine.Run(engine.Build());
 
-        var pathFinding = Assert.Single(report.Findings.Where(f => f.RuleId == "REF-DATAMODEL-PATH"));
+        var pathFinding = Assert.Single(report.Findings, f => f.RuleId == "REF-DATAMODEL-PATH");
         Assert.Contains("project.gnre", pathFinding.Message);
         Assert.Contains("\"model\"", pathFinding.Message);
 
-        var typeFinding = Assert.Single(report.Findings.Where(f => f.RuleId == "REF-DATATYPE-ID"));
+        var typeFinding = Assert.Single(report.Findings, f => f.RuleId == "REF-DATATYPE-ID");
         Assert.Contains("modele", typeFinding.Message);
     }
 
@@ -153,9 +153,9 @@ public sealed class InMemoryAppDirectoryTests
         var report = ValidationEngine.Run(engine.Build());
 
         var paths = report.Findings.Where(f => f.RuleId == "REF-DATAMODEL-PATH").ToList();
-        Assert.Equal(1, paths.Count());
-        Assert.Contains("project.address", paths[0].Message);
-        Assert.Contains("\"other\"", paths[0].Message);
+        var path = Assert.Single(paths);
+        Assert.Contains("project.address", path.Message);
+        Assert.Contains("\"other\"", path.Message);
     }
 
     [Fact]
@@ -188,9 +188,9 @@ public sealed class InMemoryAppDirectoryTests
         var report = ValidationEngine.Run(engine.Build());
 
         var paths = report.Findings.Where(f => f.RuleId == "REF-DATAMODEL-PATH").ToList();
-        Assert.Equal(1, paths.Count());
-        Assert.Contains("applicant.fnr", paths[0].Message);
-        Assert.Contains("\"model\"", paths[0].Message);
+        var path = Assert.Single(paths);
+        Assert.Contains("applicant.fnr", path.Message);
+        Assert.Contains("\"model\"", path.Message);
     }
 
     [Fact]
@@ -219,9 +219,9 @@ public sealed class InMemoryAppDirectoryTests
         var report = ValidationEngine.Run(AppConfigEngine.Open(dir).Build());
 
         var kinds = report.Findings.Where(f => f.RuleId == "BINDING-KIND").ToList();
-        Assert.Equal(1, kinds.Count());
-        Assert.Contains("warns", kinds[0].Message);
-        Assert.Contains("\"model\"", kinds[0].Message);
+        var kind = Assert.Single(kinds);
+        Assert.Contains("warns", kind.Message);
+        Assert.Contains("\"model\"", kind.Message);
     }
 
     [Fact]
@@ -345,7 +345,7 @@ public sealed class InMemoryAppDirectoryTests
 
         var report = ValidationEngine.Run(AppConfigEngine.Open(dir).Build());
 
-        var single = Assert.Single(report.Findings.Where(f => f.RuleId == "REF-DATAMODEL-PATH"));
+        var single = Assert.Single(report.Findings, f => f.RuleId == "REF-DATAMODEL-PATH");
         Assert.Contains("lines[0].missing", single.Message);
     }
 
@@ -363,7 +363,7 @@ public sealed class InMemoryAppDirectoryTests
 
         var report = ValidationEngine.Run(AppConfigEngine.Open(dir).Build());
 
-        var syntax = Assert.Single(report.Findings.Where(f => f.RuleId == "SYNTAX-VALID"));
+        var syntax = Assert.Single(report.Findings, f => f.RuleId == "SYNTAX-VALID");
         Assert.Equal("App/ui/Task_1/layouts/Bad.json", syntax.Position.File);
         Assert.True(syntax.Position.Line > 0);
 
@@ -424,7 +424,7 @@ public sealed class InMemoryAppDirectoryTests
 
         var report = AppConfigEngine.Open(dir).ValidateSchemas();
 
-        Assert.Equal(report.Findings.Count(), report.Findings.Distinct().Count());
+        Assert.Equal(report.Findings.Count, report.Findings.Distinct().Count());
         Assert.Equal(1, report.Findings.Count(f => f.RuleId == "JSONSCHEMA-VALID" && f.Message.Contains("size")));
     }
 
@@ -481,7 +481,7 @@ public sealed class InMemoryAppDirectoryTests
 
         var report = ValidationEngine.Run(AppConfigEngine.Open(dir).Build());
 
-        var single = Assert.Single(report.Findings.Where(f => f.RuleId == "UNIQUE-PAGE-IN-ORDER"));
+        var single = Assert.Single(report.Findings, f => f.RuleId == "UNIQUE-PAGE-IN-ORDER");
         Assert.Contains("P1", single.Message);
     }
 
@@ -784,7 +784,7 @@ public sealed class InMemoryAppDirectoryTests
 
         var report = ValidationEngine.Run(AppConfigEngine.Open(dir).Build());
 
-        var single = Assert.Single(report.Findings.Where(f => f.RuleId == "PROCESS-TASK-TYPE"));
+        var single = Assert.Single(report.Findings, f => f.RuleId == "PROCESS-TASK-TYPE");
         Assert.True(single.Message.Contains("signign") && single.Severity == Severity.Warning);
     }
 
@@ -816,7 +816,7 @@ public sealed class InMemoryAppDirectoryTests
 
         var report = ValidationEngine.Run(AppConfigEngine.Open(dir).Build());
 
-        var single = Assert.Single(report.Findings.Where(f => f.RuleId == "CROSS-GROUP-CHILD-PAGE"));
+        var single = Assert.Single(report.Findings, f => f.RuleId == "CROSS-GROUP-CHILD-PAGE");
         Assert.Contains("\"b\"", single.Message);
     }
 
@@ -841,7 +841,7 @@ public sealed class InMemoryAppDirectoryTests
 
         var report = ValidationEngine.Run(AppConfigEngine.Open(dir).Build());
 
-        var single = Assert.Single(report.Findings.Where(f => f.RuleId == "SELECTION-OPTIONS"));
+        var single = Assert.Single(report.Findings, f => f.RuleId == "SELECTION-OPTIONS");
         Assert.Contains("dd-bad", single.Message);
     }
 
@@ -887,7 +887,7 @@ public sealed class InMemoryAppDirectoryTests
 
         var report = ValidationEngine.Run(AppConfigEngine.Open(dir).Build());
 
-        var single = Assert.Single(report.Findings.Where(f => f.RuleId == "UNUSED-LAYOUT-FOLDER"));
+        var single = Assert.Single(report.Findings, f => f.RuleId == "UNUSED-LAYOUT-FOLDER");
         Assert.Contains("\"Leftover\"", single.Message);
     }
 

--- a/src/libs/dotnet/Altinn.Studio.AppConfig.Tests/Validation/OverlayAppDirectoryTests.cs
+++ b/src/libs/dotnet/Altinn.Studio.AppConfig.Tests/Validation/OverlayAppDirectoryTests.cs
@@ -109,12 +109,14 @@ public sealed class OverlayAppDirectoryTests
         Assert.Contains("a/resource.en.json", ov.EnumerateFiles("a", "resource.*.json", recursive: false));
     }
 
+    private static readonly string[] _nonRecursiveJsonFiles = ["a/one.json", "a/two.json"];
+
     [Fact]
     public void EnumerateFiles_RespectsSearchPatternAndRecursion()
     {
         var ov = new OverlayAppDirectory(BaseDir());
         var nonrec = ov.EnumerateFiles("a", "*.json", recursive: false).ToList();
-        Assert.Equal(new[] { "a/one.json", "a/two.json" }.OrderBy(s => s), nonrec.OrderBy(s => s));
+        Assert.Equal(_nonRecursiveJsonFiles.OrderBy(s => s), nonrec.OrderBy(s => s));
 
         var rec = ov.EnumerateFiles("a", "*.json", recursive: true).ToList();
         Assert.Contains("a/b/three.json", rec);

--- a/src/libs/dotnet/Altinn.Studio.AppConfig.Tests/Validation/RepGroupChildIndexRuleTests.cs
+++ b/src/libs/dotnet/Altinn.Studio.AppConfig.Tests/Validation/RepGroupChildIndexRuleTests.cs
@@ -38,7 +38,7 @@ public sealed class RepGroupChildIndexRuleTests
             )
             .Validate();
 
-        var finding = Assert.Single(report.Findings.Where(f => f.RuleId == Rule));
+        var finding = Assert.Single(report.Findings, f => f.RuleId == Rule);
         Assert.Contains("items[0].subfield", finding.Message);
         Assert.Contains("bind \"items.subfield\"", finding.Message);
     }
@@ -60,7 +60,7 @@ public sealed class RepGroupChildIndexRuleTests
             )
             .Validate();
 
-        Assert.Single(report.Findings.Where(f => f.RuleId == Rule));
+        Assert.Single(report.Findings, f => f.RuleId == Rule);
     }
 
     [Fact]

--- a/src/libs/dotnet/Altinn.Studio.AppConfig.Tests/Validation/RuleFalsePositiveTests.cs
+++ b/src/libs/dotnet/Altinn.Studio.AppConfig.Tests/Validation/RuleFalsePositiveTests.cs
@@ -1067,7 +1067,7 @@ public sealed class RuleFalsePositiveTests
         );
         var engine = AppConfigEngine.Open(dir);
 
-        Assert.Single(engine.Validate().Findings.Where(f => f.RuleId == "APP-VERSION-SUPPORTED"));
+        Assert.Single(engine.Validate().Findings, f => f.RuleId == "APP-VERSION-SUPPORTED");
 
         dir.Set("App/App.csproj", V8Csproj.Replace("8.12.0", "9.1.0"));
         var after = engine.Validate().Findings;
@@ -1111,7 +1111,7 @@ public sealed class RuleFalsePositiveTests
     {
         var bpmn = ExprBpmn.Replace("EXPR", """["equals",["dataModel","ghostPath","model"],true]""");
         var findings = ValidateBpmnExpr("""["equals",["dataModel","ghostPath","model"],true]""");
-        var f = Assert.Single(findings.Where(x => x.RuleId == "REF-DATAMODEL-PATH"));
+        var f = Assert.Single(findings, x => x.RuleId == "REF-DATAMODEL-PATH");
         Assert.Contains("ghostPath", f.Message);
         Assert.Equal("App/config/process/process.bpmn", f.Position.File);
         var lines = bpmn.Split('\n');

--- a/src/libs/dotnet/Altinn.Studio.AppConfig.Tests/Validation/RuleRegistryTests.cs
+++ b/src/libs/dotnet/Altinn.Studio.AppConfig.Tests/Validation/RuleRegistryTests.cs
@@ -25,7 +25,7 @@ public sealed class RuleRegistryTests
     public void Registry_RuleIdsAreUniqueAndSorted()
     {
         var ids = ValidationEngine.AllRules.Select(r => r.Metadata.Id).ToList();
-        Assert.Equal(ids.Count(), ids.Distinct().Count());
+        Assert.Equal(ids.Count, ids.Distinct().Count());
         Assert.Equal(ids, ids.OrderBy(x => x, StringComparer.Ordinal));
     }
 }

--- a/src/libs/dotnet/Altinn.Studio.AppConfig.Tests/Validation/SchemaCoverageTests.cs
+++ b/src/libs/dotnet/Altinn.Studio.AppConfig.Tests/Validation/SchemaCoverageTests.cs
@@ -22,7 +22,8 @@ public sealed class SchemaCoverageTests
         var report = AppConfigEngine.Open(dir).ValidateSchemas();
 
         var skip = Assert.Single(
-            report.Findings.Where(f => f.Severity == Severity.Info && f.Message.Contains("not schema-checked"))
+            report.Findings,
+            f => f.Severity == Severity.Info && f.Message.Contains("not schema-checked")
         );
         Assert.Equal("JSONSCHEMA-VALID", skip.RuleId);
         Assert.Equal("App/config/applicationmetadata.json", skip.Position.File);

--- a/src/libs/dotnet/Altinn.Studio.AppConfig.Tests/Validation/SpanByteColumnTests.cs
+++ b/src/libs/dotnet/Altinn.Studio.AppConfig.Tests/Validation/SpanByteColumnTests.cs
@@ -59,7 +59,7 @@ public sealed class SpanByteColumnTests
         Assert.Equal((3, expectedCol), (id.Line, id.Column));
         Assert.Equal(expectedCol + "Soknad".Length, id.EndColumn);
 
-        var prop = Assert.Single(info.Properties.Where(p => p.Name == "Navn"));
+        var prop = Assert.Single(info.Properties, p => p.Name == "Navn");
         var propSpan = prop.Span ?? throw new InvalidOperationException("property span missing");
         var propStart = propPrefix.IndexOf("public", StringComparison.Ordinal);
         Assert.Equal(Encoding.UTF8.GetByteCount(propPrefix.AsSpan(0, propStart)) + 1, propSpan.Column);

--- a/src/libs/dotnet/Altinn.Studio.AppConfig/Validation/Rules/Meta/AppVersionSupportedRule.cs
+++ b/src/libs/dotnet/Altinn.Studio.AppConfig/Validation/Rules/Meta/AppVersionSupportedRule.cs
@@ -25,6 +25,9 @@ internal sealed class AppVersionSupportedRule : IValidationRule
     public IEnumerable<Finding> Check(AppModel app)
     {
         if (app.UnsupportedAppVersion is { } v)
-            yield return Metadata.Report($"{v.Reason}; this tool supports Altinn.App v9 apps only. To upgrade the app, try `studioctl app upgrade`.", v.Position);
+            yield return Metadata.Report(
+                $"{v.Reason}; this tool supports Altinn.App v9 apps only. To upgrade the app, try `studioctl app upgrade`.",
+                v.Position
+            );
     }
 }


### PR DESCRIPTION
## Description

`LspServer.cs` was an 891-line class owning transport framing, JSON-RPC method binding, workspace root management, document overlay state, validation scheduling, diagnostic publishing, UTF-16 mapping, navigation, completion, hover, rename, code actions, code lenses, URI conversion, and error handling.

This splits it into single-responsibility components with no behavior change:

- **`Logger.cs`** — leveled stderr logging (`LogLevel` enum moved here)
- **`LspTransport.cs`** — Content-Length framing over the raw streams, server-initiated notifications, parse-error replies, and the StreamJsonRpc `FrameHandler`; shared `LspJson` serializer options
- **`WorkspaceState.cs`** — workspace root, open-document overlay, engine/symbol-index lifecycle, URI/path conversion, and the `Utf16Mapper` cache
- **`LspConversions.cs`** — conversions between engine coordinates (1-based lines, UTF-8 byte columns) and LSP coordinates (0-based lines, UTF-16 characters): positions, ranges, diagnostics, locations
- **`DiagnosticsPublisher.cs`** — debounced validation runs and per-URI deduplicated `publishDiagnostics`
- **`LanguageFeatures.cs`** — hover, definition/references, completion, rename/prepareRename, code actions, code lenses
- **`LspServer.cs`** — reduced to the JSON-RPC `Target`, lifecycle (initialize/shutdown/exit, workspace-folder and document notifications), the handler lock, and wiring (~280 lines)

The public surface (`new LspServer(input, output).Run()`) is unchanged; the existing black-box protocol tests pass as-is.

## Verification

- `dotnet build studioctl-lsp` and `dotnet build studioctl-server` succeed
- `dotnet test studioctl-lsp.Tests`: 20/20 passed
- `csharpier format` applied

## Windows URI fix

Also fixes the double-drive bug on Windows (`c:\c:\...` in "not an altinn app directory"): VS Code percent-encodes the drive colon in file URIs (`file:///c%3A/...`), and `System.Uri` only detects a DOS path when the colon is literal in the raw URI, so `LocalPath` leaked a leading separator (`\c:\...`) that `Path.GetFullPath` then resolved against the current drive. `WorkspaceState.LocalPath` now trims the stray separator before a drive letter on Windows, with unit tests covering the encoded, literal, and Unix URI forms (`InternalsVisibleTo` added for the test project).

🤖 Generated with [Claude Code](https://claude.com/claude-code)