### PR TITLE
perf(app-frontend): isolate component focus requests

### DIFF
--- a/src/App/frontend/src/components/form/Form.tsx
+++ b/src/App/frontend/src/components/form/Form.tsx
@@ -27,6 +27,7 @@ import { useQueryKey } from 'src/hooks/navigation';
 import { useAsRef } from 'src/hooks/useAsRef';
 import { useCurrentView, useNavigatePage, useStartUrl } from 'src/hooks/useNavigatePage';
 import { getComponentCapabilities } from 'src/layout';
+import { FocusComponentRequestFromUrl } from 'src/layout/focusComponent';
 import { GenericComponent } from 'src/layout/GenericComponent';
 import { getPageTitle } from 'src/utils/getPageTitle';
 import type { AnyValidation, BaseValidation, NodeRefValidation } from 'src/features/validation';
@@ -144,6 +145,7 @@ export function FormPage({ currentPageId }: { currentPageId: string | undefined 
       </Flex>
       <ReadyForPrint type='load' />
       <HandleNavigationFocusComponent />
+      <FocusComponentRequestFromUrl />
     </>
   );
 }

--- a/src/App/frontend/src/layout/GenericComponent.test.tsx
+++ b/src/App/frontend/src/layout/GenericComponent.test.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 
 import { getFormBootstrapMock } from 'src/__mocks__/getFormBootstrapMock';
-import { findElementToFocus, GenericComponent } from 'src/layout/GenericComponent';
+import { findElementToFocus } from 'src/layout/focusComponent';
+import { GenericComponent } from 'src/layout/GenericComponent';
 import { renderWithInstanceAndLayout } from 'src/test/renderWithProviders';
 import type { CompExternal } from 'src/layout/layout';
 

--- a/src/App/frontend/src/layout/GenericComponent.tsx
+++ b/src/App/frontend/src/layout/GenericComponent.tsx
@@ -1,18 +1,14 @@
-import React, { useEffect, useMemo, useRef } from 'react';
-import { useSearchParams } from 'react-router';
-import type { SetURLSearchParams } from 'react-router';
+import React, { useEffect, useMemo } from 'react';
 
 import { FatalError, FatalErrorEmpty, Flex } from '@app/form-component';
 import classNames from 'classnames';
 
 import { AppLanguageTranslatorProvider } from 'src/AppLanguageTranslatorProvider';
-import { SearchParams } from 'src/core/routing/types';
-import { useIsNavigating } from 'src/core/routing/useIsNavigating';
 import { useDevToolsStore } from 'src/features/devtools/data/DevToolsStore';
 import { ExprVal } from 'src/features/expressions/types';
 import { FormStore } from 'src/features/form/FormContext';
 import { Lang } from 'src/features/language/Lang';
-import { replaceAndPreventResetOptions } from 'src/features/navigation/navigationOptions';
+import { useHandleFocusComponent } from 'src/layout/focusComponent';
 import { FormComponentContextProvider } from 'src/layout/FormComponentContext';
 import classes from 'src/layout/GenericComponent.module.css';
 import { getComponentDef } from 'src/layout/index';
@@ -217,98 +213,4 @@ export function ComponentErrorList({ baseComponentId, errors }: { baseComponentI
       </p>
     </FatalError>
   );
-}
-
-function useHandleFocusComponent(nodeId: string, containerDivRef: React.RefObject<HTMLDivElement | null>) {
-  const [searchParams, setSearchParams] = useSearchParams();
-  const indexedId = searchParams.get(SearchParams.FocusComponentId);
-  const errorBinding = searchParams.get(SearchParams.FocusErrorBinding);
-
-  const abortController = useRef(new AbortController());
-  const pathnameWas = window.location.pathname;
-  const isNavigating = useIsNavigating();
-  const shouldFocus = indexedId && indexedId == nodeId && !isNavigating;
-
-  useEffect(() => {
-    const div = containerDivRef.current;
-    if (shouldFocus && div) {
-      try {
-        requestAnimationFrame(() => {
-          !abortController.current.signal.aborted && div.scrollIntoView({ behavior: 'instant' });
-        });
-
-        const field = findElementToFocus(div, errorBinding);
-        if (field && !abortController.current.signal.aborted) {
-          field.focus();
-        }
-      } finally {
-        if (!abortController.current.signal.aborted && pathnameWas === window.location.pathname) {
-          // Only cleanup when pathname is the same as what it was during render. Navigation might have occurred, especially
-          // in Cypress tests where state changes will happen rapidly. These search params are cleaned up in
-          // useNavigatePage() automatically, so it shouldn't be a problem if the page has been changed. If something
-          // else happens, we'll re-render and get a new chance to clean up later.
-          cleanupQuery(searchParams, setSearchParams);
-        }
-      }
-    }
-  }, [containerDivRef, errorBinding, pathnameWas, nodeId, searchParams, setSearchParams, shouldFocus]);
-
-  useEffect(
-    () => () => {
-      // Abort on unmount so that we do not keep trying to focus this component
-      abortController.current.abort();
-    },
-    [abortController],
-  );
-}
-
-function cleanupQuery(searchParams: URLSearchParams, setSearchParams: SetURLSearchParams) {
-  if (searchParams.has(SearchParams.FocusComponentId) || searchParams.has(SearchParams.FocusErrorBinding)) {
-    const newSearchParams = new URLSearchParams(searchParams);
-    newSearchParams.delete(SearchParams.FocusComponentId);
-    newSearchParams.delete(SearchParams.FocusErrorBinding);
-    setSearchParams(newSearchParams, replaceAndPreventResetOptions);
-  }
-}
-
-export function findElementToFocus(div: HTMLDivElement | null, binding: string | null) {
-  if (!div) {
-    return undefined;
-  }
-
-  const targetElements = Array.from(
-    div.querySelectorAll<HTMLElement>(
-      ['input', 'textarea', 'select', 'button', '[tabindex]:not([tabindex="-1"])', '[contenteditable="true"]'].join(
-        ',',
-      ),
-    ),
-  );
-
-  if (targetElements.length === 0) {
-    return undefined;
-  }
-
-  const hasBinding = binding !== null;
-
-  if (hasBinding) {
-    const matchesBinding = (element: HTMLElement) => element.dataset.bindingkey === binding;
-    const bindingInput = targetElements.find(
-      (element) => matchesBinding(element) && element.matches('input,textarea,select'),
-    );
-    if (bindingInput) {
-      return bindingInput;
-    }
-
-    const anyBinding = targetElements.find(matchesBinding);
-    if (anyBinding) {
-      return anyBinding;
-    }
-  }
-
-  const firstInputLike = targetElements.find((element) => element.matches('input,textarea,select'));
-  if (firstInputLike) {
-    return firstInputLike;
-  }
-
-  return targetElements[0];
 }

--- a/src/App/frontend/src/layout/focusComponent.test.tsx
+++ b/src/App/frontend/src/layout/focusComponent.test.tsx
@@ -1,0 +1,129 @@
+import React, { useRef } from 'react';
+import { MemoryRouter } from 'react-router';
+
+import { act, render, screen, waitFor } from '@testing-library/react';
+
+import {
+  type FocusComponentRequest,
+  FocusComponentRequestFromUrl,
+  setFocusComponentRequest,
+  setFocusComponentUrlCleanup,
+  useFocusComponentRequest,
+  useHandleFocusComponent,
+} from 'src/layout/focusComponent';
+
+describe('focusComponent', () => {
+  beforeEach(() => {
+    setFocusComponentRequest(undefined);
+    setFocusComponentUrlCleanup(undefined);
+    HTMLElement.prototype.scrollIntoView = jest.fn();
+    window.requestAnimationFrame = (callback) => {
+      callback(0);
+      return 0;
+    };
+  });
+
+  afterEach(() => {
+    act(() => setFocusComponentRequest(undefined));
+    setFocusComponentUrlCleanup(undefined);
+    jest.restoreAllMocks();
+  });
+
+  it('does not re-render a subscriber when a focus request targets another component', () => {
+    const renderRequests: (FocusComponentRequest | undefined)[] = [];
+
+    function FocusRequestConsumer() {
+      const request = useFocusComponentRequest('node-a');
+      renderRequests.push(request);
+      return <span>{request?.nodeId ?? 'none'}</span>;
+    }
+
+    render(<FocusRequestConsumer />);
+    expect(renderRequests).toHaveLength(1);
+
+    act(() => setFocusComponentRequest({ nodeId: 'node-b', errorBinding: null }));
+
+    expect(renderRequests).toHaveLength(1);
+    expect(screen.getByText('none')).toBeInTheDocument();
+  });
+
+  it('re-renders when the focus request targets the subscriber', () => {
+    const renderRequests: (FocusComponentRequest | undefined)[] = [];
+
+    function FocusRequestConsumer() {
+      const request = useFocusComponentRequest('node-a');
+      renderRequests.push(request);
+      return <span>{request?.errorBinding ?? 'none'}</span>;
+    }
+
+    render(<FocusRequestConsumer />);
+    act(() => setFocusComponentRequest({ nodeId: 'node-a', errorBinding: 'name' }));
+
+    expect(renderRequests).toHaveLength(2);
+    expect(screen.getByText('name')).toBeInTheDocument();
+  });
+
+  it('publishes focus requests from URL parameters', async () => {
+    function FocusRequestConsumer() {
+      const request = useFocusComponentRequest('node-a');
+      return <span>{request?.errorBinding ?? 'none'}</span>;
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/page?focusComponentId=node-a&focusErrorBinding=name']}>
+        <FocusComponentRequestFromUrl />
+        <FocusRequestConsumer />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.getByText('name')).toBeInTheDocument());
+  });
+
+  it('focuses the requested component and cleans focus URL parameters', async () => {
+    const cleanup = jest.fn();
+    setFocusComponentUrlCleanup(cleanup);
+
+    function FocusTarget() {
+      const ref = useRef<HTMLDivElement | null>(null);
+      useHandleFocusComponent('node-a', ref);
+      return (
+        <div ref={ref}>
+          <button data-bindingkey='name'>Button</button>
+          <input
+            data-bindingkey='name'
+            aria-label='Name'
+          />
+        </div>
+      );
+    }
+
+    render(<FocusTarget />);
+    act(() => setFocusComponentRequest({ nodeId: 'node-a', errorBinding: 'name' }));
+
+    await waitFor(() => expect(screen.getByLabelText('Name')).toHaveFocus());
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps focus URL parameters until the requested component mounts', async () => {
+    const cleanup = jest.fn();
+    setFocusComponentUrlCleanup(cleanup);
+    act(() => setFocusComponentRequest({ nodeId: 'node-a', errorBinding: null }));
+
+    expect(cleanup).not.toHaveBeenCalled();
+
+    function FocusTarget() {
+      const ref = useRef<HTMLDivElement | null>(null);
+      useHandleFocusComponent('node-a', ref);
+      return (
+        <div ref={ref}>
+          <input aria-label='Name' />
+        </div>
+      );
+    }
+
+    render(<FocusTarget />);
+
+    await waitFor(() => expect(screen.getByLabelText('Name')).toHaveFocus());
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/App/frontend/src/layout/focusComponent.ts
+++ b/src/App/frontend/src/layout/focusComponent.ts
@@ -1,0 +1,145 @@
+import { useEffect, useRef, useSyncExternalStore } from 'react';
+import { useSearchParams } from 'react-router';
+import type React from 'react';
+
+import { SearchParams } from 'src/core/routing/types';
+import { replaceAndPreventResetOptions } from 'src/features/navigation/navigationOptions';
+import { useQueryKey } from 'src/hooks/navigation';
+
+export type FocusComponentRequest = {
+  nodeId: string;
+  errorBinding: string | null;
+};
+
+const focusComponentListeners = new Set<() => void>();
+let currentFocusComponentRequest: FocusComponentRequest | undefined;
+let cleanupFocusComponentUrl: (() => void) | undefined;
+
+export function setFocusComponentRequest(request: FocusComponentRequest | undefined) {
+  currentFocusComponentRequest = request;
+  for (const listener of focusComponentListeners) {
+    listener();
+  }
+}
+
+export function setFocusComponentUrlCleanup(cleanup: (() => void) | undefined) {
+  cleanupFocusComponentUrl = cleanup;
+}
+
+export function useFocusComponentRequest(nodeId: string): FocusComponentRequest | undefined {
+  return useSyncExternalStore(
+    (listener) => {
+      focusComponentListeners.add(listener);
+      return () => focusComponentListeners.delete(listener);
+    },
+    () => (currentFocusComponentRequest?.nodeId === nodeId ? currentFocusComponentRequest : undefined),
+    () => undefined,
+  );
+}
+
+export function useHandleFocusComponent(nodeId: string, containerDivRef: React.RefObject<HTMLDivElement | null>) {
+  const focusRequest = useFocusComponentRequest(nodeId);
+  const abortController = useRef(new AbortController());
+  const pathnameWas = window.location.pathname;
+
+  useEffect(() => {
+    const div = containerDivRef.current;
+    if (focusRequest && div) {
+      try {
+        requestAnimationFrame(() => {
+          if (!abortController.current.signal.aborted) {
+            div.scrollIntoView({ behavior: 'instant' });
+          }
+        });
+
+        const field = findElementToFocus(div, focusRequest.errorBinding);
+        if (field && !abortController.current.signal.aborted) {
+          field.focus();
+        }
+      } finally {
+        if (!abortController.current.signal.aborted && pathnameWas === window.location.pathname) {
+          cleanupFocusComponentUrl?.();
+        }
+      }
+    }
+  }, [containerDivRef, focusRequest, pathnameWas]);
+
+  useEffect(
+    () => () => {
+      abortController.current.abort();
+    },
+    [],
+  );
+}
+
+export function FocusComponentRequestFromUrl() {
+  const focusComponentId = useQueryKey(SearchParams.FocusComponentId);
+  const focusErrorBinding = useQueryKey(SearchParams.FocusErrorBinding);
+  const [, setSearchParams] = useSearchParams();
+
+  useEffect(() => {
+    setFocusComponentRequest(
+      focusComponentId
+        ? {
+            nodeId: focusComponentId,
+            errorBinding: focusErrorBinding,
+          }
+        : undefined,
+    );
+  }, [focusComponentId, focusErrorBinding]);
+
+  useEffect(() => {
+    setFocusComponentUrlCleanup(() => {
+      setSearchParams((params) => {
+        if (!params.has(SearchParams.FocusComponentId) && !params.has(SearchParams.FocusErrorBinding)) {
+          return params;
+        }
+
+        const nextParams = new URLSearchParams(params);
+        nextParams.delete(SearchParams.FocusComponentId);
+        nextParams.delete(SearchParams.FocusErrorBinding);
+        return nextParams;
+      }, replaceAndPreventResetOptions);
+    });
+
+    return () => setFocusComponentUrlCleanup(undefined);
+  }, [setSearchParams]);
+
+  return null;
+}
+
+export function findElementToFocus(div: HTMLDivElement | null, binding: string | null) {
+  if (!div) {
+    return undefined;
+  }
+
+  const targetElements = Array.from(
+    div.querySelectorAll<HTMLElement>(
+      ['input', 'textarea', 'select', 'button', '[tabindex]:not([tabindex="-1"])', '[contenteditable="true"]'].join(
+        ',',
+      ),
+    ),
+  );
+
+  if (targetElements.length === 0) {
+    return undefined;
+  }
+
+  if (binding !== null) {
+    const matchesBinding = (element: HTMLElement) => element.dataset.bindingkey === binding;
+    const bindingInput = targetElements.find(
+      (element) => matchesBinding(element) && element.matches('input,textarea,select'),
+    );
+    if (bindingInput) {
+      return bindingInput;
+    }
+
+    const anyBinding = targetElements.find(matchesBinding);
+    if (anyBinding) {
+      return anyBinding;
+    }
+  }
+
+  const firstInputLike = targetElements.find((element) => element.matches('input,textarea,select'));
+  return firstInputLike ?? targetElements[0];
+}

--- a/src/App/frontend/src/layout/focusComponent.ts
+++ b/src/App/frontend/src/layout/focusComponent.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useSyncExternalStore } from 'react';
+import { useEffect, useSyncExternalStore } from 'react';
 import { useSearchParams } from 'react-router';
 import type React from 'react';
 
@@ -39,37 +39,29 @@ export function useFocusComponentRequest(nodeId: string): FocusComponentRequest 
 
 export function useHandleFocusComponent(nodeId: string, containerDivRef: React.RefObject<HTMLDivElement | null>) {
   const focusRequest = useFocusComponentRequest(nodeId);
-  const abortController = useRef(new AbortController());
   const pathnameWas = window.location.pathname;
 
   useEffect(() => {
     const div = containerDivRef.current;
     if (focusRequest && div) {
-      try {
-        requestAnimationFrame(() => {
-          if (!abortController.current.signal.aborted) {
-            div.scrollIntoView({ behavior: 'instant' });
-          }
-        });
+      const animationFrame = requestAnimationFrame(() => {
+        div.scrollIntoView({ behavior: 'instant' });
+      });
 
+      try {
         const field = findElementToFocus(div, focusRequest.errorBinding);
-        if (field && !abortController.current.signal.aborted) {
+        if (field) {
           field.focus();
         }
       } finally {
-        if (!abortController.current.signal.aborted && pathnameWas === window.location.pathname) {
+        if (pathnameWas === window.location.pathname) {
           cleanupFocusComponentUrl?.();
         }
       }
+
+      return () => cancelAnimationFrame(animationFrame);
     }
   }, [containerDivRef, focusRequest, pathnameWas]);
-
-  useEffect(
-    () => () => {
-      abortController.current.abort();
-    },
-    [],
-  );
 }
 
 export function FocusComponentRequestFromUrl() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Every `GenericComponent` currently subscribes to router search parameters to determine whether it should handle a focus request. Updating a focus parameter therefore rerenders the rendered component tree even though only one node can act on the request.

This change publishes URL focus requests once at the form boundary and stores the active request in a small external store. Each component subscribes only to its own node ID, so requests targeting other nodes keep its snapshot stable. URL cleanup is still deferred until the target component has mounted and handled focus.

The existing focus-element selection tests remain in place, and new tests cover targeted subscriptions, URL publication, focus handling, and deferred cleanup.

Verification performed:

- `NODE_ENV=test yarn --cwd src/App/frontend test src/layout/focusComponent.test.tsx src/layout/GenericComponent.test.tsx --runInBand` — 2 suites and 12 tests passed.
- Targeted ESLint for the five changed files — passed.
- `yarn --cwd src/App/frontend tsc` — passed.
- Manual UI verification was not performed.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved URL-driven navigation to automatically scroll to and focus the relevant form field.
  * Prioritises the field associated with a validation error when available, otherwise selects the most suitable focusable element.
  * Automatically cleans up focus-related URL parameters after focusing is applied.

* **Tests**
  * Added coverage for targeted focus requests, URL-driven focus publication, deferred focusing until mount, and URL cleanup behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->