### PR TITLE
chore(resource-adm): remove old selfIdentifiedUserEnabled and EnterpriseUserEnabled fields from UI and model

### DIFF
--- a/src/Designer/backend/src/Designer/Models/ServiceResource.cs
+++ b/src/Designer/backend/src/Designer/Models/ServiceResource.cs
@@ -102,16 +102,6 @@ public class ServiceResource
     public ResourceAccessListMode AccessListMode { get; set; }
 
     /// <summary>
-    /// The user acting on behalf of party can be a selfidentifed users
-    /// </summary>
-    public bool SelfIdentifiedUserEnabled { get; set; }
-
-    /// <summary>
-    /// The user acting on behalf of party can be an enterprise users
-    /// </summary>
-    public bool EnterpriseUserEnabled { get; set; }
-
-    /// <summary>
     /// ResourceType
     /// </summary>
     [JsonConverter(typeof(JsonStringEnumConverter))]

--- a/src/Designer/frontend/packages/shared/src/types/AppConfig.ts
+++ b/src/Designer/frontend/packages/shared/src/types/AppConfig.ts
@@ -19,8 +19,6 @@ export type AppConfigNew = {
   rightDescription?: SupportedLanguage;
   keywords?: Keyword[];
   status?: StatusOption;
-  selfIdentifiedUserEnabled?: boolean;
-  enterpriseUserEnabled?: boolean;
   contactPoints?: ContactPoint[];
   visible?: boolean;
 };

--- a/src/Designer/frontend/packages/shared/src/types/ResourceAdm.ts
+++ b/src/Designer/frontend/packages/shared/src/types/ResourceAdm.ts
@@ -22,8 +22,6 @@ export interface Resource {
   version?: string;
   resourceReferences?: ResourceReference[];
   status?: ResourceStatusOption;
-  selfIdentifiedUserEnabled?: boolean;
-  enterpriseUserEnabled?: boolean;
   availableForType?: ResourceAvailableForTypeOption[];
   contactPoints?: ResourceContactPoint[];
   accessListMode?: ResourceAccessListMode;

--- a/src/Designer/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.test.tsx
+++ b/src/Designer/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.test.tsx
@@ -41,8 +41,6 @@ const mockResource1: Resource = {
   delegable: true,
   rightDescription: { nb: '', nn: '', en: '' },
   status: 'Completed',
-  selfIdentifiedUserEnabled: false,
-  enterpriseUserEnabled: false,
   availableForType: ['Company'],
   contactPoints: [mockContactPoint],
 };
@@ -337,45 +335,6 @@ describe('AboutResourcePage', () => {
     expect(mockOnSaveResource).toHaveBeenCalledWith({
       ...mockResource1,
       status: mockStatus,
-    });
-  });
-
-  it('handles self identifiable switch changes', async () => {
-    const user = userEvent.setup();
-    render(<AboutResourcePage {...defaultProps} />);
-
-    const input = screen.getByLabelText(
-      textMock('resourceadm.about_resource_self_identified_show_text', {
-        shouldText: textMock('resourceadm.switch_should_not'),
-      }),
-    );
-    expect(input).not.toBeChecked();
-
-    await user.click(input);
-
-    expect(mockOnSaveResource).toHaveBeenCalledWith({
-      ...mockResource1,
-      selfIdentifiedUserEnabled: true,
-    });
-  });
-
-  it('handles enterprise switch changes', async () => {
-    const user = userEvent.setup();
-    render(<AboutResourcePage {...defaultProps} />);
-
-    const input = screen.getByLabelText(
-      textMock('resourceadm.about_resource_enterprise_show_text', {
-        shouldText: textMock('resourceadm.switch_should_not'),
-      }),
-    );
-
-    expect(input).not.toBeChecked();
-
-    await user.click(input);
-
-    expect(mockOnSaveResource).toHaveBeenCalledWith({
-      ...mockResource1,
-      enterpriseUserEnabled: true,
     });
   });
 

--- a/src/Designer/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.tsx
+++ b/src/Designer/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.tsx
@@ -325,30 +325,6 @@ export const AboutResourcePage = ({
           errors={validationErrors.filter((error) => error.field === 'status')}
         />
         {resourceData.resourceType !== 'MaskinportenSchema' && (
-          <ResourceSwitchInput
-            id='selfIdentifiedUserEnabled'
-            label={t('resourceadm.about_resource_self_identified_label')}
-            description={t('resourceadm.about_resource_self_identified_text')}
-            value={resourceData.selfIdentifiedUserEnabled ?? false}
-            onChange={(isChecked: boolean) =>
-              handleSave({ ...resourceData, selfIdentifiedUserEnabled: isChecked })
-            }
-            toggleTextTranslationKey='resourceadm.about_resource_self_identified_show_text'
-          />
-        )}
-        {resourceData.resourceType !== 'MaskinportenSchema' && (
-          <ResourceSwitchInput
-            id='enterpriseUserEnabled'
-            label={t('resourceadm.about_resource_enterprise_label')}
-            description={t('resourceadm.about_resource_enterprise_text')}
-            value={resourceData.enterpriseUserEnabled ?? false}
-            onChange={(isChecked: boolean) =>
-              handleSave({ ...resourceData, enterpriseUserEnabled: isChecked })
-            }
-            toggleTextTranslationKey='resourceadm.about_resource_enterprise_show_text'
-          />
-        )}
-        {resourceData.resourceType !== 'MaskinportenSchema' && (
           <ResourceCheckboxGroup
             id='availableForType'
             options={availableForOptions}


### PR DESCRIPTION
## Description
- remove old selfIdentifiedUserEnabled and EnterpriseUserEnabled fields from UI and model. These fields are no longer in use

## Issue
- https://github.com/Altinn/altinn-resource-registry/issues/818

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Replaced separate self-identified and enterprise access toggles with a unified access-list mode.
  - Removed the two corresponding switches from resource administration.

- **New Features**
  - Added support for resource descriptions, keywords and status metadata in configuration.

- **Bug Fixes**
  - Updated resource administration behaviour and validation to align with the new access-list settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->