### PR TITLE
docs(cli): document local dev flows (dev-mode env images and --dev-frontend)

### DIFF
--- a/.github/workflows/cli-build-test.yaml
+++ b/.github/workflows/cli-build-test.yaml
@@ -7,8 +7,7 @@ on:
       - "src/cli/**"
       - "src/tools/releaser/**"
       - .github/workflows/cli-build-test.yaml
-      - "!**/AGENTS.md"
-      - "!**/CLAUDE.md"
+      - "!**/*.md"
   workflow_dispatch:
 
 concurrency:

--- a/src/cli/AGENTS.md
+++ b/src/cli/AGENTS.md
@@ -25,3 +25,26 @@ make test      # 6. Unit tests
 - Handle errors
 - Avoid nolint, the bar should be high
 - Respect fieldalignment lints (`make lint-fix` auto-corrects struct field ordering)
+
+### Local dev flows (build/serve from source)
+
+By default `env up` pulls release images from GHCR and `run` serves the app's bundled
+frontend. Two independent switches let you build/serve from the local checkout instead;
+see @README.md for the full contributor walkthrough.
+
+- **Locally built environment images** — `STUDIOCTL_INTERNAL_DEV=true studioctl env up`,
+  run from inside the monorepo. Truthy is `1`/`true` (`config.IsTruthyEnv`). This flips
+  `env up` from `ReleaseMode` to `DevMode`, building the `localtest`, `pdf3`, and
+  `workflow-engine` images from local Dockerfiles. Detection lives in
+  `detectImageMode`/`resolveDevImageMode` (`internal/cmd/env/localtest/env.go`): it requires
+  a detected Studio repo root with `src/Runtime/localtest/Dockerfile`, else it warns and
+  falls back to release images. This is the same switch CI uses, so a dev-mode run exercises
+  the real app⇄services contract.
+- **Locally served frontend** — `studioctl run --dev-frontend` (also `app run` / `app env`).
+  Sets `AppSettings__AppFrontendAssetBaseUrl` (see `internal/cmd/app/env.go`) to the
+  `frontendDevServer` component URL, host-bridged to host port `8080` where
+  `src/App/frontend`'s webpack dev server (`yarn start`) listens. The
+  `app-frontend.local.altinn.cloud` host must resolve — `studioctl env hosts add` writes it;
+  `env up` does not touch the hosts file.
+- The topology/host wiring for both lives in `internal/envtopology/` (`topology.yaml`,
+  `ComponentFrontendDevServer`) and `internal/cmd/env/localtest/components/topology.go`.

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -91,3 +91,74 @@ make fmt
 make lint
 make test
 ```
+
+## Running a fully local build (contributors)
+
+By default `studioctl env up` pulls pre-built release images from GHCR and
+`studioctl run` serves the released app frontend bundled into the app image. When you
+are changing the runtime/platform services or the app frontend themselves, you can build
+and serve everything from your local checkout instead.
+
+### Build the environment images from local source
+
+Set `STUDIOCTL_INTERNAL_DEV=true` and run `env up` from **inside your altinn-studio
+checkout**:
+
+```sh
+cd altinn-studio          # anywhere inside the monorepo working tree
+STUDIOCTL_INTERNAL_DEV=true studioctl env up
+```
+
+In this mode studioctl builds the `localtest`, `pdf3`, and `workflow-engine` images from
+the Dockerfiles in your working tree instead of pulling release images. It confirms this
+with a `Building and starting localtest environment (dev mode)...` message, and the first
+run is slower because the images are built locally.
+
+Requirements and behaviour:
+
+- The current directory must be within a Studio repo checkout. studioctl detects the repo
+  root and expects `src/Runtime/localtest/Dockerfile` to exist.
+- If `STUDIOCTL_INTERNAL_DEV` is set but no Studio repo is detected (or the Dockerfile is
+  missing), studioctl prints a warning and falls back to release images.
+- Truthy values are `1` and `true` (case-insensitive); anything else is treated as unset.
+- This is the same switch CI uses to build the engine/platform services from the PR source,
+  so a local dev-mode run exercises the same app⇄services contract as CI.
+
+To go back to release images, simply run `studioctl env up` again without the variable
+(after `studioctl env down`).
+
+### Serve the app against the frontend dev server
+
+To run your app against a locally served **app frontend** (`src/App/frontend`) instead of
+the released bundle, start the frontend dev server and pass `--dev-frontend`:
+
+```sh
+# 1. Start the app frontend dev server (listens on host port 8080)
+cd src/App/frontend
+yarn                       # only when dependencies changed
+yarn start
+
+# 2. In another terminal, run your app pointed at that dev server
+cd <your-app-repo>
+studioctl run --dev-frontend
+```
+
+`--dev-frontend` sets `AppSettings__AppFrontendAssetBaseUrl` to
+`http://app-frontend.local.altinn.cloud:8000`, which the localtest ingress host-bridges to
+the dev server on host port `8080`. The `app-frontend.local.altinn.cloud` hostname must
+resolve on your machine — ensure the studioctl-managed hosts entries are present with:
+
+```sh
+studioctl env hosts add      # env up does not modify the hosts file for you
+```
+
+The same flag works on `studioctl app run --dev-frontend` and on
+`studioctl app env --dev-frontend --json`, the latter being useful to feed the environment
+into an IDE run configuration.
+
+> Related: `studioctl env up --dev-workflow-engine` routes the workflow-engine component to
+> a host process instead of a container, for the equivalent loop on that service.
+
+The two switches are independent and compose: run `STUDIOCTL_INTERNAL_DEV=true studioctl
+env up` for locally built services and `studioctl run --dev-frontend` for a locally served
+frontend, together or separately.


### PR DESCRIPTION
## Description

Documents the two independent "build/serve from source" switches in studioctl, which until now were only discoverable by reading the code:

- **`STUDIOCTL_INTERNAL_DEV=true studioctl env up`** — builds the `localtest`, `pdf3`, and `workflow-engine` images from the local checkout instead of pulling release images from GHCR (the same switch CI uses). Includes the repo-root detection requirements and the fallback-to-release behaviour.
- **`studioctl run --dev-frontend`** — points the app at the `src/App/frontend` webpack dev server via the host bridge, including the `studioctl env hosts add` prerequisite.

`README.md` gets the full contributor walkthrough; `AGENTS.md` gets a compact version with pointers to the detection and topology code (`detectImageMode`, `internal/envtopology/`).

Docs only — no code changes.

## Verification

- Flag/env-var names and code pointers cross-checked against `src/cli/internal` (`config.IsTruthyEnv`, `detectImageMode`/`resolveDevImageMode`, `internal/cmd/app/env.go`, `internal/envtopology/`).
- Both flows exercised repeatedly during workflow-engine integration work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance for running a fully local development loop using locally built service images (including detection, fallback behaviour, and how to revert to release images).
  * Documented `--dev-frontend` for serving frontend assets from the local dev server, including required host resolution and supported commands, plus how it composes with other development options.
* **Chores**
  * Updated CI to ignore Markdown-only changes in pull requests, reducing unnecessary workflow runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->