### PR TITLE
ci: allow Percy to capture local app assets

### DIFF
--- a/.github/workflows/app-frontend-cypress.yml
+++ b/.github/workflows/app-frontend-cypress.yml
@@ -190,6 +190,12 @@ jobs:
         if: env.ENABLE_PERCY == 'true'
         shell: bash
         run: |
+          echo "Percy discovery browser:"
+          realpath /usr/bin/google-chrome
+          /usr/bin/google-chrome --version
+          echo "Cypress browser:"
+          realpath "${CHROME_PATH:-$(command -v chrome)}"
+          "${CHROME_PATH:-chrome}" --version
           curl \
             --dump-header - \
             --fail \
@@ -234,6 +240,15 @@ jobs:
           else
             npx cypress "${cypress_args[@]}"
           fi
+
+      - name: Upload Percy browser network log
+        if: always() && env.ENABLE_PERCY == 'true'
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: percy-netlog-${{ matrix.containers }}
+          path: /tmp/percy-netlog.json
+          if-no-files-found: error
+          retention-days: 1
 
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         if: failure()

--- a/.github/workflows/app-frontend-cypress.yml
+++ b/.github/workflows/app-frontend-cypress.yml
@@ -186,6 +186,19 @@ jobs:
           CYPRESS_CACHE_FOLDER: ${{ github.workspace }}/.cache/Cypress
         run: npx cypress install
 
+      - name: Verify Percy stylesheet access
+        if: env.ENABLE_PERCY == 'true'
+        shell: bash
+        run: |
+          curl \
+            --dump-header - \
+            --fail \
+            --location \
+            --max-time 30 \
+            --output /dev/null \
+            --show-error \
+            http://app-frontend.local.altinn.cloud:8000/altinn-app-frontend.css
+
       - name: Cypress run
         shell: bash
         env:

--- a/.github/workflows/app-frontend-cypress.yml
+++ b/.github/workflows/app-frontend-cypress.yml
@@ -194,6 +194,7 @@ jobs:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }} # CYPRESS_RECORD_KEY comes from "org secrets"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+          PERCY_LOGLEVEL: debug
           PERCY_PARALLEL_TOTAL: 6
           PERCY_PARALLEL_NONCE: ${{ github.run_id }}-${{ github.run_attempt }}
           PERCY_BRANCH: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/app-frontend-cypress.yml
+++ b/.github/workflows/app-frontend-cypress.yml
@@ -241,15 +241,6 @@ jobs:
             npx cypress "${cypress_args[@]}"
           fi
 
-      - name: Upload Percy browser network log
-        if: always() && env.ENABLE_PERCY == 'true'
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
-        with:
-          name: percy-netlog-${{ matrix.containers }}
-          path: /tmp/percy-netlog.json
-          if-no-files-found: error
-          retention-days: 1
-
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         if: failure()
         with:

--- a/.github/workflows/app-frontend-cypress.yml
+++ b/.github/workflows/app-frontend-cypress.yml
@@ -186,25 +186,6 @@ jobs:
           CYPRESS_CACHE_FOLDER: ${{ github.workspace }}/.cache/Cypress
         run: npx cypress install
 
-      - name: Verify Percy stylesheet access
-        if: env.ENABLE_PERCY == 'true'
-        shell: bash
-        run: |
-          echo "Percy discovery browser:"
-          realpath /usr/bin/google-chrome
-          /usr/bin/google-chrome --version
-          echo "Cypress browser:"
-          realpath "${CHROME_PATH:-$(command -v chrome)}"
-          "${CHROME_PATH:-chrome}" --version
-          curl \
-            --dump-header - \
-            --fail \
-            --location \
-            --max-time 30 \
-            --output /dev/null \
-            --show-error \
-            http://app-frontend.local.altinn.cloud:8000/altinn-app-frontend.css
-
       - name: Cypress run
         shell: bash
         env:
@@ -213,7 +194,6 @@ jobs:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }} # CYPRESS_RECORD_KEY comes from "org secrets"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
-          PERCY_LOGLEVEL: debug
           PERCY_PARALLEL_TOTAL: 6
           PERCY_PARALLEL_NONCE: ${{ github.run_id }}-${{ github.run_attempt }}
           PERCY_BRANCH: ${{ github.head_ref || github.ref_name }}

--- a/src/App/frontend/package.json
+++ b/src/App/frontend/package.json
@@ -191,16 +191,16 @@
     "version": 2,
     "discovery": {
       "allowed-hostnames": [
+        "local.altinn.cloud",
         "localhost",
-        "localhost:8080",
         "app-frontend.local.altinn.cloud",
-        "app-frontend.local.altinn.cloud:8000",
         "altinncdn.no"
       ],
-      "network-idle-timeout": 1000,
-      "disable-cache": true,
       "launch-options": {
         "executable": "/usr/bin/google-chrome",
+        "args": [
+          "--log-net-log=/tmp/percy-netlog.json"
+        ],
         "timeout": 30000
       }
     }

--- a/src/App/frontend/package.json
+++ b/src/App/frontend/package.json
@@ -199,7 +199,7 @@
       "launch-options": {
         "executable": "/usr/bin/google-chrome",
         "args": [
-          "--log-net-log=/tmp/percy-netlog.json"
+          "--disable-features=LocalNetworkAccessChecks"
         ],
         "timeout": 30000
       }

--- a/src/App/frontend/package.json
+++ b/src/App/frontend/package.json
@@ -197,6 +197,8 @@
         "app-frontend.local.altinn.cloud:8000",
         "altinncdn.no"
       ],
+      "network-idle-timeout": 1000,
+      "disable-cache": true,
       "launch-options": {
         "executable": "/usr/bin/google-chrome",
         "timeout": 30000

--- a/src/App/frontend/package.json
+++ b/src/App/frontend/package.json
@@ -191,9 +191,10 @@
     "version": 2,
     "discovery": {
       "allowed-hostnames": [
-        "local.altinn.cloud",
         "localhost",
+        "localhost:8080",
         "app-frontend.local.altinn.cloud",
+        "app-frontend.local.altinn.cloud:8000",
         "altinncdn.no"
       ],
       "launch-options": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Percy snapshots rendered without application styling because Chrome 150 blocked the discovery browser's requests to loopback-backed `studioctl` hosts. The captured Chrome network logs report `ERR_BLOCKED_BY_LOCAL_NETWORK_ACCESS_CHECKS` for the local stylesheet and SVG resources.

Disable `LocalNetworkAccessChecks` only in Percy's discovery-browser launch options.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

- Chrome and Cypress browser diagnostics confirmed that both use the installed Chrome for Testing 150 binary.
- Percy netlogs confirmed local resources failed with `ERR_BLOCKED_BY_LOCAL_NETWORK_ACCESS_CHECKS`.
- `yarn prettier --check .github/workflows/app-frontend-cypress.yml src/App/frontend/package.json`
- `git diff --check origin/main...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of browser-based visual checks by ensuring local content loads consistently during test runs.
  * Reduced the likelihood of false failures caused by browser network access restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->