### PR TITLE
fix: fix permissions for setup-dotnet on github-runners-single workflows

### DIFF
--- a/src/github-runner/Dockerfile
+++ b/src/github-runner/Dockerfile
@@ -130,7 +130,7 @@ RUN apt-get update \
     && git config --system checkout.workers 4 \
     && git config --system checkout.thresholdForParallelism 100 \
     && usermod -aG docker runner \
-    && chown -R runner:runner /home/runner/.cache /home/runner/.npm /home/runner/.nuget /home/runner/go /home/runner/_work /opt/tools /opt/corepack
+    && chown -R runner:runner /home/runner/.cache /home/runner/.npm /home/runner/.nuget /home/runner/go /home/runner/_work /opt/tools /opt/corepack /usr/share/dotnet
 
 ENV CGO_ENABLED=1
 ENV DOTNET_ROOT=/usr/share/dotnet


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The setup-dotnet action currently fails to install new .net versions because of missing permissions to `/usr/share/dotnet`.
This PR adds `/usr/share/dotnet` to the directories owned by the runner user.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime file permissions for bundled tooling and cache directories, helping ensure reliable operation in managed execution environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->