### PR TITLE
fix: convert layout to pdf in v9

### DIFF
--- a/src/Designer/backend/src/Designer/Services/Implementation/AppDevelopmentService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/AppDevelopmentService.cs
@@ -192,8 +192,9 @@ public class AppDevelopmentService : IAppDevelopmentService
             altinnRepoEditingContext.Repo,
             altinnRepoEditingContext.Developer
         );
-        bool appUsesLayoutSets = altinnAppGitRepository.AppUsesLayoutSets();
-        if (appUsesLayoutSets)
+        // Honor layoutSetName like the read path does. v9 apps use set folders without a
+        // layout-sets.json, so AppUsesLayoutSets() alone would write to the wrong file.
+        if (_appVersionService.IsV9App(altinnRepoEditingContext) || altinnAppGitRepository.AppUsesLayoutSets())
         {
             await altinnAppGitRepository.SaveLayoutSettings(layoutSetName, layoutSettings);
             return;

--- a/src/Designer/backend/tests/Designer.Tests/Services/AppDevelopmentServiceTest.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/AppDevelopmentServiceTest.cs
@@ -107,6 +107,51 @@ public class AppDevelopmentServiceTest : IDisposable
     }
 
     [Fact]
+    public async Task SaveLayoutSettings_ToAppWithSetFolderButNoLayoutSetsFile_ShouldPersistPdfLayoutNameForSameSet()
+    {
+        // Regression: v9 apps have set folders but no layout-sets.json. Save and read must resolve
+        // the same Settings.json for a layoutSetName, else pdfLayoutName is lost (PDF convert revert).
+        string layoutSetName = "layoutSet1";
+        string pdfLayoutName = "layoutFile1";
+        string layoutSettingsSchemaUrl = "https://altinncdn.no/schemas/json/layout/layoutSettings.schema.v1.json";
+        string targetRepository = TestDataHelper.GenerateTestRepoName();
+        AltinnRepoEditingContext editingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(
+            _org,
+            targetRepository,
+            _developer
+        );
+
+        _appVersionServiceMock.Setup(s => s.IsV9App(It.IsAny<AltinnRepoEditingContext>())).Returns(true);
+
+        CreatedTestRepoPath = await TestDataHelper.CopyRepositoryForTest(
+            _org,
+            _repository,
+            _developer,
+            targetRepository
+        );
+
+        // Remove layout-sets.json to mimic a v9 app (set folders without the manifest).
+        File.Delete(Path.Combine(CreatedTestRepoPath, "App", "ui", "layout-sets.json"));
+
+        var layoutSettingsToSave = JsonNode.Parse(
+            $@"{{
+            ""$schema"": ""{layoutSettingsSchemaUrl}"",
+            ""pages"": {{
+                ""order"": [],
+                ""pdfLayoutName"": ""{pdfLayoutName}""
+            }}
+        }}"
+        );
+
+        await _appDevelopmentService.SaveLayoutSettings(editingContext, layoutSettingsToSave, layoutSetName);
+
+        var savedLayoutSettings = await _appDevelopmentService.GetLayoutSettings(editingContext, layoutSetName);
+
+        Assert.NotNull(savedLayoutSettings);
+        Assert.Equal(pdfLayoutName, savedLayoutSettings!["pages"]!["pdfLayoutName"]!.GetValue<string>());
+    }
+
+    [Fact]
     public async Task GetLayoutSettings_FromAppWithLayoutSet_ShouldReturnSettings()
     {
         string layoutSetName = "layoutSet1";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

v9 apps don't have a layout-sets.json file. As a result, when converting a PDF, the backend calls the SaveLayoutSettings method. However, the method only checked whether the app used layout-sets.json, which worked correctly for v8. Since layout-sets.json no longer exists in v9, the method resolved the wrong path and saved the settings to the root settings.json file instead.

This PR fixes the issue by adding an additional check to determine whether the app is running v9 or later, ensuring that the correct settings path is used.

<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Layout settings for v9 applications are now saved and restored correctly when layout set metadata is unavailable.
  * Preserves PDF layout selections when saving settings for applications with set folders.

* **Tests**
  * Added regression coverage for saving and reading layout settings in this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->