### PR TITLE
refactor: move `PrintButton` layout component to lib

### DIFF
--- a/app-libs/form-component/src/layout-components/PrintButton/PrintButton.mdx
+++ b/app-libs/form-component/src/layout-components/PrintButton/PrintButton.mdx
@@ -1,0 +1,9 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+import { LayoutComponentDocs } from '../common/storybook';
+import * as PrintButtonStories from './PrintButton.stories';
+import { PRINT_BUTTON_PROP_CATEGORIES } from './PrintButton.stories';
+
+<Meta of={PrintButtonStories} />
+
+<LayoutComponentDocs categories={PRINT_BUTTON_PROP_CATEGORIES} />

--- a/app-libs/form-component/src/layout-components/PrintButton/PrintButton.stories.tsx
+++ b/app-libs/form-component/src/layout-components/PrintButton/PrintButton.stories.tsx
@@ -1,3 +1,4 @@
+import { fn } from 'storybook/test';
 import type { PropCategories } from '@app/form-component/layout-components/common/storybook';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
@@ -8,7 +9,7 @@ export const PRINT_BUTTON_PROP_CATEGORIES = {
   title: 'text',
   componentId: 'content',
   onClick: 'runtime',
-  innerGrid: 'runtime',
+  innerGrid: 'content',
 } satisfies PropCategories<PrintButtonProps>;
 
 const meta = {
@@ -20,8 +21,7 @@ const meta = {
   },
   args: {
     componentId: 'print-button-preview',
-    title: 'Skriv ut',
-    onClick: () => undefined,
+    onClick: fn(),
   },
 } satisfies Meta<typeof PrintButton>;
 
@@ -31,8 +31,8 @@ type Story = StoryObj<typeof meta>;
 
 export const Preview: Story = {};
 
-export const DefaultTextKey: Story = {
+export const CustomText: Story = {
   args: {
-    title: undefined,
+    title: 'Skriv ut',
   },
 };

--- a/app-libs/form-component/src/layout-components/PrintButton/PrintButton.stories.tsx
+++ b/app-libs/form-component/src/layout-components/PrintButton/PrintButton.stories.tsx
@@ -1,0 +1,38 @@
+import type { PropCategories } from '@app/form-component/layout-components/common/storybook';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { PrintButton } from './PrintButton';
+import type { PrintButtonProps } from './PrintButton';
+
+export const PRINT_BUTTON_PROP_CATEGORIES = {
+  title: 'text',
+  componentId: 'content',
+  onClick: 'runtime',
+  innerGrid: 'runtime',
+} satisfies PropCategories<PrintButtonProps>;
+
+const meta = {
+  title: 'LayoutComponents/PrintButton',
+  component: PrintButton,
+  excludeStories: ['PRINT_BUTTON_PROP_CATEGORIES'],
+  parameters: {
+    layout: 'padded',
+  },
+  args: {
+    componentId: 'print-button-preview',
+    title: 'Skriv ut',
+    onClick: () => undefined,
+  },
+} satisfies Meta<typeof PrintButton>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Preview: Story = {};
+
+export const DefaultTextKey: Story = {
+  args: {
+    title: undefined,
+  },
+};

--- a/app-libs/form-component/src/layout-components/PrintButton/PrintButton.test.tsx
+++ b/app-libs/form-component/src/layout-components/PrintButton/PrintButton.test.tsx
@@ -1,0 +1,44 @@
+import type { ComponentProps } from 'react';
+
+import {
+  renderWithTranslations,
+  type RenderWithTranslationsOptions,
+} from '@app/form-component/test/renderWithTranslations';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { PrintButton } from './PrintButton';
+
+const render = (
+  props?: Partial<ComponentProps<typeof PrintButton>>,
+  options?: RenderWithTranslationsOptions,
+) =>
+  renderWithTranslations(
+    <PrintButton componentId='pb-1' onClick={() => undefined} {...props} />,
+    options,
+  );
+
+describe('PrintButton', () => {
+  it('resolves and displays the title key', () => {
+    render({ title: 'my.title' }, { overrides: { 'my.title': 'Skriv ut' } });
+    expect(screen.getByRole('button', { name: 'Skriv ut' })).toBeInTheDocument();
+  });
+
+  it('falls back to general.print_button_text when title is omitted', () => {
+    render(undefined, { language: 'nb' });
+    expect(screen.getByRole('button', { name: 'Print / Lagre PDF' })).toBeInTheDocument();
+  });
+
+  it('calls onClick when the button is pressed', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render({ title: 'my.title', onClick }, { overrides: { 'my.title': 'Skriv ut' } });
+    await user.click(screen.getByRole('button', { name: 'Skriv ut' }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the form-content wrapper for the given componentId', () => {
+    render({ componentId: 'print-1' });
+    expect(document.getElementById('form-content-print-1')).toBeInTheDocument();
+  });
+});

--- a/app-libs/form-component/src/layout-components/PrintButton/PrintButton.test.tsx
+++ b/app-libs/form-component/src/layout-components/PrintButton/PrintButton.test.tsx
@@ -32,8 +32,8 @@ describe('PrintButton', () => {
   it('calls onClick when the button is pressed', async () => {
     const user = userEvent.setup();
     const onClick = vi.fn();
-    render({ title: 'my.title', onClick }, { overrides: { 'my.title': 'Skriv ut' } });
-    await user.click(screen.getByRole('button', { name: 'Skriv ut' }));
+    render({ onClick });
+    await user.click(screen.getByRole('button'));
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 

--- a/app-libs/form-component/src/layout-components/PrintButton/PrintButton.tsx
+++ b/app-libs/form-component/src/layout-components/PrintButton/PrintButton.tsx
@@ -1,0 +1,28 @@
+import { Button } from '@app/form-component/app-components/Button';
+import { useTranslation } from '@app/form-component/LanguageTranslatorProvider';
+import { ComponentStructure } from '@app/form-component/layout-components/common/ComponentStructure';
+import type { IGridStyling } from '@app/form-component/app-components/Flex';
+
+export interface PrintButtonProps {
+  componentId: string;
+  title?: string;
+  onClick: () => void;
+  innerGrid?: IGridStyling;
+}
+
+export function PrintButton({
+  componentId,
+  title = 'general.print_button_text',
+  onClick,
+  innerGrid,
+}: PrintButtonProps) {
+  const { lang } = useTranslation();
+
+  return (
+    <ComponentStructure componentId={componentId} innerGrid={innerGrid}>
+      <Button variant='secondary' color='first' onClick={onClick}>
+        {lang(title)}
+      </Button>
+    </ComponentStructure>
+  );
+}

--- a/app-libs/form-component/src/layout-components/PrintButton/index.ts
+++ b/app-libs/form-component/src/layout-components/PrintButton/index.ts
@@ -1,0 +1,2 @@
+export { PrintButton } from './PrintButton';
+export type { PrintButtonProps } from './PrintButton';

--- a/app-libs/form-component/src/layout-components/index.ts
+++ b/app-libs/form-component/src/layout-components/index.ts
@@ -13,6 +13,7 @@ export * from './Image';
 export * from './InstanceInformation';
 export * from './Link';
 export * from './Paragraph';
+export * from './PrintButton';
 export * from './Tabs';
 export * from './Text';
 export * from './TextArea';

--- a/src/App/frontend/src/layout/PrintButton/PrintButtonComponent.tsx
+++ b/src/App/frontend/src/layout/PrintButton/PrintButtonComponent.tsx
@@ -1,25 +1,22 @@
 import React from 'react';
 
-import { Button } from '@app/form-component';
+import { PrintButton } from '@app/form-component';
 
 import type { PropsFromGenericComponent } from '..';
 
-import { Lang } from 'src/features/language/Lang';
-import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
+import { useComponentStructureData } from 'src/utils/layout/useComponentStructureData';
 import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 
 export const PrintButtonComponent = ({ baseComponentId }: PropsFromGenericComponent<'PrintButton'>) => {
   const { textResourceBindings } = useItemWhenType(baseComponentId, 'PrintButton');
+  const { componentId, innerGrid } = useComponentStructureData(baseComponentId);
 
   return (
-    <ComponentStructureWrapper baseComponentId={baseComponentId}>
-      <Button
-        variant='secondary'
-        color='first'
-        onClick={window.print}
-      >
-        <Lang id={textResourceBindings?.title ?? 'general.print_button_text'} />
-      </Button>
-    </ComponentStructureWrapper>
+    <PrintButton
+      componentId={componentId}
+      title={textResourceBindings?.title}
+      onClick={window.print}
+      innerGrid={innerGrid}
+    />
   );
 };

--- a/src/App/frontend/src/layout/PrintButton/PrintButtonComponent.tsx
+++ b/src/App/frontend/src/layout/PrintButton/PrintButtonComponent.tsx
@@ -15,7 +15,7 @@ export const PrintButtonComponent = ({ baseComponentId }: PropsFromGenericCompon
     <PrintButton
       componentId={componentId}
       title={textResourceBindings?.title}
-      onClick={window.print}
+      onClick={() => window.print()}
       innerGrid={innerGrid}
     />
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Moves the **PrintButton** layout component's presentational logic from app-frontend (`src/layout/PrintButton`) into `@app/form-component` (`layout-components/PrintButton`).

**Lib** owns presentation: shared `Button` (secondary/first), title via `useTranslation` (default key `general.print_button_text`), and `ComponentStructure` for the `form-content` wrapper + `innerGrid`. 

**Wrapper** (`PrintButtonComponent.tsx`) only resolves runtime data (`useItemWhenType`, `useComponentStructureData`) and passes props into the lib component, including `onClick={window.print}`.

Adds Storybook stories + docs (`PRINT_BUTTON_PROP_CATEGORIES` / `LayoutComponentDocs`) and lib unit tests.



CLOSES: #19654 

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable print button component with configurable text and styling.
  * Button label now uses the provided translation, with a standard fallback when text is not configured.
  * Clicking the button opens the browser print dialog.
* **Documentation**
  * Added Storybook documentation and examples for the print button.
* **Tests**
  * Added tests covering translated labels, fallback text, click behaviour, and rendered structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->