### PR TITLE
ci(workflow-engine): add PR-time Docker build check

### DIFF
--- a/.github/workflows/runtime-workflow-engine-docker-build.yaml
+++ b/.github/workflows/runtime-workflow-engine-docker-build.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
       - name: Build image
         run: docker build -f ${{ matrix.dockerfile }} .

--- a/.github/workflows/runtime-workflow-engine-docker-build.yaml
+++ b/.github/workflows/runtime-workflow-engine-docker-build.yaml
@@ -1,0 +1,57 @@
+name: Runtime Workflow Engine - Docker build
+
+# Verifies both workflow-engine Docker images actually build on PRs.
+#
+# The existing *-tests workflows already cover source: they run
+# `dotnet build`/`dotnet test`, so compile/restore breakage fails there and
+# would fail an equivalent docker build too. What they DON'T cover is the
+# Dockerfiles themselves — COPY layout, publish flags, the ENTRYPOINT, and
+# the pinned base-image digests (they use actions/setup-dotnet, not the base
+# images). Nothing builds the standalone workflow-engine/Dockerfile at all
+# (only the app image is built, and only on push to main), so a Dockerfile
+# regression could otherwise stay dormant until someone builds it locally.
+#
+# This job is therefore scoped to the Dockerfiles and their .dockerignore
+# only — the parts no other workflow exercises. Source changes intentionally
+# do NOT trigger it, since the dotnet workflows already gate those.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
+    paths:
+      - 'src/Runtime/workflow-engine/Dockerfile'
+      - 'src/Runtime/workflow-engine/Dockerfile.dockerignore'
+      - 'src/Runtime/workflow-engine-app/Dockerfile'
+      - 'src/Runtime/workflow-engine-app/Dockerfile.dockerignore'
+      - '.github/workflows/runtime-workflow-engine-docker-build.yaml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  docker-build:
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
+    name: Build ${{ matrix.name }} image
+    runs-on: self-hosted-single
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: workflow-engine
+            dockerfile: Runtime/workflow-engine/Dockerfile
+          - name: workflow-engine-app
+            dockerfile: Runtime/workflow-engine-app/Dockerfile
+    defaults:
+      run:
+        working-directory: src
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Build image
+        run: docker build -f ${{ matrix.dockerfile }} .


### PR DESCRIPTION
## Why

While looking at #19582 (a Renovate base-image digest bump touching only the two `Dockerfile`s) I noticed it triggered **no CI at all**. Digging in revealed a coverage gap:

- `runtime-workflow-engine-tests.yaml` and `runtime-workflow-engine-app-tests.yaml` already cover source via `dotnet build`/`dotnet test`, but their `paths:` filters **exclude the Dockerfiles**, and they build with `actions/setup-dotnet` — **not** the Docker base images. So nothing on a PR exercises the Dockerfiles: COPY layout, publish flags, the `ENTRYPOINT`, or the pinned base-image digests.
- `workflow-engine-app/Dockerfile` is only built by `deploy-runtime-workflow-engine-app.yaml`, and only on **push to `main`** (post-merge) — so app-image breakage is caught at merge, not on the PR.
- **`workflow-engine/Dockerfile` (the standalone engine) is built by no workflow at all** — its only reference is the local-dev `docker-compose.yaml`. A regression there could stay dormant until someone builds it locally.

## What

New workflow `runtime-workflow-engine-docker-build.yaml` that `docker build`s **both** images (no push).

- **Scoped to the Dockerfiles and their `.dockerignore` only** — the surface no other workflow exercises. Source changes intentionally do **not** trigger it: the dotnet workflows already gate compile/restore, and those failures would fail an equivalent docker build too (pure redundancy). The `COPY` statements here are whole-directory, so a source rename can't break a COPY path either.
- Matrix over both Dockerfiles, `fail-fast: false` so one failure doesn't mask the other.
- Same context (`src/`) and conventions as the deploy workflow; `self-hosted-single` runner; standard draft/closed `if:` guard and concurrency group matching the sibling workflows.
- Complementary to the dotnet workflows: those use the SDK from `setup-dotnet`, whereas this uses the **pinned base-image digests**, so digest bumps like #19582 are now actually validated.

## Notes

- Single-arch build only (deploy does `linux/amd64,linux/arm64`); this is a build-sanity gate, not a release build.
- Verified locally: both `docker build`s succeed from the `src/` context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated Docker build validation for the workflow engine and workflow engine app.
  * Builds run on relevant pull requests and can also be triggered manually.
  * Draft and closed pull requests are excluded, and in-progress builds are cancelled when superseded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->