### PR TITLE
fix: return after context.Fail in StorageAccessHandler

### DIFF
--- a/src/Runtime/localtest/src/Services/Storage/Implementation/StorageAccessHandler.cs
+++ b/src/Runtime/localtest/src/Services/Storage/Implementation/StorageAccessHandler.cs
@@ -99,6 +99,7 @@ namespace Altinn.Platform.Storage.Authorization
             if (!DecisionHelper.ValidatePdpDecision(response.Response, context.User))
             {
                 context.Fail();
+                return;
             }
 
             context.Succeed(requirement);


### PR DESCRIPTION
﻿## Summary
- Add `return` after `context.Fail()` when `ValidatePdpDecision` fails in `StorageAccessHandler`
- Prevents falling through to `context.Succeed(requirement)` so deny is expressed in control flow (not only via `HasFailed` precedence)

Closes #19348

## Test plan
- [ ] Code review: fail path returns before Succeed
- [ ] Existing Storage PEP / authorization tests still pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected storage access handling so failed policy validation immediately stops processing.
  * Prevented invalid access requests from continuing through the successful access path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->