### PR TITLE
ci: require changelog entries for user-visible studioctl changes

### DIFF
--- a/.github/workflows/cli-changelog.yaml
+++ b/.github/workflows/cli-changelog.yaml
@@ -1,0 +1,49 @@
+name: CLI - Changelog entry
+
+# Requires PRs that change studioctl code to add an entry to src/cli/CHANGELOG.md
+# under [Unreleased], via the releaser's `validate-changelog` command. Apply the
+# 'skip-changelog' label to PRs with no user-visible change (refactors, test-only
+# or CI-only work); the labeled/unlabeled triggers re-evaluate the check when the
+# label is toggled. Markdown-only changes under src/cli do not trigger the check.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
+    paths:
+      - 'src/cli/**'
+      - '!src/cli/**/*.md'
+      - '.github/workflows/cli-changelog.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  require-changelog-entry:
+    name: Require studioctl changelog entry
+    if: ${{ !github.event.pull_request.draft && !contains(github.event.pull_request.labels.*.name, 'skip-changelog') }}
+    runs-on: self-hosted-single
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: 'src/tools/releaser/go.mod'
+          cache-dependency-path: src/tools/releaser/go.sum
+
+      - name: Validate studioctl changelog entry
+        working-directory: src/tools/releaser
+        run: |
+          go run . validate-changelog \
+            -component studioctl \
+            -base "${{ github.event.pull_request.base.sha }}" \
+            -head "${{ github.event.pull_request.head.sha }}"

--- a/src/cli/AGENTS.md
+++ b/src/cli/AGENTS.md
@@ -30,10 +30,11 @@ make test      # 6. Unit tests
 
 - **Every PR with a user-visible studioctl change** (new commands/flags, behavior changes,
   fixes, runtime image bumps) **must add an entry to `CHANGELOG.md`** under `## [Unreleased]`,
-  using the Keep a Changelog categories (Added/Changed/Fixed/…). CI only validates the
-  structure of changelogs a PR touches (`.github/workflows/changelog.yml`) — nothing fails
-  when the entry is missing entirely, so a forgotten entry ships silently in the next
-  release's notes.
+  using the Keep a Changelog categories (Added/Changed/Fixed/…). CI enforces this:
+  `.github/workflows/cli-changelog.yaml` fails PRs that change studioctl code without a new
+  `[Unreleased]` entry. For changes with no user-visible effect (refactors, test-only or
+  CI-only work), apply the `skip-changelog` label instead. The structure of any changed
+  changelog is validated separately (`.github/workflows/changelog.yml`).
 - Releases are changelog-promotion PRs: move `[Unreleased]` into a new `## [<version>] - <date>`
   section and label the PR `release/studioctl`; merging it triggers
   `.github/workflows/release-studioctl.yaml`. Use `src/tools/releaser`

--- a/src/cli/AGENTS.md
+++ b/src/cli/AGENTS.md
@@ -26,6 +26,20 @@ make test      # 6. Unit tests
 - Avoid nolint, the bar should be high
 - Respect fieldalignment lints (`make lint-fix` auto-corrects struct field ordering)
 
+### Changelog & releases
+
+- **Every PR with a user-visible studioctl change** (new commands/flags, behavior changes,
+  fixes, runtime image bumps) **must add an entry to `CHANGELOG.md`** under `## [Unreleased]`,
+  using the Keep a Changelog categories (Added/Changed/Fixed/…). CI only validates the
+  structure of changelogs a PR touches (`.github/workflows/changelog.yml`) — nothing fails
+  when the entry is missing entirely, so a forgotten entry ships silently in the next
+  release's notes.
+- Releases are changelog-promotion PRs: move `[Unreleased]` into a new `## [<version>] - <date>`
+  section and label the PR `release/studioctl`; merging it triggers
+  `.github/workflows/release-studioctl.yaml`. Use `src/tools/releaser`
+  (`go run . prepare -component studioctl -version vX.Y.Z-preview.N`) or promote manually,
+  and validate with `go run . validate-changelog` / `resolve-version`.
+
 ### Local dev flows (build/serve from source)
 
 By default `env up` pulls release images from GHCR and `run` serves the app's bundled


### PR DESCRIPTION
Makes the studioctl changelog expectation explicit — in docs and as a CI gate.

Why: CI (`changelog.yml`) only validates the *structure* of changelogs a PR touches — nothing enforced that a CLI PR adds a `CHANGELOG.md` entry at all, so a missing entry shipped silently in the next release's notes. #19636 hit exactly this: the `feedback`-after-service-task upgrade advisor landed without an entry (backfilled in #19643).

Changes:

- **`src/cli/AGENTS.md`**: new *Changelog & releases* section documenting the entry expectation, the `skip-changelog` escape, and the release flow (promotion PR + `release/studioctl` label + `releaser` commands).
- **`.github/workflows/cli-changelog.yaml`** (new): runs the releaser's `validate-changelog -component studioctl` on PRs that change studioctl code. Fails when no new `[Unreleased]` entry is added. The `skip-changelog` label opts out for changes with no user-visible effect, and `labeled`/`unlabeled` events re-evaluate the check when the label is toggled — this is also why it's a dedicated cheap workflow instead of a job in `cli-build-test.yaml`, whose 3-OS build matrix shouldn't re-run on label changes. Markdown-only changes under `src/cli` don't trigger it, and release-promotion PRs are recognized by the releaser and pass.

Verified against real history:

- `validate-changelog -base d2333e05f8~1 -head d2333e05f8` (#19636) → **fails** with `changelog was not modified` (the gate would have caught it)
- `9adb7ce3a8` (#19540) → passes (new `[Unreleased]` entry)
- the #19643 promotion branch → passes (release-promotion recognized)

`yarn docs:validate` passes. Note: to make this blocking, the `Require studioctl changelog entry` check must also be added to branch protection; as-is it's a visible failing check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated validation to ensure relevant studioctl changes include a changelog entry before merging.
  * Validation runs for applicable, non-draft pull requests and can be bypassed for non-user-visible changes using the designated label.

* **Documentation**
  * Added guidance for maintaining studioctl changelog entries and preparing release notes.
  * Documented the process for promoting unreleased changes into versioned release sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->