### PR TITLE
perf(app-frontend): reduce data-binding transposition allocations

### DIFF
--- a/src/App/frontend/src/utils/databindings/DataBinding.test.ts
+++ b/src/App/frontend/src/utils/databindings/DataBinding.test.ts
@@ -1,0 +1,63 @@
+import { transposeDataBinding } from 'src/utils/databindings/DataBinding';
+import type { IDataModelReference } from 'src/layout/common.generated';
+
+const dataType = 'model';
+
+function binding(field: string, type = dataType): IDataModelReference {
+  return { dataType: type, field };
+}
+
+describe('transposeDataBinding', () => {
+  it('copies nested array indexes to matching subject segments', () => {
+    const result = transposeDataBinding({
+      currentLocation: binding('groups[2].items[3].value'),
+      subject: binding('groups.items.label'),
+    });
+
+    expect(result).toEqual(binding('groups[2].items[3].label'));
+  });
+
+  it('does not treat a same-prefix field as a matching segment', () => {
+    const subject = binding('personName');
+
+    const result = transposeDataBinding({
+      currentLocation: binding('person[2]'),
+      subject,
+    });
+
+    expect(result).toEqual(subject);
+  });
+
+  it('stops before changing a subject that already has an array index', () => {
+    const subject = binding('groups[9].items.label');
+
+    const result = transposeDataBinding({
+      currentLocation: binding('groups[2].items[3].value'),
+      subject,
+    });
+
+    expect(result).toEqual(subject);
+  });
+
+  it('uses the provided row index for a repeating-group location', () => {
+    const result = transposeDataBinding({
+      currentLocation: binding('groups'),
+      subject: binding('groups.label'),
+      rowIndex: 4,
+      currentLocationIsRepGroup: true,
+    });
+
+    expect(result).toEqual(binding('groups[4].label'));
+  });
+
+  it('returns the original subject when data types differ', () => {
+    const subject = binding('groups.items.label', 'other-model');
+
+    const result = transposeDataBinding({
+      currentLocation: binding('groups[2].items[3].value'),
+      subject,
+    });
+
+    expect(result).toBe(subject);
+  });
+});

--- a/src/App/frontend/src/utils/databindings/DataBinding.ts
+++ b/src/App/frontend/src/utils/databindings/DataBinding.ts
@@ -71,31 +71,47 @@ export function transposeDataBinding({
     return subject;
   }
 
-  const ourBinding = new DataBinding(currentLocation);
-  const theirBinding = new DataBinding(subject);
-  const lastIdx = ourBinding.parts.length - 1;
+  const currentParts = currentLocation.field.split('.');
+  const subjectParts = subject.field.split('.');
+  const lastIdx = currentParts.length - 1;
 
-  for (const ours of ourBinding.parts) {
-    const theirs = theirBinding.at(ours.parentIndex);
+  for (const [index, currentPart] of currentParts.entries()) {
+    const subjectPart = subjectParts[index];
+    const current = parseBindingPart(currentPart);
+    const target = subjectPart === undefined ? undefined : parseBindingPart(subjectPart);
 
-    if (ours.base !== theirs?.base) {
+    if (current.base !== target?.base) {
       break;
     }
 
-    const arrayIndex = ours.parentIndex === lastIdx && currentLocationIsRepGroup ? rowIndex : ours.arrayIndex;
+    const arrayIndex = index === lastIdx && currentLocationIsRepGroup ? rowIndex : current.arrayIndex;
 
     if (arrayIndex === undefined) {
       continue;
     }
 
-    if (theirs.hasArrayIndex()) {
+    if (target.arrayIndex !== undefined) {
       // Stop early. We cannot add our row index here, because it makes no sense when an earlier group
       // index changed.we cannot possibly
       break;
     }
 
-    theirs.arrayIndex = arrayIndex;
+    subjectParts[index] = `${target.base}[${arrayIndex}]`;
   }
 
-  return theirBinding.export();
+  return { dataType: subject.dataType, field: subjectParts.join('.') };
+}
+
+function parseBindingPart(raw: string): { base: string; arrayIndex: number | undefined } {
+  const arrayStart = raw.lastIndexOf('[');
+  if (arrayStart === -1 || !raw.endsWith(']')) {
+    return { base: raw, arrayIndex: undefined };
+  }
+
+  const rawIndex = raw.slice(arrayStart + 1, -1);
+  if (!/^\d+$/.test(rawIndex)) {
+    return { base: raw, arrayIndex: undefined };
+  }
+
+  return { base: raw.slice(0, arrayStart), arrayIndex: Number(rawIndex) };
 }

--- a/src/App/frontend/src/utils/databindings/DataBinding.ts
+++ b/src/App/frontend/src/utils/databindings/DataBinding.ts
@@ -1,59 +1,5 @@
 import type { IDataModelReference } from 'src/layout/common.generated';
 
-/**
- * Simple class to let you work with (and mutate) a data model binding (possibly including array index accessors)
- * It breaks the data binding into DataBindingPart classes.
- */
-export class DataBinding {
-  public readonly parts: DataBindingPart[];
-
-  public constructor(public readonly binding: IDataModelReference) {
-    this.parts = binding.field.split('.').map((part, index) => new DataBindingPart(this, index, part));
-  }
-
-  public at(index: number): DataBindingPart | undefined {
-    return this.parts[index];
-  }
-
-  public export(): IDataModelReference {
-    return {
-      dataType: this.binding.dataType,
-      field: this.parts.map((part) => part.toString()).join('.'),
-    };
-  }
-}
-
-export class DataBindingPart {
-  public readonly base: string;
-  public arrayIndex: number | undefined = undefined;
-
-  public constructor(
-    public readonly parent: DataBinding,
-    public readonly parentIndex: number,
-    raw: string,
-  ) {
-    const arrayIndex = raw.match(/(\[\d+])?$/);
-    if (arrayIndex && arrayIndex[1]) {
-      this.arrayIndex = parseInt(arrayIndex[1].substring(1, arrayIndex[1].length - 1));
-      this.base = raw.substring(0, raw.length - arrayIndex[1].length);
-    } else {
-      this.base = raw;
-    }
-  }
-
-  public hasArrayIndex(): boolean {
-    return this.arrayIndex !== undefined;
-  }
-
-  public toString(): string {
-    if (this.arrayIndex !== undefined) {
-      return `${this.base}[${this.arrayIndex}]`;
-    }
-
-    return this.base;
-  }
-}
-
 interface TransposeDataBindingParams {
   subject: IDataModelReference;
   currentLocation: IDataModelReference;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Expression data-model lookups repeatedly constructed `DataBinding` and `DataBindingPart` object graphs, parsed each segment with regular expressions, mutated the target, and serialized it again. CPU profiles showed this work accumulating across hidden expressions in repeating rows.

This change transposes matching field segments directly while preserving data-type checks, same-prefix handling, existing-index early exit, nested indexes, and repeating-group row-index overrides. A repository-wide search found no remaining consumers of the old `DataBinding` and `DataBindingPart` wrappers, so they are removed instead of retaining a second parser and an unused internal API.

## Verification

- `yarn --cwd src/App/frontend test src/utils/databindings/DataBinding.test.ts --runInBand` — 5 tests passed
- `yarn --cwd src/App/frontend eslint src/utils/databindings/DataBinding.ts src/utils/databindings/DataBinding.test.ts` — passed
- `yarn --cwd src/App/frontend tsc` — passed

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved data-binding transposition for nested repeating groups and array-based fields.
  - Preserved existing field indexes when they are already defined.
  - Correctly applies row-specific indexes where required.
  - Prevented incompatible data types from being altered during transposition.

- **Tests**
  - Added coverage for nested paths, repeating-group mappings, existing indexes, and incompatible data types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
