### PR TITLE
fix(resource-adm): consider MigratedApp resources when checking if a resource identifier exists

### DIFF
--- a/src/Designer/backend/src/Designer/Services/Implementation/ResourceRegistryService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/ResourceRegistryService.cs
@@ -69,7 +69,7 @@ public class ResourceRegistryService : IResourceRegistry
 
     public async Task<bool> ServiceResourceExists(string id, string env)
     {
-        var resourceList = await GetServiceResourceList(env, includeApps: false, includeMigratedApps: false);
+        var resourceList = await GetServiceResourceList(env, includeApps: false, includeMigratedApps: true);
         return resourceList.Any((serviceResource) => serviceResource.Identifier.Equals(id));
     }
 


### PR DESCRIPTION
## Description
- The check for whether a resource identifier exists should also account for MigratedApp resources. Without this, trying to publish an update to a MigratedApp resource will result in a POST (instead of a PUT) request to resource registry, which will fail with a 409 Conflict.

## Issue
- https://github.com/Altinn/altinn-resource-registry/issues/824

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resource existence checks now correctly recognise resources associated with migrated applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->