### PR TITLE
refactor: remove SubformPdfServiceTask's unreachable pre-generation cleanup

### DIFF
--- a/src/App/backend/src/Altinn.App.Core/Internal/Process/ProcessTasks/ServiceTasks/SubformPdfServiceTask.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/Process/ProcessTasks/ServiceTasks/SubformPdfServiceTask.cs
@@ -3,13 +3,21 @@ using Altinn.App.Core.Features.Process;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.Pdf;
 using Altinn.App.Core.Internal.Process.Elements.AltinnExtensionProperties;
-using Altinn.Platform.Storage.Interface.Enums;
 using Altinn.Platform.Storage.Interface.Models;
 using Microsoft.Extensions.Logging;
 using KeyValueEntry = Altinn.Platform.Storage.Interface.Models.KeyValueEntry;
 
 namespace Altinn.App.Core.Internal.Process.ProcessTasks.ServiceTasks;
 
+/// <summary>
+/// Generates one PDF per subform data element. There is deliberately no pre-generation cleanup
+/// here: stale PDFs from a previous visit to the task are removed by the CleanupGeneratedFromTask
+/// task-start command, and a failed attempt persists nothing (data changes commit only on callback
+/// success), so any element this task could see in its state-blob instance is already gone. The one
+/// remaining duplication window - a retry after a success the engine failed to record - cannot be
+/// closed from the blob (it predates the lost save) and is accepted until Storage-side idempotent
+/// aggregate mutations land (altinn-storage#1049).
+/// </summary>
 internal sealed class SubformPdfServiceTask(
     IProcessReader processReader,
     IPdfService pdfService,
@@ -30,9 +38,6 @@ internal sealed class SubformPdfServiceTask(
         string? filenameTextResourceKey = config.FilenameTextResourceKey;
         string subformComponentId = config.SubformComponentId;
         string subformDataTypeId = config.SubformDataTypeId;
-
-        // Clean up any existing PDFs from previous failed attempts
-        RemoveDataElementsGeneratedFromTask(context.InstanceDataMutator, taskId);
 
         List<DataElement> subformDataElements = instance.Data.Where(x => x.DataType == subformDataTypeId).ToList();
 
@@ -85,20 +90,5 @@ internal sealed class SubformPdfServiceTask(
         }
 
         return subformPdfConfiguration.Validate();
-    }
-
-    private static void RemoveDataElementsGeneratedFromTask(IInstanceDataMutator instanceDataMutator, string taskId)
-    {
-        Instance instance = instanceDataMutator.Instance;
-        var dataElements =
-            instance.Data?.Where(de =>
-                de.References?.Exists(r => r.ValueType == ReferenceType.Task && r.Value == taskId) is true
-            )
-            ?? [];
-
-        foreach (var dataElement in dataElements)
-        {
-            instanceDataMutator.RemoveDataElement(dataElement);
-        }
     }
 }

--- a/src/App/backend/test/Altinn.App.Core.Tests/Internal/Process/ServiceTasks/SubformPdfServiceTaskTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Internal/Process/ServiceTasks/SubformPdfServiceTaskTests.cs
@@ -164,28 +164,6 @@ public class SubformPdfServiceTaskTests
         await Assert.ThrowsAsync<ApplicationConfigException>(async () => await _serviceTask.Execute(context));
     }
 
-    // ===== CLEANUP TESTS =====
-
-    [Fact]
-    public async Task Execute_Should_RemoveDataElementsGeneratedFromTask()
-    {
-        // Arrange
-        SetupProcessReader();
-        var instance = CreateInstanceWithSubformDataAndPreviousPdfs();
-        var mutatorMock = new Mock<IInstanceDataMutator>();
-        mutatorMock.Setup(x => x.Instance).Returns(instance);
-        var context = new ServiceTaskContext { InstanceDataMutator = mutatorMock.Object, CancellationToken = default };
-
-        // Act
-        await _serviceTask.Execute(context);
-
-        // Assert - verify RemoveDataElement was called for data elements generated from this task
-        mutatorMock.Verify(
-            x => x.RemoveDataElement(It.Is<DataElementIdentifier>(id => id.Guid == PreviousPdfGuid)),
-            Times.Once
-        );
-    }
-
     // ===== METADATA TESTS =====
 
     [Fact]
@@ -424,40 +402,6 @@ public class SubformPdfServiceTaskTests
     // ===== INTEGRATION SCENARIOS =====
 
     [Fact]
-    public async Task Execute_Should_CleanupBeforePdfGeneration()
-    {
-        // Arrange
-        SetupProcessReader();
-        var instance = CreateInstanceWithSubformDataAndPreviousPdfs();
-        var mutatorMock = new Mock<IInstanceDataMutator>();
-        mutatorMock.Setup(x => x.Instance).Returns(instance);
-        var context = new ServiceTaskContext { InstanceDataMutator = mutatorMock.Object, CancellationToken = default };
-
-        // Act
-        await _serviceTask.Execute(context);
-
-        // Assert - cleanup should remove previously generated data elements
-        mutatorMock.Verify(
-            x => x.RemoveDataElement(It.Is<DataElementIdentifier>(id => id.Guid == PreviousPdfGuid)),
-            Times.Once
-        );
-
-        // And PDFs should be generated
-        _pdfServiceMock.Verify(
-            x =>
-                x.GenerateAndStoreSubformPdf(
-                    It.IsAny<IInstanceDataMutator>(),
-                    It.IsAny<string?>(),
-                    It.IsAny<SubformPdfContext>(),
-                    It.IsAny<List<KeyValueEntry>?>(),
-                    It.IsAny<StorageAuthenticationMethod?>(),
-                    It.IsAny<CancellationToken>()
-                ),
-            Times.Exactly(2)
-        );
-    }
-
-    [Fact]
     public async Task Execute_WithMultipleSubformDataElements_Should_PassCorrectMetadataForEach()
     {
         // Arrange
@@ -681,27 +625,6 @@ public class SubformPdfServiceTaskTests
             Data = new List<DataElement>
             {
                 new() { Id = "single-data-element", DataType = SubformDataTypeId },
-            },
-        };
-    }
-
-    private static readonly Guid PreviousPdfGuid = Guid.Parse("00000000-0000-0000-0000-000000000099");
-
-    private static Instance CreateInstanceWithSubformDataAndPreviousPdfs()
-    {
-        return new Instance
-        {
-            Process = new ProcessState { CurrentTask = new ProcessElementInfo { ElementId = "taskId" } },
-            Data = new List<DataElement>
-            {
-                new() { Id = "data-element-1", DataType = SubformDataTypeId },
-                new() { Id = "data-element-2", DataType = SubformDataTypeId },
-                new()
-                {
-                    Id = PreviousPdfGuid.ToString(),
-                    DataType = "ref-data-as-pdf",
-                    References = [new Reference { ValueType = ReferenceType.Task, Value = "taskId" }],
-                },
             },
         };
     }


### PR DESCRIPTION
## What

Downscoped from the original fresh-fetch cleanup approach after reviewing altinn-storage#1049 (see below). This is now a pure deletion: `SubformPdfServiceTask`'s private `RemoveDataElementsGeneratedFromTask` and its call are removed, with a class-doc note recording why no pre-generation cleanup exists.

## Why the cleanup is dead code in v9

- Stale PDFs from **previous visits** to the task are removed by `CleanupGeneratedFromTask` at task start (pre-commit, same transition) — including subform PDFs, which carry the same `GeneratedFrom`/`Task` reference.
- A **failed attempt** persists nothing: PDF writes go through the deferred `IInstanceDataMutator` unit of work and the callback controller saves only on success.
- Therefore the state-blob instance this cleanup reads can never contain an element it would remove.

The one genuine duplication window — an engine step retry after a success whose recording was lost — is invisible to the state blob by construction, so no blob-based cleanup can address it. Per team decision this edge is **accepted for now**: the real fix is altinn-storage#1049 (transactional aggregate instance mutations with `Idempotency-Key` + `If-Instance-Version-Match` replay), which makes the retried save a server-side idempotent replay of the original — no duplicate element, no client-side cleanup. Adoption (app-lib `CommitMutation` client, state-blob carrying `Instance-Version` + a per-step idempotency key, localtest parity) is tracked on #19280 section B and sequences naturally with the `IStorageClient` consolidation (ADR 007 / #19396).

This also settles the conflict flagged in #19280 (mirror `RemoveDataElementsGeneratedFromTask` per #18888's original plan vs. remove it per Altinn/app-lib-dotnet#1750): **remove**.

## Tests

- The two `SubformPdfServiceTaskTests` cases that pinned the in-task cleanup are deleted with it; the remaining 15 pass.
- Full Altinn.App.Core.Tests suite green locally (2803/2803).
- Sanity-checked separately that `CleanupGeneratedFromTask` covers subform and main PDFs alike: all `PdfService` paths tag `generatedFromTask`, and the subform-only metadata `Update` round-trip preserves `References` (the insert response includes them).

Related: eFormidling half of section B in #19642.

🤖 Generated with [Claude Code](https://claude.com/claude-code)