### PR TITLE
feat: retry a failed service task via process/resume, and expose the reject flow in the test app

### DIFF
--- a/src/App/frontend/src/features/instance/useProcessNext.tsx
+++ b/src/App/frontend/src/features/instance/useProcessNext.tsx
@@ -17,7 +17,7 @@ import { Lang } from 'src/features/language/Lang';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useOnFormSubmitValidation } from 'src/features/validation/callbacks/onFormSubmitValidation';
 import { useNavigateToTask } from 'src/hooks/useNavigatePage';
-import { doProcessNext } from 'src/queries/queries';
+import { doProcessNext, doProcessResume } from 'src/queries/queries';
 import { TaskKeys } from 'src/routesBuilder';
 import type { BackendValidationIssue } from 'src/features/validation';
 import type { IActionType, IInstance, IProcess, IProcessWorkflowFailure, ProblemDetails } from 'src/types/shared';
@@ -172,6 +172,84 @@ export function useProcessNext({ action }: ProcessNextProps = {}) {
 
 export function useProcessNextOutsideFormProvider({ action }: ProcessNextProps = {}) {
   return useProcessNextInternal({ action });
+}
+
+/**
+ * Resumes the terminally failed workflow that owns the current task (POST process/resume). This is
+ * the engine-era analogue of "retry the service task": the engine re-runs the failed step (and its
+ * dependents) in place, whereas a plain process/next is rejected with 409/resumeRequired while the
+ * workflow is failed. The mutation shares the process/next scope so a retry and a reject can never
+ * run concurrently, but deliberately not its mutation key: the key gates ProcessWrapper's
+ * full-screen loader, and the failed task view should stay mounted (button spinner) while resuming.
+ */
+export function useProcessResume() {
+  const reFetchInstanceData = useInstanceDataQuery({ enabled: false }).refetch;
+  const process = useCurrentInstance()?.process;
+  const navigateToTask = useNavigateToTask();
+  const instanceId = useLaxInstanceId();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    scope: { id: 'process/next' },
+    mutationKey: ['processResume'] as const,
+    mutationFn: async () => {
+      if (!instanceId) {
+        throw new Error('Missing instance ID. Cannot perform process/resume.');
+      }
+
+      return doProcessResume(instanceId)
+        .then(() => true)
+        .catch(async (error: HttpClientError<ProcessNextProblemDetails | undefined>) => {
+          // Same convergence rule as process/next: when the response is a workflow state the
+          // polled status can represent (still retrying, failed again, timed out), refetch and let
+          // ProcessWrapper's state machine render it instead of surfacing a hard error.
+          const processNextState = error.response?.data?.processNextState;
+          const workflowFailure = error.response?.data?.workflowFailure;
+          if (processNextState === 'retrying' || processNextState === 'resumeRequired' || workflowFailure) {
+            const refetchResult = await reFetchInstanceData();
+            if (refetchResult.isError) {
+              throw refetchResult.error;
+            }
+            return false;
+          }
+
+          throw error;
+        });
+    },
+    onSuccess: async (resumed) => {
+      if (!resumed) {
+        return;
+      }
+
+      // The resume response carries only the process state, and instance polling is off while the
+      // workflow is failed - so converge explicitly: refetch the instance (the source of truth the
+      // process query derives from) and navigate to the settled task like a successful
+      // process/next would have.
+      const { data: newInstance } = await reFetchInstanceData();
+      const task = getTargetTaskFromProcess(newInstance?.process);
+      if (task) {
+        navigateToTask(task);
+      }
+      await invalidateFormDataQueries(queryClient);
+    },
+    onError: async (error: HttpClientError<ProcessNextProblemDetails | undefined>) => {
+      window.logError('Process resume failed:\n', error);
+
+      // E.g. a concurrent session already resumed (409 "does not need to be resumed"): converge on
+      // the fresh state before reporting anything.
+      const { data: newInstance } = await reFetchInstanceData();
+      const newCurrentTask = newInstance?.process?.currentTask;
+
+      if (newCurrentTask?.elementId && newCurrentTask?.elementId !== process?.currentTask?.elementId) {
+        navigateToTask(newCurrentTask.elementId);
+      }
+
+      toast(<Lang id={error.response?.data?.detail ?? error.message ?? 'process_error.submit_error_please_retry'} />, {
+        type: 'error',
+        autoClose: false,
+      });
+    },
+  });
 }
 
 export function getTargetTaskFromProcess(processData: IProcess | undefined) {

--- a/src/App/frontend/src/features/process/service/ServiceTask.test.tsx
+++ b/src/App/frontend/src/features/process/service/ServiceTask.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { getInstanceWithProcessMock } from 'src/__mocks__/getInstanceDataMock';
+import { ServiceTask } from 'src/features/process/service/ServiceTask';
+import { doProcessNext, doProcessResume } from 'src/queries/queries';
+import { renderWithInstanceAndLayout } from 'src/test/renderWithProviders';
+import type { IInstanceWithProcess } from 'src/core/api-client/instance.api';
+import type { IProcessWorkflow } from 'src/types/shared';
+
+jest.mock('src/queries/queries', () => ({
+  ...jest.requireActual<typeof import('src/queries/queries')>('src/queries/queries'),
+  doProcessNext: jest.fn(),
+  doProcessResume: jest.fn(),
+}));
+
+function getServiceTaskInstance(workflow?: IProcessWorkflow): IInstanceWithProcess {
+  const instance = getInstanceWithProcessMock();
+  instance.process.currentTask = {
+    ...instance.process.currentTask!,
+    elementId: 'Task_Service',
+    elementType: 'ServiceTask',
+    altinnTaskType: 'scenario',
+    userActions: [{ id: 'write', authorized: true, type: 'ProcessAction' }],
+  };
+  instance.process.workflow = workflow;
+  return instance;
+}
+
+async function renderServiceTask(workflow?: IProcessWorkflow, after?: IInstanceWithProcess) {
+  let mutated = false;
+  await renderWithInstanceAndLayout({
+    renderer: () => <ServiceTask />,
+    taskId: 'Task_Service',
+    apis: {
+      instanceApi: {
+        getInstance: async () => (mutated && after ? after : getServiceTaskInstance(workflow)),
+      },
+    },
+  });
+  return {
+    markMutated: () => {
+      mutated = true;
+    },
+  };
+}
+
+describe('ServiceTask retry button', () => {
+  beforeEach(() => {
+    jest.mocked(doProcessNext).mockReset();
+    jest.mocked(doProcessResume).mockReset();
+  });
+
+  it('retries a workflow failure owned by this service task via process/resume, not process/next', async () => {
+    // A terminally failed workflow blocks process/next (409/resumeRequired) until it is resumed,
+    // so when the failure is owned by the current service task the retry button must go through
+    // POST process/resume - the engine re-runs the failed step in place.
+    const user = userEvent.setup();
+    const settled = getServiceTaskInstance();
+    settled.process.currentTask = {
+      ...settled.process.currentTask!,
+      elementId: 'Task_2',
+      elementType: 'Task',
+      altinnTaskType: 'data',
+    };
+
+    const { markMutated } = await renderServiceTask(
+      { status: 'failed', targetTask: 'Task_Service', failure: { kind: 'stepFailed' } },
+      settled,
+    );
+    jest.mocked(doProcessResume).mockImplementation(async () => {
+      markMutated();
+      return { data: settled.process } as Awaited<ReturnType<typeof doProcessResume>>;
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Prøv igjen' }));
+
+    expect(doProcessResume).toHaveBeenCalledTimes(1);
+    expect(doProcessNext).not.toHaveBeenCalled();
+  });
+
+  it('advances a parked (non-failed) service task via process/next', async () => {
+    // Without a terminal failure the task is merely parked; process/next is still the correct way
+    // to (re)trigger the advance, exactly like before the resume endpoint existed.
+    const user = userEvent.setup();
+    const instance = getServiceTaskInstance();
+    jest
+      .mocked(doProcessNext)
+      .mockImplementation(async () => ({ data: instance }) as Awaited<ReturnType<typeof doProcessNext>>);
+
+    await renderServiceTask(undefined);
+
+    await user.click(screen.getByRole('button', { name: 'Prøv igjen' }));
+
+    expect(doProcessNext).toHaveBeenCalledTimes(1);
+    expect(doProcessResume).not.toHaveBeenCalled();
+  });
+
+  it('a resume that fails again converges on the refetched workflow state instead of toasting', async () => {
+    // Because setupTests makes window.logError throw, this also proves the mutation's error path
+    // is NOT taken: the workflowFailure body is consumed by the state machine (refetch), the view
+    // stays on the recoverable service task screen, and no raw backend detail reaches the citizen.
+    const user = userEvent.setup();
+    jest.mocked(doProcessResume).mockImplementation(async () => {
+      throw Object.assign(new Error('Request failed with status code 500'), {
+        response: {
+          status: 500,
+          data: {
+            title: 'Something went wrong while resuming the current task.',
+            detail: 'A workflow step failed while performing the process action.',
+            workflowFailure: { kind: 'stepFailed', retryAction: 'resumeWorkflow' },
+          },
+        },
+      });
+    });
+
+    await renderServiceTask({ status: 'failed', targetTask: 'Task_Service', failure: { kind: 'stepFailed' } });
+
+    await user.click(screen.getByRole('button', { name: 'Prøv igjen' }));
+
+    expect(doProcessResume).toHaveBeenCalledTimes(1);
+    expect(await screen.findByRole('button', { name: 'Prøv igjen' })).toBeInTheDocument();
+  });
+});

--- a/src/App/frontend/src/features/process/service/ServiceTask.tsx
+++ b/src/App/frontend/src/features/process/service/ServiceTask.tsx
@@ -3,9 +3,10 @@ import React from 'react';
 import { Button } from '@app/form-component';
 import { Heading, Paragraph } from '@digdir/designsystemet-react';
 
+import { useIsWorkflowFailedOnCurrentServiceTask } from 'src/components/process/WorkflowEngine';
 import { ReadyForPrint } from 'src/components/ReadyForPrint';
 import { useAppOwner } from 'src/core/texts/appTexts';
-import { useProcessNextOutsideFormProvider } from 'src/features/instance/useProcessNext';
+import { useProcessNextOutsideFormProvider, useProcessResume } from 'src/features/instance/useProcessNext';
 import { useIsAuthorized } from 'src/features/instance/useProcessQuery';
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
@@ -57,14 +58,23 @@ export function ServiceTask() {
 const RetryButton = () => {
   const { langAsString } = useLanguage();
   const canRetry = useIsAuthorized()('write');
+  const failedOnCurrentServiceTask = useIsWorkflowFailedOnCurrentServiceTask();
   // Use mutate (not mutateAsync): failures are handled by the mutation's own onError (toast +
   // refetch), and an un-awaited mutateAsync would surface them as unhandled promise rejections.
-  const { mutate: processRetry, isPending: isRetrying } = useProcessNextOutsideFormProvider();
+  const { mutate: processNext, isPending: isAdvancing } = useProcessNextOutsideFormProvider();
+  const { mutate: processResume, isPending: isResuming } = useProcessResume();
+
+  // A failure owned by this service task means its workflow is terminally failed: process/next is
+  // blocked (409/resumeRequired) until the workflow is resumed, so "retry" must go through
+  // process/resume - the engine re-runs the failed step in place. Without such a failure the task
+  // is merely parked, and process/next is the correct way to (re)trigger the advance.
+  const retry = failedOnCurrentServiceTask ? processResume : processNext;
+  const isRetrying = isAdvancing || isResuming;
 
   return (
     <Button
       id='service-task-retry-button'
-      onClick={() => processRetry()}
+      onClick={() => retry()}
       disabled={!canRetry}
       isLoading={isRetrying}
       loadingLabel={langAsString('general.loading')}

--- a/src/App/frontend/src/queries/queries.ts
+++ b/src/App/frontend/src/queries/queries.ts
@@ -22,6 +22,7 @@ import {
   getPaymentInformationForTaskUrl,
   getPdfFormatUrl,
   getProcessNextUrl,
+  getProcessResumeUrl,
   getUpdateFileTagsUrl,
   refreshJwtTokenUrl,
 } from 'src/utils/urls/appUrlHelper';
@@ -36,10 +37,12 @@ import type { IPdfFormat } from 'src/features/pdf/types';
 import type { BackendValidationIssuesWithSource } from 'src/features/validation';
 import type { IRawOption } from 'src/layout/common.generated';
 import type { ActionResult } from 'src/layout/CustomButton/CustomButtonComponent';
-import type { IActionType, IData, PostalCodesRegistry } from 'src/types/shared';
+import type { IActionType, IData, IProcess, PostalCodesRegistry } from 'src/types/shared';
 
 export const doProcessNext = async (instanceId: string, language?: string, action?: IActionType) =>
   httpPut<IInstanceWithProcess>(getProcessNextUrl(instanceId, language, true), action ? { action } : null);
+
+export const doProcessResume = async (instanceId: string) => httpPost<IProcess>(getProcessResumeUrl(instanceId));
 
 export const doAttachmentUpload = async (
   instanceId: string,

--- a/src/App/frontend/src/queries/types.ts
+++ b/src/App/frontend/src/queries/types.ts
@@ -2,7 +2,7 @@ import type * as queries from 'src/queries/queries';
 
 type IgnoredQueriesAndMutations = keyof Pick<
   typeof queries,
-  'fetchExternalApi' | 'doProcessNext' | 'doUpdateAttachmentTags'
+  'fetchExternalApi' | 'doProcessNext' | 'doProcessResume' | 'doUpdateAttachmentTags'
 >;
 
 type KeysStartingWith<T, U extends string> = {

--- a/src/App/frontend/src/types/shared.ts
+++ b/src/App/frontend/src/types/shared.ts
@@ -198,8 +198,9 @@ export interface IProcess {
   /**
    * Live workflow-engine annotation resolved on every process/instance read. It sits next to the
    * (unchanged) committed `currentTask`: `idle` means render normally, `processing` means a
-   * transition is in flight, and `failed` means the transition failed terminally and awaits an
-   * ops-driven resume. Optional so older backends that don't emit it are treated as `idle`.
+   * transition is in flight, and `failed` means the transition failed terminally and awaits a
+   * resume - user-driven (process/resume) when the current service task owns the failure,
+   * ops-driven otherwise. Optional so older backends that don't emit it are treated as `idle`.
    */
   workflow?: IProcessWorkflow;
 }
@@ -251,7 +252,10 @@ interface IProcessWorkflowProcessing {
   startedAt?: string;
 }
 
-/** A transition failed terminally and awaits an ops-driven resume. */
+/**
+ * A transition failed terminally and awaits a resume - user-driven (process/resume) when the
+ * current service task owns the failure, ops-driven otherwise.
+ */
 interface IProcessWorkflowFailed {
   status: 'failed';
   /** BPMN element id the failed transition targets. Omitted when unresolved. */

--- a/src/App/frontend/src/utils/urls/appUrlHelper.ts
+++ b/src/App/frontend/src/utils/urls/appUrlHelper.ts
@@ -87,6 +87,8 @@ export const getProcessNextUrl = (instanceId: string, language?: string, returnI
   return `${appPath}/instances/${instanceId}/process/next${queryString}`;
 };
 
+export const getProcessResumeUrl = (instanceId: string) => `${appPath}/instances/${instanceId}/process/resume`;
+
 /**
  * Builds the platform authentication URL that triggers a step-up to security level high (`idporten-loa-high`),
  * returning the user to the app (`goTo`) once the higher level has been obtained.

--- a/src/App/frontend/test/e2e/integration/process-transition-test/workflow-status.ts
+++ b/src/App/frontend/test/e2e/integration/process-transition-test/workflow-status.ts
@@ -6,19 +6,23 @@ const appFrontend = new AppFrontend();
  * E2E for the live workflow-status state machine (ADR 2026-07-08), driving the REAL workflow engine
  * via the ttd/process-transition-test app instead of intercept stubbing.
  *
- * The app is Task_1 (data) -> gateway -> [Task_Service (service task) ->] Task_2 (data) -> gateway
- * -> EndEvent, where Task_2's reject action routes back to Task_1 (backwards navigation). The
- * gateway after Task_1 routes through Task_Service ONLY when the postCommit path is chosen; every
- * other path goes straight to Task_2. Task_1 has a form of "levers" that two app hooks read to
- * control the forward transition. The levers describe a scenario:
+ * The app is Task_1 (data) -> gateway -> [Task_Service (service task) -> gateway ->] Task_2 (data)
+ * -> gateway -> EndEvent, where Task_2's reject action routes back to Task_1 (backwards
+ * navigation) and Task_Service's reject action routes back to Task_1 as well (backing out of a
+ * failed service task from its failure view). The gateway after Task_1 routes through Task_Service
+ * ONLY when the postCommit path is chosen; every other path goes straight to Task_2. Task_1 has a
+ * form of "levers" that two app hooks read to control the forward transition. The levers describe
+ * a scenario:
  *   - path       WHERE the transition misbehaves: "none" (clean), "preCommit" (fail before the
  *                Storage commit, committed=Task_1) or "postCommit" (fail after it,
  *                committed=Task_Service).
  *   - delayMs    a delay injected on every attempt, regardless of attempts/end state.
  *   - attempts   how many times the engine tries the transition; every attempt but the last fails
  *                transiently (auto-retried), and the last settles on endState. attempts=1 => no retry.
- *   - endState   what happens on the last attempt: "success" (transition completes) or
- *                "failure" (terminal failure -> error page).
+ *   - endState   what happens on the last attempt: "success" (transition completes), "failure"
+ *                (terminal failure -> error page; every replay fails the same way) or
+ *                "failureThenSuccess" (terminal failure once, then success when the failed step
+ *                is re-run via process/resume - i.e. the failed task view's "Prøv igjen").
  *
  * The two hooks:
  *   - preCommit: an IOnTaskEndingHandler runs the scenario PRE-commit (committed=Task_1), so the
@@ -40,14 +44,17 @@ const appFrontend = new AppFrontend();
  *                 engine already exhausted its retry budget, so the page is static until a refresh.
  *                 EXCEPTION: a failure owned by the current service task renders the service task's
  *                 own view instead (same heading, but WITH "Prøv igjen"/"Gå tilbake" recovery
- *                 buttons) — see the failed (post-commit) test.
+ *                 buttons) — see the failed (post-commit) test. "Prøv igjen" resumes the failed
+ *                 workflow (POST process/resume — a plain process/next is 409-blocked while the
+ *                 workflow is failed) and "Gå tilbake" rejects back to Task_1 — see the two
+ *                 recovery tests.
  */
 
 type Levers = {
   path?: 'none' | 'preCommit' | 'postCommit';
   delayMs?: 0 | 3000 | 8000 | 15000 | 30000;
   attempts?: 1 | 2 | 3 | 5;
-  endState?: 'success' | 'failure';
+  endState?: 'success' | 'failure' | 'failureThenSuccess';
 };
 
 // Button labels from the app's resource.nb.json: Task_1 advances with "Gå til Task 2", Task_2
@@ -81,6 +88,7 @@ const leverLabels = {
   endState: {
     success: 'Suksess – overgangen fullføres',
     failure: 'Feil – behandlingen stopper og feilsiden vises',
+    failureThenSuccess: 'Feil, så suksess – behandlingen stopper, men «Prøv igjen» lykkes',
   },
 } as const;
 
@@ -227,11 +235,12 @@ describe('Live workflow status (real engine)', () => {
 
     // A failure OWNED by the current service task (workflow.targetTask === committed service task)
     // does not use the terminal error page: it renders the service task's own view, which keeps the
-    // recovery affordances. Same heading text, but WITH a retry button - the generic failed page
-    // deliberately has none (cf. the pre-commit failed test above).
+    // recovery affordances. Same heading text, but WITH retry/back buttons - the generic failed
+    // page deliberately has none (cf. the pre-commit failed test above).
     cy.findByRole('heading', { name: 'Noe gikk galt', timeout: 30000 }).should('be.visible');
     cy.contains('En feil oppstod under automatisk behandling av skjemaet.').should('be.visible');
     cy.findByRole('button', { name: 'Prøv igjen' }).should('be.visible');
+    cy.findByRole('button', { name: 'Gå tilbake' }).should('be.visible');
 
     // Stale-url guard (ProcessWrapper regression): load the OLD Task_1 url while Storage has already
     // committed currentTask forward to Task_Service. The wrong-task guard must not bury the failure
@@ -242,6 +251,49 @@ describe('Live workflow status (real engine)', () => {
     cy.findByRole('button', { name: 'Prøv igjen' }).should('be.visible');
     cy.contains('Denne delen av skjemaet er ikke tilgjengelig').should('not.exist');
     cy.findByRole('button', { name: task1AdvanceButton }).should('not.exist');
+  });
+
+  it('recovery (post-commit): "Prøv igjen" resumes the failed workflow and advances to Task_2', () => {
+    cy.startAppInstance(appFrontend.apps.processTransitionTest, { cyUser: 'manager' });
+    // failureThenSuccess: the single attempt fails permanently, but the service task keeps its
+    // attempt counter, so the resume-driven replay of the failed step succeeds.
+    fillLevers({ path: 'postCommit', attempts: 1, endState: 'failureThenSuccess' });
+
+    cy.findByRole('button', { name: task1AdvanceButton }).click();
+    cy.findByRole('heading', { name: 'Noe gikk galt', timeout: 30000 }).should('be.visible');
+
+    // "Prøv igjen" must NOT be a plain process/next (that is 409-blocked while the workflow is
+    // failed): it resumes the failed workflow (POST process/resume), the engine re-runs the failed
+    // step, the service task succeeds this time and auto-advances - and the page navigates onto the
+    // committed Task_2 without a reload.
+    cy.findByRole('button', { name: 'Prøv igjen' }).click();
+    cy.findByRole('heading', { name: /Task 2/, timeout: 45000 }).should('be.visible');
+    cy.contains('Denne delen av skjemaet er ikke tilgjengelig').should('not.exist');
+    cy.get('#finishedLoading').should('exist');
+    cy.findByRole('button', { name: task2SubmitButton }).should('be.visible');
+  });
+
+  it('recovery (post-commit): "Gå tilbake" rejects the failed service task back to Task_1', () => {
+    cy.startAppInstance(appFrontend.apps.processTransitionTest, { cyUser: 'manager' });
+    fillLevers({ path: 'postCommit', attempts: 1, endState: 'failure' });
+
+    cy.findByRole('button', { name: task1AdvanceButton }).click();
+    cy.findByRole('heading', { name: 'Noe gikk galt', timeout: 30000 }).should('be.visible');
+
+    // Backing out: the bpmn-allowed reject supersedes the terminally failed workflow (the engine
+    // writes it off) and Gateway_Service routes the reject back to Task_1, where the levers are
+    // editable again.
+    cy.findByRole('button', { name: 'Gå tilbake' }).click();
+    cy.findByRole('heading', { name: /Task 1/, timeout: 30000 }).should('be.visible');
+    cy.get('#finishedLoading').should('exist');
+
+    // The failure lever is still selected (the data lives on Task_1); flip the scenario to a clean
+    // run and the resubmission goes through the service task to Task_2.
+    cy.get('#endState').should('have.value', leverLabels.endState.failure);
+    fillLevers({ endState: 'success' });
+    cy.findByRole('button', { name: task1AdvanceButton }).click();
+    cy.findByRole('heading', { name: /Task 2/, timeout: 45000 }).should('be.visible');
+    cy.get('#finishedLoading').should('exist');
   });
 
   it('retryable (pre-commit): engine auto-retries to success, no manual retry needed', () => {

--- a/src/test/apps/process-transition-test/App/config/process/process.bpmn
+++ b/src/test/apps/process-transition-test/App/config/process/process.bpmn
@@ -12,6 +12,7 @@
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_Start_Task1</bpmn:incoming>
       <bpmn:incoming>Flow_Gateway_Task1</bpmn:incoming>
+      <bpmn:incoming>Flow_GatewayS_Task1</bpmn:incoming>
       <bpmn:outgoing>Flow_Task1_GatewayPC</bpmn:outgoing>
     </bpmn:task>
     <!-- Routes the forward transition through the scenario service task ONLY when the postCommit
@@ -29,15 +30,27 @@
       <bpmn:outgoing>Flow_GatewayPC_Service</bpmn:outgoing>
       <bpmn:outgoing>Flow_GatewayPC_Task2</bpmn:outgoing>
     </bpmn:exclusiveGateway>
+    <!-- 'reject' lets the user abandon the service task from its failure view ("Gå tilbake"):
+         the engine writes the failed workflow off and the reject transition routes back to
+         Task_1 via Gateway_Service. The forward path (success auto-advance, and the user's
+         resume-driven retry) exits the same gateway towards Task_2. -->
     <bpmn:serviceTask id="Task_Service" name="Behandling">
       <bpmn:extensionElements>
         <altinn:taskExtension>
           <altinn:taskType>scenario</altinn:taskType>
+          <altinn:actions>
+            <altinn:action>reject</altinn:action>
+          </altinn:actions>
         </altinn:taskExtension>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_GatewayPC_Service</bpmn:incoming>
-      <bpmn:outgoing>Flow_Service_Task2</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Service_GatewayS</bpmn:outgoing>
     </bpmn:serviceTask>
+    <bpmn:exclusiveGateway id="Gateway_Service">
+      <bpmn:incoming>Flow_Service_GatewayS</bpmn:incoming>
+      <bpmn:outgoing>Flow_GatewayS_Task1</bpmn:outgoing>
+      <bpmn:outgoing>Flow_GatewayS_Task2</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
     <bpmn:task id="Task_2" name="Task 2">
       <bpmn:extensionElements>
         <altinn:taskExtension>
@@ -48,7 +61,7 @@
         </altinn:taskExtension>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_GatewayPC_Task2</bpmn:incoming>
-      <bpmn:incoming>Flow_Service_Task2</bpmn:incoming>
+      <bpmn:incoming>Flow_GatewayS_Task2</bpmn:incoming>
       <bpmn:outgoing>Flow_Task2_Gateway</bpmn:outgoing>
     </bpmn:task>
     <bpmn:exclusiveGateway id="Gateway_1">
@@ -67,7 +80,13 @@
     <bpmn:sequenceFlow id="Flow_GatewayPC_Task2" sourceRef="Gateway_PostCommit" targetRef="Task_2">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">["notEquals", ["dataModel", "path"], "postCommit"]</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_Service_Task2" sourceRef="Task_Service" targetRef="Task_2" />
+    <bpmn:sequenceFlow id="Flow_Service_GatewayS" sourceRef="Task_Service" targetRef="Gateway_Service" />
+    <bpmn:sequenceFlow id="Flow_GatewayS_Task1" sourceRef="Gateway_Service" targetRef="Task_1">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">["equals", ["gatewayAction"], "reject"]</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_GatewayS_Task2" sourceRef="Gateway_Service" targetRef="Task_2">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">["notEquals", ["gatewayAction"], "reject"]</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_Task2_Gateway" sourceRef="Task_2" targetRef="Gateway_1" />
     <bpmn:sequenceFlow id="Flow_Gateway_Task1" sourceRef="Gateway_1" targetRef="Task_1">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">["equals", ["gatewayAction"], "reject"]</bpmn:conditionExpression>
@@ -89,6 +108,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Task_Service_di" bpmnElement="Task_Service">
         <dc:Bounds x="395" y="-40" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_Service_di" bpmnElement="Gateway_Service">
+        <dc:Bounds x="525" y="-25" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Task_2_di" bpmnElement="Task_2">
         <dc:Bounds x="500" y="81" width="100" height="80" />
@@ -115,9 +137,18 @@
         <di:waypoint x="470" y="121" />
         <di:waypoint x="500" y="121" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_Service_Task2_di" bpmnElement="Flow_Service_Task2">
+      <bpmndi:BPMNEdge id="Flow_Service_GatewayS_di" bpmnElement="Flow_Service_GatewayS">
         <di:waypoint x="495" y="0" />
-        <di:waypoint x="550" y="0" />
+        <di:waypoint x="525" y="0" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_GatewayS_Task1_di" bpmnElement="Flow_GatewayS_Task1">
+        <di:waypoint x="550" y="-25" />
+        <di:waypoint x="550" y="-70" />
+        <di:waypoint x="330" y="-70" />
+        <di:waypoint x="330" y="81" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_GatewayS_Task2_di" bpmnElement="Flow_GatewayS_Task2">
+        <di:waypoint x="550" y="25" />
         <di:waypoint x="550" y="81" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_Task2_Gateway_di" bpmnElement="Flow_Task2_Gateway">

--- a/src/test/apps/process-transition-test/App/config/texts/resource.nb.json
+++ b/src/test/apps/process-transition-test/App/config/texts/resource.nb.json
@@ -114,6 +114,10 @@
       "value": "Feil – behandlingen stopper og feilsiden vises"
     },
     {
+      "id": "endState.failureThenSuccess",
+      "value": "Feil, så suksess – behandlingen stopper, men «Prøv igjen» lykkes"
+    },
+    {
       "id": "Task1.hint.title",
       "value": "Tips: prøv å laste siden på nytt underveis"
     },

--- a/src/test/apps/process-transition-test/App/logic/ScenarioServiceTask.cs
+++ b/src/test/apps/process-transition-test/App/logic/ScenarioServiceTask.cs
@@ -23,9 +23,12 @@ namespace Altinn.App.Logic;
 ///
 /// Scenario shape: run <c>attempts</c> times with <c>delayMs</c> injected on each; every attempt
 /// but the last fails retryably (the engine auto-retries), and the last settles on
-/// <c>endState</c> — either <c>success</c> (auto-advance to Task_2) or <c>failure</c> (permanent
-/// failure → error page). Unlike the retired IEventsClient hack, a permanent service-task failure
-/// is a REAL terminal failure — no workflow-cancellation cheat needed.
+/// <c>endState</c> — <c>success</c> (auto-advance to Task_2), <c>failure</c> (permanent
+/// failure → error page, and every replay fails the same way), or <c>failureThenSuccess</c>
+/// (permanent failure once, then success when the failed step is re-run — the lever that makes
+/// the failed task view's "Prøv igjen" → process/resume recovery demonstrable). Unlike the
+/// retired IEventsClient hack, a permanent service-task failure is a REAL terminal failure — no
+/// workflow-cancellation cheat needed.
 /// </summary>
 public sealed class ScenarioServiceTask : IServiceTask
 {
@@ -52,7 +55,6 @@ public sealed class ScenarioServiceTask : IServiceTask
 
         int delayMs = levers.delayMs ?? 0;
         int attempts = levers.attempts ?? 1;
-        bool endInFailure = levers.endState == "failure";
 
         if (delayMs > 0)
         {
@@ -69,10 +71,21 @@ public sealed class ScenarioServiceTask : IServiceTask
             );
         }
 
-        // Last attempt: settle on the configured end state. Reset first so replaying the scenario
-        // (e.g. after navigating back from Task_2) starts again from attempt 1.
+        // First settling attempt with "failureThenSuccess": fail permanently but KEEP the attempt
+        // counter, so the resume-driven replay (the failed task view's "Prøv igjen" →
+        // process/resume re-running this step) arrives here as attempt attempts+1 and falls
+        // through to the success below.
+        if (levers.endState == "failureThenSuccess" && attempt == attempts)
+        {
+            return ServiceTaskResult.FailedPermanent(
+                $"TransitionControl forced a terminal postCommit failure after {attempts} attempt{(attempts == 1 ? "" : "s")} (recoverable: the next replay succeeds)."
+            );
+        }
+
+        // Settled: reset so replaying the scenario (e.g. after navigating back from Task_2) starts
+        // again from attempt 1. "failure" resets too — every replay fails the same way.
         AttemptTracker.Reset(instanceGuid, "postCommit");
-        return endInFailure
+        return levers.endState == "failure"
             ? ServiceTaskResult.FailedPermanent(
                 $"TransitionControl forced a terminal postCommit failure after {attempts} attempt{(attempts == 1 ? "" : "s")}."
             )

--- a/src/test/apps/process-transition-test/App/logic/TaskEndingHandler.cs
+++ b/src/test/apps/process-transition-test/App/logic/TaskEndingHandler.cs
@@ -19,7 +19,10 @@ namespace Altinn.App.Logic;
 ///
 /// Scenario shape: run <c>attempts</c> times with <c>delayMs</c> injected on each; every attempt but
 /// the last fails retryably (the engine auto-retries), and the last settles on <c>endState</c> —
-/// either <c>success</c> (transition completes) or <c>failure</c> (permanent failure → error page).
+/// <c>success</c> (transition completes), <c>failure</c> (permanent failure → error page, and every
+/// replay fails the same way), or <c>failureThenSuccess</c> (permanent failure once, then success
+/// when the failed step is re-run; on this pre-commit path there is no user-facing retry, so the
+/// replay comes from an ops-driven resume).
 /// </summary>
 public sealed class TaskEndingHandler : IOnTaskEndingHandler
 {
@@ -44,7 +47,6 @@ public sealed class TaskEndingHandler : IOnTaskEndingHandler
 
         int delayMs = levers.delayMs ?? 0;
         int attempts = levers.attempts ?? 1;
-        bool endInFailure = levers.endState == "failure";
 
         if (delayMs > 0)
         {
@@ -61,10 +63,20 @@ public sealed class TaskEndingHandler : IOnTaskEndingHandler
             );
         }
 
-        // Last attempt: settle on the configured end state. Reset first so replaying the scenario
-        // (e.g. after navigating back from Task_2) starts again from attempt 1.
+        // First settling attempt with "failureThenSuccess": fail permanently but KEEP the attempt
+        // counter, so a resume-driven replay of the failed step arrives here as attempt attempts+1
+        // and falls through to the success below.
+        if (levers.endState == "failureThenSuccess" && attempt == attempts)
+        {
+            return HookResult.FailedPermanent(
+                $"TransitionControl forced a terminal preCommit failure after {attempts} attempt{(attempts == 1 ? "" : "s")} (recoverable: the next replay succeeds)."
+            );
+        }
+
+        // Settled: reset so replaying the scenario (e.g. after navigating back from Task_2) starts
+        // again from attempt 1. "failure" resets too — every replay fails the same way.
         AttemptTracker.Reset(instanceGuid, "preCommit");
-        return endInFailure
+        return levers.endState == "failure"
             ? HookResult.FailedPermanent(
                 $"TransitionControl forced a terminal preCommit failure after {attempts} attempt{(attempts == 1 ? "" : "s")}."
             )

--- a/src/test/apps/process-transition-test/App/models/TransitionControl.cs
+++ b/src/test/apps/process-transition-test/App/models/TransitionControl.cs
@@ -30,8 +30,10 @@ namespace Altinn.App.Models.TransitionControl
         [JsonPropertyName("attempts")]
         public int? attempts { get; set; }
 
-        /// <summary>What happens on the last attempt: "success" (transition completes) or "failure"
-        /// (terminal failure, error page). Only meaningful on an error path.</summary>
+        /// <summary>What happens on the last attempt: "success" (transition completes), "failure"
+        /// (terminal failure, error page; every replay fails the same way) or "failureThenSuccess"
+        /// (terminal failure once, then success when the failed step is re-run via resume). Only
+        /// meaningful on an error path.</summary>
         [XmlElement("endState", Order = 4)]
         [JsonProperty("endState")]
         [JsonPropertyName("endState")]

--- a/src/test/apps/process-transition-test/App/ui/Task_1/layouts/Side1.json
+++ b/src/test/apps/process-transition-test/App/ui/Task_1/layouts/Side1.json
@@ -157,6 +157,10 @@
           {
             "value": "failure",
             "label": "endState.failure"
+          },
+          {
+            "value": "failureThenSuccess",
+            "label": "endState.failureThenSuccess"
           }
         ],
         "textResourceBindings": {


### PR DESCRIPTION
Stacked on #19515 (base: `feat/workflow-engine-noncritical-side-effects`).

## Problem

The default service-task failure view's **"Prøv igjen"** button still issues a plain `PUT process/next`. That contract comes from v8, where a service task executed synchronously *inside* process/next while the process was parked on it — so another process/next literally meant "run `Execute()` again". Under the v9 engine the service task is a post-commit step of an async workflow; when it fails terminally the app blocks process/next with **409 `resumeRequired`**, and the frontend deliberately swallows that body — so the button spins and silently does nothing.

## Fix

**Retry = resume.** When the workflow failure is owned by the current service task (`useIsWorkflowFailedOnCurrentServiceTask`), the retry button now calls **`POST process/resume`** → `IProcessEngine.ResumeCurrentTask` → the engine re-runs the failed step in place (cascade) — the exact v9 analogue of the v8 retry. A parked-but-not-failed service task keeps using `process/next` (still the correct advance trigger there).

- New `useProcessResume` mutation mirrors `useProcessNext`'s convergence rules: blocked (`retrying`) and failed-again (`workflowFailure`) responses refetch and hand rendering to the workflow state machine; anything else toasts. Shares `useProcessNext`'s mutation *scope* (retry/reject can't race) but not its mutation *key* (the failed view must stay mounted with a button spinner, not trip ProcessWrapper's full-screen loader).
- On success the mutation refetches the instance and navigates to the settled task explicitly — polling is deliberately off in the failed state, so nothing else would converge.

## Test app: reject flow + demonstrable recovery

- `Task_Service` now allows the bpmn **`reject`** action and exits via a new `Gateway_Service`: reject → back to `Task_1` (the failure view's "Gå tilbake", superseding the failed workflow), otherwise → `Task_2` as before. Policy already granted `reject`; the auto-advance-through-gateway pattern matches the `service-task` fixture app.
- New `endState` lever **`failureThenSuccess`**: the settling attempt fails permanently but keeps the attempt counter, so the resume-driven replay succeeds — making the "Prøv igjen" recovery reproducible manually and in e2e. Plain `failure` keeps failing on every replay (unchanged semantics).

## Related
- Closes #19619

## Tests

- New `ServiceTask.test.tsx` (3 tests): failed-owned retry hits `doProcessResume` (never `doProcessNext`); parked retry hits `doProcessNext`; a resume that fails again converges via refetch without toasting (window.logError-throws harness proves the error path isn't taken).
- Two new real-engine e2e tests in `workflow-status.ts`: retry-resume to Task_2, and reject back to Task_1 + clean resubmission.
- `yarn tsc` ✅, `yarn lint` ✅ (0 errors), `yarn test -- ServiceTask useProcessNext ProcessWrapper` ✅ (20 tests), test app `dotnet build` ✅. The new e2e tests have **not** been run against a live engine yet.

## Open questions for review

- The retry button still gates on the `write` user action (as before). Server-side, resume authorizes via `AuthorizeProcessNext(action: null)`, which for a custom task type falls back to the task-type action (`scenario` here) — the gate and the server check can theoretically disagree for exotic policies.
- `WorkflowFailed`'s "recovery is ops-driven" wording still holds for failures *not* owned by a task view; the wire-type comments were updated to reflect the user-driven variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Prøv igjen” recovery option for workflows that fail on the current service task.
  - Failed workflows can now be resumed and automatically continue to the appropriate task after successful recovery.
  - Added “Gå tilbake” support for returning to the previous task in applicable failure scenarios.
  - Added a test scenario where a failed workflow succeeds when resumed.

- **Bug Fixes**
  - Improved error handling and state updates during workflow recovery.

- **Tests**
  - Added coverage for retry, resume, failure, and recovery flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->