### PR TITLE
fix: keep main navigation item active on sub-pages

### DIFF
--- a/src/Designer/frontend/app-development/layout/PageHeader/LargeNavigationMenu/LargeNavigationMenu.test.tsx
+++ b/src/Designer/frontend/app-development/layout/PageHeader/LargeNavigationMenu/LargeNavigationMenu.test.tsx
@@ -33,6 +33,15 @@ describe('LargeNavigationMenu', () => {
     expect(activeItem).toHaveClass('active');
   });
 
+  it('should keep the parent menu item active when navigating to a sub-page of its route', () => {
+    renderLargeNavigationMenu({
+      routerInitialEntries: [`${menuItems[0].link}/some-sub-page`],
+    });
+
+    const activeItem = screen.getByRole('link', { name: menuItems[0].name });
+    expect(activeItem).toHaveClass('active');
+  });
+
   it('should set "isBeta" className for menu item that is beta', () => {
     renderLargeNavigationMenu();
     const menuItem = screen.getByRole('link', { name: menuItems[0].name });

--- a/src/Designer/frontend/app-development/layout/PageHeader/LargeNavigationMenu/LargeNavigationMenu.test.tsx
+++ b/src/Designer/frontend/app-development/layout/PageHeader/LargeNavigationMenu/LargeNavigationMenu.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { LargeNavigationMenu, type LargeNavigationMenuProps } from './LargeNavigationMenu';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { type NavigationMenuItem } from 'app-development/types/HeaderMenu/NavigationMenuItem';
 import { PageHeaderContext } from 'app-development/contexts/PageHeaderContext';
 
@@ -33,13 +33,22 @@ describe('LargeNavigationMenu', () => {
     expect(activeItem).toHaveClass('active');
   });
 
-  it('should keep the parent menu item active when navigating to a sub-page of its route', () => {
+  it('should keep the parent menu item active when on a sub-page of its route', () => {
     renderLargeNavigationMenu({
       routerInitialEntries: [`${menuItems[0].link}/some-sub-page`],
     });
 
-    const activeItem = screen.getByRole('link', { name: menuItems[0].name });
-    expect(activeItem).toHaveClass('active');
+    expect(screen.getByText(menuItems[0].name)).toHaveClass('active');
+  });
+
+  it('should not highlight a menu item whose route only matches the app name', () => {
+    renderLargeNavigationMenu({
+      componentProps: { menuItems: [{ name: 'App Named Item', link: 'my-app' }] },
+      routerInitialEntries: ['/my-org/my-app/other-route'],
+      routePath: '/:org/:app/*',
+    });
+
+    expect(screen.getByText('App Named Item')).not.toHaveClass('active');
   });
 
   it('should set "isBeta" className for menu item that is beta', () => {
@@ -58,17 +67,26 @@ describe('LargeNavigationMenu', () => {
 type Props = {
   componentProps: Partial<LargeNavigationMenuProps>;
   routerInitialEntries?: string[];
+  routePath?: string;
 };
 
 const renderLargeNavigationMenu = ({
   componentProps,
   routerInitialEntries = ['/'],
+  routePath = '*',
 }: Partial<Props> = {}) => {
   return render(
     <MemoryRouter initialEntries={routerInitialEntries}>
-      <PageHeaderContext.Provider value={{ variant: 'regular' }}>
-        <LargeNavigationMenu {...defaultProps} {...componentProps} />
-      </PageHeaderContext.Provider>
+      <Routes>
+        <Route
+          path={routePath}
+          element={
+            <PageHeaderContext.Provider value={{ variant: 'regular' }}>
+              <LargeNavigationMenu {...defaultProps} {...componentProps} />
+            </PageHeaderContext.Provider>
+          }
+        />
+      </Routes>
     </MemoryRouter>,
   );
 };

--- a/src/Designer/frontend/app-development/layout/PageHeader/LargeNavigationMenu/LargeNavigationMenu.tsx
+++ b/src/Designer/frontend/app-development/layout/PageHeader/LargeNavigationMenu/LargeNavigationMenu.tsx
@@ -3,7 +3,6 @@ import classes from './LargeNavigationMenu.module.css';
 import cn from 'classnames';
 import { NavLink, useLocation } from 'react-router-dom';
 import { StudioPageHeader } from '@studio/components';
-import { UrlUtils } from '@studio/pure-functions';
 import { type NavigationMenuItem } from 'app-development/types/HeaderMenu/NavigationMenuItem';
 
 export type LargeNavigationMenuProps = {
@@ -27,8 +26,7 @@ type HeaderButtonListItemProps = {
 };
 const HeaderButtonListItem = ({ menuItem }: HeaderButtonListItemProps): ReactElement => {
   const location = useLocation();
-  const currentRoutePath: string = UrlUtils.extractLastRouterParam(location.pathname);
-
+  const isActive: boolean = location.pathname.includes(menuItem.link);
   return (
     <li key={menuItem.name}>
       <StudioPageHeader.HeaderLink
@@ -37,8 +35,7 @@ const HeaderButtonListItem = ({ menuItem }: HeaderButtonListItemProps): ReactEle
           <NavLink data-color='neutral' to={menuItem.link} {...props}>
             <span
               className={cn({
-                [classes.active]:
-                  UrlUtils.extractLastRouterParam(menuItem.link) === currentRoutePath,
+                [classes.active]: isActive,
               })}
             >
               {menuItem.name}

--- a/src/Designer/frontend/app-development/layout/PageHeader/LargeNavigationMenu/LargeNavigationMenu.tsx
+++ b/src/Designer/frontend/app-development/layout/PageHeader/LargeNavigationMenu/LargeNavigationMenu.tsx
@@ -3,6 +3,8 @@ import classes from './LargeNavigationMenu.module.css';
 import cn from 'classnames';
 import { NavLink, useLocation } from 'react-router-dom';
 import { StudioPageHeader } from '@studio/components';
+import { UrlUtils } from '@studio/pure-functions';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { type NavigationMenuItem } from 'app-development/types/HeaderMenu/NavigationMenuItem';
 
 export type LargeNavigationMenuProps = {
@@ -26,7 +28,12 @@ type HeaderButtonListItemProps = {
 };
 const HeaderButtonListItem = ({ menuItem }: HeaderButtonListItemProps): ReactElement => {
   const location = useLocation();
-  const isActive: boolean = location.pathname.includes(menuItem.link);
+  const { app } = useStudioEnvironmentParams();
+
+  const appNameMatchesMenuItemLink = menuItem.link === app;
+  const isActive: boolean = appNameMatchesMenuItemLink
+    ? UrlUtils.extractThirdRouterParam(location.pathname) === menuItem.link
+    : location.pathname.includes(menuItem.link);
   return (
     <li key={menuItem.name}>
       <StudioPageHeader.HeaderLink


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The main navigation links (e.g. "Utforming", "Bibliotek") lost their active highlight when navigating into a sub-page of a route. For example, opening a sub-page under the UI editor removed the active state from the "Utforming" link.

The cause was that the active state compared only the **last** segment of the URL (`UrlUtils.extractLastRouterParam`). On a sub-page like `.../ui-editor/layoutSetId`, the last segment is the selected layout set id, so it no longer matched the menu item's route.


The active state no longer relies on the last router param (which broke on sub-pages). It now checks whether the main nav link is included in the URL, keeping the parent item active across all its sub-pages. If the app name coincides with a nav link, it falls back to matching the exact route segment so the wrong item isn't highlighted; otherwise the flexible includes check is used, so it stays more robust to future URL changes.

Example in bibliotek:
<img width="1667" height="562" alt="image" src="https://github.com/user-attachments/assets/2b9cd61c-aa8d-4bf4-8d22-621c641721c9" />

After:
<img width="1687" height="967" alt="image" src="https://github.com/user-attachments/assets/7a3264b4-bed9-4e7b-9aa1-e42fd2742114" />



<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Navigation menu items now remain highlighted when viewing a sub-page within their section.
  * Active menu styling continues to work correctly for direct page links and beta-labelled items.
* **Tests**
  * Added coverage to verify active highlighting across nested navigation routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->