### PR TITLE
chore: release studioctl v0.1.0-preview.18

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -8,9 +8,12 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+## [0.1.0-preview.18] - 2026-07-24
+
 ### Added
 
 - Handle the v9 C# breaking changes in `studioctl app upgrade v9`: auto-fix package-version floors (NU1605), the `IServiceTask` namespace move, and the `IEFormidlingReceivers.GetEFormidlingReceivers` signature; warn (exit code `3`) about removed APIs that need manual porting — the legacy task event interfaces (`IProcessTaskStart`/`End`/`Abandon`, `ITaskEvents`), the reworked `ServiceTaskResult` factories, and legacy eFormidling code.
+- Warn in `studioctl app upgrade v9` about `feedback` tasks placed directly after a service task in the BPMN process. In v9 the process waits on the service task itself, so such feedback tasks are usually a leftover v8 waiting pattern that should be reviewed and removed manually.
 
 ## [0.1.0-preview.17] - 2026-07-23
 


### PR DESCRIPTION
Promotes the `[Unreleased]` changelog entries to `0.1.0-preview.18`. Merging this PR triggers the studioctl release workflow (label `release/studioctl`).

Ships the v8→v9 upgrade improvements:

- C# API breaking-change migrations/detections in `studioctl app upgrade v9` (#19540)
- Warning for `feedback` tasks placed directly after a service task in the BPMN process (#19636) — this one landed without a changelog entry, so the line is added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)