### PR TITLE
fix(expressions): respect effective component visibility

### DIFF
--- a/src/App/frontend/src/features/expressions/expression-functions.ts
+++ b/src/App/frontend/src/features/expressions/expression-functions.ts
@@ -3,7 +3,7 @@ import escapeStringRegexp from 'escape-string-regexp';
 
 import { ContextNotProvided } from 'src/core/contexts/context';
 import { SearchParams } from 'src/core/routing/types';
-import { exprCastValue } from 'src/features/expressions';
+import { evalExpr, exprCastValue } from 'src/features/expressions';
 import { Decimal } from 'src/features/expressions/Decimal';
 import { ExprRuntimeError, NodeRelationNotFound } from 'src/features/expressions/errors';
 import { AverageFunctionEvaluator } from 'src/features/expressions/function-evaluators/AverageFunctionEvaluator';
@@ -11,11 +11,12 @@ import { JmespathFunctionEvaluator } from 'src/features/expressions/function-eva
 import { ObjectFunctionEvaluator } from 'src/features/expressions/function-evaluators/ObjectFunctionEvaluator';
 import { SumFunctionEvaluator } from 'src/features/expressions/function-evaluators/SumFunctionEvaluator';
 import { ExprVal } from 'src/features/expressions/types';
-import { addError, isValidValue } from 'src/features/expressions/validation';
+import { addError, ExprValidation, isValidValue } from 'src/features/expressions/validation';
 import { makeIndexedId } from 'src/features/form/layout/utils/makeIndexedId';
 import { buildAuthContext } from 'src/utils/authContext';
 import { transposeDataBinding } from 'src/utils/databindings/DataBinding';
 import { formatDateLocale } from 'src/utils/dateUtils';
+import { collectHiddenSources, evaluateHiddenSources } from 'src/utils/layout/hiddenUtils';
 import type { EvaluateExpressionParams } from 'src/features/expressions';
 import type {
   AnyExprArg,
@@ -24,6 +25,7 @@ import type {
   ExprFunctionName,
   ExprFunctions,
   ExprValToActual,
+  ExprValToActualOrExpr,
   ValidObject,
   ValidValue,
 } from 'src/features/expressions/types';
@@ -192,13 +194,7 @@ export const ExprFunctionDefinitions = {
   component: {
     args: args(required(ExprVal.String)),
     returns: ExprVal.Any,
-    needs: dataSources(
-      'layoutLookups',
-      'currentDataModelPath',
-      'hiddenComponents',
-      'dataModelNames',
-      'formDataSelector',
-    ),
+    needs: dataSources('layoutLookups', 'currentDataModelPath', 'dataModelNames', 'formDataSelector'),
   },
   dataModel: {
     args: args(required(ExprVal.String), optional(ExprVal.String)),
@@ -218,7 +214,7 @@ export const ExprFunctionDefinitions = {
   displayValue: {
     args: args(required(ExprVal.String)),
     returns: ExprVal.String,
-    needs: dataSources('displayValues', 'hiddenComponents', 'currentDataModelPath', 'layoutLookups'),
+    needs: dataSources('displayValues', 'currentDataModelPath', 'layoutLookups'),
   },
   optionLabel: {
     args: args(required(ExprVal.String), required(ExprVal.Any)),
@@ -520,7 +516,7 @@ export const ExprFunctionImplementations: { [K in ExprFunctionName]: Implementat
       throw new NodeRelationNotFound(this, id);
     }
 
-    if (this.dataSources.hiddenComponents[id] === true) {
+    if (isComponentOrAncestorHidden(this, id)) {
       return null;
     }
 
@@ -602,7 +598,7 @@ export const ExprFunctionImplementations: { [K in ExprFunctionName]: Implementat
       throw new NodeRelationNotFound(this, id);
     }
 
-    if (this.dataSources.hiddenComponents[id] === true) {
+    if (isComponentOrAncestorHidden(this, id)) {
       return null;
     }
 
@@ -963,6 +959,45 @@ function pickSimpleValue(
     return value;
   }
   return null;
+}
+
+function isComponentOrAncestorHidden(ctx: EvaluateExpressionParams<['layoutLookups']>, componentId: string) {
+  const layoutLookups = ctx.dataSources.layoutLookups;
+  const hiddenSources = collectHiddenSources(componentId, layoutLookups).reverse();
+  const pageKey = layoutLookups.componentToPage[componentId];
+  return evaluateHiddenSources({
+    hiddenSources,
+    pageOrder: [],
+    pageKey,
+    evalHiddenExpression: (expr, source) =>
+      evalEmbeddedExpression(
+        ctx as EvaluateExpressionParams,
+        expr,
+        source.type === 'hiddenPage'
+          ? `Hidden expression for page ${source.id} failed`
+          : `Expression in property ${source.type} for component ${source.id} failed`,
+      ),
+  }).hidden;
+}
+
+function evalEmbeddedExpression(
+  ctx: EvaluateExpressionParams,
+  expr: ExprValToActualOrExpr<ExprVal.Boolean> | undefined,
+  errorIntroText: string,
+) {
+  if (!ExprValidation.isValidOrScalar(expr, ExprVal.Boolean)) {
+    return false;
+  }
+
+  return evalExpr(expr, ctx.dataSources, {
+    errorIntroText,
+    defaultValue: false,
+    returnType: ExprVal.Boolean,
+    onBeforeFunctionCall: ctx.callbacks.onBeforeFunctionCall,
+    onAfterFunctionCall: ctx.callbacks.onAfterFunctionCall,
+    positionalArguments: ctx.positionalArguments,
+    valueArguments: ctx.valueArguments,
+  });
 }
 
 /**

--- a/src/App/frontend/src/features/expressions/shared-tests/functions/component/hidden-by-child-visibility-callback.json
+++ b/src/App/frontend/src/features/expressions/shared-tests/functions/component/hidden-by-child-visibility-callback.json
@@ -1,0 +1,59 @@
+{
+  "name": "Lookup for component hidden by parent child-visibility callback",
+  "comment": "This may not work on the backend at all, because it's checking the edit.mode which hides the component when tableColumns[..].showInExpandedEdit = false. We should consider backend <-> frontend compatiblity here.",
+  "expression": ["component", "bedriftsNavn"],
+  "context": {
+    "component": "bransje",
+    "rowIndices": [0],
+    "currentLayout": "Page1"
+  },
+  "expects": null,
+  "layouts": {
+    "Page1": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "bedrifter",
+            "type": "RepeatingGroup",
+            "dataModelBindings": {
+              "group": "Bedrifter"
+            },
+            "children": ["bedriftsNavn", "bransje"],
+            "edit": {
+              "mode": "hideTable"
+            },
+            "tableColumns": {
+              "bedriftsNavn": {
+                "showInExpandedEdit": false
+              }
+            }
+          },
+          {
+            "id": "bedriftsNavn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Navn"
+            }
+          },
+          {
+            "id": "bransje",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "Bedrifter.Bransje"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "dataModel": {
+    "Bedrifter": [
+      {
+        "altinnRowId": "company0",
+        "Navn": "Hell og lykke AS",
+        "Bransje": "Grus og grofting"
+      }
+    ]
+  }
+}

--- a/src/App/frontend/src/features/form/FormContext.tsx
+++ b/src/App/frontend/src/features/form/FormContext.tsx
@@ -88,7 +88,7 @@ interface FormBootstrapSliceState extends FormBootstrapContextValue {
 
 export function processBootstrap(bootstrap: FormBootstrapBase): FormBootstrapContextValue {
   const processedLayouts = processLayouts(bootstrap.layouts, bootstrap.defaultDataType);
-  const layoutLookups = makeLayoutLookups(processedLayouts.processedLayouts);
+  const layoutLookups = makeLayoutLookups(processedLayouts.processedLayouts, bootstrap.layouts);
 
   return {
     ...bootstrap,

--- a/src/App/frontend/src/features/form/layout/makeLayoutLookups.ts
+++ b/src/App/frontend/src/features/form/layout/makeLayoutLookups.ts
@@ -1,7 +1,8 @@
 import { getComponentCapabilities, getComponentDef } from 'src/layout';
 import { ContainerComponent } from 'src/layout/LayoutComponent';
+import type { ExprVal, ExprValToActualOrExpr } from 'src/features/expressions/types';
 import type { IDataModelReference } from 'src/layout/common.generated';
-import type { CompExternal, CompTypes, ILayouts } from 'src/layout/layout';
+import type { CompExternal, CompTypes, ILayoutCollection, ILayouts } from 'src/layout/layout';
 import type { ChildClaimerProps } from 'src/layout/LayoutComponent';
 import type { ChildClaimsMap } from 'src/utils/layout/generator/GeneratorContext';
 
@@ -28,6 +29,11 @@ interface PlainLayoutLookups {
           [field: string]: string[] | undefined;
         }
       | undefined;
+  };
+
+  // Map of hidden expressions for pages
+  hiddenPerPage: {
+    [pageKey: string]: ExprValToActualOrExpr<ExprVal.Boolean> | undefined;
   };
 }
 
@@ -69,11 +75,12 @@ export type LayoutLookups = PlainLayoutLookups & RelationshipLookups & LookupFun
  * Make the simple hash-maps for all components in the layouts. This is used to quickly look up component, and
  * which components are on which pages.
  */
-function makePlainLookup(layouts: ILayouts): PlainLayoutLookups {
+function makePlainLookup(layouts: ILayouts, layoutCollection: ILayoutCollection): PlainLayoutLookups {
   const allComponents: PlainLayoutLookups['allComponents'] = {};
   const allPerPage: PlainLayoutLookups['allPerPage'] = {};
   const componentToPage: PlainLayoutLookups['componentToPage'] = {};
   const dataModelToComponents: PlainLayoutLookups['dataModelToComponents'] = {};
+  const hiddenPerPage: PlainLayoutLookups['hiddenPerPage'] = {};
 
   for (const pageKey of Object.keys(layouts)) {
     const page = layouts[pageKey];
@@ -81,6 +88,7 @@ function makePlainLookup(layouts: ILayouts): PlainLayoutLookups {
       continue;
     }
 
+    hiddenPerPage[pageKey] = layoutCollection[pageKey]?.data.hidden;
     allPerPage[pageKey] = [];
     for (const component of page) {
       allComponents[component.id] = component;
@@ -104,7 +112,7 @@ function makePlainLookup(layouts: ILayouts): PlainLayoutLookups {
     }
   }
 
-  return { allComponents, allPerPage, componentToPage, dataModelToComponents };
+  return { allComponents, allPerPage, componentToPage, dataModelToComponents, hiddenPerPage };
 }
 
 /**
@@ -112,8 +120,8 @@ function makePlainLookup(layouts: ILayouts): PlainLayoutLookups {
  * page (in their defined order), and serves as a tool for looking up component definitions by id, along with
  * parent/child relationships.
  */
-export function makeLayoutLookups(layouts: ILayouts): LayoutLookups {
-  const plainLookups = makePlainLookup(layouts);
+export function makeLayoutLookups(layouts: ILayouts, layoutCollection: ILayoutCollection): LayoutLookups {
+  const plainLookups = makePlainLookup(layouts, layoutCollection);
   const componentToParent: { [componentId: string]: { type: 'page'; id: string } | { type: 'node'; id: string } } = {};
   const componentToChildren: { [componentId: string]: string[] } = {};
   const topLevelComponents: { [pageKey: string]: string[] } = {};

--- a/src/App/frontend/src/features/form/layout/utils/makeIndexedId.test.ts
+++ b/src/App/frontend/src/features/form/layout/utils/makeIndexedId.test.ts
@@ -89,7 +89,7 @@ describe('makeIndexedId', () => {
     },
   ];
 
-  const lookups = makeLayoutLookups({ Page1: layout });
+  const lookups = makeLayoutLookups({ Page1: layout }, { Page1: { data: { layout } } });
 
   it.each([
     { id: 'topLevel', rowIds: [], expected: 'topLevel' },

--- a/src/App/frontend/src/features/formBootstrap/FormBootstrap.tsx
+++ b/src/App/frontend/src/features/formBootstrap/FormBootstrap.tsx
@@ -12,6 +12,10 @@ export const formBootstrapHooks = {
     const out = FormStore.raw.useLaxSelector((s) => s.bootstrap.processedLayouts);
     return out === ContextNotProvided ? undefined : out;
   },
+  useLaxLayoutLookups: () => {
+    const out = FormStore.raw.useLaxSelector((s) => s.bootstrap.layoutLookups);
+    return out === ContextNotProvided ? undefined : out;
+  },
   useLayoutCollection: () => FormStore.raw.useSelector((s) => s.bootstrap.layouts),
   useLayoutLookups: () => FormStore.raw.useSelector((s) => s.bootstrap.layoutLookups),
   useHiddenLayoutsExpressions: () => FormStore.raw.useSelector((s) => s.bootstrap.hiddenLayoutsExpressions),

--- a/src/App/frontend/src/features/validation/ValidationStorePlugin.test.ts
+++ b/src/App/frontend/src/features/validation/ValidationStorePlugin.test.ts
@@ -68,7 +68,7 @@ describe('ValidationStorePlugin', () => {
         ],
       };
 
-      const lookups = makeLayoutLookups(layouts);
+      const lookups = makeLayoutLookups(layouts, { FormLayout: { data: { layout: layouts.FormLayout! } } });
       const nodeData: FormStoreState['nodes']['nodeData'] = {};
       for (let i = 1; i <= 200; i++) {
         nodeData[`myGroup-${i}`] = createParentNode(`myGroup-${i}`, 'myGroup');
@@ -132,7 +132,7 @@ describe('ValidationStorePlugin', () => {
         ],
       };
 
-      const lookups = makeLayoutLookups(layouts);
+      const lookups = makeLayoutLookups(layouts, { FormLayout: { data: { layout: layouts.FormLayout! } } });
       const nodeData: FormStoreState['nodes']['nodeData'] = {};
       for (let parentRow = 1; parentRow <= 20; parentRow++) {
         nodeData[`mainGroup-${parentRow}`] = createParentNode(`mainGroup-${parentRow}`, 'mainGroup');

--- a/src/App/frontend/src/layout/Subform/utils.ts
+++ b/src/App/frontend/src/layout/Subform/utils.ts
@@ -78,7 +78,6 @@ function useOverriddenDataSourcesForSubform(
 }
 
 const dataSourcesNotSupportedInSubform = new Set([
-  'hiddenComponents',
   'layoutLookups',
   'displayValues',
 ] satisfies (keyof ExpressionDataSources)[]);

--- a/src/App/frontend/src/utils/layout/hidden.ts
+++ b/src/App/frontend/src/utils/layout/hidden.ts
@@ -9,13 +9,11 @@ import { ExprValidation } from 'src/features/expressions/validation';
 import { FormStore } from 'src/features/form/FormContext';
 import { useRawPageOrder } from 'src/features/form/layoutSettings/processLayoutSettings';
 import { useShallowMemo } from 'src/hooks/useShallowMemo';
-import { getComponentDef, implementsIsChildHidden } from 'src/layout';
+import { collectHiddenSources, evaluateHiddenSources } from 'src/utils/layout/hiddenUtils';
 import { useExpressionDataSources } from 'src/utils/layout/useExpressionDataSources';
 import type { EvalExprOptions } from 'src/features/expressions';
-import type { ExprValToActualOrExpr } from 'src/features/expressions/types';
-import type { LayoutLookups } from 'src/features/form/layout/makeLayoutLookups';
-import type { CompExternal } from 'src/layout/layout';
 import type { IHiddenLayoutsExternal } from 'src/types';
+import type { HiddenSource } from 'src/utils/layout/hiddenUtils';
 import type { ExpressionDataSources } from 'src/utils/layout/useExpressionDataSources';
 
 export interface IsHiddenOptions<Reason extends boolean = false> {
@@ -49,8 +47,7 @@ export function useIsHidden<Reason extends boolean = false>(
   }
 
   const layoutLookups = FormStore.bootstrap.useLayoutLookups();
-  const hiddenPages = FormStore.bootstrap.useHiddenLayoutsExpressions();
-  const hiddenSources = findHiddenSources(baseComponentId, layoutLookups, hiddenPages).reverse();
+  const hiddenSources = collectHiddenSources(baseComponentId, layoutLookups).reverse();
   const dataSources = useExpressionDataSources(hiddenSources);
   const forcedVisible = useIsForcedVisibleByDevTools();
   const pageOrder = useRawPageOrder();
@@ -88,13 +85,9 @@ export function useIsHiddenMulti(
   }
 
   const layoutLookups = FormStore.bootstrap.useLayoutLookups();
-  const hiddenPages = FormStore.bootstrap.useHiddenLayoutsExpressions();
   const hiddenSources = useMemo(
-    () =>
-      baseComponentIds.map((baseComponentId) =>
-        findHiddenSources(baseComponentId, layoutLookups, hiddenPages).reverse(),
-      ),
-    [baseComponentIds, hiddenPages, layoutLookups],
+    () => baseComponentIds.map((baseComponentId) => collectHiddenSources(baseComponentId, layoutLookups).reverse()),
+    [baseComponentIds, layoutLookups],
   );
   const dataSources = useExpressionDataSources(hiddenSources);
   const forcedVisible = useIsForcedVisibleByDevTools();
@@ -195,121 +188,34 @@ function isHidden({
   pageOrder,
   pageKey,
 }: IsHiddenProps): HiddenWithReason {
-  if (respectPageOrder && pageKey !== undefined && !pageOrder.includes(pageKey)) {
-    return { reason: 'pageOrder', hidden: true };
-  }
+  const result = evaluateHiddenSources({
+    hiddenSources,
+    pageOrder,
+    pageKey,
+    respectPageOrder,
+    evalHiddenExpression: (expr, source) => {
+      const options: EvalExprOptions = {
+        errorIntroText:
+          source.type === 'hiddenPage'
+            ? `Hidden expression for page ${source.id} failed`
+            : `Expression in property ${source.type} for component ${source.id} failed`,
+        defaultValue: false,
+        returnType: ExprVal.Boolean,
+      };
 
-  for (const source of hiddenSources) {
-    if (source.type === 'callback') {
-      const hidden = source.callback();
-      if (hidden) {
-        return { reason: source.type, hidden: true };
+      if (!ExprValidation.isValidOrScalar(expr, ExprVal.Boolean)) {
+        return false;
       }
-      continue;
-    }
 
-    const { type, expr, id } = source;
-    const options: EvalExprOptions = {
-      errorIntroText:
-        type === 'hiddenPage'
-          ? `Hidden expression for page ${id} failed`
-          : `Expression in property ${type} for component ${id} failed`,
-      defaultValue: false,
-      returnType: ExprVal.Boolean,
-    };
+      return evalExpr(expr, dataSources, options);
+    },
+  });
 
-    if (!ExprValidation.isValidOrScalar(expr, ExprVal.Boolean)) {
-      continue;
-    }
-
-    const hidden = evalExpr(expr, dataSources, options);
-    if (hidden) {
-      return { reason: type, hidden };
-    }
+  if (result.hidden) {
+    return { hidden: true, reason: result.reason! };
   }
 
-  return { reason: undefined, hidden: false };
-}
-
-interface Expr {
-  type: 'hidden' | 'hiddenRow' | 'hiddenPage';
-  expr: ExprValToActualOrExpr<ExprVal.Boolean>;
-  id: string;
-}
-
-interface Callback {
-  type: 'callback';
-  callback: () => boolean;
-  id: string;
-}
-
-type HiddenSource = Expr | Callback;
-
-function findHiddenSources(
-  baseComponentId: string | undefined,
-  layoutLookups: LayoutLookups,
-  hiddenPages: IHiddenLayoutsExternal,
-): HiddenSource[] {
-  const out: HiddenSource[] = [];
-  if (baseComponentId === undefined) {
-    return out;
-  }
-
-  const component = layoutLookups.allComponents[baseComponentId];
-  if (component?.hidden !== undefined) {
-    out.push({ type: 'hidden', expr: component.hidden, id: baseComponentId });
-  }
-
-  let childId = baseComponentId;
-  let parent = layoutLookups.componentToParent[childId];
-  while (parent?.type === 'node') {
-    const parentComponent = layoutLookups.getComponent(parent.id);
-    const parentDef = getComponentDef(parentComponent.type);
-    if (implementsIsChildHidden(parentDef)) {
-      const tmpParentId = parent.id;
-      const tmpChildId = childId;
-      const callback = () => parentDef.isChildHidden(tmpParentId, tmpChildId, layoutLookups);
-      out.push({ type: 'callback', callback, id: parent.id });
-    }
-    if (
-      parentComponent.type === 'RepeatingGroup' &&
-      parentComponent.hiddenRow !== undefined &&
-      isInRepGroupChildren(parentComponent, childId)
-    ) {
-      out.push({ type: 'hiddenRow', expr: parentComponent.hiddenRow, id: parent.id });
-    }
-    if (parentComponent.hidden !== undefined) {
-      out.push({ type: 'hidden', expr: parentComponent.hidden, id: parent.id });
-    }
-    childId = parent.id;
-    parent = layoutLookups.componentToParent[childId];
-  }
-
-  const page = layoutLookups.componentToPage[baseComponentId];
-  const hiddenExpr = page === undefined ? undefined : hiddenPages[page];
-  if (hiddenExpr !== undefined) {
-    out.push({ type: 'hiddenPage', expr: hiddenExpr, id: page! });
-  }
-
-  return out;
-}
-
-/**
- * Checks if a baseComponentId is in the repeating group children (returns false if the baseComponentId is included
- * via rowsBefore/rowsAfter).
- */
-function isInRepGroupChildren(parent: CompExternal<'RepeatingGroup'>, baseComponentId: string) {
-  const multiPage = parent.edit?.multiPage ?? false;
-  if (!multiPage) {
-    return parent.children.includes(baseComponentId);
-  }
-  for (const childId of parent.children) {
-    const [, id] = childId.split(':', 2);
-    if (id === baseComponentId) {
-      return true;
-    }
-  }
-  return false;
+  return { hidden: false, reason: undefined };
 }
 
 function useIsForcedVisibleByDevTools() {

--- a/src/App/frontend/src/utils/layout/hiddenUtils.ts
+++ b/src/App/frontend/src/utils/layout/hiddenUtils.ts
@@ -1,0 +1,120 @@
+import { getComponentDef, implementsIsChildHidden } from 'src/layout';
+import type { ExprVal, ExprValToActualOrExpr } from 'src/features/expressions/types';
+import type { LayoutLookups } from 'src/features/form/layout/makeLayoutLookups';
+import type { CompExternal } from 'src/layout/layout';
+
+interface HiddenExprSource {
+  type: 'hidden' | 'hiddenRow' | 'hiddenPage';
+  expr: ExprValToActualOrExpr<ExprVal.Boolean>;
+  id: string;
+}
+
+interface HiddenCallbackSource {
+  type: 'callback';
+  callback: () => boolean;
+  id: string;
+}
+
+export type HiddenSource = HiddenExprSource | HiddenCallbackSource;
+export type HiddenReason = HiddenSource['type'] | 'pageOrder';
+
+interface EvaluateHiddenSourcesProps {
+  hiddenSources: HiddenSource[];
+  pageOrder: string[];
+  pageKey: string | undefined;
+  respectPageOrder?: boolean;
+  evalHiddenExpression: (expr: HiddenExprSource['expr'], source: HiddenExprSource) => boolean;
+}
+
+export function collectHiddenSources(
+  baseComponentId: string | undefined,
+  layoutLookups: LayoutLookups,
+): HiddenSource[] {
+  const out: HiddenSource[] = [];
+  if (baseComponentId === undefined) {
+    return out;
+  }
+
+  const component = layoutLookups.allComponents[baseComponentId];
+  if (component?.hidden !== undefined) {
+    out.push({ type: 'hidden', expr: component.hidden, id: baseComponentId });
+  }
+
+  let childId = baseComponentId;
+  let parent = layoutLookups.componentToParent[childId];
+  while (parent?.type === 'node') {
+    const parentComponent = layoutLookups.getComponent(parent.id);
+    const parentDef = getComponentDef(parentComponent.type);
+    if (implementsIsChildHidden(parentDef)) {
+      const tmpParentId = parent.id;
+      const tmpChildId = childId;
+      const callback = () => parentDef.isChildHidden(tmpParentId, tmpChildId, layoutLookups);
+      out.push({ type: 'callback', callback, id: parent.id });
+    }
+    if (
+      parentComponent.type === 'RepeatingGroup' &&
+      parentComponent.hiddenRow !== undefined &&
+      isInRepeatingGroupChildren(parentComponent, childId)
+    ) {
+      out.push({ type: 'hiddenRow', expr: parentComponent.hiddenRow, id: parent.id });
+    }
+    if (parentComponent.hidden !== undefined) {
+      out.push({ type: 'hidden', expr: parentComponent.hidden, id: parent.id });
+    }
+    childId = parent.id;
+    parent = layoutLookups.componentToParent[childId];
+  }
+
+  const page = layoutLookups.componentToPage[baseComponentId];
+  const hiddenExpr = page === undefined ? undefined : layoutLookups.hiddenPerPage[page];
+  if (page !== undefined && hiddenExpr !== undefined) {
+    out.push({ type: 'hiddenPage', expr: hiddenExpr, id: page });
+  }
+
+  return out;
+}
+
+export function evaluateHiddenSources({
+  hiddenSources,
+  pageOrder,
+  pageKey,
+  respectPageOrder = false,
+  evalHiddenExpression,
+}: EvaluateHiddenSourcesProps): { hidden: boolean; reason: HiddenReason | undefined } {
+  if (respectPageOrder && pageKey !== undefined && !pageOrder.includes(pageKey)) {
+    return { reason: 'pageOrder', hidden: true };
+  }
+
+  for (const source of hiddenSources) {
+    if (source.type === 'callback') {
+      if (source.callback()) {
+        return { reason: source.type, hidden: true };
+      }
+      continue;
+    }
+
+    if (evalHiddenExpression(source.expr, source)) {
+      return { reason: source.type, hidden: true };
+    }
+  }
+
+  return { reason: undefined, hidden: false };
+}
+
+/**
+ * Checks if a baseComponentId is in the repeating group children (returns false if the baseComponentId is included
+ * via rowsBefore/rowsAfter).
+ */
+function isInRepeatingGroupChildren(parent: CompExternal<'RepeatingGroup'>, baseComponentId: string) {
+  const multiPage = parent.edit?.multiPage ?? false;
+  if (!multiPage) {
+    return parent.children.includes(baseComponentId);
+  }
+  for (const childId of parent.children) {
+    const [, id] = childId.split(':', 2);
+    if (id === baseComponentId) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/App/frontend/src/utils/layout/hiddenUtils.ts
+++ b/src/App/frontend/src/utils/layout/hiddenUtils.ts
@@ -54,7 +54,7 @@ export function collectHiddenSources(
     if (
       parentComponent.type === 'RepeatingGroup' &&
       parentComponent.hiddenRow !== undefined &&
-      isInRepeatingGroupChildren(parentComponent, childId)
+      isInRepeatingGroupChildrenProperty(parentComponent, childId)
     ) {
       out.push({ type: 'hiddenRow', expr: parentComponent.hiddenRow, id: parent.id });
     }
@@ -102,10 +102,10 @@ export function evaluateHiddenSources({
 }
 
 /**
- * Checks if a baseComponentId is in the repeating group children (returns false if the baseComponentId is included
- * via rowsBefore/rowsAfter).
+ * Checks if a baseComponentId is in the repeating group children property (returns false if the baseComponentId is
+ * in other properties, like rowsBefore/rowsAfter).
  */
-function isInRepeatingGroupChildren(parent: CompExternal<'RepeatingGroup'>, baseComponentId: string) {
+function isInRepeatingGroupChildrenProperty(parent: CompExternal<'RepeatingGroup'>, baseComponentId: string) {
   const multiPage = parent.edit?.multiPage ?? false;
   if (!multiPage) {
     return parent.children.includes(baseComponentId);

--- a/src/App/frontend/src/utils/layout/useExpressionDataSources.ts
+++ b/src/App/frontend/src/utils/layout/useExpressionDataSources.ts
@@ -14,7 +14,7 @@ import { useInnerLanguageWithForcedPathSelector } from 'src/features/language/us
 import { useNavigationParam } from 'src/hooks/navigation';
 import { useShallowMemo } from 'src/hooks/useShallowMemo';
 import { useCurrentDataModelLocation } from 'src/utils/layout/DataModelLocation';
-import { useIsHiddenMulti } from 'src/utils/layout/hidden';
+import { collectHiddenSources } from 'src/utils/layout/hiddenUtils';
 import type { ExprFunctionName } from 'src/features/expressions/types';
 import type { ExternalApisResult } from 'src/features/externalApi/useExternalApi';
 import type { LayoutLookups } from 'src/features/form/layout/makeLayoutLookups';
@@ -36,14 +36,13 @@ export interface ExpressionDataSources {
   displayValues: Record<string, string | undefined>;
   externalApis: ExternalApisResult;
   formDataSelector: FormDataSelectorLax;
-  hiddenComponents: Record<string, boolean | undefined>;
   instanceDataSources: IInstanceDataSources | null;
   langToolsSelector: (dataModelPath: IDataModelReference | undefined) => IUseLanguage;
   layoutLookups: LayoutLookups;
   process: IProcess | undefined;
 }
 
-type HookBackedDataSource = Exclude<keyof ExpressionDataSources, 'displayValues' | 'hiddenComponents'>;
+type HookBackedDataSource = Exclude<keyof ExpressionDataSources, 'displayValues'>;
 type DerivedDataSource = Exclude<keyof ExpressionDataSources, HookBackedDataSource>;
 
 function typedKeys<T extends Record<string, unknown>>(obj: T): (keyof T)[] {
@@ -77,7 +76,6 @@ const hooks: { [K in HookBackedDataSource]: () => ExpressionDataSources[K] } = {
 
 const derivedDataSources: { [K in DerivedDataSource]: true } = {
   displayValues: true,
-  hiddenComponents: true,
 };
 
 export const ExpressionDataSourcesKeys = [
@@ -97,14 +95,38 @@ export type DataSourceOverrides = {
  * the same between renders, i.e. that layout configuration/expressions does not change between renders.
  */
 export function useExpressionDataSources(toEvaluate: unknown, overrides?: DataSourceOverrides): ExpressionDataSources {
+  const layoutLookups = FormStore.bootstrap.useLaxLayoutLookups();
   const { unsupportedDataSources, errorSuffix, dataSources: overriddenDataSources } = overrides ?? {};
 
-  const { neededDataSources, displayValueLookups, componentLookups } = useMemo(() => {
+  const { neededDataSources, displayValueLookups } = useMemo(() => {
     const functionCalls = new Set<ExprFunctionName>();
     const displayValueLookups = new Set<string>();
     const componentLookups = new Set<string>();
     findUsedExpressionFunctions(toEvaluate, functionCalls, displayValueLookups, componentLookups);
 
+    // When evaluating if a component is hidden, we need data sources for all expressions involved in the effective
+    // visibility calculation, including parent-hidden, hiddenRow, and page-hidden expressions.
+    const traversedComponentLookups = new Set<string>();
+    while (componentLookups.size > 0) {
+      const lookup = componentLookups.values().next().value;
+      if (lookup === undefined || !layoutLookups) {
+        break;
+      }
+
+      componentLookups.delete(lookup);
+      if (traversedComponentLookups.has(lookup)) {
+        continue;
+      }
+
+      const hiddenSources = collectHiddenSources(lookup, layoutLookups);
+      for (const source of hiddenSources) {
+        if (source.type !== 'callback') {
+          findUsedExpressionFunctions(source.expr, functionCalls, undefined, componentLookups);
+        }
+      }
+
+      traversedComponentLookups.add(lookup);
+    }
     const neededDataSources = new Set<keyof ExpressionDataSources>();
     for (const functionName of functionCalls) {
       const definition = ExprFunctionDefinitions[functionName];
@@ -119,8 +141,8 @@ export function useExpressionDataSources(toEvaluate: unknown, overrides?: DataSo
       }
     }
 
-    return { functionCalls, displayValueLookups, componentLookups, neededDataSources };
-  }, [toEvaluate, unsupportedDataSources, errorSuffix]);
+    return { functionCalls, displayValueLookups, neededDataSources };
+  }, [toEvaluate, layoutLookups, unsupportedDataSources, errorSuffix]);
 
   const output: Partial<ExpressionDataSources> = {};
 
@@ -132,8 +154,6 @@ export function useExpressionDataSources(toEvaluate: unknown, overrides?: DataSo
       output[key] = hooks[key]();
     } else if (key === 'displayValues') {
       output[key] = useDisplayDataFor([...displayValueLookups.values()]);
-    } else if (key === 'hiddenComponents') {
-      output[key] = useIsHiddenMulti([...componentLookups, ...displayValueLookups]);
     } else {
       throw new Error(`No hook found for data source ${key}`);
     }
@@ -145,7 +165,7 @@ export function useExpressionDataSources(toEvaluate: unknown, overrides?: DataSo
 function findUsedExpressionFunctions(
   subject: unknown,
   functionCalls: Set<ExprFunctionName>,
-  displayValueLookups: Set<string>,
+  displayValueLookups: Set<string> | undefined,
   componentLookups: Set<string>,
 ) {
   if (!subject || typeof subject !== 'object') {
@@ -157,7 +177,11 @@ function findUsedExpressionFunctions(
       functionCalls.add(subject[0]);
 
       if (subject[0] === 'displayValue' && typeof subject[1] === 'string') {
+        if (!displayValueLookups) {
+          throw new Error('Expression function "displayValue" cannot be called in a "hidden" property expression');
+        }
         displayValueLookups.add(subject[1]);
+        componentLookups.add(subject[1]);
       }
 
       if (subject[0] === 'component' && typeof subject[1] === 'string') {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Make component and display-value expressions evaluate visibility from the same sources as rendered components.

Page hidden expressions are included in layout lookups, and shared visibility helpers collect ancestor `hidden`, repeating-group `hiddenRow`, child-visibility callback, and page-hidden sources. The expression runner discovers dependencies in those sources before evaluating them, rather than subscribing to a hook-backed aggregate hidden-components value.

This includes regression coverage for a component hidden by a repeating-group child-visibility callback.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

Automated checks run:

- `yarn --cwd src/App/frontend tsc`
- `yarn --cwd src/App/frontend eslint src/features/expressions/expression-functions.ts src/features/form/FormContext.tsx src/features/form/layout/makeLayoutLookups.ts src/features/formBootstrap/FormBootstrap.tsx src/layout/Subform/utils.ts src/utils/layout/hidden.ts src/utils/layout/hiddenUtils.ts src/utils/layout/useExpressionDataSources.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved component visibility resolution when a component is hidden by itself, an ancestor, repeating-group context, child-visibility callbacks, or page-level rules.
  - Made expression-based visibility evaluation consistent for both component rendering and display-value logic.
  - Enhanced hidden-state evaluation for dependent expressions and improved support for hidden content within subforms.

- **Tests**
  - Added a new fixture covering components hidden via parent child-visibility rules.
  - Updated layout-lookup setup in existing tests to align with page-level hidden evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->