### PR TITLE
chore: group app-libs Renovate updates with App

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -84,7 +84,7 @@
       "groupName": "Design system in App"
     },
     {
-      "matchFileNames": ["src/App/**"],
+      "matchFileNames": ["src/App/**", "app-libs/**"],
       "additionalBranchPrefix": "app/",
       "commitMessageSuffix": " (app)"
     },


### PR DESCRIPTION
## Description

Include dependencies under `app-libs/**` in the Renovate rule that adds the `app/` branch prefix and ` (app)` commit suffix. This keeps the extracted App frontend libraries grouped with App updates instead of Studio Designer updates.

## Verification

- [x] Related issues are connected (not applicable)
- [ ] **Your** code builds clean without any errors or warnings (not run; configuration-only change)
- [x] Manual testing done (validated JSON syntax and checked the Git diff)
- [ ] Relevant automated test added (not applicable for this path-matching change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended automated dependency update configuration to include an additional application library directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->