### PR TITLE
fix: disable renaming of task in utforming when it is customReceipt

### DIFF
--- a/src/Designer/frontend/packages/ux-editor/src/components/TaskNavigation/TaskCardEditing.test.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/components/TaskNavigation/TaskCardEditing.test.tsx
@@ -197,6 +197,11 @@ describe('taskCard', () => {
     const placeholder = screen.getByPlaceholderText(/ux_editor.task_card.choose_datamodel/);
     expect(placeholder).toBeInTheDocument();
   });
+
+  it('should disable task name input when editing a protected task', () => {
+    render({ layoutSetModel: customReceiptLayoutSet });
+    expect(layoutSetNameTextbox()).toBeDisabled();
+  });
 });
 
 const render = (props?: Partial<TaskCardEditingProps>) => {

--- a/src/Designer/frontend/packages/ux-editor/src/components/TaskNavigation/TaskCardEditing.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/components/TaskNavigation/TaskCardEditing.tsx
@@ -19,6 +19,7 @@ import classes from './TaskCardEditing.module.css';
 import { getLayoutSetTypeTranslationKey } from 'app-shared/utils/layoutSetsUtils';
 import { useTranslation } from 'react-i18next';
 import { CheckmarkIcon, XMarkIcon } from '@studio/icons';
+import { PROTECTED_TASK_NAME_CUSTOM_RECEIPT } from 'app-shared/constants';
 
 export type TaskCardEditingProps = {
   layoutSetModel: UiFolderLayoutSetModel;
@@ -86,11 +87,14 @@ export const TaskCardEditing = ({ layoutSetModel, onClose }: TaskCardEditingProp
     new Set(dataType ? [dataType, ...(dataModels || [])] : dataModels || []),
   );
 
+  const isNameProtected = PROTECTED_TASK_NAME_CUSTOM_RECEIPT === layoutSetModel.id;
+
   return (
     <StudioCard className={classes.editCard}>
       <StudioParagraph data-size='xs'>{t(taskName)}</StudioParagraph>
       <StudioTextfield
         label={taskNameFieldLabel}
+        disabled={isNameProtected}
         value={id}
         error={idValidationError}
         onKeyUp={(event) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

User are not allowed to give a custom name to custom receipt in v9, because the ui folder has to be `CustomReceipt` to be identified in the app as a custom receipt. 
Utforming front page still has the possibility to this. So this PR disables the input field when task name is protected. 

Related to #19538 


<img width="961" height="491" alt="image" src="https://github.com/user-attachments/assets/139bd1df-f9a2-420b-b437-d5d51353f14d" />



<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the name of the protected custom receipt layout task from being edited.
  * Added coverage to verify that the task name field is disabled for protected tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->