### PR TITLE
chore: release studioctl v0.1.0-preview.17

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -8,9 +8,15 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+## [0.1.0-preview.17] - 2026-07-23
+
 ### Added
 
 - Notify when a newer `studioctl` release is available. The check runs at most once every few hours, caches its result under the studioctl home directory, and prints a hint to run `studioctl self update`. It is skipped in CI, for non-interactive output, and can be disabled with `STUDIOCTL_NO_UPDATE_CHECK=1`.
+
+### Changed
+
+- Update workflow-engine image.
 
 ## [0.1.0-preview.16] - 2026-07-02
 


### PR DESCRIPTION
## Description

Promotes the studioctl `[Unreleased]` changelog to **v0.1.0-preview.17**.

This is the release-trigger PR (`release/studioctl` label + `src/cli/CHANGELOG.md` change) that ships the workflow-engine image bump to `693d3e6cd3` merged in #19630. That pin is embedded into the binary via `//go:embed config.yaml`, so it only reaches users on the embedded defaults through a new release — the current latest release (`v0.1.0-preview.16`) still carries the old `5b68c250a0` pin.

### Changelog contents promoted to preview.17

- **Added** — newer-release notification (already in Unreleased).
- **Changed** — Update workflow-engine image (added here to document #19630).

## Verification

- [x] Confirmed `origin/main` `config.yaml` pins `runtime-workflow-engine-app:693d3e6cd3`
- [x] Confirmed `v0.1.0-preview.16` predates #19630 and pins `5b68c250a0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 0.1.0-preview.17, dated 23 July 2026.
  * Documented notifications when a newer release is available.
  * Added details about an updated workflow-engine image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->