### PR TITLE
test(app-frontend): stabilize Map polygon interactions

### DIFF
--- a/src/App/frontend/test/e2e/integration/component-library/map.ts
+++ b/src/App/frontend/test/e2e/integration/component-library/map.ts
@@ -2,52 +2,68 @@ import { AppFrontend } from 'test/e2e/pageobjects/app-frontend';
 
 const appFrontend = new AppFrontend();
 
+const selectors = {
+  map: '#form-content-MapPage-MapComponent-Geometries',
+  zoomAnimation: '.leaflet-zoom-anim',
+  path: 'g > path.leaflet-interactive',
+};
+
 describe('Map component', () => {
-  it('Is able to draw new geometries on a map using the toolbar', () => {
+  beforeEach(() => {
     cy.startAppInstance(appFrontend.apps.componentLibrary, { authenticationLevel: '2' });
     cy.gotoNavPage('Kart');
-
-    cy.intercept('GET', '**/**.png').as('tileRequest');
-
-    // Draw a polygon
-    cy.findByRole('link', { name: 'Draw a polygon' }).click();
-    cy.get('#form-content-MapPage-MapComponent-Geometries').click(300, 300);
-    cy.get('#form-content-MapPage-MapComponent-Geometries').click(400, 200);
-    // wait for zoom to adjust (double clicking causes a zoom)
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(200);
-    cy.get('#form-content-MapPage-MapComponent-Geometries').click(400, 400);
-    // complete polygon by clicking last point twice
-    cy.get('#form-content-MapPage-MapComponent-Geometries').click(400, 400);
-
-    cy.get('g>path').should('to.be.visible');
   });
 
-  it('Is able to draw new geometries and delete them on a map using the toolbar', () => {
-    cy.startAppInstance(appFrontend.apps.componentLibrary, { authenticationLevel: '2' });
-    cy.gotoNavPage('Kart');
-
-    cy.intercept('GET', '**/**.png').as('tileRequest');
-
+  it('Is able to draw new geometries on a map using the toolbar and delete them after', () => {
     // Draw a polygon
     cy.findByRole('link', { name: 'Draw a polygon' }).click();
-    cy.get('#form-content-MapPage-MapComponent-Geometries').click(300, 300);
-    cy.get('#form-content-MapPage-MapComponent-Geometries').click(400, 200);
-    // wait for zoom to adjust (double clicking causes a zoom)
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(200);
-    cy.get('#form-content-MapPage-MapComponent-Geometries').click(400, 400);
-    // complete polygon by clicking last point twice
-    cy.get('#form-content-MapPage-MapComponent-Geometries').click(400, 400);
-    // wait for map to adjust to new geometry
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(200);
+    cy.findByText('Click to start drawing shape.').should('exist');
+    moveAndClick(300, 300);
+    assertPath(0, false);
+
+    cy.findByText('Click to continue drawing shape.').should('exist');
+    moveAndClick(400, 200);
+    assertPath(1, false);
+
+    cy.findByText('Click to continue drawing shape.').should('exist');
+    moveAndClick(400, 400);
+    assertPath(2, false);
+
+    cy.findByText('Click first point to close this shape.').should('exist');
+    moveAndClick(300, 300);
+    assertPath(3, true);
 
     cy.get('g>path').should('to.be.visible');
 
-    cy.get('#form-content-MapPage-MapComponent-Geometries').findByRole('link', { name: 'Delete layers' }).click();
+    cy.get(selectors.map).findByRole('link', { name: 'Delete layers' }).click();
     cy.get('g>path').click('center');
     cy.findByRole('link', { name: 'Save' }).click();
     cy.get('g>path').should('not.exist');
   });
 });
+
+function moveAndClick(x: number, y: number) {
+  cy.get(selectors.zoomAnimation).should('not.exist');
+  cy.get(selectors.map).trigger('mousemove', x, y);
+  cy.get(selectors.map).click(x, y);
+  cy.get(selectors.zoomAnimation).should('not.exist');
+}
+
+function assertPath(lines: number, closed: boolean) {
+  if (lines === 0) {
+    cy.get(selectors.path).should('not.exist');
+    return;
+  }
+
+  cy.get(selectors.path)
+    .invoke('attr', 'd')
+    .should((path) => {
+      const commands = path?.match(/[MLZ]/gi) ?? [];
+      const drawnLines = commands.filter((command) => command.toUpperCase() === 'L').length;
+      const isClosed = commands.at(-1)?.toUpperCase() === 'Z';
+
+      expect(commands.at(0)?.toUpperCase()).to.equal('M');
+      expect(drawnLines + Number(isClosed)).to.equal(lines);
+      expect(isClosed).to.equal(closed);
+    });
+}

--- a/src/App/frontend/test/e2e/integration/component-library/map.ts
+++ b/src/App/frontend/test/e2e/integration/component-library/map.ts
@@ -6,6 +6,7 @@ const selectors = {
   map: '#form-content-MapPage-MapComponent-Geometries',
   zoomAnimation: '.leaflet-zoom-anim',
   path: 'g > path.leaflet-interactive',
+  drawVertex: '.leaflet-marker-icon.leaflet-editing-icon',
 };
 
 describe('Map component', () => {
@@ -22,7 +23,7 @@ describe('Map component', () => {
     assertPath(0, false);
 
     cy.findByText('Click to continue drawing shape.').should('exist');
-    moveAndClick(400, 200);
+    moveAndClick(400, 300);
     assertPath(1, false);
 
     cy.findByText('Click to continue drawing shape.').should('exist');
@@ -30,13 +31,22 @@ describe('Map component', () => {
     assertPath(2, false);
 
     cy.findByText('Click first point to close this shape.').should('exist');
-    moveAndClick(300, 300);
-    assertPath(3, true);
+    moveAndClick(300, 400);
+    assertPath(3, false);
+
+    cy.findByText('Click first point to close this shape.').should('exist');
+    cy.get(selectors.map).trigger('mousemove', 300, 300);
+    cy.findByText('Click first point to close this shape.').should('exist');
+    cy.get(selectors.map).find(selectors.drawVertex).first().should('be.visible').click();
+    assertPath(4, true);
+    // Saving refreshes the Leaflet Draw control, so wait before entering deletion mode.
+    cy.waitUntilSaved();
 
     cy.get('g>path').should('to.be.visible');
 
     cy.get(selectors.map).findByRole('link', { name: 'Delete layers' }).click();
-    cy.get('g>path').click('center');
+    cy.findByRole('link', { name: 'Save' }).should('be.visible');
+    cy.get(selectors.path).click('center');
     cy.findByRole('link', { name: 'Save' }).click();
     cy.get('g>path').should('not.exist');
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The Map component Cypress test relied on fixed delays and container-relative coordinates while drawing and deleting a polygon. Rendering-speed differences could therefore make the test advance before Leaflet was ready, miss the small closing vertex, or select an unreliable deletion point.

Replace fixed waits with assertions against Leaflet's drawing state and rendered SVG path. Close the polygon through its actual vertex marker, use a shape whose center is inside the fill, and wait for the geometry save before entering deletion mode.

## Verification

- `yarn --cwd src/App/frontend eslint test/e2e/integration/component-library/map.ts` — passed, with the existing stale Browserslist data warning.
- `npx cypress run --env environment=localtest -s test/e2e/integration/component-library/map.ts --config retries=0` — passed: 1 test, 1 passing.
- `git diff --check main...HEAD` — passed.

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end coverage for map polygon drawing and deletion.
  * Added step-by-step validation of polygon paths during creation and closure.
  * Improved test reliability by using shared setup, clearer element targeting, and save-state checks.
  * Removed redundant scenarios and replaced network-dependent waiting with UI-driven interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->