### PR TITLE
feat(studioctl): migrate/detect v8→v9 C# API breaking changes in app upgrade

### DIFF
--- a/src/App/backend/src/Altinn.App.Core/Interface/ITaskEvents.cs
+++ b/src/App/backend/src/Altinn.App.Core/Interface/ITaskEvents.cs
@@ -5,7 +5,11 @@ namespace Altinn.App.Core.Interface;
 /// <summary>
 /// Interface for implementing a receiver handling task process events.
 /// </summary>
-[Obsolete(message: "Use Altinn.App.Core.Internal.Process.ITaskEvents instead", error: true)]
+[Obsolete(
+    message: "Use the task lifecycle handlers in Altinn.App.Core.Features.Process instead: "
+        + "IOnTaskStartingHandler, IOnTaskEndingHandler and IOnTaskAbandonHandler.",
+    error: true
+)]
 public interface ITaskEvents
 {
     /// <summary>

--- a/src/App/backend/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/src/App/backend/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -2924,7 +2924,8 @@ namespace Altinn.App.Core.Interface
         Microsoft.Azure.KeyVault.KeyVaultClient GetKeyVaultClient();
         System.Threading.Tasks.Task<string> GetSecretAsync(string secretName);
     }
-    [System.Obsolete("Use Altinn.App.Core.Internal.Process.ITaskEvents instead", true)]
+    [System.Obsolete("Use the task lifecycle handlers in Altinn.App.Core.Features.Process instead: IOnT" +
+        "askStartingHandler, IOnTaskEndingHandler and IOnTaskAbandonHandler.", true)]
     public interface ITaskEvents
     {
         System.Threading.Tasks.Task OnAbandonProcessTask(string taskId, Altinn.Platform.Storage.Interface.Models.Instance instance);

--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -8,6 +8,10 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+### Added
+
+- Handle the v9 C# breaking changes in `studioctl app upgrade v9`: auto-fix package-version floors (NU1605), the `IServiceTask` namespace move, and the `IEFormidlingReceivers.GetEFormidlingReceivers` signature; warn (exit code `3`) about removed APIs that need manual porting — the legacy task event interfaces (`IProcessTaskStart`/`End`/`Abandon`, `ITaskEvents`), the reworked `ServiceTaskResult` factories, and legacy eFormidling code.
+
 ## [0.1.0-preview.17] - 2026-07-23
 
 ### Added

--- a/src/cli/studioctl-server-tests/Upgrade/v8Tov9/CSharpApiMigrationTests.cs
+++ b/src/cli/studioctl-server-tests/Upgrade/v8Tov9/CSharpApiMigrationTests.cs
@@ -1,0 +1,207 @@
+using Altinn.Studio.Cli.Upgrade.v8Tov9.CSharpApiMigration;
+
+namespace Studioctl.Tests.Upgrade.v8Tov9;
+
+public sealed class CSharpApiMigrationTests : IDisposable
+{
+    private readonly TempAppFolder _app = new();
+
+    public void Dispose() => _app.Dispose();
+
+    private CSharpSourceScanner Scanner() => new(Path.Combine(_app.Root, "App"));
+
+    // --- RemovedTaskEventInterfaceDetector -------------------------------------------------------
+
+    [Fact]
+    public void TaskEventDetector_FlagsImplementationsAndDiRegistrations()
+    {
+        _app.Write(
+            "logic/MyTaskEnd.cs",
+            """
+            using Altinn.App.Core.Features;
+            public class MyTaskEnd : IProcessTaskEnd
+            {
+                public Task End(string taskId, Instance instance) => Task.CompletedTask;
+            }
+            """
+        );
+        _app.Write(
+            "Program.cs",
+            """
+            var builder = WebApplication.CreateBuilder(args);
+            builder.Services.AddTransient<IProcessTaskEnd, MyTaskEnd>();
+            """
+        );
+
+        var result = new RemovedTaskEventInterfaceDetector(Scanner()).Detect();
+
+        Assert.True(result.ManualActionRequired);
+        Assert.Contains(result.Warnings, w => w.Contains("MyTaskEnd.cs") && w.Contains("MyTaskEnd : IProcessTaskEnd"));
+        Assert.Contains(result.Warnings, w => w.Contains("Program.cs") && w.Contains("IProcessTaskEnd"));
+    }
+
+    [Fact]
+    public void TaskEventDetector_CleanApp_ReportsNothing()
+    {
+        _app.Write(
+            "logic/MyService.cs",
+            """
+            public class MyService
+            {
+                public Task DoWork() => Task.CompletedTask;
+            }
+            """
+        );
+
+        var result = new RemovedTaskEventInterfaceDetector(Scanner()).Detect();
+
+        Assert.False(result.ManualActionRequired);
+        Assert.Empty(result.Warnings);
+    }
+
+    // --- ServiceTaskResultApiDetector ------------------------------------------------------------
+
+    [Fact]
+    public void ServiceTaskResultDetector_FlagsRemovedTypesAndFactories()
+    {
+        _app.Write(
+            "logic/MyServiceTask.cs",
+            """
+            public class MyServiceTask
+            {
+                public ServiceTaskResult Run()
+                {
+                    var handling = new ServiceTaskErrorHandling(ServiceTaskErrorStrategy.Abort);
+                    return ServiceTaskResult.FailedContinueProcessNext("reject");
+                }
+            }
+            """
+        );
+
+        var result = new ServiceTaskResultApiDetector(Scanner()).Detect();
+
+        Assert.True(result.ManualActionRequired);
+        Assert.Contains(result.Warnings, w => w.Contains("ServiceTaskErrorHandling"));
+        Assert.Contains(result.Warnings, w => w.Contains("FailedContinueProcessNext"));
+    }
+
+    // --- LegacyEFormidlingCodeDetector -----------------------------------------------------------
+
+    [Fact]
+    public void EFormidlingCodeDetector_FlagsRemovedProviderAndAppSetting()
+    {
+        _app.Write(
+            "logic/LegacyProvider.cs",
+            """
+            public class LegacyProvider : IEFormidlingLegacyConfigurationProvider
+            {
+                public bool Enabled(AppSettings settings) => settings.EnableEFormidling;
+            }
+            """
+        );
+
+        var result = new LegacyEFormidlingCodeDetector(Scanner()).Detect();
+
+        Assert.True(result.ManualActionRequired);
+        Assert.Contains(result.Warnings, w => w.Contains("LegacyProvider : IEFormidlingLegacyConfigurationProvider"));
+        Assert.Contains(result.Warnings, w => w.Contains("EnableEFormidling"));
+    }
+
+    // --- RemovedInternalProcessTypeDetector ------------------------------------------------------
+
+    [Fact]
+    public void InternalProcessTypeDetector_FlagsRemovedHandlerReference()
+    {
+        _app.Write(
+            "logic/Custom.cs",
+            """
+            public class Custom
+            {
+                private readonly EndTaskEventHandler _handler;
+            }
+            """
+        );
+
+        var result = new RemovedInternalProcessTypeDetector(Scanner()).Detect();
+
+        Assert.True(result.ManualActionRequired);
+        Assert.Contains(result.Warnings, w => w.Contains("EndTaskEventHandler"));
+    }
+
+    // --- EFormidlingReceiversSignatureMigration --------------------------------------------------
+
+    [Fact]
+    public void ReceiversMigration_AddsParameterToImplementation()
+    {
+        var path = _app.Write(
+            "logic/Receivers.cs",
+            """
+            public class Receivers : IEFormidlingReceivers
+            {
+                public Task<List<Receiver>> GetEFormidlingReceivers(Instance instance) => throw new NotImplementedException();
+            }
+            """
+        );
+
+        var result = new EFormidlingReceiversSignatureMigration(Scanner()).Migrate();
+
+        Assert.False(result.ManualActionRequired);
+        Assert.NotEmpty(result.Warnings);
+        var migrated = File.ReadAllText(path);
+        Assert.Contains("GetEFormidlingReceivers(Instance instance, string? receiverFromConfig)", migrated);
+    }
+
+    [Fact]
+    public void ReceiversMigration_IsIdempotent()
+    {
+        var path = _app.Write(
+            "logic/Receivers.cs",
+            """
+            public class Receivers : IEFormidlingReceivers
+            {
+                public Task<List<Receiver>> GetEFormidlingReceivers(Instance instance, string? receiverFromConfig) => throw new NotImplementedException();
+            }
+            """
+        );
+        var before = File.ReadAllText(path);
+
+        var result = new EFormidlingReceiversSignatureMigration(Scanner()).Migrate();
+
+        Assert.Empty(result.Warnings);
+        Assert.Equal(before, File.ReadAllText(path));
+    }
+
+    [Fact]
+    public void ReceiversMigration_IgnoresUnrelatedMethod()
+    {
+        var path = _app.Write(
+            "logic/NotAReceiver.cs",
+            """
+            public class NotAReceiver
+            {
+                public Task<List<Receiver>> GetEFormidlingReceivers(Instance instance) => throw new NotImplementedException();
+            }
+            """
+        );
+        var before = File.ReadAllText(path);
+
+        var result = new EFormidlingReceiversSignatureMigration(Scanner()).Migrate();
+
+        Assert.Empty(result.Warnings);
+        Assert.Equal(before, File.ReadAllText(path));
+    }
+
+    // --- Scanner ---------------------------------------------------------------------------------
+
+    [Fact]
+    public void Scanner_SkipsBuildOutput()
+    {
+        _app.Write("logic/Real.cs", "public class Real : IProcessTaskEnd {}");
+        _app.Write("obj/Debug/Generated.cs", "public class Generated : IProcessTaskEnd {}");
+
+        var files = Scanner().Files;
+
+        Assert.Contains(files, f => f.RelativePath.EndsWith("Real.cs", StringComparison.Ordinal));
+        Assert.DoesNotContain(files, f => f.RelativePath.Contains("obj"));
+    }
+}

--- a/src/cli/studioctl-server-tests/Upgrade/v8Tov9/CSharpApiMigrationTests.cs
+++ b/src/cli/studioctl-server-tests/Upgrade/v8Tov9/CSharpApiMigrationTests.cs
@@ -41,6 +41,24 @@ public sealed class CSharpApiMigrationTests : IDisposable
     }
 
     [Fact]
+    public void TaskEventDetector_FlagsBaseListGenericTypeArgument()
+    {
+        _app.Write(
+            "logic/Wrapper.cs",
+            """
+            public class Wrapper : List<IProcessTaskEnd>
+            {
+            }
+            """
+        );
+
+        var result = new RemovedTaskEventInterfaceDetector(Scanner()).Detect();
+
+        Assert.True(result.ManualActionRequired);
+        Assert.Contains(result.Warnings, w => w.Contains("Wrapper.cs") && w.Contains("IProcessTaskEnd"));
+    }
+
+    [Fact]
     public void TaskEventDetector_CleanApp_ReportsNothing()
     {
         _app.Write(
@@ -85,6 +103,31 @@ public sealed class CSharpApiMigrationTests : IDisposable
         Assert.Contains(result.Warnings, w => w.Contains("FailedContinueProcessNext"));
     }
 
+    [Fact]
+    public void ServiceTaskResultDetector_FlagsQualifiedFailedFactory_NotUnrelatedFailed()
+    {
+        _app.Write(
+            "logic/MyServiceTask.cs",
+            """
+            public class MyServiceTask
+            {
+                public ServiceTaskResult Run() => ServiceTaskResult.Failed(_handling);
+
+                public void Unrelated() => _telemetry.Failed("other");
+            }
+            """
+        );
+
+        var result = new ServiceTaskResultApiDetector(Scanner()).Detect();
+
+        Assert.True(result.ManualActionRequired);
+        Assert.Contains(
+            result.Warnings,
+            w => w.Contains("MyServiceTask.cs:3") && w.Contains("ServiceTaskResult.Failed")
+        );
+        Assert.DoesNotContain(result.Warnings, w => w.Contains("MyServiceTask.cs:5"));
+    }
+
     // --- LegacyEFormidlingCodeDetector -----------------------------------------------------------
 
     [Fact]
@@ -105,6 +148,59 @@ public sealed class CSharpApiMigrationTests : IDisposable
         Assert.True(result.ManualActionRequired);
         Assert.Contains(result.Warnings, w => w.Contains("LegacyProvider : IEFormidlingLegacyConfigurationProvider"));
         Assert.Contains(result.Warnings, w => w.Contains("EnableEFormidling"));
+    }
+
+    [Fact]
+    public void EFormidlingCodeDetector_FlagsLegacySingleArgShipment_NotMigratedUsage()
+    {
+        _app.Write(
+            "logic/LegacySender.cs",
+            """
+            public class LegacySender : IEFormidlingService
+            {
+                public Task SendEFormidlingShipment(Instance instance) => Task.CompletedTask;
+            }
+            """
+        );
+        _app.Write(
+            "logic/MigratedSender.cs",
+            """
+            public class MigratedSender
+            {
+                private readonly IEFormidlingService _service;
+
+                public Task Send(Instance instance, ValidAltinnEFormidlingConfiguration config) =>
+                    _service.SendEFormidlingShipment(instance, config);
+            }
+            """
+        );
+
+        var result = new LegacyEFormidlingCodeDetector(Scanner()).Detect();
+
+        Assert.True(result.ManualActionRequired);
+        Assert.Contains(result.Warnings, w => w.Contains("LegacySender.cs") && w.Contains("SendEFormidlingShipment"));
+        Assert.DoesNotContain(result.Warnings, w => w.Contains("MigratedSender.cs"));
+    }
+
+    [Fact]
+    public void EFormidlingCodeDetector_FlagsLegacySingleArgInvocation()
+    {
+        _app.Write(
+            "logic/Caller.cs",
+            """
+            public class Caller
+            {
+                private readonly IEFormidlingService _service;
+
+                public Task Send(Instance instance) => _service.SendEFormidlingShipment(instance);
+            }
+            """
+        );
+
+        var result = new LegacyEFormidlingCodeDetector(Scanner()).Detect();
+
+        Assert.True(result.ManualActionRequired);
+        Assert.Contains(result.Warnings, w => w.Contains("Caller.cs:5") && w.Contains("SendEFormidlingShipment"));
     }
 
     // --- RemovedInternalProcessTypeDetector ------------------------------------------------------
@@ -275,6 +371,60 @@ public sealed class CSharpApiMigrationTests : IDisposable
         );
 
         Assert.Equal(expected, EFormidlingReceiversSignatureMigration.ProjectEnablesNullableAnnotations(projectFile));
+    }
+
+    [Fact]
+    public void ProjectEnablesNullableAnnotations_FallsBackToNearestDirectoryBuildProps()
+    {
+        var projectFile = _app.Write(
+            "App.csproj",
+            """
+            <Project Sdk="Microsoft.NET.Sdk.Web">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """
+        );
+        _app.Write(
+            "Directory.Build.props",
+            """
+            <Project>
+              <PropertyGroup>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+            </Project>
+            """
+        );
+
+        Assert.True(EFormidlingReceiversSignatureMigration.ProjectEnablesNullableAnnotations(projectFile));
+    }
+
+    [Fact]
+    public void ProjectEnablesNullableAnnotations_ProjectFileWinsOverDirectoryBuildProps()
+    {
+        var projectFile = _app.Write(
+            "App.csproj",
+            """
+            <Project Sdk="Microsoft.NET.Sdk.Web">
+              <PropertyGroup>
+                <Nullable>disable</Nullable>
+              </PropertyGroup>
+            </Project>
+            """
+        );
+        _app.Write(
+            "Directory.Build.props",
+            """
+            <Project>
+              <PropertyGroup>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+            </Project>
+            """
+        );
+
+        Assert.False(EFormidlingReceiversSignatureMigration.ProjectEnablesNullableAnnotations(projectFile));
     }
 
     // --- Scanner ---------------------------------------------------------------------------------

--- a/src/cli/studioctl-server-tests/Upgrade/v8Tov9/CSharpApiMigrationTests.cs
+++ b/src/cli/studioctl-server-tests/Upgrade/v8Tov9/CSharpApiMigrationTests.cs
@@ -143,7 +143,10 @@ public sealed class CSharpApiMigrationTests : IDisposable
             """
         );
 
-        var result = new EFormidlingReceiversSignatureMigration(Scanner()).Migrate();
+        var result = new EFormidlingReceiversSignatureMigration(
+            Scanner(),
+            projectNullableAnnotationsEnabled: true
+        ).Migrate();
 
         Assert.False(result.ManualActionRequired);
         Assert.NotEmpty(result.Warnings);
@@ -165,7 +168,10 @@ public sealed class CSharpApiMigrationTests : IDisposable
         );
         var before = File.ReadAllText(path);
 
-        var result = new EFormidlingReceiversSignatureMigration(Scanner()).Migrate();
+        var result = new EFormidlingReceiversSignatureMigration(
+            Scanner(),
+            projectNullableAnnotationsEnabled: true
+        ).Migrate();
 
         Assert.Empty(result.Warnings);
         Assert.Equal(before, File.ReadAllText(path));
@@ -185,10 +191,90 @@ public sealed class CSharpApiMigrationTests : IDisposable
         );
         var before = File.ReadAllText(path);
 
-        var result = new EFormidlingReceiversSignatureMigration(Scanner()).Migrate();
+        var result = new EFormidlingReceiversSignatureMigration(
+            Scanner(),
+            projectNullableAnnotationsEnabled: true
+        ).Migrate();
 
         Assert.Empty(result.Warnings);
         Assert.Equal(before, File.ReadAllText(path));
+    }
+
+    [Fact]
+    public void ReceiversMigration_WithoutNullableContext_AddsUnannotatedParameter()
+    {
+        var path = _app.Write(
+            "logic/Receivers.cs",
+            """
+            public class Receivers : IEFormidlingReceivers
+            {
+                public Task<List<Receiver>> GetEFormidlingReceivers(Instance instance) => throw new NotImplementedException();
+            }
+            """
+        );
+
+        var result = new EFormidlingReceiversSignatureMigration(
+            Scanner(),
+            projectNullableAnnotationsEnabled: false
+        ).Migrate();
+
+        Assert.NotEmpty(result.Warnings);
+        var migrated = File.ReadAllText(path);
+        Assert.Contains("GetEFormidlingReceivers(Instance instance, string receiverFromConfig)", migrated);
+    }
+
+    [Fact]
+    public void ReceiversMigration_FileLevelNullableDirective_OverridesProjectDefault()
+    {
+        var enabledByDirective = _app.Write(
+            "logic/EnabledByDirective.cs",
+            """
+            #nullable enable
+            public class EnabledByDirective : IEFormidlingReceivers
+            {
+                public Task<List<Receiver>> GetEFormidlingReceivers(Instance instance) => throw new NotImplementedException();
+            }
+            """
+        );
+        var disabledByDirective = _app.Write(
+            "logic/DisabledByDirective.cs",
+            """
+            #nullable disable
+            public class DisabledByDirective : IEFormidlingReceivers
+            {
+                public Task<List<Receiver>> GetEFormidlingReceivers(Instance instance) => throw new NotImplementedException();
+            }
+            """
+        );
+
+        new EFormidlingReceiversSignatureMigration(Scanner(), projectNullableAnnotationsEnabled: false).Migrate();
+
+        Assert.Contains("string? receiverFromConfig", File.ReadAllText(enabledByDirective));
+        Assert.Contains("string receiverFromConfig", File.ReadAllText(disabledByDirective));
+        Assert.DoesNotContain("string? receiverFromConfig", File.ReadAllText(disabledByDirective));
+    }
+
+    [Theory]
+    [InlineData("<Nullable>enable</Nullable>", true)]
+    [InlineData("<Nullable>annotations</Nullable>", true)]
+    [InlineData("<Nullable>warnings</Nullable>", false)]
+    [InlineData("<Nullable>disable</Nullable>", false)]
+    [InlineData("", false)]
+    public void ProjectEnablesNullableAnnotations_ReadsCsprojNullableProperty(string property, bool expected)
+    {
+        var projectFile = _app.Write(
+            "App.csproj",
+            $"""
+            <Project Sdk="Microsoft.NET.Sdk.Web">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                {property}
+              </PropertyGroup>
+            </Project>
+            """
+        );
+
+        Assert.Equal(expected, EFormidlingReceiversSignatureMigration.ProjectEnablesNullableAnnotations(projectFile));
     }
 
     // --- Scanner ---------------------------------------------------------------------------------

--- a/src/cli/studioctl-server-tests/Upgrade/v8Tov9/CSharpApiMigrationTests.cs
+++ b/src/cli/studioctl-server-tests/Upgrade/v8Tov9/CSharpApiMigrationTests.cs
@@ -203,6 +203,27 @@ public sealed class CSharpApiMigrationTests : IDisposable
         Assert.Contains(result.Warnings, w => w.Contains("Caller.cs:5") && w.Contains("SendEFormidlingShipment"));
     }
 
+    [Fact]
+    public void EFormidlingCodeDetector_FlagsLegacyNullConditionalInvocation()
+    {
+        _app.Write(
+            "logic/Caller.cs",
+            """
+            public class Caller
+            {
+                private readonly IEFormidlingService? _service;
+
+                public Task? Send(Instance instance) => _service?.SendEFormidlingShipment(instance);
+            }
+            """
+        );
+
+        var result = new LegacyEFormidlingCodeDetector(Scanner()).Detect();
+
+        Assert.True(result.ManualActionRequired);
+        Assert.Contains(result.Warnings, w => w.Contains("Caller.cs:5") && w.Contains("SendEFormidlingShipment"));
+    }
+
     // --- RemovedInternalProcessTypeDetector ------------------------------------------------------
 
     [Fact]

--- a/src/cli/studioctl-server-tests/Upgrade/v8Tov9/NuGetDowngradeResolverTests.cs
+++ b/src/cli/studioctl-server-tests/Upgrade/v8Tov9/NuGetDowngradeResolverTests.cs
@@ -1,0 +1,76 @@
+using System.Xml.Linq;
+using Altinn.Studio.Cli.Upgrade.ProjectFile;
+using Altinn.Studio.Cli.Upgrade.v8Tov9;
+
+namespace Studioctl.Tests.Upgrade.v8Tov9;
+
+public sealed class NuGetDowngradeResolverTests : IDisposable
+{
+    private readonly TempAppFolder _app = new();
+
+    public void Dispose() => _app.Dispose();
+
+    [Fact]
+    public void ParseDowngrades_ExtractsPackageAndRequiredFloor()
+    {
+        const string output = """
+            /app/App.csproj : error NU1605: Detected package downgrade: Azure.Identity from 1.21.0 to 1.17.1
+            /app/App.csproj : error NU1605: Detected package downgrade: Azure.Extensions.AspNetCore.Configuration.Secrets from 1.5.0 to 1.4.0
+            """;
+
+        var downgrades = NuGetDowngradeResolver.ParseDowngrades(output);
+
+        Assert.Equal(2, downgrades.Count);
+        var identity = downgrades.Single(d => d.PackageId == "Azure.Identity");
+        Assert.Equal("1.21.0", identity.RequiredVersion);
+        Assert.Equal("1.17.1", identity.CurrentVersion);
+    }
+
+    [Fact]
+    public void ParseDowngrades_DeduplicatesRepeatedLines()
+    {
+        const string output = """
+            Detected package downgrade: Azure.Identity from 1.21.0 to 1.17.1
+            Detected package downgrade: Azure.Identity from 1.21.0 to 1.17.1
+            """;
+
+        var downgrades = NuGetDowngradeResolver.ParseDowngrades(output);
+
+        Assert.Single(downgrades);
+    }
+
+    [Fact]
+    public void ParseDowngrades_NoDowngrades_ReturnsEmpty()
+    {
+        Assert.Empty(NuGetDowngradeResolver.ParseDowngrades("Restore succeeded."));
+    }
+
+    [Fact]
+    public async Task SetPackageReferenceVersions_RaisesExistingReferenceOnly()
+    {
+        var csproj = _app.Write(
+            "App.csproj",
+            """
+            <Project Sdk="Microsoft.NET.Sdk.Web">
+              <ItemGroup>
+                <PackageReference Include="Azure.Identity" Version="1.17.1" />
+              </ItemGroup>
+            </Project>
+            """
+        );
+
+        var updated = await new ProjectFileRewriter(csproj).SetPackageReferenceVersions(
+            new Dictionary<string, string> { ["Azure.Identity"] = "1.21.0", ["Not.Referenced"] = "9.9.9" }
+        );
+
+        Assert.Contains("Azure.Identity", updated);
+        Assert.DoesNotContain("Not.Referenced", updated);
+
+        var doc = XDocument.Load(csproj);
+        var version = doc.Descendants("PackageReference")
+            .Single(e => e.Attribute("Include")?.Value == "Azure.Identity")
+            .Attribute("Version")
+            ?.Value;
+        Assert.Equal("1.21.0", version);
+    }
+}

--- a/src/cli/studioctl-server-tests/Upgrade/v8Tov9/ServiceTaskNamespaceMigrationTests.cs
+++ b/src/cli/studioctl-server-tests/Upgrade/v8Tov9/ServiceTaskNamespaceMigrationTests.cs
@@ -1,0 +1,50 @@
+using System.Text.RegularExpressions;
+using Altinn.Studio.Cli.Upgrade;
+using Altinn.Studio.Cli.Upgrade.v8Tov9;
+
+namespace Studioctl.Tests.Upgrade.v8Tov9;
+
+/// <summary>
+/// Covers the IServiceTask namespace rewrite (reuses <see cref="UsingNamespaceMigration"/> across the
+/// whole app source tree), including that build output is left untouched.
+/// </summary>
+public sealed class ServiceTaskNamespaceMigrationTests : IDisposable
+{
+    private const string OldNamespace = "Altinn.App.Core.Internal.Process.ProcessTasks.ServiceTasks";
+    private const string NewNamespace = "Altinn.App.Core.Features.Process";
+    private static readonly Regex AllCs = new(@"\.cs$");
+
+    private readonly TempAppFolder _app = new();
+
+    public void Dispose() => _app.Dispose();
+
+    private void Migrate()
+    {
+        using var outputScope = UpgradeConsole.Use(TextWriter.Null, TextWriter.Null);
+        var projectFile = Path.Combine(_app.Root, "App", "App.csproj");
+        new UsingNamespaceMigration(projectFile).Migrate(OldNamespace, NewNamespace, AllCs);
+    }
+
+    [Fact]
+    public void RewritesUsingAcrossAllSourceFiles()
+    {
+        var a = _app.Write("logic/A.cs", $"using {OldNamespace};\npublic class A {{}}\n");
+        var b = _app.Write("services/B.cs", $"using {OldNamespace};\npublic class B {{}}\n");
+
+        Migrate();
+
+        Assert.Contains($"using {NewNamespace};", File.ReadAllText(a));
+        Assert.DoesNotContain(OldNamespace, File.ReadAllText(a));
+        Assert.Contains($"using {NewNamespace};", File.ReadAllText(b));
+    }
+
+    [Fact]
+    public void LeavesBuildOutputUntouched()
+    {
+        var generated = _app.Write("obj/Debug/Generated.cs", $"using {OldNamespace};\npublic class G {{}}\n");
+
+        Migrate();
+
+        Assert.Contains($"using {OldNamespace};", File.ReadAllText(generated));
+    }
+}

--- a/src/cli/studioctl-server/Studioctl/Upgrade/ProjectFile/ProjectFileRewriter.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/ProjectFile/ProjectFileRewriter.cs
@@ -71,6 +71,35 @@ internal sealed class ProjectFileRewriter
     }
 
     /// <summary>
+    /// Sets the <c>Version</c> attribute of existing <c>PackageReference</c> elements. Used to raise
+    /// explicit package versions to the floors a newer Altinn.App version requires (NU1605 downgrades).
+    /// Only packages already referenced explicitly are updated; the returned set is those that were
+    /// found and changed, so the caller can report packages that need a manual reference added.
+    /// </summary>
+    /// <param name="versionsByPackage">Package id → required version.</param>
+    /// <returns>The package ids that had an explicit reference and were updated.</returns>
+    public async Task<IReadOnlyCollection<string>> SetPackageReferenceVersions(
+        IReadOnlyDictionary<string, string> versionsByPackage
+    )
+    {
+        var updated = new List<string>();
+        foreach (var (packageName, version) in versionsByPackage)
+        {
+            var packageElements = GetPackageReferenceElement(packageName);
+            if (packageElements is null || packageElements.Count == 0)
+            {
+                continue;
+            }
+
+            packageElements.ForEach(e => e.SetAttributeValue("Version", version));
+            updated.Add(packageName);
+        }
+
+        await Save();
+        return updated;
+    }
+
+    /// <summary>
     /// Converts package references to project references for local development and updates target framework
     /// </summary>
     public async Task ConvertToProjectReferences(string repoRoot)

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/BuildOutputPaths.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/BuildOutputPaths.cs
@@ -1,0 +1,26 @@
+namespace Altinn.Studio.Cli.Upgrade.v8Tov9;
+
+/// <summary>
+/// Helper for skipping build output (<c>bin</c>/<c>obj</c>) when walking an app's source tree, so
+/// migrations never read or rewrite generated files.
+/// </summary>
+internal static class BuildOutputPaths
+{
+    /// <summary>
+    /// True if <paramref name="relativePath"/> lives under a <c>bin</c> or <c>obj</c> directory at any
+    /// depth. The path is expected relative to the scanned root, using either platform separator.
+    /// </summary>
+    public static bool IsBuildOutput(string relativePath)
+    {
+        var segments = relativePath.Split(
+            new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar },
+            StringSplitOptions.RemoveEmptyEntries
+        );
+        return Array.Exists(
+            segments,
+            static segment =>
+                segment.Equals("bin", StringComparison.OrdinalIgnoreCase)
+                || segment.Equals("obj", StringComparison.OrdinalIgnoreCase)
+        );
+    }
+}

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/CSharpApiMigration/CSharpSourceScanner.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/CSharpApiMigration/CSharpSourceScanner.cs
@@ -1,0 +1,83 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Altinn.Studio.Cli.Upgrade.v8Tov9.CSharpApiMigration;
+
+/// <summary>
+/// A single app C# source file, parsed once and shared across the v8-&gt;v9 C# API migration steps so
+/// they don't each re-read and re-parse the same trees.
+/// </summary>
+internal sealed class ScannedCSharpFile
+{
+    public ScannedCSharpFile(string path, string relativePath, CompilationUnitSyntax root)
+    {
+        Path = path;
+        RelativePath = relativePath;
+        Root = root;
+    }
+
+    /// <summary>Absolute path to the file.</summary>
+    public string Path { get; }
+
+    /// <summary>Path relative to the scanned source directory, using the platform separator.</summary>
+    public string RelativePath { get; }
+
+    /// <summary>The parsed compilation unit (syntax only; no semantic model).</summary>
+    public CompilationUnitSyntax Root { get; }
+
+    /// <summary>The 1-based line number where <paramref name="node"/> starts.</summary>
+    public int GetLine(SyntaxNode node) => node.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+}
+
+/// <summary>
+/// Enumerates and parses the app's C# source files once, then hands the parsed trees to the C# API
+/// migration detectors. The v8-&gt;v9 upgrade cannot rely on a full semantic <see cref="Compilation"/>
+/// (the app usually won't restore/compile mid-upgrade), so detection is syntax-based - see
+/// <see cref="CSharpSyntaxQueries"/> for the shared queries built on top of these trees.
+/// Build output (<c>bin</c>/<c>obj</c>) is skipped.
+/// </summary>
+internal sealed class CSharpSourceScanner
+{
+    private readonly Lazy<IReadOnlyList<ScannedCSharpFile>> _files;
+
+    /// <param name="sourceDirectory">
+    /// Directory to scan recursively for <c>*.cs</c> files - typically the directory containing the
+    /// app's <c>App.csproj</c> (mirrors <see cref="UsingNamespaceMigration"/>).
+    /// </param>
+    public CSharpSourceScanner(string sourceDirectory)
+    {
+        _files = new Lazy<IReadOnlyList<ScannedCSharpFile>>(() => Load(sourceDirectory));
+    }
+
+    /// <summary>Convenience overload that scans the directory containing <paramref name="projectFile"/>.</summary>
+    public static CSharpSourceScanner ForProject(string projectFile) =>
+        new(System.IO.Path.GetDirectoryName(projectFile) ?? projectFile);
+
+    /// <summary>The parsed app source files (lazily loaded on first access).</summary>
+    public IReadOnlyList<ScannedCSharpFile> Files => _files.Value;
+
+    private static IReadOnlyList<ScannedCSharpFile> Load(string sourceDirectory)
+    {
+        if (!Directory.Exists(sourceDirectory))
+        {
+            return Array.Empty<ScannedCSharpFile>();
+        }
+
+        var files = new List<ScannedCSharpFile>();
+        foreach (var path in Directory.EnumerateFiles(sourceDirectory, "*.cs", SearchOption.AllDirectories))
+        {
+            var relativePath = Path.GetRelativePath(sourceDirectory, path);
+            if (BuildOutputPaths.IsBuildOutput(relativePath))
+            {
+                continue;
+            }
+
+            var content = File.ReadAllText(path);
+            var root = CSharpSyntaxTree.ParseText(content).GetCompilationUnitRoot();
+            files.Add(new ScannedCSharpFile(path, relativePath, root));
+        }
+
+        return files;
+    }
+}

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/CSharpApiMigration/CSharpSyntaxQueries.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/CSharpApiMigration/CSharpSyntaxQueries.cs
@@ -1,0 +1,167 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Altinn.Studio.Cli.Upgrade.v8Tov9.CSharpApiMigration;
+
+/// <summary>A single syntactic match found in an app C# file.</summary>
+/// <param name="RelativePath">File path relative to the scanned source directory.</param>
+/// <param name="Line">1-based line where the match starts.</param>
+/// <param name="Symbol">A short description of what matched (e.g. <c>"MyHandler : IProcessTaskEnd"</c>).</param>
+internal readonly record struct CSharpApiMatch(string RelativePath, int Line, string Symbol)
+{
+    /// <summary>A <c>path:line</c> location string for use in warning messages.</summary>
+    public string Location => $"{RelativePath}:{Line}";
+}
+
+/// <summary>
+/// Reusable, syntax-only queries over <see cref="ScannedCSharpFile"/> trees, shared by the v8-&gt;v9 C#
+/// API migration detectors. These match on <em>simple</em> (unqualified) names, so a fully-qualified
+/// reference such as <c>Altinn.App.Core.Features.IProcessTaskEnd</c> matches the same as
+/// <c>IProcessTaskEnd</c>. That is deliberate: the detectors only <em>warn</em>, so a slightly broad
+/// match that occasionally over-reports is preferable to missing a real breaking usage. There is no
+/// semantic model, so these cannot resolve a variable's declared type - member-name queries match on
+/// the member name alone (see <see cref="MemberReferences"/>).
+/// </summary>
+internal static class CSharpSyntaxQueries
+{
+    /// <summary>
+    /// Type declarations (class/record/struct/interface) whose base list names any of
+    /// <paramref name="interfaceSimpleNames"/>. Used to find app types implementing a removed or
+    /// changed interface. <see cref="CSharpApiMatch.Symbol"/> is <c>"&lt;TypeName&gt; : &lt;InterfaceName&gt;"</c>.
+    /// </summary>
+    public static IEnumerable<CSharpApiMatch> TypesImplementing(
+        ScannedCSharpFile file,
+        IReadOnlySet<string> interfaceSimpleNames
+    )
+    {
+        foreach (var type in file.Root.DescendantNodes().OfType<TypeDeclarationSyntax>())
+        {
+            if (type.BaseList is null)
+            {
+                continue;
+            }
+
+            foreach (var baseType in type.BaseList.Types)
+            {
+                var name = SimpleName(baseType.Type);
+                if (name is not null && interfaceSimpleNames.Contains(name))
+                {
+                    yield return new CSharpApiMatch(
+                        file.RelativePath,
+                        file.GetLine(type),
+                        $"{type.Identifier.Text} : {name}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Any reference to a type whose simple name is in <paramref name="typeSimpleNames"/>: a bare
+    /// identifier, a generic name, or a type argument (so this also catches DI registrations such as
+    /// <c>AddTransient&lt;IProcessTaskEnd, Foo&gt;()</c> and object creations such as
+    /// <c>new ServiceTaskErrorHandling(...)</c>). Base-list occurrences are excluded so callers can
+    /// combine this with <see cref="TypesImplementing"/> without double-reporting the same line.
+    /// </summary>
+    public static IEnumerable<CSharpApiMatch> TypeReferences(
+        ScannedCSharpFile file,
+        IReadOnlySet<string> typeSimpleNames
+    )
+    {
+        foreach (var name in file.Root.DescendantNodes().OfType<SimpleNameSyntax>())
+        {
+            if (!typeSimpleNames.Contains(name.Identifier.Text))
+            {
+                continue;
+            }
+
+            // Skip the name half of a member access (e.g. the `Member` in `X.Member`); those are
+            // handled by MemberReferences/InvokedMethods and are not type references.
+            if (name.Parent is MemberAccessExpressionSyntax memberAccess && memberAccess.Name == name)
+            {
+                continue;
+            }
+
+            // Skip base-list entries - TypesImplementing owns those.
+            if (name.FirstAncestorOrSelf<BaseListSyntax>() is not null && IsInBaseType(name))
+            {
+                continue;
+            }
+
+            yield return new CSharpApiMatch(file.RelativePath, file.GetLine(name), name.Identifier.Text);
+        }
+    }
+
+    /// <summary>
+    /// Invocations of a method whose simple name is in <paramref name="methodSimpleNames"/>, e.g. the
+    /// removed <c>ServiceTaskResult.FailedContinueProcessNext(...)</c> factory. Matches both
+    /// <c>Type.Method(...)</c> and bare <c>Method(...)</c> call sites.
+    /// </summary>
+    public static IEnumerable<CSharpApiMatch> InvokedMethods(
+        ScannedCSharpFile file,
+        IReadOnlySet<string> methodSimpleNames
+    )
+    {
+        foreach (var invocation in file.Root.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        {
+            var invokedName = invocation.Expression switch
+            {
+                MemberAccessExpressionSyntax memberAccess => memberAccess.Name.Identifier.Text,
+                SimpleNameSyntax simple => simple.Identifier.Text,
+                _ => null,
+            };
+
+            if (invokedName is not null && methodSimpleNames.Contains(invokedName))
+            {
+                yield return new CSharpApiMatch(file.RelativePath, file.GetLine(invocation), invokedName);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Member accesses <c>X.member</c> where <c>member</c> is in <paramref name="memberNames"/>,
+    /// regardless of what <c>X</c> is. Used for distinctive members like
+    /// <c>AppSettings.EnableEFormidling</c> that cannot be resolved without a semantic model; the
+    /// member name is distinctive enough that matching on it alone is an acceptable heuristic.
+    /// </summary>
+    public static IEnumerable<CSharpApiMatch> MemberReferences(ScannedCSharpFile file, IReadOnlySet<string> memberNames)
+    {
+        foreach (var access in file.Root.DescendantNodes().OfType<MemberAccessExpressionSyntax>())
+        {
+            if (memberNames.Contains(access.Name.Identifier.Text))
+            {
+                yield return new CSharpApiMatch(file.RelativePath, file.GetLine(access), access.Name.Identifier.Text);
+            }
+        }
+    }
+
+    private static bool IsInBaseType(SyntaxNode node)
+    {
+        for (var current = node; current is not null; current = current.Parent)
+        {
+            if (current is BaseTypeSyntax)
+            {
+                return true;
+            }
+
+            if (current is BaseListSyntax)
+            {
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>The trailing (unqualified) identifier of a type reference, or <c>null</c>.</summary>
+    private static string? SimpleName(TypeSyntax? type) =>
+        type switch
+        {
+            IdentifierNameSyntax identifier => identifier.Identifier.Text,
+            GenericNameSyntax generic => generic.Identifier.Text,
+            QualifiedNameSyntax qualified => qualified.Right.Identifier.Text,
+            AliasQualifiedNameSyntax alias => alias.Name.Identifier.Text,
+            NullableTypeSyntax nullable => SimpleName(nullable.ElementType),
+            _ => null,
+        };
+}

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/CSharpApiMigration/CSharpSyntaxQueries.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/CSharpApiMigration/CSharpSyntaxQueries.cs
@@ -82,8 +82,10 @@ internal static class CSharpSyntaxQueries
                 continue;
             }
 
-            // Skip base-list entries - TypesImplementing owns those.
-            if (name.FirstAncestorOrSelf<BaseListSyntax>() is not null && IsInBaseType(name))
+            // Skip the base type's own name - TypesImplementing owns that. A removed type used as a
+            // generic type ARGUMENT in a base list (e.g. `: SomeBase<IProcessTaskEnd>`) is not
+            // resolved by TypesImplementing (which only sees the outer name) and must be reported here.
+            if (IsBaseTypeOwnName(name))
             {
                 continue;
             }
@@ -119,6 +121,91 @@ internal static class CSharpSyntaxQueries
     }
 
     /// <summary>
+    /// Invocations <c>Receiver.Method(...)</c> where the receiver's trailing simple name is
+    /// <paramref name="receiverSimpleName"/> and the method name is in
+    /// <paramref name="methodNames"/>. Use for method names too generic to match bare (e.g. the
+    /// removed <c>ServiceTaskResult.Failed(...)</c> factory, where matching any <c>Failed(...)</c>
+    /// call would over-report unrelated code).
+    /// </summary>
+    public static IEnumerable<CSharpApiMatch> InvokedMethodsOn(
+        ScannedCSharpFile file,
+        string receiverSimpleName,
+        IReadOnlySet<string> methodNames
+    )
+    {
+        foreach (var invocation in file.Root.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        {
+            if (
+                invocation.Expression is MemberAccessExpressionSyntax memberAccess
+                && methodNames.Contains(memberAccess.Name.Identifier.Text)
+                && TrailingName(memberAccess.Expression) == receiverSimpleName
+            )
+            {
+                yield return new CSharpApiMatch(
+                    file.RelativePath,
+                    file.GetLine(invocation),
+                    $"{receiverSimpleName}.{memberAccess.Name.Identifier.Text}"
+                );
+            }
+        }
+    }
+
+    /// <summary>
+    /// Invocations of <paramref name="methodName"/> (member-access or bare) carrying exactly
+    /// <paramref name="argumentCount"/> arguments. Use when only one arity of a still-existing
+    /// method was removed (e.g. the single-argument <c>SendEFormidlingShipment(Instance)</c>).
+    /// </summary>
+    public static IEnumerable<CSharpApiMatch> InvokedMethodsWithArity(
+        ScannedCSharpFile file,
+        string methodName,
+        int argumentCount
+    )
+    {
+        foreach (var invocation in file.Root.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        {
+            var invokedName = invocation.Expression switch
+            {
+                MemberAccessExpressionSyntax memberAccess => memberAccess.Name.Identifier.Text,
+                SimpleNameSyntax simple => simple.Identifier.Text,
+                _ => null,
+            };
+
+            if (invokedName == methodName && invocation.ArgumentList.Arguments.Count == argumentCount)
+            {
+                yield return new CSharpApiMatch(
+                    file.RelativePath,
+                    file.GetLine(invocation),
+                    $"{methodName}({argumentCount} arg)"
+                );
+            }
+        }
+    }
+
+    /// <summary>
+    /// Declarations of a method named <paramref name="methodName"/> with exactly
+    /// <paramref name="parameterCount"/> parameters - an app still implementing a removed overload
+    /// shape.
+    /// </summary>
+    public static IEnumerable<CSharpApiMatch> MethodDeclarations(
+        ScannedCSharpFile file,
+        string methodName,
+        int parameterCount
+    )
+    {
+        foreach (var method in file.Root.DescendantNodes().OfType<MethodDeclarationSyntax>())
+        {
+            if (method.Identifier.Text == methodName && method.ParameterList.Parameters.Count == parameterCount)
+            {
+                yield return new CSharpApiMatch(
+                    file.RelativePath,
+                    file.GetLine(method),
+                    $"{methodName}({parameterCount} param)"
+                );
+            }
+        }
+    }
+
+    /// <summary>
     /// Member accesses <c>X.member</c> where <c>member</c> is in <paramref name="memberNames"/>,
     /// regardless of what <c>X</c> is. Used for distinctive members like
     /// <c>AppSettings.EnableEFormidling</c> that cannot be resolved without a semantic model; the
@@ -135,23 +222,38 @@ internal static class CSharpSyntaxQueries
         }
     }
 
-    private static bool IsInBaseType(SyntaxNode node)
+    /// <summary>
+    /// Whether <paramref name="name"/> is the name that identifies a base-list entry itself - the
+    /// name <see cref="TypesImplementing"/> resolves and reports - as opposed to a name nested
+    /// inside it (a generic type argument).
+    /// </summary>
+    private static bool IsBaseTypeOwnName(SimpleNameSyntax name)
     {
-        for (var current = node; current is not null; current = current.Parent)
+        var baseType = name.FirstAncestorOrSelf<BaseTypeSyntax>();
+        if (baseType is null)
         {
-            if (current is BaseTypeSyntax)
-            {
-                return true;
-            }
-
-            if (current is BaseListSyntax)
-            {
-                return false;
-            }
+            return false;
         }
 
-        return false;
+        SyntaxNode definingName = baseType.Type switch
+        {
+            QualifiedNameSyntax qualified => qualified.Right,
+            AliasQualifiedNameSyntax alias => alias.Name,
+            var type => type,
+        };
+
+        return name == definingName;
     }
+
+    /// <summary>The trailing (unqualified) identifier of an expression, or <c>null</c>.</summary>
+    private static string? TrailingName(ExpressionSyntax expression) =>
+        expression switch
+        {
+            SimpleNameSyntax simple => simple.Identifier.Text,
+            MemberAccessExpressionSyntax memberAccess => memberAccess.Name.Identifier.Text,
+            AliasQualifiedNameSyntax alias => alias.Name.Identifier.Text,
+            _ => null,
+        };
 
     /// <summary>The trailing (unqualified) identifier of a type reference, or <c>null</c>.</summary>
     private static string? SimpleName(TypeSyntax? type) =>

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/CSharpApiMigration/CSharpSyntaxQueries.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/CSharpApiMigration/CSharpSyntaxQueries.cs
@@ -109,6 +109,8 @@ internal static class CSharpSyntaxQueries
             var invokedName = invocation.Expression switch
             {
                 MemberAccessExpressionSyntax memberAccess => memberAccess.Name.Identifier.Text,
+                // Null-conditional calls (`x?.Method(...)`) bind the name via a member binding.
+                MemberBindingExpressionSyntax memberBinding => memberBinding.Name.Identifier.Text,
                 SimpleNameSyntax simple => simple.Identifier.Text,
                 _ => null,
             };
@@ -166,6 +168,8 @@ internal static class CSharpSyntaxQueries
             var invokedName = invocation.Expression switch
             {
                 MemberAccessExpressionSyntax memberAccess => memberAccess.Name.Identifier.Text,
+                // Null-conditional calls (`x?.Method(...)`) bind the name via a member binding.
+                MemberBindingExpressionSyntax memberBinding => memberBinding.Name.Identifier.Text,
                 SimpleNameSyntax simple => simple.Identifier.Text,
                 _ => null,
             };

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/CSharpApiMigration/EFormidlingReceiversSignatureMigration.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/CSharpApiMigration/EFormidlingReceiversSignatureMigration.cs
@@ -1,0 +1,117 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Altinn.Studio.Cli.Upgrade.v8Tov9.CSharpApiMigration;
+
+/// <summary>
+/// Auto-migration for the <c>IEFormidlingReceivers.GetEFormidlingReceivers</c> signature change. In v9
+/// the method gains a second parameter, <c>string? receiverFromConfig</c> (the receiver org number
+/// configured on the eFormidling BPMN service task), and the old single-argument overload is removed -
+/// so an app implementing the old shape no longer satisfies the interface (CS0535). Adding the
+/// parameter is mechanical and gets the app compiling, so we apply it automatically and emit a warning
+/// asking the developer to decide whether the app should honour the new value.
+/// </summary>
+internal sealed class EFormidlingReceiversSignatureMigration
+{
+    private const string InterfaceName = "IEFormidlingReceivers";
+    private const string MethodName = "GetEFormidlingReceivers";
+    private const string NewParameterName = "receiverFromConfig";
+
+    private readonly CSharpSourceScanner _scanner;
+
+    public EFormidlingReceiversSignatureMigration(CSharpSourceScanner scanner)
+    {
+        _scanner = scanner;
+    }
+
+    public MigrationResult Migrate()
+    {
+        var warnings = new List<string>();
+
+        foreach (var file in _scanner.Files)
+        {
+            var methods = FindMethodsToMigrate(file.Root).ToArray();
+            if (methods.Length == 0)
+            {
+                continue;
+            }
+
+            var lines = methods.Select(file.GetLine).ToArray();
+            var updatedRoot = file.Root.ReplaceNodes(methods, static (original, _) => AddReceiverParameter(original));
+            File.WriteAllText(file.Path, updatedRoot.ToFullString());
+
+            foreach (var line in lines)
+            {
+                warnings.Add(
+                    $"{file.RelativePath}:{line}: added '{NewParameterName}' parameter to {MethodName}. "
+                        + "Review whether the implementation should use it (the receiver org number configured on the "
+                        + "eFormidling service task) instead of ignoring it."
+                );
+            }
+        }
+
+        // This is an auto-migration: the app compiles again, so it does not require manual action even
+        // though we ask the developer to review usage of the new parameter.
+        return new MigrationResult(ManualActionRequired: false, warnings);
+    }
+
+    private static IEnumerable<MethodDeclarationSyntax> FindMethodsToMigrate(CompilationUnitSyntax root)
+    {
+        foreach (var type in root.DescendantNodes().OfType<TypeDeclarationSyntax>())
+        {
+            var implementsInterface = type.BaseList?.Types.Any(baseType => SimpleName(baseType.Type) == InterfaceName);
+
+            foreach (var method in type.Members.OfType<MethodDeclarationSyntax>())
+            {
+                if (method.Identifier.Text != MethodName)
+                {
+                    continue;
+                }
+
+                // Only the old single-parameter overload; a method already carrying the extra parameter
+                // (two parameters) has been migrated, so this is idempotent.
+                if (method.ParameterList.Parameters.Count != 1)
+                {
+                    continue;
+                }
+
+                var isExplicitInterfaceImpl = SimpleName(method.ExplicitInterfaceSpecifier?.Name) == InterfaceName;
+                if (implementsInterface == true || isExplicitInterfaceImpl)
+                {
+                    yield return method;
+                }
+            }
+        }
+    }
+
+    private static MethodDeclarationSyntax AddReceiverParameter(MethodDeclarationSyntax method)
+    {
+        var newParameter = SyntaxFactory
+            .Parameter(SyntaxFactory.Identifier(NewParameterName))
+            .WithType(SyntaxFactory.ParseTypeName("string?").WithTrailingTrivia(SyntaxFactory.Space))
+            .WithLeadingTrivia(SyntaxFactory.Space);
+
+        return method.WithParameterList(method.ParameterList.AddParameters(newParameter));
+    }
+
+    private static string? SimpleName(TypeSyntax? type) =>
+        type switch
+        {
+            IdentifierNameSyntax identifier => identifier.Identifier.Text,
+            GenericNameSyntax generic => generic.Identifier.Text,
+            QualifiedNameSyntax qualified => qualified.Right.Identifier.Text,
+            AliasQualifiedNameSyntax alias => alias.Name.Identifier.Text,
+            _ => null,
+        };
+
+    private static string? SimpleName(NameSyntax? name) =>
+        name switch
+        {
+            IdentifierNameSyntax identifier => identifier.Identifier.Text,
+            GenericNameSyntax generic => generic.Identifier.Text,
+            QualifiedNameSyntax qualified => qualified.Right.Identifier.Text,
+            AliasQualifiedNameSyntax alias => alias.Name.Identifier.Text,
+            _ => null,
+        };
+}

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/CSharpApiMigration/EFormidlingReceiversSignatureMigration.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/CSharpApiMigration/EFormidlingReceiversSignatureMigration.cs
@@ -34,21 +34,51 @@ internal sealed class EFormidlingReceiversSignatureMigration
     /// <summary>
     /// Whether the project enables nullable reference type <em>annotations</em> (<c>enable</c> or
     /// <c>annotations</c>; <c>warnings</c> enables only the warning context, where <c>string?</c>
-    /// would still raise CS8632).
+    /// would still raise CS8632). Reads the project file first (its properties evaluate after the
+    /// auto-imported props and win), then falls back to the nearest <c>Directory.Build.props</c> up
+    /// the directory tree - the two places an app realistically sets <c>&lt;Nullable&gt;</c>. This is
+    /// not full MSBuild evaluation (conditional property groups and explicit imports are not
+    /// followed); per-file <c>#nullable</c> directives override the project default either way.
     /// </summary>
     public static bool ProjectEnablesNullableAnnotations(string projectFile)
     {
+        if (ReadNullableProperty(projectFile) is { } fromProject)
+        {
+            return IsAnnotationsEnabled(fromProject);
+        }
+
+        for (
+            var directory = Path.GetDirectoryName(Path.GetFullPath(projectFile));
+            directory is not null;
+            directory = Path.GetDirectoryName(directory)
+        )
+        {
+            var propsFile = Path.Combine(directory, "Directory.Build.props");
+            if (File.Exists(propsFile))
+            {
+                // MSBuild auto-imports only the nearest Directory.Build.props; stop at the first hit.
+                return ReadNullableProperty(propsFile) is { } fromProps && IsAnnotationsEnabled(fromProps);
+            }
+        }
+
+        return false;
+    }
+
+    private static string? ReadNullableProperty(string msbuildFile)
+    {
         try
         {
-            var value = XDocument.Load(projectFile).Descendants("Nullable").LastOrDefault()?.Value.Trim();
-            return string.Equals(value, "enable", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(value, "annotations", StringComparison.OrdinalIgnoreCase);
+            return XDocument.Load(msbuildFile).Descendants("Nullable").LastOrDefault()?.Value.Trim();
         }
         catch (Exception ex) when (ex is System.Xml.XmlException or IOException or UnauthorizedAccessException)
         {
-            return false;
+            return null;
         }
     }
+
+    private static bool IsAnnotationsEnabled(string nullableValue) =>
+        string.Equals(nullableValue, "enable", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(nullableValue, "annotations", StringComparison.OrdinalIgnoreCase);
 
     public MigrationResult Migrate()
     {

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/CSharpApiMigration/EFormidlingReceiversSignatureMigration.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/CSharpApiMigration/EFormidlingReceiversSignatureMigration.cs
@@ -1,3 +1,4 @@
+using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -11,6 +12,9 @@ namespace Altinn.Studio.Cli.Upgrade.v8Tov9.CSharpApiMigration;
 /// so an app implementing the old shape no longer satisfies the interface (CS0535). Adding the
 /// parameter is mechanical and gets the app compiling, so we apply it automatically and emit a warning
 /// asking the developer to decide whether the app should honour the new value.
+/// The parameter is annotated <c>string?</c> only where a nullable annotation context is active
+/// (project <c>&lt;Nullable&gt;</c> or a preceding <c>#nullable</c> directive) - the v8 app template
+/// has no nullable context, where <c>string?</c> would raise CS8632 on every build.
 /// </summary>
 internal sealed class EFormidlingReceiversSignatureMigration
 {
@@ -19,10 +23,31 @@ internal sealed class EFormidlingReceiversSignatureMigration
     private const string NewParameterName = "receiverFromConfig";
 
     private readonly CSharpSourceScanner _scanner;
+    private readonly bool _projectNullableAnnotationsEnabled;
 
-    public EFormidlingReceiversSignatureMigration(CSharpSourceScanner scanner)
+    public EFormidlingReceiversSignatureMigration(CSharpSourceScanner scanner, bool projectNullableAnnotationsEnabled)
     {
         _scanner = scanner;
+        _projectNullableAnnotationsEnabled = projectNullableAnnotationsEnabled;
+    }
+
+    /// <summary>
+    /// Whether the project enables nullable reference type <em>annotations</em> (<c>enable</c> or
+    /// <c>annotations</c>; <c>warnings</c> enables only the warning context, where <c>string?</c>
+    /// would still raise CS8632).
+    /// </summary>
+    public static bool ProjectEnablesNullableAnnotations(string projectFile)
+    {
+        try
+        {
+            var value = XDocument.Load(projectFile).Descendants("Nullable").LastOrDefault()?.Value.Trim();
+            return string.Equals(value, "enable", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(value, "annotations", StringComparison.OrdinalIgnoreCase);
+        }
+        catch (Exception ex) when (ex is System.Xml.XmlException or IOException or UnauthorizedAccessException)
+        {
+            return false;
+        }
     }
 
     public MigrationResult Migrate()
@@ -38,7 +63,14 @@ internal sealed class EFormidlingReceiversSignatureMigration
             }
 
             var lines = methods.Select(file.GetLine).ToArray();
-            var updatedRoot = file.Root.ReplaceNodes(methods, static (original, _) => AddReceiverParameter(original));
+            var updatedRoot = file.Root.ReplaceNodes(
+                methods,
+                (original, _) =>
+                    AddReceiverParameter(
+                        original,
+                        nullable: NullableAnnotationsActiveAt(file.Root, original, _projectNullableAnnotationsEnabled)
+                    )
+            );
             File.WriteAllText(file.Path, updatedRoot.ToFullString());
 
             foreach (var line in lines)
@@ -85,14 +117,46 @@ internal sealed class EFormidlingReceiversSignatureMigration
         }
     }
 
-    private static MethodDeclarationSyntax AddReceiverParameter(MethodDeclarationSyntax method)
+    private static MethodDeclarationSyntax AddReceiverParameter(MethodDeclarationSyntax method, bool nullable)
     {
         var newParameter = SyntaxFactory
             .Parameter(SyntaxFactory.Identifier(NewParameterName))
-            .WithType(SyntaxFactory.ParseTypeName("string?").WithTrailingTrivia(SyntaxFactory.Space))
+            .WithType(
+                SyntaxFactory.ParseTypeName(nullable ? "string?" : "string").WithTrailingTrivia(SyntaxFactory.Space)
+            )
             .WithLeadingTrivia(SyntaxFactory.Space);
 
         return method.WithParameterList(method.ParameterList.AddParameters(newParameter));
+    }
+
+    /// <summary>
+    /// Syntactic approximation of the nullable annotation context at <paramref name="method"/>: the
+    /// last preceding <c>#nullable</c> directive targeting annotations wins; without one, the
+    /// project-level default applies. (No semantic model is available - see
+    /// <see cref="CSharpSourceScanner"/>.)
+    /// </summary>
+    private static bool NullableAnnotationsActiveAt(
+        CompilationUnitSyntax root,
+        MethodDeclarationSyntax method,
+        bool projectDefault
+    )
+    {
+        var lastDirective = root.DescendantNodes(descendIntoTrivia: true)
+            .OfType<NullableDirectiveTriviaSyntax>()
+            .LastOrDefault(directive =>
+                directive.SpanStart < method.SpanStart
+                && (
+                    directive.TargetToken.IsKind(SyntaxKind.None)
+                    || directive.TargetToken.IsKind(SyntaxKind.AnnotationsKeyword)
+                )
+            );
+
+        return lastDirective?.SettingToken.Kind() switch
+        {
+            SyntaxKind.EnableKeyword => true,
+            SyntaxKind.DisableKeyword => false,
+            _ => projectDefault, // no directive, or `restore` back to the project default
+        };
     }
 
     private static string? SimpleName(TypeSyntax? type) =>

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/CSharpApiMigration/LegacyEFormidlingCodeDetector.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/CSharpApiMigration/LegacyEFormidlingCodeDetector.cs
@@ -1,0 +1,59 @@
+namespace Altinn.Studio.Cli.Upgrade.v8Tov9.CSharpApiMigration;
+
+/// <summary>
+/// Warn-only detector for the eFormidling C# breaks that cannot be transformed safely: the removed
+/// single-argument <c>IEFormidlingService.SendEFormidlingShipment(Instance)</c>, the deleted
+/// <c>IEFormidlingLegacyConfigurationProvider</c>, and code references to the removed
+/// <c>AppSettings.EnableEFormidling</c> property (the config key itself is stripped by the eFormidling
+/// service-task migration; this covers C# that read the property). The related
+/// <c>IEFormidlingReceivers</c> signature change is handled by its own auto-migration and is not
+/// reported here.
+/// </summary>
+internal sealed class LegacyEFormidlingCodeDetector
+{
+    private static readonly IReadOnlySet<string> _removedTypes = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "IEFormidlingService",
+        "IEFormidlingLegacyConfigurationProvider",
+    };
+
+    private static readonly IReadOnlySet<string> _removedMembers = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "EnableEFormidling",
+    };
+
+    private const string InterfaceSummary =
+        "eFormidling interfaces changed in v9. IEFormidlingLegacyConfigurationProvider is removed, and "
+        + "IEFormidlingService.SendEFormidlingShipment no longer accepts just an Instance - the supported "
+        + "overload is SendEFormidlingShipment(Instance, ValidAltinnEFormidlingConfiguration), driven by the "
+        + "eFormidling BPMN service task. Update or remove these implementations by hand. Usages found:";
+
+    private const string SettingSummary =
+        "AppSettings.EnableEFormidling is removed in v9; the on/off gate now lives on the eFormidling BPMN "
+        + "service task as <altinn:disabled>. Remove these code references. Usages found:";
+
+    private readonly CSharpSourceScanner _scanner;
+
+    public LegacyEFormidlingCodeDetector(CSharpSourceScanner scanner)
+    {
+        _scanner = scanner;
+    }
+
+    public MigrationResult Detect()
+    {
+        var interfaceMatches = _scanner.Files.SelectMany(file =>
+            CSharpSyntaxQueries
+                .TypesImplementing(file, _removedTypes)
+                .Concat(CSharpSyntaxQueries.TypeReferences(file, _removedTypes))
+        );
+
+        var settingMatches = _scanner.Files.SelectMany(file =>
+            CSharpSyntaxQueries.MemberReferences(file, _removedMembers)
+        );
+
+        return WarnOnlyDetector.Combine(
+            WarnOnlyDetector.Report(InterfaceSummary, interfaceMatches),
+            WarnOnlyDetector.Report(SettingSummary, settingMatches)
+        );
+    }
+}

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/CSharpApiMigration/LegacyEFormidlingCodeDetector.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/CSharpApiMigration/LegacyEFormidlingCodeDetector.cs
@@ -11,11 +11,16 @@ namespace Altinn.Studio.Cli.Upgrade.v8Tov9.CSharpApiMigration;
 /// </summary>
 internal sealed class LegacyEFormidlingCodeDetector
 {
+    // IEFormidlingService itself still exists in v9 - only the single-argument
+    // SendEFormidlingShipment(Instance) overload was removed, so type references to the service
+    // are fine and only the legacy call/implementation shape is detected (see Detect()).
     private static readonly IReadOnlySet<string> _removedTypes = new HashSet<string>(StringComparer.Ordinal)
     {
-        "IEFormidlingService",
         "IEFormidlingLegacyConfigurationProvider",
     };
+
+    private const string LegacyShipmentMethod = "SendEFormidlingShipment";
+    private const int LegacyShipmentArity = 1;
 
     private static readonly IReadOnlySet<string> _removedMembers = new HashSet<string>(StringComparer.Ordinal)
     {
@@ -45,6 +50,8 @@ internal sealed class LegacyEFormidlingCodeDetector
             CSharpSyntaxQueries
                 .TypesImplementing(file, _removedTypes)
                 .Concat(CSharpSyntaxQueries.TypeReferences(file, _removedTypes))
+                .Concat(CSharpSyntaxQueries.InvokedMethodsWithArity(file, LegacyShipmentMethod, LegacyShipmentArity))
+                .Concat(CSharpSyntaxQueries.MethodDeclarations(file, LegacyShipmentMethod, LegacyShipmentArity))
         );
 
         var settingMatches = _scanner.Files.SelectMany(file =>

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/CSharpApiMigration/RemovedInternalProcessTypeDetector.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/CSharpApiMigration/RemovedInternalProcessTypeDetector.cs
@@ -1,0 +1,56 @@
+namespace Altinn.Studio.Cli.Upgrade.v8Tov9.CSharpApiMigration;
+
+/// <summary>
+/// Warn-only detector for the internal in-process engine handler types removed in v9, when the
+/// in-process process orchestration was replaced by the external workflow engine's command model.
+/// These live under <c>Altinn.App.Core.Internal.Process.*</c> and are not part of the app-facing
+/// extensibility surface, so app references are rare - but an app that did reach into them will no
+/// longer compile, so we report (never rewrite) any references for manual rework.
+/// </summary>
+internal sealed class RemovedInternalProcessTypeDetector
+{
+    private static readonly IReadOnlySet<string> _removedTypes = new HashSet<string>(StringComparer.Ordinal)
+    {
+        // Removed handler interfaces
+        "IProcessEventDispatcher",
+        "IProcessEventHandlerDelegator",
+        "IProcessTaskInitializer",
+        "IProcessTaskFinalizer",
+        "IStartTaskEventHandler",
+        "IEndTaskEventHandler",
+        "IAbandonTaskEventHandler",
+        "IEndEventEventHandler",
+        // Removed handler implementations
+        "ProcessEventDispatcher",
+        "ProcessEventHandlingDelegator",
+        "ProcessTaskInitializer",
+        "StartTaskEventHandler",
+        "EndTaskEventHandler",
+        "AbandonTaskEventHandler",
+        "EndEventEventHandler",
+    };
+
+    private const string Summary =
+        "This app references internal in-process engine handler types that were removed in v9 (the in-process "
+        + "process orchestration was replaced by the external workflow engine's command pipeline). These were "
+        + "never part of the supported app API and have no drop-in replacement; rework the logic against the "
+        + "supported task lifecycle handlers in Altinn.App.Core.Features.Process. References found:";
+
+    private readonly CSharpSourceScanner _scanner;
+
+    public RemovedInternalProcessTypeDetector(CSharpSourceScanner scanner)
+    {
+        _scanner = scanner;
+    }
+
+    public MigrationResult Detect()
+    {
+        var matches = _scanner.Files.SelectMany(file =>
+            CSharpSyntaxQueries
+                .TypesImplementing(file, _removedTypes)
+                .Concat(CSharpSyntaxQueries.TypeReferences(file, _removedTypes))
+        );
+
+        return WarnOnlyDetector.Report(Summary, matches);
+    }
+}

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/CSharpApiMigration/RemovedTaskEventInterfaceDetector.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/CSharpApiMigration/RemovedTaskEventInterfaceDetector.cs
@@ -1,0 +1,49 @@
+namespace Altinn.Studio.Cli.Upgrade.v8Tov9.CSharpApiMigration;
+
+/// <summary>
+/// Warn-only detector for the removed v8 process task event interfaces. In v9 the split
+/// <c>IProcessTaskStart</c>/<c>IProcessTaskEnd</c>/<c>IProcessTaskAbandon</c> interfaces (namespace
+/// <c>Altinn.App.Core.Features</c>) and the combined <c>ITaskEvents</c> are gone, replaced by the task
+/// lifecycle handlers in <c>Altinn.App.Core.Features.Process</c>. The rewrite is not mechanical - the
+/// method shape changes (a <c>ShouldRunForTask</c> gate plus an <c>Execute</c> taking an
+/// <c>IInstanceDataMutator</c> instead of <c>Instance</c>/<c>prefill</c>, returning <c>HookResult</c>,
+/// and required to be idempotent) - so this only reports the usages a developer must port by hand,
+/// including the now-dangling DI registrations (<c>AddTransient&lt;IProcessTaskEnd, ...&gt;()</c>).
+/// </summary>
+internal sealed class RemovedTaskEventInterfaceDetector
+{
+    private static readonly IReadOnlySet<string> _removedInterfaces = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "IProcessTaskStart",
+        "IProcessTaskEnd",
+        "IProcessTaskAbandon",
+        "ITaskEvents",
+    };
+
+    private const string Summary =
+        "Removed process task event interfaces (IProcessTaskStart/IProcessTaskEnd/IProcessTaskAbandon/ITaskEvents) "
+        + "are used by this app and must be ported by hand. Replace them with the task lifecycle handlers in "
+        + "Altinn.App.Core.Features.Process (IOnTaskStartingHandler/IOnTaskEndingHandler/IOnTaskAbandonHandler): "
+        + "split the logic into ShouldRunForTask(taskId) and Execute(context); read and write instance data via "
+        + "context.InstanceDataMutator (the Instance object and prefill dictionary are no longer passed in); return "
+        + "a HookResult (Success/FailedRetryable/FailedPermanent); and make handlers idempotent, as the workflow "
+        + "engine may retry them. Remember to update the matching DI registrations. Usages found:";
+
+    private readonly CSharpSourceScanner _scanner;
+
+    public RemovedTaskEventInterfaceDetector(CSharpSourceScanner scanner)
+    {
+        _scanner = scanner;
+    }
+
+    public MigrationResult Detect()
+    {
+        var matches = _scanner.Files.SelectMany(file =>
+            CSharpSyntaxQueries
+                .TypesImplementing(file, _removedInterfaces)
+                .Concat(CSharpSyntaxQueries.TypeReferences(file, _removedInterfaces))
+        );
+
+        return WarnOnlyDetector.Report(Summary, matches);
+    }
+}

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/CSharpApiMigration/ServiceTaskResultApiDetector.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/CSharpApiMigration/ServiceTaskResultApiDetector.cs
@@ -1,0 +1,52 @@
+namespace Altinn.Studio.Cli.Upgrade.v8Tov9.CSharpApiMigration;
+
+/// <summary>
+/// Warn-only detector for the reworked <c>ServiceTaskResult</c> API on custom <c>IServiceTask</c>
+/// implementations. The <c>IServiceTask</c> namespace move itself is auto-migrated (see the
+/// <c>UsingNamespaceMigration</c> step); what cannot be auto-migrated is the result construction: the
+/// v8 <c>ServiceTaskErrorHandling</c> record and <c>ServiceTaskErrorStrategy</c> enum are removed, and
+/// the <c>Failed(...)</c>/<c>FailedAbortProcessNext()</c>/<c>FailedContinueProcessNext(...)</c>
+/// factories are replaced by <c>FailedRetryable</c>/<c>FailedPermanent</c>/<c>SuccessWithoutAutoAdvance</c>.
+/// Mapping the old abort/continue strategy onto the new retryable/permanent + auto-advance model is a
+/// judgement call, so this reports the call sites rather than transforming them.
+/// </summary>
+internal sealed class ServiceTaskResultApiDetector
+{
+    private static readonly IReadOnlySet<string> _removedTypes = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "ServiceTaskErrorHandling",
+        "ServiceTaskErrorStrategy",
+    };
+
+    private static readonly IReadOnlySet<string> _removedFactories = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "FailedAbortProcessNext",
+        "FailedContinueProcessNext",
+    };
+
+    private const string Summary =
+        "The ServiceTaskResult API changed in v9. The ServiceTaskErrorHandling record and "
+        + "ServiceTaskErrorStrategy enum are removed, along with the FailedAbortProcessNext()/"
+        + "FailedContinueProcessNext(...) factories. Rebuild the result using "
+        + "ServiceTaskResult.FailedRetryable(message) (transient failure the engine should retry), "
+        + "FailedPermanent(message) (give up), Success(action) or SuccessWithoutAutoAdvance() (succeed but "
+        + "park the task instead of auto-advancing). Call sites found:";
+
+    private readonly CSharpSourceScanner _scanner;
+
+    public ServiceTaskResultApiDetector(CSharpSourceScanner scanner)
+    {
+        _scanner = scanner;
+    }
+
+    public MigrationResult Detect()
+    {
+        var matches = _scanner.Files.SelectMany(file =>
+            CSharpSyntaxQueries
+                .TypeReferences(file, _removedTypes)
+                .Concat(CSharpSyntaxQueries.InvokedMethods(file, _removedFactories))
+        );
+
+        return WarnOnlyDetector.Report(Summary, matches);
+    }
+}

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/CSharpApiMigration/ServiceTaskResultApiDetector.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/CSharpApiMigration/ServiceTaskResultApiDetector.cs
@@ -24,9 +24,20 @@ internal sealed class ServiceTaskResultApiDetector
         "FailedContinueProcessNext",
     };
 
+    // `Failed` is too generic a name to match bare calls (unlike the distinctive factories above),
+    // so the removed Failed(ServiceTaskErrorHandling) factory is only matched receiver-qualified.
+    private static readonly IReadOnlySet<string> _removedQualifiedFactories = new HashSet<string>(
+        StringComparer.Ordinal
+    )
+    {
+        "Failed",
+    };
+
+    private const string ResultTypeName = "ServiceTaskResult";
+
     private const string Summary =
         "The ServiceTaskResult API changed in v9. The ServiceTaskErrorHandling record and "
-        + "ServiceTaskErrorStrategy enum are removed, along with the FailedAbortProcessNext()/"
+        + "ServiceTaskErrorStrategy enum are removed, along with the Failed(...)/FailedAbortProcessNext()/"
         + "FailedContinueProcessNext(...) factories. Rebuild the result using "
         + "ServiceTaskResult.FailedRetryable(message) (transient failure the engine should retry), "
         + "FailedPermanent(message) (give up), Success(action) or SuccessWithoutAutoAdvance() (succeed but "
@@ -45,6 +56,7 @@ internal sealed class ServiceTaskResultApiDetector
             CSharpSyntaxQueries
                 .TypeReferences(file, _removedTypes)
                 .Concat(CSharpSyntaxQueries.InvokedMethods(file, _removedFactories))
+                .Concat(CSharpSyntaxQueries.InvokedMethodsOn(file, ResultTypeName, _removedQualifiedFactories))
         );
 
         return WarnOnlyDetector.Report(Summary, matches);

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/CSharpApiMigration/V9MigrationDocs.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/CSharpApiMigration/V9MigrationDocs.cs
@@ -1,0 +1,16 @@
+namespace Altinn.Studio.Cli.Upgrade.v8Tov9.CSharpApiMigration;
+
+/// <summary>
+/// Central list of documentation links referenced by the v8-&gt;v9 C# API migration warnings, kept in
+/// one place so they are easy to keep current. (The build-time analyzer errors ALTINNAPP0600/0601
+/// historically linked to 404 pages - see issue #19419; the working guides are below.)
+/// </summary>
+internal static class V9MigrationDocs
+{
+    /// <summary>Guide for generating PDFs with a PDF service task (replaces <c>enablePdfCreation</c>).</summary>
+    public const string Pdf = "https://docs.altinn.studio/nb/altinn-studio/v8/guides/development/pdf";
+
+    /// <summary>Guide for configuring eFormidling on a BPMN eFormidling service task.</summary>
+    public const string EFormidlingServiceTask =
+        "https://docs.altinn.studio/nb/altinn-studio/v8/guides/development/eformidling/service-task/";
+}

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/CSharpApiMigration/WarnOnlyDetector.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/CSharpApiMigration/WarnOnlyDetector.cs
@@ -1,0 +1,42 @@
+namespace Altinn.Studio.Cli.Upgrade.v8Tov9.CSharpApiMigration;
+
+/// <summary>
+/// Shared shaping for the warn-only C# API detectors: a v9 break that cannot be transformed safely is
+/// reported (never rewritten). Given the matched usages and a guidance summary, this produces a
+/// <see cref="MigrationResult"/> that flags <see cref="MigrationResult.ManualActionRequired"/> when
+/// anything matched, with a leading summary line followed by one sorted, de-duplicated line per usage.
+/// When nothing matched it returns a clean, no-action result.
+/// </summary>
+internal static class WarnOnlyDetector
+{
+    public static MigrationResult Report(string summary, IEnumerable<CSharpApiMatch> matches)
+    {
+        var distinct = matches
+            .Distinct()
+            .OrderBy(static match => match.RelativePath, StringComparer.Ordinal)
+            .ThenBy(static match => match.Line)
+            .ThenBy(static match => match.Symbol, StringComparer.Ordinal)
+            .ToList();
+
+        if (distinct.Count == 0)
+        {
+            return new MigrationResult(ManualActionRequired: false, Array.Empty<string>());
+        }
+
+        var warnings = new List<string>(distinct.Count + 1) { summary };
+        warnings.AddRange(distinct.Select(static match => $"{match.Location}: {match.Symbol}"));
+        return new MigrationResult(ManualActionRequired: true, warnings);
+    }
+
+    /// <summary>
+    /// Combines several results (e.g. when one detector reports on distinct concerns with different
+    /// guidance): warnings are concatenated in order and <see cref="MigrationResult.ManualActionRequired"/>
+    /// is set if any input set it.
+    /// </summary>
+    public static MigrationResult Combine(params MigrationResult[] results)
+    {
+        var warnings = results.SelectMany(static result => result.Warnings).ToList();
+        var manualActionRequired = Array.Exists(results, static result => result.ManualActionRequired);
+        return new MigrationResult(manualActionRequired, warnings);
+    }
+}

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/NuGetDowngradeResolver.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/NuGetDowngradeResolver.cs
@@ -1,0 +1,136 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+using Altinn.Studio.Cli.Upgrade.ProjectFile;
+using Altinn.Studio.StudioctlServer.Platform;
+
+namespace Altinn.Studio.Cli.Upgrade.v8Tov9;
+
+/// <summary>
+/// Auto-migration for the explicit package version floors a v9 app requires. Bumping Altinn.App.* to
+/// v9 raises the floors of some transitive dependencies (e.g. Azure.Identity, Azure.Extensions...
+/// Secrets); an app that pins those lower via an explicit <c>PackageReference</c> then fails to restore
+/// with NU1605 ("Detected package downgrade"). Rather than hard-code a list that will drift, this runs
+/// <c>dotnet restore</c>, parses the reported downgrades, and raises the offending explicit references
+/// to the required floor - repeating until restore is clean or no further progress is possible.
+/// </summary>
+internal sealed class NuGetDowngradeResolver
+{
+    // A restore normally reports every downgrade at once, but raising one floor can surface another,
+    // so we iterate a few times. Termination is also guaranteed by the "attempted" set below.
+    private const int MaxIterations = 5;
+
+    private static readonly Regex _downgradePattern = new(
+        @"Detected package downgrade:\s+(?<id>\S+)\s+from\s+(?<from>\S+)\s+to\s+(?<to>\S+)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant
+    );
+
+    /// <param name="projectFolder">Working directory for <c>dotnet restore</c>.</param>
+    /// <param name="projectFile">The app's project file to rewrite.</param>
+    public async Task<MigrationResult> ResolveAsync(
+        string projectFolder,
+        string projectFile,
+        CancellationToken cancellationToken
+    )
+    {
+        var warnings = new List<string>();
+        var manualActionRequired = false;
+
+        // Guards against re-processing the same "id@version" downgrade forever (e.g. a downgrade for a
+        // package with no explicit reference, which restore keeps reporting after we warn about it).
+        var attempted = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        for (var iteration = 0; iteration < MaxIterations; iteration++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var restoreOutput = await RunRestoreAsync(projectFile, projectFolder, cancellationToken);
+            var downgrades = ParseDowngrades(restoreOutput);
+
+            var pending = downgrades.Where(d => attempted.Add($"{d.PackageId}@{d.RequiredVersion}")).ToList();
+            if (pending.Count == 0)
+            {
+                // Either restore is clean, or everything it still reports is something we already tried
+                // to fix (and warned about). Either way, no further progress is possible here.
+                break;
+            }
+
+            // Last-wins if a package appears twice; restore reports a single required floor per package.
+            var floors = pending
+                .GroupBy(d => d.PackageId, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(g => g.Key, g => g.Last().RequiredVersion, StringComparer.OrdinalIgnoreCase);
+
+            var rewriter = new ProjectFileRewriter(projectFile);
+            var updated = await rewriter.SetPackageReferenceVersions(floors);
+
+            foreach (var (packageId, version) in floors)
+            {
+                if (updated.Contains(packageId))
+                {
+                    warnings.Add($"Raised {packageId} to {version} to satisfy the v9 dependency floor.");
+                }
+                else
+                {
+                    manualActionRequired = true;
+                    warnings.Add(
+                        $"{packageId} is resolved below the v9 floor {version} but has no explicit "
+                            + $"PackageReference to raise. Add <PackageReference Include=\"{packageId}\" "
+                            + $"Version=\"{version}\" /> manually."
+                    );
+                }
+            }
+        }
+
+        return new MigrationResult(manualActionRequired, warnings);
+    }
+
+    /// <summary>Parses NU1605 "Detected package downgrade: X from A to B" lines from restore output.</summary>
+    internal static IReadOnlyList<PackageDowngrade> ParseDowngrades(string output)
+    {
+        var downgrades = new List<PackageDowngrade>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (Match match in _downgradePattern.Matches(output))
+        {
+            var id = match.Groups["id"].Value;
+            var required = match.Groups["from"].Value;
+            var current = match.Groups["to"].Value;
+            if (seen.Add($"{id}@{required}"))
+            {
+                downgrades.Add(new PackageDowngrade(id, required, current));
+            }
+        }
+
+        return downgrades;
+    }
+
+    private static async Task<string> RunRestoreAsync(
+        string projectFile,
+        string projectFolder,
+        CancellationToken cancellationToken
+    )
+    {
+        var startInfo = ProcessUtil.CreateStartInfo("dotnet", "restore", projectFile);
+        startInfo.WorkingDirectory = projectFolder;
+        startInfo.RedirectStandardOutput = true;
+        startInfo.RedirectStandardError = true;
+
+        using var process =
+            Process.Start(startInfo) ?? throw new InvalidOperationException("Failed to start dotnet restore.");
+        var stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+        await process.WaitForExitAsync(cancellationToken);
+
+        // NU1605 makes restore exit non-zero; we don't treat that as fatal - the downgrade text is what
+        // we're after, and it appears on stdout/stderr regardless of exit code.
+        var builder = new StringBuilder();
+        builder.Append(await stdoutTask);
+        builder.Append('\n');
+        builder.Append(await stderrTask);
+        return builder.ToString();
+    }
+
+    /// <param name="PackageId">The package with a downgrade.</param>
+    /// <param name="RequiredVersion">The floor required by the dependency graph (the "from" version).</param>
+    /// <param name="CurrentVersion">The lower version the explicit reference currently resolves to.</param>
+    internal readonly record struct PackageDowngrade(string PackageId, string RequiredVersion, string CurrentVersion);
+}

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/NuGetDowngradeResolver.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/NuGetDowngradeResolver.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -118,7 +119,28 @@ internal sealed class NuGetDowngradeResolver
             Process.Start(startInfo) ?? throw new InvalidOperationException("Failed to start dotnet restore.");
         var stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
         var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
-        await process.WaitForExitAsync(cancellationToken);
+        try
+        {
+            await process.WaitForExitAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            // WaitForExitAsync only stops waiting on cancellation; the restore (and its child
+            // processes) keeps running unless killed explicitly.
+            try
+            {
+                if (!process.HasExited)
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+            }
+            catch (Exception ex) when (ex is InvalidOperationException or Win32Exception or NotSupportedException)
+            {
+                // Best-effort: the process may have exited between the check and the kill.
+            }
+
+            throw;
+        }
 
         // NU1605 makes restore exit non-zero; we don't treat that as fatal - the downgrade text is what
         // we're after, and it appears on stdout/stderr regardless of exit code.

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/UsingNamespaceMigration.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/UsingNamespaceMigration.cs
@@ -50,6 +50,11 @@ internal sealed class UsingNamespaceMigration
         foreach (var csharpFile in Directory.EnumerateFiles(projectDirectory, "*.cs", SearchOption.AllDirectories))
         {
             var relativePath = Path.GetRelativePath(projectDirectory, csharpFile);
+            if (BuildOutputPaths.IsBuildOutput(relativePath))
+            {
+                continue;
+            }
+
             if (pathMatcher.IsMatch(relativePath))
             {
                 yield return csharpFile;

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/V8Tov9Upgrade.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/V8Tov9Upgrade.cs
@@ -294,7 +294,10 @@ internal static class V8Tov9Upgrade
         try
         {
             var scanner = CSharpSourceScanner.ForProject(projectFile);
-            var migration = new EFormidlingReceiversSignatureMigration(scanner);
+            var migration = new EFormidlingReceiversSignatureMigration(
+                scanner,
+                EFormidlingReceiversSignatureMigration.ProjectEnablesNullableAnnotations(projectFile)
+            );
             var result = migration.Migrate();
 
             foreach (var warning in result.Warnings)

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/V8Tov9Upgrade.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/V8Tov9Upgrade.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 using Altinn.Studio.Cli.Upgrade.ProjectFile;
+using Altinn.Studio.Cli.Upgrade.v8Tov9.CSharpApiMigration;
 using Altinn.Studio.Cli.Upgrade.v8Tov9.IndexMigration;
 using Altinn.Studio.Cli.Upgrade.v8Tov9.LayoutSetsMigration;
 using Altinn.Studio.Cli.Upgrade.v8Tov9.RuleConfiguration;
@@ -28,6 +29,15 @@ internal static class V8Tov9Upgrade
         @"^Program\.cs$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant
     );
+
+    private static readonly Regex _allCSharpFilesMatcher = new(
+        @"\.cs$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant
+    );
+
+    // Namespace the IServiceTask interface moved from / to between v8 and v9.
+    private const string ServiceTaskOldNamespace = "Altinn.App.Core.Internal.Process.ProcessTasks.ServiceTasks";
+    private const string ServiceTaskNewNamespace = "Altinn.App.Core.Features.Process";
 
     internal static async Task<int> RunAsync(V8Tov9UpgradeOptions options)
     {
@@ -89,6 +99,26 @@ internal static class V8Tov9Upgrade
 
         options.CancellationToken.ThrowIfCancellationRequested();
         returnCode = CombineExitCodes(returnCode, await MigrateOpenApiNamespace(projectFile));
+
+        // The v9 Altinn.App packages raise some transitive dependency floors; an app pinning them lower
+        // fails to restore (NU1605). Only relevant when we actually bumped the csproj to v9 packages.
+        if (!options.SkipCsprojUpgrade && !options.ConvertPackageReferences)
+        {
+            options.CancellationToken.ThrowIfCancellationRequested();
+            returnCode = CombineExitCodes(
+                returnCode,
+                await MigrateNuGetDowngrades(projectFolder, projectFile, options.CancellationToken)
+            );
+        }
+
+        options.CancellationToken.ThrowIfCancellationRequested();
+        returnCode = CombineExitCodes(returnCode, await MigrateServiceTaskNamespace(projectFile));
+
+        options.CancellationToken.ThrowIfCancellationRequested();
+        returnCode = CombineExitCodes(returnCode, await MigrateEFormidlingReceiversSignature(projectFile));
+
+        options.CancellationToken.ThrowIfCancellationRequested();
+        returnCode = CombineExitCodes(returnCode, await CheckRemovedCSharpApis(projectFile));
 
         options.CancellationToken.ThrowIfCancellationRequested();
         returnCode = CombineExitCodes(returnCode, await MigrateLaunchSettings(projectFile));
@@ -191,6 +221,134 @@ internal static class V8Tov9Upgrade
         {
             await UpgradeConsole.Error.WriteLineAsync($"Error migrating OpenAPI namespace in Program.cs: {ex.Message}");
             return 1;
+        }
+    }
+
+    /// <summary>
+    /// Raises explicit package versions to the floors the v9 Altinn.App packages require (NU1605
+    /// downgrades), driven dynamically by parsing <c>dotnet restore</c> output.
+    /// </summary>
+    static async Task<int> MigrateNuGetDowngrades(
+        string projectFolder,
+        string projectFile,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            await UpgradeConsole.Out.WriteLineAsync(
+                "Checking for package downgrades against the v9 dependency floors..."
+            );
+
+            var resolver = new NuGetDowngradeResolver();
+            var result = await resolver.ResolveAsync(projectFolder, projectFile, cancellationToken);
+
+            foreach (var warning in result.Warnings)
+            {
+                await UpgradeConsole.Out.WriteLineAsync($"  {warning}");
+            }
+
+            if (result.ManualActionRequired)
+            {
+                await UpgradeConsole.Out.WriteLineAsync(
+                    "Some package downgrades need manual follow-up. Review the messages above."
+                );
+                return ExitManualActionRequired;
+            }
+
+            return ExitSuccess;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            await UpgradeConsole.Error.WriteLineAsync($"Error resolving package downgrades: {ex.Message}");
+            return ExitError;
+        }
+    }
+
+    /// <summary>Rewrites the IServiceTask namespace usings across all app C# files.</summary>
+    static async Task<int> MigrateServiceTaskNamespace(string projectFile)
+    {
+        try
+        {
+            var migration = new UsingNamespaceMigration(projectFile);
+            migration.Migrate(ServiceTaskOldNamespace, ServiceTaskNewNamespace, _allCSharpFilesMatcher);
+            return ExitSuccess;
+        }
+        catch (Exception ex)
+        {
+            await UpgradeConsole.Error.WriteLineAsync($"Error migrating IServiceTask namespace: {ex.Message}");
+            return ExitError;
+        }
+    }
+
+    /// <summary>
+    /// Adds the new <c>receiverFromConfig</c> parameter to app implementations of
+    /// <c>IEFormidlingReceivers.GetEFormidlingReceivers</c> so they satisfy the v9 interface.
+    /// </summary>
+    static async Task<int> MigrateEFormidlingReceiversSignature(string projectFile)
+    {
+        try
+        {
+            var scanner = CSharpSourceScanner.ForProject(projectFile);
+            var migration = new EFormidlingReceiversSignatureMigration(scanner);
+            var result = migration.Migrate();
+
+            foreach (var warning in result.Warnings)
+            {
+                await UpgradeConsole.Out.WriteLineAsync($"  {warning}");
+            }
+
+            return ExitSuccess;
+        }
+        catch (Exception ex)
+        {
+            await UpgradeConsole.Error.WriteLineAsync($"Error migrating IEFormidlingReceivers signature: {ex.Message}");
+            return ExitError;
+        }
+    }
+
+    /// <summary>
+    /// Reports (never rewrites) app usages of removed/changed v9 C# APIs that require human judgement:
+    /// the removed process task event interfaces, the reworked ServiceTaskResult API, legacy eFormidling
+    /// code, and removed internal engine handler types.
+    /// </summary>
+    static async Task<int> CheckRemovedCSharpApis(string projectFile)
+    {
+        try
+        {
+            await UpgradeConsole.Out.WriteLineAsync("Checking for removed or changed v9 C# APIs...");
+
+            var scanner = CSharpSourceScanner.ForProject(projectFile);
+            var result = WarnOnlyDetector.Combine(
+                new RemovedTaskEventInterfaceDetector(scanner).Detect(),
+                new ServiceTaskResultApiDetector(scanner).Detect(),
+                new LegacyEFormidlingCodeDetector(scanner).Detect(),
+                new RemovedInternalProcessTypeDetector(scanner).Detect()
+            );
+
+            foreach (var warning in result.Warnings)
+            {
+                await UpgradeConsole.Out.WriteLineAsync($"  {warning}");
+            }
+
+            if (result.ManualActionRequired)
+            {
+                await UpgradeConsole.Out.WriteLineAsync(
+                    "Removed or changed C# APIs need manual follow-up. Review the messages above."
+                );
+                return ExitManualActionRequired;
+            }
+
+            return ExitSuccess;
+        }
+        catch (Exception ex)
+        {
+            await UpgradeConsole.Error.WriteLineAsync($"Error checking for removed C# APIs: {ex.Message}");
+            return ExitError;
         }
     }
 


### PR DESCRIPTION
## Description

The `studioctl app upgrade` (v8→v9) bumps `Altinn.App.Api`/`Altinn.App.Core` to v9 but does not handle the **C# breaking changes** that follow, leaving many apps non-buildable with no guidance (see #19419). This adds a C# API migration layer to the `v8Tov9` upgrade, split cleanly into **auto-fixes** and **warn-only detections** (the latter flag `ManualActionRequired` → exit code `3`, never rewriting code we can't transform safely).

Line drawn deliberately: config/artifact migration is already well-covered; **source-code** changes that require human judgement are reported, not guessed.

### Auto-migrate
- **Dynamic NuGet floor resolver** — runs `dotnet restore`, parses `NU1605` downgrades, and raises the offending explicit `PackageReference` versions to the v9 floors. No hard-coded package list, so it won't drift.
- **`IServiceTask` namespace rewrite** — `Altinn.App.Core.Internal.Process.ProcessTasks.ServiceTasks` → `Altinn.App.Core.Features.Process`, across the whole app source tree.
- **`IEFormidlingReceivers.GetEFormidlingReceivers`** — adds the new `string? receiverFromConfig` parameter (Roslyn rewrite, idempotent, implementers only) and warns to review usage. The parameter is annotated `string?` only where the app has an active nullable annotation context (project `<Nullable>` or a preceding `#nullable` directive) and plain `string` otherwise — the v8 app template has no nullable context, where `string?` would raise CS8632 on every build.

### Warn-only (report, never rewrite)
- Removed process task event interfaces (`IProcessTaskStart`/`End`/`Abandon`, `ITaskEvents`) + dangling DI registrations → directed to the `IOnTaskStarting/Ending/AbandonHandler` family (`ShouldRunForTask` + `Execute`, `IInstanceDataMutator`, `HookResult`, idempotency).
- Reworked `ServiceTaskResult` API (removed `ServiceTaskErrorHandling`/`ServiceTaskErrorStrategy` + `Failed*`/`FailedAbortProcessNext`/`FailedContinueProcessNext`).
- Legacy eFormidling code (`IEFormidlingService` single-arg, `IEFormidlingLegacyConfigurationProvider`, `AppSettings.EnableEFormidling`).
- Removed internal in-process engine handler types.

### Foundation
Syntax-only `CSharpSourceScanner` + reusable `CSharpSyntaxQueries` + `WarnOnlyDetector`, shared by the detectors; plus a shared `BuildOutputPaths` filter (also applied to `UsingNamespaceMigration` so tree-wide rewrites skip `bin`/`obj`).

### Library fix (backend)
`ITaskEvents` was `[Obsolete(error: true)]` pointing to a **non-existent** `Altinn.App.Core.Internal.Process.ITaskEvents` — an unsuppressable compile-error dead-end. Now points to the real `IOnTask*Handler` replacements (PublicApi snapshot updated accordingly).

## Notes / follow-ups
- ~~**Deferred:** PR #19410's `IProcessEngine` renames (hold until merged).~~ #19410 was closed unmerged (superseded by the durable-yield initiative, #19621), so nothing is deferred anymore. If #19622 later changes the app-facing `ServiceTaskResult` surface, the detector guidance should be revisited then.
- Rebased onto main after #19571/#19636; verified the detector guidance still matches the current API surface (`ServiceTaskResult.Success`/`SuccessWithoutAutoAdvance`/`FailedRetryable`/`FailedPermanent`, `HookResult`, `IOnTask*Handler` shapes) and that the new `WarnFeedbackTasksBehindServiceTasks` advisory step from main is preserved in the pipeline.
- The NU1605 restore loop is exercised via its pure parser + project-file setter in tests (real restore is network/integration-bound), mirroring `V9PackageVersionResolver`.
- The `IServiceTask` namespace rewrite assumes apps referenced only `IServiceTask`/`ServiceTaskResult` from the old namespace (documented in-code).

## Verification
- [x] Relevant automated tests added — 22 new unit tests
- [x] `dotnet test studioctl-server-tests` green after rebase (93/93)
- [x] Full `Altinn.App.Core.Tests` suite green after the PublicApi snapshot update
- [x] CSharpier clean (server + tests)
- [x] **Manual testing against a real v8 app** — built an app from the `app-template-dotnet` **v8.3.7** template, seeded it with legacy API usage (an `IProcessTaskEnd` implementation + DI registration, an `IServiceTask` using the old namespace and removed `ServiceTaskResult` factories, a single-arg `IEFormidlingReceivers` implementer), and ran the real `studioctl app upgrade v9` (local dev build, real companion server, real `dotnet restore`). Every auto-fix applied correctly, every warn-only detector fired with accurate file:line references, and exit code 3 propagated to the CLI. Hand-porting the flagged code exactly as the warning texts instruct produced a **cleanly compiling v9 app with no migration-related warnings**. This run is also what surfaced the CS8632 nullable-context issue, fixed in this PR.

Fixes #19081. Refs #19419.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the v8-to-v9 `studioctl app upgrade v9` workflow with additional automatic C# API migrations.
  * Automatically applies eligible NU1605 downgrade “version floor” fixes by updating existing package references.
  * Updates `IServiceTask` namespace usage and migrates `IEFormidlingReceivers.GetEFormidlingReceivers` receiver signatures, including nullable handling.
  * Adds warn-only reporting for removed/changed APIs and legacy eFormidling issues (exit code **3**).
* **Bug Fixes**
  * Improved obsolete API guidance to direct to the current task lifecycle handlers.
  * Namespace and migration steps now skip generated build output more reliably.
* **Documentation**
  * Updated upgrade notes for new warning behaviour and exit code expectations.
* **Tests**
  * Expanded v8-to-v9 upgrade tests for detection, migrations, and project-file rewriting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->