### PR TITLE
fix(designer): restore backend format check

### DIFF
--- a/src/Designer/backend/src/Designer/Controllers/PreviewController.cs
+++ b/src/Designer/backend/src/Designer/Controllers/PreviewController.cs
@@ -95,7 +95,8 @@ public partial class PreviewController(
         // As a first step we return hardcoded HTML from the backend so the preview iframe renders it.
         if (appVersionService.IsV9App(AltinnRepoEditingContext.FromOrgRepoDeveloper(org, app, developer)))
         {
-            const string HTML = "<!DOCTYPE html><html><head><title>Preview</title></head>"
+            const string HTML =
+                "<!DOCTYPE html><html><head><title>Preview</title></head>"
                 + "<body><h1>Hello from the Designer backend (v9 preview)</h1></body></html>";
             return Content(HTML, "text/html");
         }


### PR DESCRIPTION
## Description

Formats the HTML constant in `PreviewController` so the repository-wide Designer backend CSharpier check passes again.

The unformatted statement was introduced by #19620 in merge commit `f38810f2c8c8696247241e8e38694b5e5b377044`. Because the workflow checks every Designer backend file, it also causes unrelated backend PRs such as #18996 to fail their format check.

This is formatting only and does not change runtime behavior.

## Verification

- [x] Related breaking PR is referenced above
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual verification done with `dotnet csharpier check .`
- [ ] Relevant automated test added (not applicable for formatting-only change)

Commands run from `src/Designer/backend`:

```bash
dotnet tool restore
dotnet csharpier check .
dotnet build src/Designer/Designer.csproj
```

CSharpier checked 1,424 files successfully; the Designer build completed with 0 warnings and 0 errors.
