### PR TITLE
fix: datamodel selector for create subform in v9

### DIFF
--- a/src/Designer/frontend/packages/ux-editor/src/components/TaskNavigation/AddSubformCard/CreateSubformMode.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/components/TaskNavigation/AddSubformCard/CreateSubformMode.tsx
@@ -129,6 +129,7 @@ export const CreateSubformMode = ({
           <StudioSelect
             label={t('ux_editor.task_card.select_data_model')}
             onChange={(e) => handleDataModelName(e.target.value)}
+            value={newSubform.dataModelName}
           >
             {RenderDataModelOptions(dataModelIds)}
           </StudioSelect>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Before

https://github.com/user-attachments/assets/d9779398-dcb3-40ea-a1aa-633d9a5832e9


After

https://github.com/user-attachments/assets/dc08ee61-b2d5-4190-884a-d465a4394d5f




<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the data model selector so it consistently displays the currently selected option when switching tabs or updating the selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->