### PR TITLE
fix: recover repository sync from stale remote refs

### DIFF
--- a/src/Designer/backend/src/Designer/Middleware/UserRequestSynchronization/RepoUserWide/RequestSyncEvaluators/EndpointNameSyncEligibilityEvaluator.cs
+++ b/src/Designer/backend/src/Designer/Middleware/UserRequestSynchronization/RepoUserWide/RequestSyncEvaluators/EndpointNameSyncEligibilityEvaluator.cs
@@ -32,7 +32,9 @@ public class EndpointNameSyncEligibilityEvaluator : IRepoUserSyncEligibilityEval
                 nameof(RepositoryController.ResetLocalRepository),
                 nameof(RepositoryController.CommitAndPushRepo),
                 nameof(RepositoryController.Commit),
-                nameof(RepositoryController.Push)
+                nameof(RepositoryController.Push),
+                nameof(RepositoryController.DeleteBranch),
+                nameof(RepositoryController.CheckoutBranch)
             )
         },
         {

--- a/src/Designer/backend/src/Designer/Services/Implementation/Organisation/OrgLibraryService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/Organisation/OrgLibraryService.cs
@@ -31,6 +31,7 @@ public class OrgLibraryService(
 {
     private const string DefaultCommitMessage = "Update shared resources.";
     private const string JsonExtension = ".json";
+    private static readonly TimeSpan s_lockWaitTimeout = TimeSpan.FromSeconds(30);
 
     /// <inheritdoc />
     public async Task<string> GetLatestCommitOnBranch(
@@ -130,6 +131,7 @@ public class OrgLibraryService(
         ValidateCommitMessage(request.CommitMessage);
         await using var _ = await synchronizationLockService.AcquireRepoUserWideLockAsync(
             authenticatedContext.RepoEditingContext,
+            s_lockWaitTimeout,
             cancellationToken: cancellationToken
         );
         sourceControl.CloneIfNotExists(authenticatedContext);

--- a/src/Designer/backend/src/Designer/Services/Implementation/Organisation/OrgLibraryService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/Organisation/OrgLibraryService.cs
@@ -11,6 +11,7 @@ using Altinn.Studio.Designer.Constants;
 using Altinn.Studio.Designer.Exceptions.OrgLibrary;
 using Altinn.Studio.Designer.Helpers;
 using Altinn.Studio.Designer.Infrastructure.GitRepository;
+using Altinn.Studio.Designer.Middleware.UserRequestSynchronization.Abstractions;
 using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Models.Dto;
 using Altinn.Studio.Designer.Services.Interfaces;
@@ -24,7 +25,8 @@ public class OrgLibraryService(
     IGiteaClient giteaClient,
     ISourceControl sourceControl,
     IAltinnGitRepositoryFactory altinnGitRepositoryFactory,
-    ISharedContentClient sharedContentClient
+    ISharedContentClient sharedContentClient,
+    ILockService synchronizationLockService
 ) : IOrgLibraryService
 {
     private const string DefaultCommitMessage = "Update shared resources.";
@@ -126,6 +128,10 @@ public class OrgLibraryService(
             AltinnAuthenticatedRepoEditingContext.FromOrgRepoDeveloperToken(org, repository, developer, token);
 
         ValidateCommitMessage(request.CommitMessage);
+        await using var _ = await synchronizationLockService.AcquireRepoUserWideLockAsync(
+            authenticatedContext.RepoEditingContext,
+            cancellationToken: cancellationToken
+        );
         sourceControl.CloneIfNotExists(authenticatedContext);
 
         string latestCommitSha = await giteaClient.GetLatestCommitOnBranch(

--- a/src/Designer/backend/src/Designer/Services/Implementation/SourceControlService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/SourceControlService.cs
@@ -134,7 +134,7 @@ public class SourceControlService(
                 try
                 {
                     Tree head = repo.Head.Tip.Tree;
-                    MergeResult mergeResult = ExecuteWithRemoteTrackingRefRecovery(
+                    MergeResult mergeResult = self.ExecuteWithRemoteTrackingRefRecovery(
                         repo,
                         repo.Head.RemoteName,
                         () =>
@@ -219,7 +219,7 @@ public class SourceControlService(
                 foreach (Remote remote in repo.Network.Remotes)
                 {
                     IEnumerable<string> refSpecs = remote.FetchRefSpecs.Select(x => x.Specification);
-                    ExecuteWithRemoteTrackingRefRecovery(
+                    self.ExecuteWithRemoteTrackingRefRecovery(
                         repo,
                         remote.Name,
                         () => Commands.Fetch(repo, remote.Name, refSpecs, fetchOptions, logMessage)
@@ -229,11 +229,7 @@ public class SourceControlService(
         );
     }
 
-    private static void ExecuteWithRemoteTrackingRefRecovery(
-        LibGit2Sharp.Repository repo,
-        string remoteName,
-        Action operation
-    )
+    private void ExecuteWithRemoteTrackingRefRecovery(LibGit2Sharp.Repository repo, string remoteName, Action operation)
     {
         ExecuteWithRemoteTrackingRefRecovery(
             repo,
@@ -246,7 +242,7 @@ public class SourceControlService(
         );
     }
 
-    private static T ExecuteWithRemoteTrackingRefRecovery<T>(
+    private T ExecuteWithRemoteTrackingRefRecovery<T>(
         LibGit2Sharp.Repository repo,
         string? remoteName,
         Func<T> operation
@@ -258,7 +254,13 @@ public class SourceControlService(
         }
         catch (LibGit2SharpException ex) when (ReferencesRemoteTrackingBranch(ex, remoteName))
         {
-            RemoveRemoteTrackingBranches(repo, remoteName!);
+            int removedRefCount = RemoveRemoteTrackingBranches(repo, remoteName!);
+            AddActivityEvent(
+                "remote_tracking_refs.recovery",
+                new ActivityTagsCollection { { "remote", remoteName }, { "removed_ref_count", removedRefCount } }
+            );
+
+            // A failed retry leaves the refs removed; a later successful fetch recreates them.
             return operation();
         }
     }
@@ -270,11 +272,13 @@ public class SourceControlService(
             return false;
         }
 
+        // LibGit2Sharp 0.31.0 exposes no error code for these failures; libgit2 includes the
+        // affected refs/remotes/{remote}/ path in the message, using platform-specific separators.
         return exception.Message.Contains($"refs/remotes/{remoteName}/", StringComparison.Ordinal)
             || exception.Message.Contains($"refs\\remotes\\{remoteName}\\", StringComparison.Ordinal);
     }
 
-    private static void RemoveRemoteTrackingBranches(LibGit2Sharp.Repository repo, string remoteName)
+    private static int RemoveRemoteTrackingBranches(LibGit2Sharp.Repository repo, string remoteName)
     {
         // The retry recreates direct tracking refs. Symbolic metadata such as origin/HEAD is retained.
         string prefix = $"refs/remotes/{remoteName}/";
@@ -291,6 +295,8 @@ public class SourceControlService(
         {
             repo.Refs.Remove(reference);
         }
+
+        return refsToRemove.Count;
     }
 
     /// <inheritdoc/>

--- a/src/Designer/backend/src/Designer/Services/Implementation/SourceControlService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/SourceControlService.cs
@@ -134,10 +134,15 @@ public class SourceControlService(
                 try
                 {
                     Tree head = repo.Head.Tip.Tree;
-                    MergeResult mergeResult = Commands.Pull(
+                    MergeResult mergeResult = ExecuteWithRemoteTrackingRefRecovery(
                         repo,
-                        self.GetDeveloperSignature(ctx.authenticatedContext.Developer),
-                        pullOptions
+                        repo.Head.RemoteName,
+                        () =>
+                            Commands.Pull(
+                                repo,
+                                self.GetDeveloperSignature(ctx.authenticatedContext.Developer),
+                                pullOptions
+                            )
                     );
                     mergeStatus = mergeResult.Status.ToString();
 
@@ -214,10 +219,78 @@ public class SourceControlService(
                 foreach (Remote remote in repo.Network.Remotes)
                 {
                     IEnumerable<string> refSpecs = remote.FetchRefSpecs.Select(x => x.Specification);
-                    Commands.Fetch(repo, remote.Name, refSpecs, fetchOptions, logMessage);
+                    ExecuteWithRemoteTrackingRefRecovery(
+                        repo,
+                        remote.Name,
+                        () => Commands.Fetch(repo, remote.Name, refSpecs, fetchOptions, logMessage)
+                    );
                 }
             }
         );
+    }
+
+    private static void ExecuteWithRemoteTrackingRefRecovery(
+        LibGit2Sharp.Repository repo,
+        string remoteName,
+        Action operation
+    )
+    {
+        ExecuteWithRemoteTrackingRefRecovery(
+            repo,
+            remoteName,
+            () =>
+            {
+                operation();
+                return true;
+            }
+        );
+    }
+
+    private static T ExecuteWithRemoteTrackingRefRecovery<T>(
+        LibGit2Sharp.Repository repo,
+        string? remoteName,
+        Func<T> operation
+    )
+    {
+        try
+        {
+            return operation();
+        }
+        catch (LibGit2SharpException ex) when (ReferencesRemoteTrackingBranch(ex, remoteName))
+        {
+            RemoveRemoteTrackingBranches(repo, remoteName!);
+            return operation();
+        }
+    }
+
+    private static bool ReferencesRemoteTrackingBranch(LibGit2SharpException exception, string? remoteName)
+    {
+        if (remoteName is null)
+        {
+            return false;
+        }
+
+        return exception.Message.Contains($"refs/remotes/{remoteName}/", StringComparison.Ordinal)
+            || exception.Message.Contains($"refs\\remotes\\{remoteName}\\", StringComparison.Ordinal);
+    }
+
+    private static void RemoveRemoteTrackingBranches(LibGit2Sharp.Repository repo, string remoteName)
+    {
+        // The retry recreates direct tracking refs. Symbolic metadata such as origin/HEAD is retained.
+        string prefix = $"refs/remotes/{remoteName}/";
+        List<string> refsToRemove = repo
+            .Refs.Where(reference =>
+                reference is DirectReference
+                && reference.IsRemoteTrackingBranch
+                && reference.CanonicalName.StartsWith(prefix, StringComparison.Ordinal)
+            )
+            .Select(reference => reference.CanonicalName)
+            .ToList();
+
+        foreach (string reference in refsToRemove)
+        {
+            repo.Refs.Remove(reference);
+        }
     }
 
     /// <inheritdoc/>

--- a/src/Designer/backend/tests/Designer.Tests/Controllers/RepositoryController/CheckoutBranchTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Controllers/RepositoryController/CheckoutBranchTests.cs
@@ -4,14 +4,11 @@ using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Altinn.Studio.Designer.Clients.Interfaces;
-using Altinn.Studio.Designer.Configuration;
 using Altinn.Studio.Designer.Enums;
 using Altinn.Studio.Designer.Exceptions;
 using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Services.Interfaces;
 using Designer.Tests.Controllers.ApiTests;
-using Designer.Tests.Mocks;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
@@ -33,8 +30,7 @@ public class CheckoutBranchTests
 
     protected override void ConfigureTestServices(IServiceCollection services)
     {
-        services.Configure<ServiceRepositorySettings>(c => c.RepositoryLocation = TestRepositoriesLocation);
-        services.AddSingleton<IGiteaClient, IGiteaClientMock>();
+        base.ConfigureTestServices(services);
         services.AddSingleton(_sourceControlMock.Object);
     }
 

--- a/src/Designer/backend/tests/Designer.Tests/Controllers/RepositoryController/DeleteBranchTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Controllers/RepositoryController/DeleteBranchTests.cs
@@ -1,13 +1,10 @@
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Altinn.Studio.Designer.Clients.Interfaces;
-using Altinn.Studio.Designer.Configuration;
 using Altinn.Studio.Designer.Constants;
 using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Services.Interfaces;
 using Designer.Tests.Controllers.ApiTests;
-using Designer.Tests.Mocks;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
@@ -29,8 +26,7 @@ namespace Designer.Tests.Controllers.RepositoryController
 
         protected override void ConfigureTestServices(IServiceCollection services)
         {
-            services.Configure<ServiceRepositorySettings>(c => c.RepositoryLocation = TestRepositoriesLocation);
-            services.AddSingleton<IGiteaClient, IGiteaClientMock>();
+            base.ConfigureTestServices(services);
             services.AddSingleton(_sourceControlMock.Object);
         }
 

--- a/src/Designer/backend/tests/Designer.Tests/Services/OrgLibraryServiceTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/OrgLibraryServiceTests.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Clients.Interfaces;
 using Altinn.Studio.Designer.Infrastructure.GitRepository;
+using Altinn.Studio.Designer.Middleware.UserRequestSynchronization.Abstractions;
 using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Models.Dto;
 using Altinn.Studio.Designer.Services.Implementation.Organisation;
@@ -209,12 +210,14 @@ public class OrgLibraryServiceTests
         Mock<ISourceControl> sourceControl = new();
         Mock<IAltinnGitRepositoryFactory> altinnGitRepositoryFactory = overrideFactory ?? new();
         Mock<ISharedContentClient> sharedContentClient = new();
+        Mock<ILockService> synchronizationLockService = new();
 
         return new(
             giteaClient.Object,
             sourceControl.Object,
             altinnGitRepositoryFactory.Object,
-            sharedContentClient.Object
+            sharedContentClient.Object,
+            synchronizationLockService.Object
         );
     }
 }

--- a/src/Designer/backend/tests/Designer.Tests/Services/SourceControlServiceTest.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/SourceControlServiceTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Security.Claims;
@@ -54,7 +55,7 @@ public class SourceControlServiceTest : IDisposable
         _sourceControlService = new SourceControlService(
             _settings,
             _giteaClientMock.Object,
-            new Mock<IGitServerAuthHeadersProvider>().Object
+            CreateAuthHeadersProvider()
         );
     }
 
@@ -367,6 +368,146 @@ public class SourceControlServiceTest : IDisposable
         Assert.Empty(result);
     }
 
+    [Theory]
+    [InlineData("develop", "develop/test", false)]
+    [InlineData("develop/test", "develop", false)]
+    [InlineData("develop", "develop/test", true)]
+    [InlineData("develop/test", "develop", true)]
+    public void FetchRemoteChanges_RemoteBranchShapeChangedByPush_RebuildsRemoteTrackingBranches(
+        string staleRemoteBranchName,
+        string replacementRemoteBranchName,
+        bool packRefs
+    )
+    {
+        VerifyRemoteTrackingBranchesAreRebuilt(
+            staleRemoteBranchName,
+            replacementRemoteBranchName,
+            packRefs,
+            context => _sourceControlService.FetchRemoteChanges(context),
+            expectPulledChanges: false
+        );
+    }
+
+    [Theory]
+    [InlineData("develop", "develop/test", false)]
+    [InlineData("develop/test", "develop", false)]
+    [InlineData("develop", "develop/test", true)]
+    [InlineData("develop/test", "develop", true)]
+    public void PullRemoteChanges_RemoteBranchShapeChangedByPush_RebuildsRemoteTrackingBranches(
+        string staleRemoteBranchName,
+        string replacementRemoteBranchName,
+        bool packRefs
+    )
+    {
+        VerifyRemoteTrackingBranchesAreRebuilt(
+            staleRemoteBranchName,
+            replacementRemoteBranchName,
+            packRefs,
+            context => _sourceControlService.PullRemoteChanges(context),
+            expectPulledChanges: true
+        );
+    }
+
+    private void VerifyRemoteTrackingBranchesAreRebuilt(
+        string staleRemoteBranchName,
+        string replacementRemoteBranchName,
+        bool packRefs,
+        Action<AltinnAuthenticatedRepoEditingContext> synchronize,
+        bool expectPulledChanges
+    )
+    {
+        Setup();
+        string repoName = TestDataHelper.GenerateTestRepoName();
+        string remoteRepoDir = TestDataHelper.GetTestDataRepositoryDirectory(_org, $"{repoName}-remote", _developer);
+        string publisherRepoDir = TestDataHelper.GetTestDataRepositoryDirectory(
+            _org,
+            $"{repoName}-publisher",
+            _developer
+        );
+        _repoDir = TestDataHelper.GetTestDataRepositoryDirectory(_org, repoName, _developer);
+        var editingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(_org, repoName, _developer);
+        AltinnAuthenticatedRepoEditingContext authenticatedContext =
+            AltinnAuthenticatedRepoEditingContext.FromEditingContext(editingContext, "dummytoken");
+
+        try
+        {
+            Directory.CreateDirectory(remoteRepoDir);
+            Repository.Init(remoteRepoDir, true);
+            Directory.CreateDirectory(publisherRepoDir);
+            Repository.Init(publisherRepoDir);
+
+            using (var publisherRepo = new Repository(publisherRepoDir))
+            {
+                LibGit2Sharp.Commit initialCommit = CommitFile(
+                    publisherRepo,
+                    publisherRepoDir,
+                    "test.txt",
+                    "Initial content"
+                );
+                EnsureServiceDefaultBranch(publisherRepo);
+                publisherRepo.CreateBranch(staleRemoteBranchName, initialCommit);
+                publisherRepo.CreateBranch("deleted-remotely", initialCommit);
+                Remote remote = publisherRepo.Network.Remotes.Add("origin", remoteRepoDir);
+                PushBranch(publisherRepo, remote, General.DefaultBranch);
+                PushBranch(publisherRepo, remote, staleRemoteBranchName);
+                PushBranch(publisherRepo, remote, "deleted-remotely");
+            }
+
+            Repository.Clone(remoteRepoDir, _repoDir);
+
+            using (var clonedRepo = new Repository(_repoDir))
+            {
+                Assert.NotNull(clonedRepo.Branches[$"origin/{staleRemoteBranchName}"]);
+                Assert.NotNull(clonedRepo.Branches["origin/deleted-remotely"]);
+                Assert.Equal(
+                    $"refs/remotes/origin/{General.DefaultBranch}",
+                    Assert.IsType<SymbolicReference>(clonedRepo.Refs["refs/remotes/origin/HEAD"]).TargetIdentifier
+                );
+                clonedRepo.CreateBranch("local-only");
+                File.WriteAllText(Path.Join(_repoDir, "local-change.txt"), "Local work");
+            }
+
+            if (packRefs)
+            {
+                PackRefs(_repoDir);
+            }
+
+            using (var publisherRepo = new Repository(publisherRepoDir))
+            {
+                Remote remote = publisherRepo.Network.Remotes["origin"];
+                DeleteRemoteBranch(publisherRepo, remote, staleRemoteBranchName);
+                DeleteRemoteBranch(publisherRepo, remote, "deleted-remotely");
+                publisherRepo.CreateBranch(replacementRemoteBranchName, publisherRepo.Head.Tip);
+                PushBranch(publisherRepo, remote, replacementRemoteBranchName);
+                CommitFile(publisherRepo, publisherRepoDir, "remote-change.txt", "Remote work", "Remote change");
+                PushBranch(publisherRepo, remote, General.DefaultBranch);
+            }
+
+            synchronize(authenticatedContext);
+
+            using var repo = new Repository(_repoDir);
+            Assert.Null(repo.Branches[$"origin/{staleRemoteBranchName}"]);
+            Assert.NotNull(repo.Branches[$"origin/{replacementRemoteBranchName}"]);
+            Assert.Null(repo.Branches["origin/deleted-remotely"]);
+            Assert.NotNull(repo.Branches["local-only"]);
+            Assert.Equal(
+                $"refs/remotes/origin/{General.DefaultBranch}",
+                Assert.IsType<SymbolicReference>(repo.Refs["refs/remotes/origin/HEAD"]).TargetIdentifier
+            );
+            Assert.Equal("Local work", File.ReadAllText(Path.Join(_repoDir, "local-change.txt")));
+            Assert.Equal(expectPulledChanges, File.Exists(Path.Join(_repoDir, "remote-change.txt")));
+            Assert.Equal(
+                expectPulledChanges,
+                repo.Head.Tip.Id == repo.Branches[$"origin/{General.DefaultBranch}"].Tip.Id
+            );
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(remoteRepoDir);
+            DeleteDirectoryIfExists(publisherRepoDir);
+        }
+    }
+
     private static HttpContext GetHttpContextForTestUser(string userName)
     {
         List<Claim> claims = new();
@@ -400,13 +541,17 @@ public class SourceControlServiceTest : IDisposable
                 + Path.DirectorySeparatorChar,
         };
 
-        SourceControlService service = new(
-            repoSettings,
-            giteaMock.Object,
-            new Mock<IGitServerAuthHeadersProvider>().Object
-        );
+        SourceControlService service = new(repoSettings, giteaMock.Object, CreateAuthHeadersProvider());
 
         return service;
+    }
+
+    private static IGitServerAuthHeadersProvider CreateAuthHeadersProvider()
+    {
+        Mock<IGitServerAuthHeadersProvider> authHeadersProvider = new();
+        authHeadersProvider.Setup(provider => provider.GetAuthHeaders()).Returns(new Dictionary<string, string>());
+
+        return authHeadersProvider.Object;
     }
 
     private AltinnRepoEditingContext CreateTestRepository(string repoName, string additionalBranch = null)
@@ -444,6 +589,51 @@ public class SourceControlServiceTest : IDisposable
         File.WriteAllText(filePath, content);
     }
 
+    private static LibGit2Sharp.Commit CommitFile(
+        Repository repo,
+        string repoDirectory,
+        string fileName,
+        string content,
+        string commitMessage = "Initial commit"
+    )
+    {
+        string filePath = Path.Join(repoDirectory, fileName);
+        File.WriteAllText(filePath, content);
+        Commands.Stage(repo, fileName);
+        var signature = new LibGit2Sharp.Signature("testUser", "testUser@test.com", DateTimeOffset.Now);
+        return repo.Commit(commitMessage, signature, signature);
+    }
+
+    private static void PushBranch(Repository repo, Remote remote, string branchName)
+    {
+        repo.Network.Push(remote, $"refs/heads/{branchName}:refs/heads/{branchName}", new PushOptions());
+    }
+
+    private static void DeleteRemoteBranch(Repository repo, Remote remote, string branchName)
+    {
+        repo.Network.Push(remote, $":refs/heads/{branchName}", new PushOptions());
+        repo.Branches.Remove(branchName);
+    }
+
+    private static void PackRefs(string repositoryDirectory)
+    {
+        ProcessStartInfo startInfo = new("git")
+        {
+            WorkingDirectory = repositoryDirectory,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add("pack-refs");
+        startInfo.ArgumentList.Add("--all");
+
+        using Process process = Process.Start(startInfo);
+        string standardError = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        Assert.True(process.ExitCode == 0, standardError);
+    }
+
     private string GetHeadBranchName()
     {
         using var repo = new Repository(_repoDir);
@@ -469,11 +659,17 @@ public class SourceControlServiceTest : IDisposable
         {
             return;
         }
+
+        DeleteDirectoryIfExists(_repoDir);
+    }
+
+    private static void DeleteDirectoryIfExists(string directory)
+    {
         try
         {
-            if (Directory.Exists(_repoDir))
+            if (Directory.Exists(directory))
             {
-                Directory.Delete(_repoDir, true);
+                Directory.Delete(directory, true);
             }
         }
         catch (Exception ex)

--- a/src/Designer/backend/tests/Designer.Tests/Services/SourceControlServiceTest.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/SourceControlServiceTest.cs
@@ -621,13 +621,13 @@ public class SourceControlServiceTest : IDisposable
         {
             WorkingDirectory = repositoryDirectory,
             RedirectStandardError = true,
-            RedirectStandardOutput = true,
             UseShellExecute = false,
         };
         startInfo.ArgumentList.Add("pack-refs");
         startInfo.ArgumentList.Add("--all");
 
-        using Process process = Process.Start(startInfo);
+        using Process process =
+            Process.Start(startInfo) ?? throw new InvalidOperationException("Failed to start 'git pack-refs'.");
         string standardError = process.StandardError.ReadToEnd();
         process.WaitForExit();
 


### PR DESCRIPTION
## Description

Supersedes #18996 with a smaller recovery model for remote branch name transitions such as `develop` to `develop/test` and the inverse.

Fetch and pull now run normally first. If libgit2 reports a failure inside the selected remote's `refs/remotes` namespace, Designer removes that remote's direct tracking refs and retries once. Fetch recreates those derived refs; local branches, the index, working-tree files, commits, and symbolic metadata such as `origin/HEAD` remain untouched.

The recovery is independent of exact libgit2 error wording, handles loose and packed refs, and clears multiple blockers in one pass. Routine synchronization performs no additional ref deletion. Branch checkout/deletion are covered by the existing repo-user request lock, and shared-resource updates acquire the same lock for their exact `{org}-content` clone.

The original failure was reproduced in dev: the branch replacement reached Gitea, while Designer's `/pull` endpoint failed in `Commands.Pull -> Commands.Fetch` on the stale local tracking ref.

## Verification

- [x] Related issues are connected (supersedes #18996)
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (replacement branch is ready for dev deployment)
- [x] Relevant automated test added

Commands run:

```bash
dotnet build Designer.sln --no-restore --verbosity minimal
dotnet test tests/Designer.Tests/Designer.Tests.csproj --no-restore --filter "FullyQualifiedName~SourceControlServiceTest|FullyQualifiedName~OrgLibraryServiceTests" --verbosity minimal
dotnet csharpier check .
git diff --check upstream/main...HEAD
```

Results:

- Designer solution build succeeded with 0 warnings and 0 errors
- 25 focused tests passed
- fetch and pull cover both branch-shape directions with loose and packed refs
- pull coverage advances the tracked branch and verifies the working tree is updated
- local branch, local work, and symbolic `origin/HEAD` preservation are verified
- all 1,424 backend C# files pass CSharpier
- independent reviewer completed with no remaining findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded repository endpoint eligibility so branch deletion and checkout can be synchronised.

* **Bug Fixes**
  * Improved fetch and pull resilience when remote-tracking branches are outdated or malformed, with automatic recovery and retry.
  * Reduced the risk of concurrent shared-resource updates interfering by serialising repository-scoped updates.

* **Tests**
  * Added coverage verifying remote-tracking branches are rebuilt correctly after remote branch shape changes, including packed references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->