### PR TITLE
fix: show loading spinner during page navigation

### DIFF
--- a/src/Designer/frontend/app-development/router/PageRoutes.tsx
+++ b/src/Designer/frontend/app-development/router/PageRoutes.tsx
@@ -38,7 +38,7 @@ const router = createBrowserRouter(
             key={route.path}
             path={route.path}
             element={
-              <Suspense fallback={<StudioPageSpinner spinnerTitle='' />}>
+              <Suspense key={route.path} fallback={<StudioPageSpinner spinnerTitle='' />}>
                 <route.subapp />
               </Suspense>
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The lazy-route `Suspense` spinner stopped showing after the React Router 6 → 7 upgrade (#19115), which wraps navigations in `startTransition`. React suppresses a fallback during a transition when the boundary is already visible, and since every route reused the same `<Suspense>` at the `<Outlet />`, the spinner never appeared.

Adding `key={route.path}` forces a freshly-mounted boundary per feature switch, so React shows the fallback again (keyed by path so sub-navigation within a feature keeps its state).



Before:

https://github.com/user-attachments/assets/7222cf5c-2256-4d99-b064-c35792c4e107




After:

https://github.com/user-attachments/assets/3c457dd1-64a9-4ddc-96fd-ed96d84fa05a




<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route transitions by ensuring each page loads within its own loading boundary.
  * Prevented loading states from being incorrectly reused between different routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->