### PR TITLE
refactor(app-frontend): decouple navigation hook responsibilities

### DIFF
--- a/src/App/frontend/src/components/form/Form.tsx
+++ b/src/App/frontend/src/components/form/Form.tsx
@@ -25,7 +25,7 @@ import { useOnFormSubmitValidation } from 'src/features/validation/callbacks/onF
 import { useTaskErrors } from 'src/features/validation/selectors/taskErrors';
 import { useQueryKey } from 'src/hooks/navigation';
 import { useAsRef } from 'src/hooks/useAsRef';
-import { useCurrentView, useNavigatePage, useStartUrl } from 'src/hooks/useNavigatePage';
+import { useCurrentView, useIsValidPageId, useNavigateToPage, useStartUrl } from 'src/hooks/useNavigatePage';
 import { getComponentCapabilities } from 'src/layout';
 import { GenericComponent } from 'src/layout/GenericComponent';
 import { getPageTitle } from 'src/utils/getPageTitle';
@@ -49,7 +49,7 @@ export function FormPage({ currentPageId }: { currentPageId: string | undefined 
   const [searchParams, setSearchParams] = useSearchParams();
   const shouldValidateFormPage = searchParams.get(SearchParams.Validate);
   const onFormSubmitValidation = useOnFormSubmitValidation();
-  const { isValidPageId } = useNavigatePage();
+  const isValidPageId = useIsValidPageId();
   const shouldNavigateToStart = !currentPageId || !isValidPageId(currentPageId);
 
   useEffect(() => {
@@ -155,7 +155,8 @@ export function FormPage({ currentPageId }: { currentPageId: string | undefined 
  */
 function useRedirectToStoredPage() {
   const pageKey = useCurrentView();
-  const { isValidPageId, navigateToPage } = useNavigatePage();
+  const isValidPageId = useIsValidPageId();
+  const navigateToPage = useNavigateToPage();
   const applicationMetadataId = getApplicationMetadata()?.id;
 
   const instanceId = useLaxInstanceId();

--- a/src/App/frontend/src/components/form/LinkToPotentialPage.tsx
+++ b/src/App/frontend/src/components/form/LinkToPotentialPage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router';
 import type { LinkProps } from 'react-router';
 
-import { useNavigatePage } from 'src/hooks/useNavigatePage';
+import { useIsValidPageId } from 'src/hooks/useNavigatePage';
 import { useIsHiddenPage } from 'src/utils/layout/hidden';
 
 type Props = LinkProps & { children?: React.ReactNode };
@@ -18,7 +18,7 @@ export const LinkToPotentialPage = (props: Props) => {
   const page = lastPart.split(/[?#]/)[0];
 
   const isHiddenPage = useIsHiddenPage(page);
-  const { isValidPageId } = useNavigatePage();
+  const isValidPageId = useIsValidPageId();
 
   const shouldShowLink = isValidPageId(page) && !isHiddenPage;
   if (shouldShowLink) {

--- a/src/App/frontend/src/components/presentation/BackNavigationButton.tsx
+++ b/src/App/frontend/src/components/presentation/BackNavigationButton.tsx
@@ -13,7 +13,7 @@ import { useLanguage } from 'src/features/language/useLanguage';
 import { useSelectedParty } from 'src/features/party/PartiesProvider';
 import { useIsSubformPage, useNavigationParam } from 'src/hooks/navigation';
 import { useIsMobile } from 'src/hooks/useDeviceWidths';
-import { useNavigatePage } from 'src/hooks/useNavigatePage';
+import { useExitSubform } from 'src/hooks/useNavigatePage';
 import { useIsAnyProcessing, useIsThisProcessing, useProcessingMutation } from 'src/hooks/useProcessingMutation';
 import { getDialogIdFromDataValues, getMessageBoxUrl } from 'src/utils/urls/urlHelper';
 
@@ -24,7 +24,7 @@ export function BackNavigationButton(props: { className?: string }) {
   const mainPageKey = useNavigationParam('mainPageKey');
   const isSubform = useIsSubformPage();
 
-  const { exitSubform } = useNavigatePage();
+  const exitSubform = useExitSubform();
   const performProcess = useProcessingMutation('exit-subform');
   const isExitingSubform = useIsThisProcessing('exit-subform');
   const isAnyProcessing = useIsAnyProcessing();

--- a/src/App/frontend/src/components/presentation/Progress.tsx
+++ b/src/App/frontend/src/components/presentation/Progress.tsx
@@ -5,11 +5,11 @@ import { getLabelId } from '@app/form-component';
 import classes from 'src/components/presentation/Progress.module.css';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { useNavigationParam } from 'src/hooks/navigation';
-import { useNavigatePage } from 'src/hooks/useNavigatePage';
+import { usePageOrder } from 'src/hooks/useNavigatePage';
 
 export const Progress = () => {
   const currentPageId = useNavigationParam('pageKey');
-  const { order } = useNavigatePage();
+  const order = usePageOrder();
   const { langAsString } = useLanguage();
 
   if (!currentPageId) {

--- a/src/App/frontend/src/features/devtools/components/DevNavigationButtons/DevNavigationButtons.tsx
+++ b/src/App/frontend/src/features/devtools/components/DevNavigationButtons/DevNavigationButtons.tsx
@@ -8,7 +8,7 @@ import classes from 'src/features/devtools/components/DevNavigationButtons/DevNa
 import { FormStore } from 'src/features/form/FormContext';
 import { useRawPageOrder } from 'src/features/form/layoutSettings/processLayoutSettings';
 import { useNavigationParam } from 'src/hooks/navigation';
-import { useNavigatePage } from 'src/hooks/useNavigatePage';
+import { useNavigateToPage } from 'src/hooks/useNavigatePage';
 import { useHiddenPages } from 'src/utils/layout/hidden';
 import { optionFilter } from 'src/utils/options';
 
@@ -23,7 +23,7 @@ export function DevNavigationButtons() {
 
 const InnerDevNavigationButtons = () => {
   const pageKey = useNavigationParam('pageKey');
-  const { navigateToPage } = useNavigatePage();
+  const navigateToPage = useNavigateToPage();
   const hiddenPages = useHiddenPages();
   const rawOrder = useRawPageOrder();
   const allPages = Object.keys(FormStore.bootstrap.useLayouts() ?? {});

--- a/src/App/frontend/src/features/navigation/components/SubformsForPage.tsx
+++ b/src/App/frontend/src/features/navigation/components/SubformsForPage.tsx
@@ -12,7 +12,7 @@ import classes from 'src/features/navigation/components/SubformsForPage.module.c
 import { isSubformValidation } from 'src/features/validation';
 import { useComponentValidationsFor } from 'src/features/validation/selectors/componentValidationsForNode';
 import { useNavigationParam } from 'src/hooks/navigation';
-import { useNavigatePage } from 'src/hooks/useNavigatePage';
+import { useEnterSubform } from 'src/hooks/useNavigatePage';
 import { useIsAnyProcessing } from 'src/hooks/useProcessingMutation';
 import {
   getSubformEntryDisplayName,
@@ -124,7 +124,7 @@ function SubformLink({
   hasErrors: boolean;
 }) {
   const disabled = useIsAnyProcessing();
-  const { enterSubform } = useNavigatePage();
+  const enterSubform = useEnterSubform();
   const { isSubformDataFetching, subformData, subformDataError } = useSubformFormData(dataElement.id);
   const subformDataSources = useExpressionDataSourcesForSubform(dataElement.dataType, subformData, entryDisplayName);
 

--- a/src/App/frontend/src/features/navigation/utils.ts
+++ b/src/App/frontend/src/features/navigation/utils.ts
@@ -17,7 +17,7 @@ import { useGetAltinnTaskType } from 'src/features/instance/useProcessQuery';
 import { ValidationMask } from 'src/features/validation';
 import { getVisibilityMask } from 'src/features/validation/utils';
 import { useNavigationParam } from 'src/hooks/navigation';
-import { useNavigatePage, useVisitedPages } from 'src/hooks/useNavigatePage';
+import { usePageOrder, useVisitedPages } from 'src/hooks/useNavigatePage';
 import { useHiddenPages } from 'src/utils/layout/hidden';
 import type { NavigationReceipt, NavigationTask } from 'src/features/form/ui/types';
 
@@ -158,7 +158,7 @@ export function useGetNavigationIsPrevented() {
   const currentPageId = useNavigationParam('pageKey') ?? '';
   const layoutCollection = FormStore.bootstrap.useLayoutCollection();
   const globalValidationOnNavigation = usePageSettings().validationOnNavigation;
-  const { order } = useNavigatePage();
+  const order = usePageOrder();
   const validationsSelector = FormStore.nodes.useLaxValidationsSelector();
   const allNodeIds = FormStore.raw.useLaxMemoSelector((state) => {
     const result = Object.fromEntries<string[]>(order.map((page) => [page, []]));

--- a/src/App/frontend/src/hooks/useNavigatePage.ts
+++ b/src/App/frontend/src/hooks/useNavigatePage.ts
@@ -175,20 +175,13 @@ export function useIsValidTaskId() {
   );
 }
 
-export function useNavigatePage() {
-  const isStateless = useIsStateless();
-  const navigate = useOurNavigate();
+export function useIsValidPageId() {
   const navParams = useAllNavigationParamsAsRef();
   const getTaskType = useGetTaskTypeById();
-  const refetchInitialValidations = useRefetchInitialValidations();
-  const [_searchParams] = useSearchParams();
-  const searchParamsRef = useAsRef(_searchParams);
-
-  const { autoSaveBehavior } = usePageSettings();
   const order = usePageOrder();
   const orderRef = useAsRef(order);
 
-  const isValidPageId = useCallback(
+  return useCallback(
     (_pageId: string) => {
       // The page ID may be URL encoded already, if we got this from react-router.
       const pageId = decodeURIComponent(_pageId);
@@ -199,31 +192,28 @@ export function useNavigatePage() {
     },
     [getTaskType, navParams, orderRef],
   );
+}
 
-  /**
-   * For stateless apps, this is how we redirect to the
-   * initial page of the app. We replace the url, to not
-   * have the initial page (i.e. the page without a
-   * pageKey) in the history.
-   */
-  useEffect(() => {
-    const currentPageId = navParams.current.pageKey ?? '';
-    if (isStateless && orderRef.current[0] !== undefined && (!currentPageId || !isValidPageId(currentPageId))) {
-      navigate(`/${orderRef.current[0]}?${searchParamsRef.current}`, undefined, replaceAndPreventResetOptions);
-    }
-  }, [isStateless, orderRef, navigate, isValidPageId, navParams, searchParamsRef]);
-
+export function useMaybeSaveOnPageChange() {
+  const { autoSaveBehavior } = usePageSettings();
   const waitForSave = FormStore.data.useWaitForSave();
-  const maybeSaveOnPageChange = useCallback(async () => {
+
+  return useCallback(async () => {
     await waitForSave(autoSaveBehavior === 'onChangePage');
   }, [autoSaveBehavior, waitForSave]);
+}
 
+export function useNavigateToPage() {
+  const isStateless = useIsStateless();
+  const navigate = useOurNavigate();
+  const navParams = useAllNavigationParamsAsRef();
+  const orderRef = useAsRef(usePageOrder());
+  const maybeSaveOnPageChange = useMaybeSaveOnPageChange();
   const [_, setVisitedPages] = useVisitedPages();
 
-  const navigateToPage = useCallback(
+  return useCallback(
     async (page?: string, options?: NavigateToPageOptions) => {
       const preventScrollReset = options?.searchParams?.has(SearchParams.FocusComponentId);
-      const shouldExitSubform = options?.searchParams?.has(SearchParams.ExitSubform, 'true') ?? false;
       const navOptions: NavigateOptions = {
         replace: options?.replace ?? false,
         ...(preventScrollReset ? preventFocusAndScrollResetOptions : undefined),
@@ -232,16 +222,13 @@ export function useNavigatePage() {
         window.logWarn('navigateToPage called without page');
         return;
       }
-      if (!orderRef.current.includes(page) && !shouldExitSubform) {
+      if (!orderRef.current.includes(page)) {
         window.logWarn('navigateToPage called with invalid page:', `"${page}"`);
         return;
       }
 
       if (options?.skipAutoSave !== true) {
         await maybeSaveOnPageChange();
-      }
-      if (shouldExitSubform) {
-        await refetchInitialValidations();
       }
 
       setVisitedPages((visitedPages) => {
@@ -261,7 +248,7 @@ export function useNavigatePage() {
       const { instanceOwnerPartyId, instanceGuid, taskId, mainPageKey, componentId, dataElementId } = navParams.current;
 
       // Subform
-      if (mainPageKey && componentId && dataElementId && !shouldExitSubform) {
+      if (mainPageKey && componentId && dataElementId) {
         const url = `/instance/${instanceOwnerPartyId}/${instanceGuid}/${taskId}/${mainPageKey}/${componentId}/${dataElementId}/${page}${searchParams}`;
         return navigate(url, options, navOptions);
       }
@@ -269,15 +256,119 @@ export function useNavigatePage() {
       const url = `/instance/${instanceOwnerPartyId}/${instanceGuid}/${taskId}/${page}${searchParams}`;
       navigate(url, options, navOptions);
     },
-    [orderRef, isStateless, navParams, navigate, maybeSaveOnPageChange, refetchInitialValidations, setVisitedPages],
+    [orderRef, isStateless, navParams, navigate, maybeSaveOnPageChange, setVisitedPages],
   );
+}
+
+export function useExitSubform() {
+  const isStateless = useIsStateless();
+  const navigate = useOurNavigate();
+  const navParams = useAllNavigationParamsAsRef();
+  const refetchInitialValidations = useRefetchInitialValidations();
+  const maybeSaveOnPageChange = useMaybeSaveOnPageChange();
+  const [_, setVisitedPages] = useVisitedPages();
+
+  return useCallback(async () => {
+    const { mainPageKey, componentId, pageKey, instanceOwnerPartyId, instanceGuid, taskId } = navParams.current;
+    if (!mainPageKey) {
+      window.logWarn('Tried to close subform page while not in a subform.');
+      return;
+    }
+
+    await maybeSaveOnPageChange();
+    await refetchInitialValidations();
+
+    setVisitedPages((visitedPages) => {
+      if (!pageKey || visitedPages.includes(pageKey)) {
+        return visitedPages;
+      }
+      return [...visitedPages, pageKey];
+    });
+
+    const searchParams = new URLSearchParams();
+    searchParams.set(SearchParams.ExitSubform, 'true');
+    if (componentId) {
+      searchParams.set(SearchParams.FocusComponentId, componentId);
+    }
+
+    const search = `?${searchParams.toString()}`;
+    if (isStateless) {
+      return navigate(`/${mainPageKey}${search}`, { resetReturnToView: false }, preventFocusAndScrollResetOptions);
+    }
+
+    const url = `/instance/${instanceOwnerPartyId}/${instanceGuid}/${taskId}/${mainPageKey}${search}`;
+    return navigate(url, { resetReturnToView: false }, preventFocusAndScrollResetOptions);
+  }, [isStateless, maybeSaveOnPageChange, navigate, navParams, refetchInitialValidations, setVisitedPages]);
+}
+
+export function useEnterSubform() {
+  const navigate = useOurNavigate();
+  const navParams = useAllNavigationParamsAsRef();
+  const refetchInitialValidations = useRefetchInitialValidations();
+  const orderRef = useAsRef(usePageOrder());
+  const maybeSaveOnPageChange = useMaybeSaveOnPageChange();
+
+  return useCallback(
+    async ({
+      nodeId,
+      dataElementId,
+      page,
+      validate,
+    }: {
+      nodeId: string;
+      dataElementId: string;
+      page?: string;
+      validate?: boolean;
+    }) => {
+      if (page && !orderRef.current.includes(page)) {
+        window.logWarn('enterSubform called with invalid page:', `"${page}"`);
+        return;
+      }
+      const { instanceOwnerPartyId, instanceGuid, taskId, pageKey } = navParams.current;
+      const url = `/instance/${instanceOwnerPartyId}/${instanceGuid}/${taskId}/${page ?? pageKey}/${nodeId}/${dataElementId}${validate ? '?validate=true' : ''}`;
+
+      await maybeSaveOnPageChange();
+      refetchInitialValidations();
+      return navigate(url);
+    },
+    [maybeSaveOnPageChange, navigate, navParams, orderRef, refetchInitialValidations],
+  );
+}
+
+function useEnsureValidCurrentPage() {
+  const isStateless = useIsStateless();
+  const navigate = useOurNavigate();
+  const navParams = useAllNavigationParamsAsRef();
+  const [_searchParams] = useSearchParams();
+  const searchParamsRef = useAsRef(_searchParams);
+  const orderRef = useAsRef(usePageOrder());
+  const isValidPageId = useIsValidPageId();
+
+  /**
+   * For stateless apps, this is how we redirect to the
+   * initial page of the app. We replace the url, to not
+   * have the initial page (i.e. the page without a
+   * pageKey) in the history.
+   */
+  useEffect(() => {
+    const currentPageId = navParams.current.pageKey ?? '';
+    if (isStateless && orderRef.current[0] !== undefined && (!currentPageId || !isValidPageId(currentPageId))) {
+      navigate(`/${orderRef.current[0]}?${searchParamsRef.current}`, undefined, replaceAndPreventResetOptions);
+    }
+  }, [isStateless, orderRef, navigate, isValidPageId, navParams, searchParamsRef]);
+}
+
+export function useNavigateToNextPage() {
+  const navParams = useAllNavigationParamsAsRef();
+  const navigateToPage = useNavigateToPage();
+  const orderRef = useAsRef(usePageOrder());
 
   /**
    * This function fetch the next page index on function
    * invocation and then navigates to the next page. This is
    * to be able to chain multiple ClientActions together.
    */
-  const navigateToNextPage = useCallback(
+  return useCallback(
     async (options?: NavigateToPageOptions) => {
       const currentPage = navParams.current.pageKey;
       const nextPage = getNextPageKey(orderRef.current, currentPage);
@@ -290,6 +381,12 @@ export function useNavigatePage() {
     },
     [navParams, navigateToPage, orderRef],
   );
+}
+
+export function useNavigateToPreviousPage() {
+  const navParams = useAllNavigationParamsAsRef();
+  const navigateToPage = useNavigateToPage();
+  const orderRef = useAsRef(usePageOrder());
 
   /**
    * This function fetches the previous page index on
@@ -297,7 +394,7 @@ export function useNavigatePage() {
    * page. This is to be able to chain multiple ClientActions
    * together.
    */
-  const navigateToPreviousPage = useCallback(
+  return useCallback(
     async (options?: NavigateToPageOptions) => {
       const previousPage = getPreviousPageKey(orderRef.current, navParams.current.pageKey);
 
@@ -309,44 +406,19 @@ export function useNavigatePage() {
     },
     [navParams, navigateToPage, orderRef],
   );
+}
 
-  const exitSubform = async () => {
-    if (!navParams.current.mainPageKey) {
-      window.logWarn('Tried to close subform page while not in a subform.');
-      return;
-    }
+export function useNavigatePage() {
+  useEnsureValidCurrentPage();
 
-    const searchParams = new URLSearchParams();
-    searchParams.set(SearchParams.ExitSubform, 'true');
-    const componentToNavigateTo = navParams.current.componentId;
-    if (componentToNavigateTo) {
-      searchParams.set(SearchParams.FocusComponentId, componentToNavigateTo);
-    }
-    await navigateToPage(navParams.current.mainPageKey, { searchParams, resetReturnToView: false });
-  };
-
-  const enterSubform = async ({
-    nodeId,
-    dataElementId,
-    page,
-    validate,
-  }: {
-    nodeId: string;
-    dataElementId: string;
-    page?: string;
-    validate?: boolean;
-  }) => {
-    if (page && !orderRef.current.includes(page)) {
-      window.logWarn('enterSubform called with invalid page:', `"${page}"`);
-      return;
-    }
-    const { instanceOwnerPartyId, instanceGuid, taskId, pageKey } = navParams.current;
-    const url = `/instance/${instanceOwnerPartyId}/${instanceGuid}/${taskId}/${page ?? pageKey}/${nodeId}/${dataElementId}${validate ? '?validate=true' : ''}`;
-
-    await maybeSaveOnPageChange();
-    refetchInitialValidations();
-    return navigate(url);
-  };
+  const order = usePageOrder();
+  const isValidPageId = useIsValidPageId();
+  const navigateToPage = useNavigateToPage();
+  const navigateToNextPage = useNavigateToNextPage();
+  const navigateToPreviousPage = useNavigateToPreviousPage();
+  const maybeSaveOnPageChange = useMaybeSaveOnPageChange();
+  const exitSubform = useExitSubform();
+  const enterSubform = useEnterSubform();
 
   return {
     navigateToPage,
@@ -376,7 +448,7 @@ const emptyArray = [];
 
 export function useNavigateToComponent() {
   const layoutLookups = FormStore.bootstrap.useLayoutLookups();
-  const { navigateToPage } = useNavigatePage();
+  const navigateToPage = useNavigateToPage();
   const currentPageId = useCurrentView();
   const [searchParams, setSearchParams] = useSearchParams();
 

--- a/src/App/frontend/src/layout/Subform/SubformComponent.tsx
+++ b/src/App/frontend/src/layout/Subform/SubformComponent.tsx
@@ -16,7 +16,7 @@ import { useAddEntryMutation, useDeleteEntryMutation } from 'src/features/subfor
 import { isSubformValidation } from 'src/features/validation';
 import { useComponentValidationsFor } from 'src/features/validation/selectors/componentValidationsForNode';
 import { useIsSubformPage } from 'src/hooks/navigation';
-import { useNavigatePage } from 'src/hooks/useNavigatePage';
+import { useEnterSubform } from 'src/hooks/useNavigatePage';
 import { useIsAnyProcessing, useIsThisProcessing, useProcessingMutation } from 'src/hooks/useProcessingMutation';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import { ComponentErrorList } from 'src/layout/GenericComponent';
@@ -53,7 +53,7 @@ export function SubformComponent({ baseComponentId }: PropsFromGenericComponent<
   const addSubformEntryMutation = useAddEntryMutation(dataType);
   const subformEntries = useInstanceDataElements(dataType);
 
-  const { enterSubform } = useNavigatePage();
+  const enterSubform = useEnterSubform();
   const lock = FormStore.data.useLocking(id);
   const performProcess = useProcessingMutation('add-subform');
   const isAdding = useIsThisProcessing('add-subform');
@@ -212,7 +212,7 @@ function SubformTableRow({
   );
 
   const { langAsString } = useLanguage();
-  const { enterSubform } = useNavigatePage();
+  const enterSubform = useEnterSubform();
 
   const { mutate: deleteSubformEntry, isPending: isDeleting } = useDeleteEntryMutation();
   const deleteButtonText = langAsString('general.delete');

--- a/src/App/frontend/src/layout/Subform/SubformWrapper.tsx
+++ b/src/App/frontend/src/layout/Subform/SubformWrapper.tsx
@@ -9,7 +9,7 @@ import { FormProvider } from 'src/features/form/FormProvider';
 import { getDefaultDataTypeFromUiFolder } from 'src/features/form/ui';
 import { PdfWrapper } from 'src/features/pdf/PdfWrapper';
 import { useNavigationParam } from 'src/hooks/navigation';
-import { useNavigatePage } from 'src/hooks/useNavigatePage';
+import { useNavigateToPage } from 'src/hooks/useNavigatePage';
 import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 
 export function SubformWrapper({ baseComponentId, children }: PropsWithChildren<{ baseComponentId: string }>) {
@@ -47,7 +47,7 @@ export function SubformForm() {
 
 export const RedirectBackToMainForm = () => {
   const mainPageKey = useNavigationParam('mainPageKey');
-  const { navigateToPage } = useNavigatePage();
+  const navigateToPage = useNavigateToPage();
 
   useEffect(() => {
     navigateToPage(mainPageKey);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`BackNavigationButton` only needs to exit a subform, but the combined `useNavigatePage()` hook also initializes page ordering and hidden-page expression evaluation. This makes a navigation control that can render outside a form context depend on form state it never uses.

Split the navigation API into focused hooks for page validation, page changes, page traversal, and subform entry/exit. Callers now subscribe only to the behavior they need, while `useNavigatePage()` remains as a compatibility facade for consumers that need the complete API.

## Verification

- `yarn --cwd src/App/frontend tsc` — passed.
- `yarn --cwd src/App/frontend lint` — passed with 45 existing warnings and no errors.
- `yarn --cwd src/App/frontend test src/features/navigation/AppNavigation.test.tsx --runInBand` — could not complete successfully because the local test environment loads React's production build; all 21 tests fail before exercising navigation with `TypeError: React.act is not a function`.
- `git diff --check main...HEAD` — passed.

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
