### PR TITLE
chore: bump studioctl workflow-engine image to latest main build

### DIFF
--- a/src/Runtime/workflow-engine-app/README.md
+++ b/src/Runtime/workflow-engine-app/README.md
@@ -56,7 +56,7 @@ No Docker Compose setup needed — tests use Testcontainers for PostgreSQL and W
 
 ```yaml
 image: ghcr.io/altinn/altinn-studio/runtime-workflow-engine-app
-tag: "5b68c250a0"
+tag: "693d3e6cd3"
 ```
 
 > Passing `--dev-workflow-engine` instead **disables** that container and routes the engine binding to a local host process (so you can run it yourself with `dotnet run`). In that mode the pinned tag is not used — only the default `studioctl env up` consumes it.

--- a/src/cli/internal/config/config.yaml
+++ b/src/cli/internal/config/config.yaml
@@ -12,7 +12,7 @@ images:
       tag: "694406e93c"
     workflow-engine:
       image: ghcr.io/altinn/altinn-studio/runtime-workflow-engine-app
-      tag: "5b68c250a0"
+      tag: "693d3e6cd3"
     workflow-engine-db:
       image: postgres
       tag: "18.3"


### PR DESCRIPTION
## Description

Pins the `studioctl env up` workflow-engine image to `693d3e6cd3` — the main build from the #19595 merge (dashboard chains view) — superseding `5b68c250a0`. This also picks up the non-blocking side-effects chain work from #19515.

Image verified present on GHCR (linux/amd64 + linux/arm64):
`ghcr.io/altinn/altinn-studio/runtime-workflow-engine-app:693d3e6cd3`

Follows the precedent from #19391 (config pin + README example kept in sync).

## Verification

- [x] `docker manifest inspect` confirms the tag exists for both platforms
- [x] `go test ./internal/config/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the default runtime workflow engine container image to a newer version.
  - Updated the documented configuration example to match the new image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->