### PR TITLE
refactor: move InstanceInformation layout compoenent to lib

### DIFF
--- a/app-libs/form-component/src/layout-components/InstanceInformation/InstanceInformation.mdx
+++ b/app-libs/form-component/src/layout-components/InstanceInformation/InstanceInformation.mdx
@@ -1,0 +1,9 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+import { LayoutComponentDocs } from '../common/storybook';
+import * as InstanceInformationStories from './InstanceInformation.stories';
+import { INSTANCE_INFORMATION_PROP_CATEGORIES } from './InstanceInformation.stories';
+
+<Meta of={InstanceInformationStories} />
+
+<LayoutComponentDocs categories={INSTANCE_INFORMATION_PROP_CATEGORIES} />

--- a/app-libs/form-component/src/layout-components/InstanceInformation/InstanceInformation.module.css
+++ b/app-libs/form-component/src/layout-components/InstanceInformation/InstanceInformation.module.css
@@ -1,0 +1,23 @@
+.table {
+  border: 0;
+  margin: 36px 0 0;
+  padding: 0;
+  width: auto;
+  height: auto;
+}
+
+@media print {
+  .table {
+    margin-bottom: 1.25rem;
+  }
+}
+
+.table td {
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+}
+
+.key {
+  padding-right: 1.5625rem;
+}

--- a/app-libs/form-component/src/layout-components/InstanceInformation/InstanceInformation.stories.tsx
+++ b/app-libs/form-component/src/layout-components/InstanceInformation/InstanceInformation.stories.tsx
@@ -1,0 +1,55 @@
+import type { PropCategories } from '@app/form-component/layout-components/common/storybook';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { InstanceInformation } from './InstanceInformation';
+import type { InstanceInformationProps } from './InstanceInformation';
+
+export const INSTANCE_INFORMATION_PROP_CATEGORIES = {
+  title: 'text',
+  description: 'text',
+  help: 'text',
+  componentId: 'content',
+  labelGrid: 'content',
+  innerGrid: 'content',
+  summaryDataObject: 'runtime',
+} satisfies PropCategories<InstanceInformationProps>;
+
+const exampleSummary = {
+  'Dato sendt': { value: '23.07.2026 10:32', hideFromVisualTesting: true },
+  Avsender: { value: '12345678901-Ola Nordmann' },
+  Mottaker: { value: 'Digdir' },
+  Referansenummer: { value: 'a1b2c3d4', hideFromVisualTesting: true },
+};
+
+const meta = {
+  title: 'LayoutComponents/InstanceInformation',
+  component: InstanceInformation,
+  excludeStories: ['INSTANCE_INFORMATION_PROP_CATEGORIES'],
+  parameters: {
+    layout: 'padded',
+  },
+  args: {
+    componentId: 'instance-information-preview',
+    title: 'Informasjon om innsendingen',
+    summaryDataObject: exampleSummary,
+  },
+} satisfies Meta<typeof InstanceInformation>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Preview: Story = {};
+
+export const WithDescriptionAndHelp: Story = {
+  args: {
+    description: 'Disse opplysningene er hentet fra innsendingen.',
+    help: 'Referansenummeret kan brukes hvis du kontakter etaten.',
+  },
+};
+
+export const WithoutTitle: Story = {
+  args: {
+    title: undefined,
+  },
+};

--- a/app-libs/form-component/src/layout-components/InstanceInformation/InstanceInformation.test.tsx
+++ b/app-libs/form-component/src/layout-components/InstanceInformation/InstanceInformation.test.tsx
@@ -1,0 +1,62 @@
+import { renderWithTranslations } from '@app/form-component/test/renderWithTranslations';
+import { screen } from '@testing-library/react';
+
+import { InstanceInformation } from './InstanceInformation';
+
+const summary = {
+  Avsender: { value: 'Ola Nordmann' },
+  Mottaker: { value: 'Digdir' },
+  'Dato sendt': { value: '23.07.2026', hideFromVisualTesting: true },
+};
+
+describe('InstanceInformation', () => {
+  it('renders summary rows for the given data', () => {
+    renderWithTranslations(<InstanceInformation componentId='ii-1' summaryDataObject={summary} />);
+    expect(screen.getByText('Avsender:')).toBeInTheDocument();
+    expect(screen.getByText('Ola Nordmann')).toBeInTheDocument();
+    expect(screen.getByText('Mottaker:')).toBeInTheDocument();
+    expect(screen.getByText('Digdir')).toBeInTheDocument();
+  });
+
+  it('marks rows that should be hidden from visual testing', () => {
+    const { container } = renderWithTranslations(
+      <InstanceInformation componentId='ii-1' summaryDataObject={summary} />,
+    );
+    const hiddenCell = container.querySelector('.no-visual-testing');
+    expect(hiddenCell).toHaveTextContent('23.07.2026');
+  });
+
+  it('renders the form-content wrapper for the given componentId', () => {
+    renderWithTranslations(<InstanceInformation componentId='ii-1' summaryDataObject={summary} />);
+    expect(document.getElementById('form-content-ii-1')).toBeInTheDocument();
+  });
+
+  it('renders a fieldset legend when a title key is supplied', () => {
+    renderWithTranslations(
+      <InstanceInformation componentId='ii-1' title='my.title' summaryDataObject={summary} />,
+      { overrides: { 'my.title': 'Informasjon om innsendingen' } },
+    );
+    expect(screen.getByText('Informasjon om innsendingen')).toBeInTheDocument();
+  });
+
+  it('renders description and help when keys are supplied', () => {
+    renderWithTranslations(
+      <InstanceInformation
+        componentId='ii-1'
+        title='my.title'
+        description='my.desc'
+        help='my.help'
+        summaryDataObject={summary}
+      />,
+      {
+        overrides: {
+          'my.title': 'Informasjon',
+          'my.desc': 'Hentet fra innsendingen',
+          'my.help': 'Bruk referansen ved kontakt',
+        },
+      },
+    );
+    expect(screen.getByText('Hentet fra innsendingen')).toBeInTheDocument();
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+});

--- a/app-libs/form-component/src/layout-components/InstanceInformation/InstanceInformation.tsx
+++ b/app-libs/form-component/src/layout-components/InstanceInformation/InstanceInformation.tsx
@@ -1,0 +1,84 @@
+import type { ReactNode } from 'react';
+
+import { Fieldset } from '@app/form-component/app-components';
+import { useTranslation } from '@app/form-component/LanguageTranslatorProvider';
+import { ComponentStructure } from '@app/form-component/layout-components/common/ComponentStructure';
+import { Description } from '@app/form-component/layout-components/common/Description';
+import { HelpTextContainer } from '@app/form-component/layout-components/common/HelpTextContainer';
+import cn from 'classnames';
+import type { IGridStyling } from '@app/form-component/app-components/Flex';
+
+import classes from './InstanceInformation.module.css';
+
+export type InstanceSummaryDataObject = {
+  [name: string]: {
+    value: string | boolean | number | null | undefined;
+    hideFromVisualTesting?: boolean;
+  };
+};
+
+export interface InstanceInformationProps {
+  summaryDataObject: InstanceSummaryDataObject;
+  componentId?: string;
+  title?: string;
+  description?: string;
+  help?: string;
+  labelGrid?: IGridStyling;
+  innerGrid?: IGridStyling;
+}
+
+function SummaryTable({ summaryDataObject }: { summaryDataObject: InstanceSummaryDataObject }) {
+  return (
+    <table className={classes.table}>
+      <tbody>
+        {Object.entries(summaryDataObject).map(([key, value]) => (
+          <tr key={key}>
+            <td className={classes.key}>{key}:</td>
+            <td className={cn({ ['no-visual-testing']: value.hideFromVisualTesting })}>
+              {value.value}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+export function InstanceInformation({
+  componentId,
+  summaryDataObject,
+  title,
+  description,
+  help,
+  labelGrid,
+  innerGrid,
+}: InstanceInformationProps) {
+  const { lang, langAsString } = useTranslation();
+
+  const table = <SummaryTable summaryDataObject={summaryDataObject} />;
+  const content = componentId ? (
+    <ComponentStructure componentId={componentId} innerGrid={innerGrid}>
+      {table}
+    </ComponentStructure>
+  ) : (
+    table
+  );
+
+  if (!title && !description && !help) {
+    return content;
+  }
+
+  const legendNode: ReactNode = title ? <>{lang(title)}</> : undefined;
+  const descriptionNode = description ? (
+    <Description componentId={componentId} description={lang(description)} />
+  ) : undefined;
+  const helpNode = help ? (
+    <HelpTextContainer id={componentId} title={langAsString(title)} helpText={lang(help)} />
+  ) : undefined;
+
+  return (
+    <Fieldset grid={labelGrid} legend={legendNode} description={descriptionNode} help={helpNode}>
+      {content}
+    </Fieldset>
+  );
+}

--- a/app-libs/form-component/src/layout-components/InstanceInformation/index.ts
+++ b/app-libs/form-component/src/layout-components/InstanceInformation/index.ts
@@ -1,0 +1,2 @@
+export { InstanceInformation } from './InstanceInformation';
+export type { InstanceInformationProps, InstanceSummaryDataObject } from './InstanceInformation';

--- a/app-libs/form-component/src/layout-components/index.ts
+++ b/app-libs/form-component/src/layout-components/index.ts
@@ -9,6 +9,7 @@ export * from './Header';
 export * from './IFrame';
 export * from './ImageUpload';
 export * from './Image';
+export * from './InstanceInformation';
 export * from './Link';
 export * from './Paragraph';
 export * from './Tabs';

--- a/src/App/frontend/src/layout/InstanceInformation/InstanceInformationComponent.tsx
+++ b/src/App/frontend/src/layout/InstanceInformation/InstanceInformationComponent.tsx
@@ -1,20 +1,18 @@
 import React from 'react';
 
-import { Fieldset, PrettyDateAndTime } from '@app/form-component';
+import { InstanceInformation as InstanceInformationLayout, PrettyDateAndTime } from '@app/form-component';
 import { formatDate, formatISO } from 'date-fns';
+import type { InstanceSummaryDataObject } from '@app/form-component';
 
 import type { PropsFromGenericComponent } from '..';
 
-import { AltinnSummaryTable } from 'src/components/table/AltinnSummaryTable';
 import { useAppReceiver } from 'src/core/texts/appTexts';
 import { useInstanceDataQuery, useLaxInstanceId } from 'src/features/instance/InstanceContext';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { useInstanceOwnerParty } from 'src/features/party/PartiesProvider';
-import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import { toTimeZonedDate } from 'src/utils/dateUtils';
-import { useExternalItem } from 'src/utils/layout/hooks';
-import { useLabel } from 'src/utils/layout/useLabel';
-import type { SummaryDataObject } from 'src/components/table/AltinnSummaryTable';
+import { useComponentStructureData } from 'src/utils/layout/useComponentStructureData';
+import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { IUseLanguage } from 'src/features/language/useLanguage';
 import type { CompInternal } from 'src/layout/layout';
 
@@ -25,7 +23,7 @@ export const returnInstanceMetaDataObject = (
   instanceReceiver?: string | boolean | null | undefined,
   instanceReferenceNumber?: string | boolean | null | undefined,
 ) => {
-  const obj: SummaryDataObject = {};
+  const obj: InstanceSummaryDataObject = {};
   const { langAsString } = langTools;
 
   if (instanceDateSent) {
@@ -59,15 +57,12 @@ export const returnInstanceMetaDataObject = (
 
 export const getInstanceReferenceNumber = (instanceId: string): string => instanceId.split('/')[1].split('-')[4];
 
-export function InstanceInformation({ elements }: Pick<CompInternal<'InstanceInformation'>, 'elements'>) {
+function useInstanceSummaryData(elements: CompInternal<'InstanceInformation'>['elements']): InstanceSummaryDataObject {
   const { dateSent, sender, receiver, referenceNumber } = elements || {};
-
   const langTools = useLanguage();
-
   const lastChanged = useInstanceDataQuery({ select: (data) => data.lastChanged }).data;
   const instanceId = useLaxInstanceId();
   const appReceiver = useAppReceiver();
-
   const instanceOwnerParty = useInstanceOwnerParty();
 
   const instanceDateSent =
@@ -83,41 +78,50 @@ export function InstanceInformation({ elements }: Pick<CompInternal<'InstanceInf
 
   const instanceReferenceNumber = referenceNumber !== false && instanceId && getInstanceReferenceNumber(instanceId);
 
-  const instanceMetaDataObject = returnInstanceMetaDataObject(
+  return returnInstanceMetaDataObject(
     langTools,
     instanceDateSent,
     instanceSender,
     instanceReceiver,
     instanceReferenceNumber,
   );
+}
 
-  if (!instanceMetaDataObject) {
+export function InstanceInformation({ elements }: Pick<CompInternal<'InstanceInformation'>, 'elements'>) {
+  const summaryDataObject = useInstanceSummaryData(elements);
+
+  if (!summaryDataObject) {
     return null;
   }
 
-  return <AltinnSummaryTable summaryDataObject={instanceMetaDataObject} />;
+  return <InstanceInformationLayout summaryDataObject={summaryDataObject} />;
 }
 
 export function InstanceInformationComponent({
   baseComponentId,
   overrideDisplay,
 }: PropsFromGenericComponent<'InstanceInformation'>) {
-  const { grid, elements } = useExternalItem(baseComponentId, 'InstanceInformation');
-  const { labelText, getDescriptionComponent, getHelpTextComponent } = useLabel({
-    baseComponentId,
-    overrideDisplay,
-  });
+  const { grid, elements, textResourceBindings } = useItemWhenType(baseComponentId, 'InstanceInformation');
+  const { componentId, innerGrid } = useComponentStructureData(baseComponentId);
+  const summaryDataObject = useInstanceSummaryData(elements);
+
+  const renderLabel = overrideDisplay?.renderLabel ?? true;
+  const inTable = overrideDisplay?.renderedInTable === true;
+  const showLabel = renderLabel && !inTable;
+
+  if (!summaryDataObject) {
+    return null;
+  }
 
   return (
-    <Fieldset
-      grid={grid?.labelGrid}
-      legend={labelText}
-      description={getDescriptionComponent()}
-      help={getHelpTextComponent()}
-    >
-      <ComponentStructureWrapper baseComponentId={baseComponentId}>
-        <InstanceInformation elements={elements} />
-      </ComponentStructureWrapper>
-    </Fieldset>
+    <InstanceInformationLayout
+      componentId={componentId}
+      summaryDataObject={summaryDataObject}
+      title={showLabel ? textResourceBindings?.title : undefined}
+      description={showLabel ? textResourceBindings?.description : undefined}
+      help={showLabel ? textResourceBindings?.help : undefined}
+      labelGrid={grid?.labelGrid}
+      innerGrid={innerGrid}
+    />
   );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Moves the **InstanceInformation** layout component's presentational logic from app-frontend (`src/layout/InstanceInformation`) into `@app/form-component` (`layout-components/InstanceInformation`). 
**Lib** owns presentation: Fieldset (title/description/help), `ComponentStructure` for the `form-content` wrapper + `innerGrid`, and the summary table for resolved label/value rows. 
**Wrapper** (`InstanceInformationComponent.tsx`) only resolves runtime data (instance date, sender, receiver, reference number via instance/party hooks), builds `summaryDataObject`, and passes props into the lib component. 
Adds Storybook stories + docs (`INSTANCE_INFORMATION_PROP_CATEGORIES` / `LayoutComponentDocs`) and lib unit tests.

CLODES: #19627 

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an instance information component that displays summary details in a structured, printable table.
  * Added support for optional titles, descriptions and help text.
  * Added Storybook examples covering standard, descriptive and title-free presentations.

* **Documentation**
  * Added component documentation and property guidance.

* **Tests**
  * Added coverage for displayed values, dates, titles, descriptions, help text and accessibility-related structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->