### PR TITLE
fix(maskinporten): well-known audience refresh could latch off permanently, and outages amplified token-request latency

### DIFF
--- a/src/App/backend/src/Altinn.App.Core/Features/Maskinporten/MaskinportenClient.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Maskinporten/MaskinportenClient.cs
@@ -17,7 +17,7 @@ using Microsoft.IdentityModel.Tokens;
 namespace Altinn.App.Core.Features.Maskinporten;
 
 /// <inheritdoc/>
-internal sealed class MaskinportenClient : IMaskinportenClient
+internal sealed class MaskinportenClient : IMaskinportenClient, IDisposable
 {
     /// <summary>
     /// The margin to take into consideration when determining if a token has expired (seconds).
@@ -46,7 +46,7 @@ internal sealed class MaskinportenClient : IMaskinportenClient
     /// </summary>
     private static readonly TimeSpan _wellKnownFetchTimeout = TimeSpan.FromSeconds(10);
 
-    private sealed record WellKnownCacheEntry(string Issuer, DateTimeOffset FetchedAt, bool IsFallback = false);
+    private sealed record WellKnownCacheEntry(string Issuer, DateTimeOffset FetchedAt, bool IsFallback);
 
     internal MaskinportenSettings Settings =>
         _options.Get(Variant == VariantDefault ? Microsoft.Extensions.Options.Options.DefaultName : Variant);
@@ -71,6 +71,7 @@ internal sealed class MaskinportenClient : IMaskinportenClient
     // Well-known cache with background refresh
     private WellKnownCacheEntry? _wellKnownCache;
     private int _wellKnownRefreshing;
+    private readonly SemaphoreSlim _wellKnownFetchLock = new(1, 1);
 
     /// <summary>
     /// Instantiates a new <see cref="MaskinportenClient"/> object.
@@ -452,14 +453,17 @@ internal sealed class MaskinportenClient : IMaskinportenClient
     /// <summary>
     /// Retrieves the OAuth issuer from the well-known metadata endpoint for use as the JWT audience claim.
     /// Uses cached value if fresh. When stale, triggers background refresh and returns stale value immediately.
-    /// Only blocks on first call (cold start).
+    /// Only blocks on cold start (no cache yet), and at most one fetch is in flight at a time — concurrent
+    /// cold callers wait for it and reuse its result.
     /// </summary>
     /// <remarks>
     /// When the lookup fails, the audience falls back to <see cref="MaskinportenSettings.Authority"/> with a
-    /// trailing slash. Maskinporten only accepts an audience equal to its issuer or token endpoint URL, so the
-    /// fallback keeps token requests working through a well-known outage only when the configured Authority
-    /// equals the issuer URL — true for the standard Maskinporten environments, but not for e.g. a proxy host.
-    /// In that case grant requests fail with "Invalid audience" until the well-known lookup recovers.
+    /// trailing slash, cached for <see cref="WellKnownFallbackRetryInterval"/> so that an outage fails fast
+    /// instead of every caller blocking on its own fetch attempt. Maskinporten only accepts an audience equal
+    /// to its issuer or token endpoint URL, so the fallback keeps token requests working through a well-known
+    /// outage only when the configured Authority equals the issuer URL — true for the standard Maskinporten
+    /// environments, but not for e.g. a proxy host. In that case grant requests fail with "Invalid audience"
+    /// until the well-known lookup recovers.
     /// </remarks>
     internal ValueTask<string> GetAudienceFromWellKnown(CancellationToken cancellationToken = default)
     {
@@ -493,11 +497,21 @@ internal sealed class MaskinportenClient : IMaskinportenClient
 
     private async ValueTask<string> FetchWellKnownBlocking(CancellationToken cancellationToken)
     {
+        // Single-flight: concurrent cold callers would otherwise each run their own blocking fetch
+        // (N x 10s during an outage). The first caller fetches; the rest wait here and reuse the entry.
+        await _wellKnownFetchLock.WaitAsync(cancellationToken);
         try
         {
+            // An entry can only appear here if another caller completed a fetch while we waited.
+            var cached = Volatile.Read(ref _wellKnownCache);
+            if (cached is not null)
+            {
+                return cached.Issuer;
+            }
+
             var metadata = await FetchWellKnownMetadata(Settings.Authority, cancellationToken);
             var now = _timeProvider.GetUtcNow();
-            Volatile.Write(ref _wellKnownCache, new WellKnownCacheEntry(metadata.Issuer, now));
+            Volatile.Write(ref _wellKnownCache, new WellKnownCacheEntry(metadata.Issuer, now, IsFallback: false));
             return metadata.Issuer;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -523,6 +537,10 @@ internal sealed class MaskinportenClient : IMaskinportenClient
             );
             return authorityFallback;
         }
+        finally
+        {
+            _wellKnownFetchLock.Release();
+        }
     }
 
     private async Task RefreshWellKnownInBackground()
@@ -531,7 +549,7 @@ internal sealed class MaskinportenClient : IMaskinportenClient
         {
             var metadata = await FetchWellKnownMetadata(Settings.Authority, CancellationToken.None);
             var now = _timeProvider.GetUtcNow();
-            Volatile.Write(ref _wellKnownCache, new WellKnownCacheEntry(metadata.Issuer, now));
+            Volatile.Write(ref _wellKnownCache, new WellKnownCacheEntry(metadata.Issuer, now, IsFallback: false));
         }
         catch (Exception ex)
         {
@@ -659,4 +677,6 @@ internal sealed class MaskinportenClient : IMaskinportenClient
     }
 
     private sealed record CacheFactoryState(MaskinportenClient Self, MaskinportenTokenRequest Request);
+
+    public void Dispose() => _wellKnownFetchLock.Dispose();
 }

--- a/src/App/backend/src/Altinn.App.Core/Features/Maskinporten/MaskinportenClient.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Maskinporten/MaskinportenClient.cs
@@ -31,11 +31,22 @@ internal sealed class MaskinportenClient : IMaskinportenClient
     internal static readonly TimeSpan WellKnownCacheDuration = TimeSpan.FromHours(1);
 
     /// <summary>
+    /// Duration to cache the fallback audience after a failed well-known lookup, so that an outage
+    /// fails fast instead of every caller blocking on its own fetch attempt.
+    /// </summary>
+    internal static readonly TimeSpan WellKnownFallbackRetryInterval = TimeSpan.FromSeconds(30);
+
+    /// <summary>
     /// Upper bound for a single outbound call to Maskinporten or the Altinn token exchange endpoint.
     /// </summary>
     private static readonly TimeSpan _requestTimeout = TimeSpan.FromSeconds(30);
 
-    private sealed record WellKnownCacheEntry(string Issuer, DateTimeOffset FetchedAt);
+    /// <summary>
+    /// Upper bound for a single fetch of the OAuth well-known metadata document.
+    /// </summary>
+    private static readonly TimeSpan _wellKnownFetchTimeout = TimeSpan.FromSeconds(10);
+
+    private sealed record WellKnownCacheEntry(string Issuer, DateTimeOffset FetchedAt, bool IsFallback = false);
 
     internal MaskinportenSettings Settings =>
         _options.Get(Variant == VariantDefault ? Microsoft.Extensions.Options.Options.DefaultName : Variant);
@@ -443,23 +454,35 @@ internal sealed class MaskinportenClient : IMaskinportenClient
     /// Uses cached value if fresh. When stale, triggers background refresh and returns stale value immediately.
     /// Only blocks on first call (cold start).
     /// </summary>
+    /// <remarks>
+    /// When the lookup fails, the audience falls back to <see cref="MaskinportenSettings.Authority"/> with a
+    /// trailing slash. Maskinporten only accepts an audience equal to its issuer or token endpoint URL, so the
+    /// fallback keeps token requests working through a well-known outage only when the configured Authority
+    /// equals the issuer URL — true for the standard Maskinporten environments, but not for e.g. a proxy host.
+    /// In that case grant requests fail with "Invalid audience" until the well-known lookup recovers.
+    /// </remarks>
     internal ValueTask<string> GetAudienceFromWellKnown(CancellationToken cancellationToken = default)
     {
         var cached = Volatile.Read(ref _wellKnownCache);
         var now = _timeProvider.GetUtcNow();
 
-        // Fresh cache - return immediately
-        if (cached is not null && now - cached.FetchedAt < WellKnownCacheDuration)
-        {
-            return new ValueTask<string>(cached.Issuer);
-        }
-
-        // Stale cache - trigger background refresh, return stale immediately
         if (cached is not null)
         {
+            // Fresh cache - return immediately. Fallback entries are retried on a much shorter
+            // interval than real ones, so a well-known outage heals quickly.
+            var freshness = cached.IsFallback ? WellKnownFallbackRetryInterval : WellKnownCacheDuration;
+            if (now - cached.FetchedAt < freshness)
+            {
+                return new ValueTask<string>(cached.Issuer);
+            }
+
+            // Stale cache - trigger background refresh, return stale immediately.
+            // The refresh serves all future callers, so it must not observe this caller's cancellation:
+            // Task.Run with a pre-cancelled token never invokes the delegate, which would leave
+            // _wellKnownRefreshing latched at 1 for the lifetime of this singleton.
             if (Interlocked.CompareExchange(ref _wellKnownRefreshing, 1, 0) == 0)
             {
-                _ = Task.Run(() => RefreshWellKnownInBackground(), cancellationToken);
+                _ = Task.Run(RefreshWellKnownInBackground, CancellationToken.None);
             }
             return new ValueTask<string>(cached.Issuer);
         }
@@ -477,12 +500,27 @@ internal sealed class MaskinportenClient : IMaskinportenClient
             Volatile.Write(ref _wellKnownCache, new WellKnownCacheEntry(metadata.Issuer, now));
             return metadata.Issuer;
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // The caller is gone - don't taint the shared cache with a fallback entry.
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to fetch OAuth metadata, falling back to authority");
             var authorityFallback = Settings.Authority;
             if (authorityFallback[^1] != '/')
                 authorityFallback += '/';
+
+            // Cache the fallback so subsequent callers fail fast instead of each blocking on a fetch.
+            // Once WellKnownFallbackRetryInterval lapses, the stale branch above retries in the
+            // background. Never clobber an entry a concurrent successful fetch may have written.
+            var now = _timeProvider.GetUtcNow();
+            Interlocked.CompareExchange(
+                ref _wellKnownCache,
+                new WellKnownCacheEntry(authorityFallback, now, IsFallback: true),
+                null
+            );
             return authorityFallback;
         }
     }
@@ -511,7 +549,7 @@ internal sealed class MaskinportenClient : IMaskinportenClient
     )
     {
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        cts.CancelAfter(TimeSpan.FromSeconds(10));
+        cts.CancelAfter(_wellKnownFetchTimeout);
         cancellationToken = cts.Token;
         var wellKnownUrl = new Uri(new Uri(authority), ".well-known/oauth-authorization-server");
         using var client = _httpClientFactory.CreateClient();

--- a/src/App/backend/src/Altinn.App.Core/Features/Maskinporten/MaskinportenClient.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Maskinporten/MaskinportenClient.cs
@@ -17,7 +17,14 @@ using Microsoft.IdentityModel.Tokens;
 namespace Altinn.App.Core.Features.Maskinporten;
 
 /// <inheritdoc/>
-internal sealed class MaskinportenClient : IMaskinportenClient, IDisposable
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Design",
+    "CA1001:Types that own disposable fields should be disposable",
+    Justification = "Process-lifetime singleton. The SemaphoreSlim never allocates its wait handle "
+        + "(AvailableWaitHandle is not accessed), so there is nothing to dispose — disposing it would "
+        + "instead hang queued waiters if shutdown overlaps an in-flight well-known lookup."
+)]
+internal sealed class MaskinportenClient : IMaskinportenClient
 {
     /// <summary>
     /// The margin to take into consideration when determining if a token has expired (seconds).
@@ -677,6 +684,4 @@ internal sealed class MaskinportenClient : IMaskinportenClient, IDisposable
     }
 
     private sealed record CacheFactoryState(MaskinportenClient Self, MaskinportenTokenRequest Request);
-
-    public void Dispose() => _wellKnownFetchLock.Dispose();
 }

--- a/src/App/backend/test/Altinn.App.Core.Tests/Features/Maskinporten/MaskinportenClientTest.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Features/Maskinporten/MaskinportenClientTest.cs
@@ -803,6 +803,226 @@ public class MaskinportenClientTests
         Assert.Equal("https://maskinporten.dev/", result);
     }
 
+    [Theory]
+    [MemberData(nameof(Variants))]
+    public async Task GetAudienceFromWellKnown_BackgroundRefreshSurvivesPreCancelledToken(string variant)
+    {
+        // Arrange
+        await using var fixture = Fixture.Create();
+        var client = fixture.Client(variant);
+        const string issuer1 = "https://issuer1.maskinporten.no/";
+        const string issuer2 = "https://issuer2.maskinporten.no/";
+        var currentIssuer = issuer1;
+
+        fixture
+            .HttpClientFactoryMock.Setup(x => x.CreateClient(It.IsAny<string>()))
+            .Returns(() =>
+            {
+                var mockHandler = new Mock<HttpMessageHandler>();
+                mockHandler
+                    .Protected()
+                    .Setup<Task<HttpResponseMessage>>(
+                        "SendAsync",
+                        ItExpr.IsAny<HttpRequestMessage>(),
+                        ItExpr.IsAny<CancellationToken>()
+                    )
+                    .ReturnsAsync(() =>
+                        new HttpResponseMessage
+                        {
+                            StatusCode = HttpStatusCode.OK,
+                            Content = new StringContent(JsonSerializer.Serialize(new { issuer = currentIssuer })),
+                        }
+                    );
+                return new HttpClient(mockHandler.Object);
+            });
+
+        // Act - populate the cache, then let it expire
+        var result1 = await client.GetAudienceFromWellKnown();
+        currentIssuer = issuer2;
+        fixture.FakeTime.Advance(MaskinportenClient.WellKnownCacheDuration + TimeSpan.FromSeconds(1));
+
+        // A cancelled caller observing the stale cache must not prevent the background refresh:
+        // Task.Run with a pre-cancelled token never invokes its delegate, which used to leave the
+        // refresh flag latched for the lifetime of this singleton (no refresh ever again).
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+        var result2 = await client.GetAudienceFromWellKnown(cts.Token);
+
+        // Wait for the background refresh to complete
+        string result3 = issuer1;
+        var timeout = TimeSpan.FromSeconds(5);
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < timeout)
+        {
+            result3 = await client.GetAudienceFromWellKnown();
+            if (result3 == issuer2)
+                break;
+            await Task.Delay(10);
+        }
+
+        // Assert
+        Assert.Equal(issuer1, result1);
+        Assert.Equal(issuer1, result2); // Returns stale immediately, even for a cancelled caller
+        Assert.Equal(issuer2, result3); // The refresh still happened
+    }
+
+    [Theory]
+    [MemberData(nameof(Variants))]
+    public async Task GetAudienceFromWellKnown_CachesFallbackOnFailure_FailsFastWithinRetryInterval(string variant)
+    {
+        // Arrange
+        await using var fixture = Fixture.Create();
+        var client = fixture.Client(variant);
+        var callCount = 0;
+
+        fixture
+            .HttpClientFactoryMock.Setup(x => x.CreateClient(It.IsAny<string>()))
+            .Returns(() =>
+            {
+                callCount++;
+                var mockHandler = new Mock<HttpMessageHandler>();
+                mockHandler
+                    .Protected()
+                    .Setup<Task<HttpResponseMessage>>(
+                        "SendAsync",
+                        ItExpr.IsAny<HttpRequestMessage>(),
+                        ItExpr.IsAny<CancellationToken>()
+                    )
+                    .ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.InternalServerError });
+                return new HttpClient(mockHandler.Object);
+            });
+
+        // Act - first call blocks, fails and caches the fallback
+        var result1 = await client.GetAudienceFromWellKnown();
+        var result2 = await client.GetAudienceFromWellKnown();
+        fixture.FakeTime.Advance(MaskinportenClient.WellKnownFallbackRetryInterval - TimeSpan.FromSeconds(1));
+        var result3 = await client.GetAudienceFromWellKnown();
+
+        // Assert - subsequent calls within the retry interval reuse the cached fallback (no blocking refetch)
+        Assert.Equal(client.Settings.Authority, result1);
+        Assert.Equal(client.Settings.Authority, result2);
+        Assert.Equal(client.Settings.Authority, result3);
+        Assert.Equal(1, callCount);
+    }
+
+    [Theory]
+    [MemberData(nameof(Variants))]
+    public async Task GetAudienceFromWellKnown_FallbackRetriesInBackgroundAndRecovers(string variant)
+    {
+        // Arrange
+        await using var fixture = Fixture.Create();
+        var client = fixture.Client(variant);
+        const string realIssuer = "https://issuer.maskinporten.no/";
+        var shouldFail = true;
+        var callCount = 0;
+
+        fixture
+            .HttpClientFactoryMock.Setup(x => x.CreateClient(It.IsAny<string>()))
+            .Returns(() =>
+            {
+                callCount++;
+                var mockHandler = new Mock<HttpMessageHandler>();
+                mockHandler
+                    .Protected()
+                    .Setup<Task<HttpResponseMessage>>(
+                        "SendAsync",
+                        ItExpr.IsAny<HttpRequestMessage>(),
+                        ItExpr.IsAny<CancellationToken>()
+                    )
+                    .ReturnsAsync(() =>
+                        shouldFail
+                            ? new HttpResponseMessage { StatusCode = HttpStatusCode.InternalServerError }
+                            : new HttpResponseMessage
+                            {
+                                StatusCode = HttpStatusCode.OK,
+                                Content = new StringContent(JsonSerializer.Serialize(new { issuer = realIssuer })),
+                            }
+                    );
+                return new HttpClient(mockHandler.Object);
+            });
+
+        // Act - first call fails and caches the fallback, then the well-known endpoint recovers
+        var result1 = await client.GetAudienceFromWellKnown();
+        shouldFail = false;
+        fixture.FakeTime.Advance(MaskinportenClient.WellKnownFallbackRetryInterval + TimeSpan.FromSeconds(1));
+
+        // Stale fallback - returns immediately and refreshes in the background
+        var result2 = await client.GetAudienceFromWellKnown();
+
+        // Wait for the background refresh to complete
+        string result3 = result2;
+        var timeout = TimeSpan.FromSeconds(5);
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < timeout)
+        {
+            result3 = await client.GetAudienceFromWellKnown();
+            if (result3 == realIssuer)
+                break;
+            await Task.Delay(10);
+        }
+
+        // Once recovered, the normal cache duration applies again
+        fixture.FakeTime.Advance(TimeSpan.FromMinutes(30));
+        var callCountAfterRecovery = callCount;
+        var result4 = await client.GetAudienceFromWellKnown();
+
+        // Assert
+        Assert.Equal(client.Settings.Authority, result1);
+        Assert.Equal(client.Settings.Authority, result2);
+        Assert.Equal(realIssuer, result3);
+        Assert.Equal(realIssuer, result4);
+        Assert.Equal(callCountAfterRecovery, callCount); // No refetch within the normal cache duration
+    }
+
+    [Theory]
+    [MemberData(nameof(Variants))]
+    public async Task GetAudienceFromWellKnown_CallerCancellationPropagatesAndDoesNotCacheFallback(string variant)
+    {
+        // Arrange
+        await using var fixture = Fixture.Create();
+        var client = fixture.Client(variant);
+        const string realIssuer = "https://issuer.maskinporten.no/";
+
+        fixture
+            .HttpClientFactoryMock.Setup(x => x.CreateClient(It.IsAny<string>()))
+            .Returns(() =>
+            {
+                var mockHandler = new Mock<HttpMessageHandler>();
+                mockHandler
+                    .Protected()
+                    .Setup<Task<HttpResponseMessage>>(
+                        "SendAsync",
+                        ItExpr.IsAny<HttpRequestMessage>(),
+                        ItExpr.IsAny<CancellationToken>()
+                    )
+                    .Returns(
+                        (HttpRequestMessage _, CancellationToken token) =>
+                        {
+                            token.ThrowIfCancellationRequested();
+                            return Task.FromResult(
+                                new HttpResponseMessage
+                                {
+                                    StatusCode = HttpStatusCode.OK,
+                                    Content = new StringContent(JsonSerializer.Serialize(new { issuer = realIssuer })),
+                                }
+                            );
+                        }
+                    );
+                return new HttpClient(mockHandler.Object);
+            });
+
+        // Act - a cancelled caller on the cold path propagates the cancellation
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await client.GetAudienceFromWellKnown(cts.Token)
+        );
+
+        // Assert - the aborted attempt did not cache a fallback entry; the next caller gets the real issuer
+        var result = await client.GetAudienceFromWellKnown();
+        Assert.Equal(realIssuer, result);
+    }
+
     [Fact]
     public async Task GenerateJwtGrant_IncludesConsumerOrgAndResourceClaims()
     {

--- a/src/App/backend/test/Altinn.App.Core.Tests/Features/Maskinporten/MaskinportenClientTest.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Features/Maskinporten/MaskinportenClientTest.cs
@@ -961,6 +961,9 @@ public class MaskinportenClientTests
             await Task.Delay(10);
         }
 
+        // Let any straggler background refresh land before snapshotting the call count
+        await Task.Delay(50);
+
         // Once recovered, the normal cache duration applies again
         fixture.FakeTime.Advance(TimeSpan.FromMinutes(30));
         var callCountAfterRecovery = callCount;
@@ -972,6 +975,57 @@ public class MaskinportenClientTests
         Assert.Equal(realIssuer, result3);
         Assert.Equal(realIssuer, result4);
         Assert.Equal(callCountAfterRecovery, callCount); // No refetch within the normal cache duration
+    }
+
+    [Theory]
+    [MemberData(nameof(Variants))]
+    public async Task GetAudienceFromWellKnown_ColdStartIsSingleFlighted(string variant)
+    {
+        // Arrange
+        await using var fixture = Fixture.Create();
+        var client = fixture.Client(variant);
+        const string realIssuer = "https://issuer.maskinporten.no/";
+        var fetchStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFetch = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var fetchCount = 0;
+
+        fixture
+            .HttpClientFactoryMock.Setup(x => x.CreateClient(It.IsAny<string>()))
+            .Returns(() =>
+            {
+                Interlocked.Increment(ref fetchCount);
+                var mockHandler = new Mock<HttpMessageHandler>();
+                mockHandler
+                    .Protected()
+                    .Setup<Task<HttpResponseMessage>>(
+                        "SendAsync",
+                        ItExpr.IsAny<HttpRequestMessage>(),
+                        ItExpr.IsAny<CancellationToken>()
+                    )
+                    .Returns(
+                        async (HttpRequestMessage _, CancellationToken _) =>
+                        {
+                            fetchStarted.TrySetResult();
+                            await releaseFetch.Task;
+                            return new HttpResponseMessage
+                            {
+                                StatusCode = HttpStatusCode.OK,
+                                Content = new StringContent(JsonSerializer.Serialize(new { issuer = realIssuer })),
+                            };
+                        }
+                    );
+                return new HttpClient(mockHandler.Object);
+            });
+
+        // Act - start concurrent cold callers, let the first fetch begin, then release it
+        var tasks = Enumerable.Range(0, 10).Select(_ => client.GetAudienceFromWellKnown().AsTask()).ToArray();
+        await fetchStarted.Task;
+        releaseFetch.SetResult();
+        var results = await Task.WhenAll(tasks);
+
+        // Assert - everyone got the issuer from a single fetch
+        Assert.All(results, r => Assert.Equal(realIssuer, r));
+        Assert.Equal(1, fetchCount);
     }
 
     [Theory]

--- a/src/App/backend/test/Altinn.App.Core.Tests/Features/Maskinporten/MaskinportenClientTest.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Features/Maskinporten/MaskinportenClientTest.cs
@@ -961,8 +961,15 @@ public class MaskinportenClientTests
             await Task.Delay(10);
         }
 
-        // Let any straggler background refresh land before snapshotting the call count
-        await Task.Delay(50);
+        // Let any straggler background refresh land before snapshotting the call count:
+        // poll until the count has been stable for one interval (bounded by the outer timeout below)
+        var settle = Stopwatch.StartNew();
+        var previousCount = -1;
+        while (previousCount != callCount && settle.Elapsed < TimeSpan.FromSeconds(5))
+        {
+            previousCount = callCount;
+            await Task.Delay(50);
+        }
 
         // Once recovered, the normal cache duration applies again
         fixture.FakeTime.Advance(TimeSpan.FromMinutes(30));

--- a/src/App/backend/test/Altinn.App.Core.Tests/Features/Maskinporten/MaskinportenClientTest.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Features/Maskinporten/MaskinportenClientTest.cs
@@ -1019,12 +1019,58 @@ public class MaskinportenClientTests
 
         // Act - start concurrent cold callers, let the first fetch begin, then release it
         var tasks = Enumerable.Range(0, 10).Select(_ => client.GetAudienceFromWellKnown().AsTask()).ToArray();
-        await fetchStarted.Task;
+        await fetchStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
         releaseFetch.SetResult();
         var results = await Task.WhenAll(tasks);
 
         // Assert - everyone got the issuer from a single fetch
         Assert.All(results, r => Assert.Equal(realIssuer, r));
+        Assert.Equal(1, fetchCount);
+    }
+
+    [Theory]
+    [MemberData(nameof(Variants))]
+    public async Task GetAudienceFromWellKnown_ColdStartIsSingleFlighted_DuringOutage(string variant)
+    {
+        // Arrange
+        await using var fixture = Fixture.Create();
+        var client = fixture.Client(variant);
+        var fetchStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFetch = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var fetchCount = 0;
+
+        fixture
+            .HttpClientFactoryMock.Setup(x => x.CreateClient(It.IsAny<string>()))
+            .Returns(() =>
+            {
+                Interlocked.Increment(ref fetchCount);
+                var mockHandler = new Mock<HttpMessageHandler>();
+                mockHandler
+                    .Protected()
+                    .Setup<Task<HttpResponseMessage>>(
+                        "SendAsync",
+                        ItExpr.IsAny<HttpRequestMessage>(),
+                        ItExpr.IsAny<CancellationToken>()
+                    )
+                    .Returns(
+                        async (HttpRequestMessage _, CancellationToken _) =>
+                        {
+                            fetchStarted.TrySetResult();
+                            await releaseFetch.Task;
+                            return new HttpResponseMessage { StatusCode = HttpStatusCode.InternalServerError };
+                        }
+                    );
+                return new HttpClient(mockHandler.Object);
+            });
+
+        // Act - start concurrent cold callers against a failing endpoint, let the first fetch begin, then release it
+        var tasks = Enumerable.Range(0, 10).Select(_ => client.GetAudienceFromWellKnown().AsTask()).ToArray();
+        await fetchStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        releaseFetch.SetResult();
+        var results = await Task.WhenAll(tasks);
+
+        // Assert - a single failed fetch produced the fallback for everyone (no N x blocking fetches)
+        Assert.All(results, r => Assert.Equal(client.Settings.Authority, r));
         Assert.Equal(1, fetchCount);
     }
 


### PR DESCRIPTION
Fixes #19653

## What

The well-known audience lookup in `MaskinportenClient` (process-lifetime singleton, `default` + `internal` variants) had one bug and one bad failure mode:

1. **Refresh-flag latch (bug).** `_wellKnownRefreshing` was claimed *before* `Task.Run(action, cancellationToken)`, and `Task.Run` never invokes the delegate when the token is already cancelled — so the `finally` that resets the flag never ran. One cancelled request observing a stale cache (client disconnect at the wrong moment, possible once per hour) permanently disabled all future refreshes, silently. The background refresh serves every future caller, so it now runs unconditionally (`CancellationToken.None`, matching the intent already present inside the refresh method).

2. **Outage latency amplification.** A failed lookup returned the fallback but never wrote the cache, so during a well-known outage *every* token request re-entered the blocking path and burned the full 10s fetch timeout (~40s worst case combined with the 30s outbound budget from #19648). Failed lookups are now cached as fallback entries with a short retry window (`WellKnownFallbackRetryInterval`, 30s): the first failure caches, subsequent callers fail fast, and once the window lapses the existing stale branch retries in the background. Recovery flips back to the real issuer and the normal 1h freshness.

3. **Cold-start single-flight.** Concurrent cold callers each ran their own blocking fetch (the issue's §2 assumed fallback caching alone would fix this, but the first concurrent wave still stampeded — N × 10s during an outage). A `SemaphoreSlim(1,1)` now gates the cold path: the first caller fetches, the rest wait and reuse the entry it wrote.

Also: caller cancellation on the cold path now propagates instead of tainting the shared cache with a fallback entry (the only caller already rethrows OCE unwrapped, and a pre-cancelled caller previously hit OCE at the subsequent token POST anyway — net exposure unchanged); the inline 10s fetch timeout is hoisted to a named constant (issue §4); and the §3 fallback-audience limitation is documented in the method remarks.

## Acceptance criteria

- [x] A pre-cancelled caller token can no longer latch `_wellKnownRefreshing`; background refresh always runs and resets the flag
- [x] A failed cold-start lookup caches the fallback; callers within the retry window fail fast (no blocking refetch)
- [x] After the window, retries happen in the background; recovery restores the real issuer and 1h freshness
- [x] Concurrent cold callers produce exactly one fetch (success and outage variants)
- [x] Happy path unchanged; all pre-existing tests pass unmodified
- [x] No public API or telemetry contract changes (`MaskinportenClient` is internal; PublicApi snapshot untouched)

## Deliberately not done

- **Telemetry signal for persistent fallback (issue §3 option):** telemetry is a public contract in this repo (changes are breaking), so this stays a log-only signal. Documented as a known limitation in the method remarks instead.
- **Authority-reload cache invalidation (issue §4):** explicitly deferred by the issue as very low priority.
- **Blocking retry for a stale fallback entry:** adversarial review pointed out that a single transient blip now pins the fallback audience for up to 30s (previously the next caller re-fetched — blockingly — and recovered immediately). Kept the issue's non-blocking design: in every shipped environment the fallback *is* the correct audience, so predictable caller latency wins; the affected case (non-standard `Authority`, e.g. a proxy host) is documented in the remarks. The 30s window is an internal constant if tuning is ever needed.
- **`Dispose` on the fetch lock:** deliberately absent, with a justified CA1001 suppression. `SemaphoreSlim.Dispose` frees nothing here (the wait handle is lazily allocated only via `AvailableWaitHandle`, never accessed) and would convert a shutdown-overlapping lookup into a *hang* (disposal nulls the async-waiter queue without completing waiters — verified empirically in review).

## How it was verified

- New tests (all mutation-tested — each fails when the specific production change it guards is reverted):
  - `GetAudienceFromWellKnown_BackgroundRefreshSurvivesPreCancelledToken` (the latch)
  - `GetAudienceFromWellKnown_CachesFallbackOnFailure_FailsFastWithinRetryInterval` (fail-fast)
  - `GetAudienceFromWellKnown_FallbackRetriesInBackgroundAndRecovers` (recovery + 1h freshness restore)
  - `GetAudienceFromWellKnown_ColdStartIsSingleFlighted` / `…_DuringOutage` (single-flight, both paths)
  - `GetAudienceFromWellKnown_CallerCancellationPropagatesAndDoesNotCacheFallback`
- Two adversarial review passes (separate model, isolated worktree) covering memory-model interleavings, OCE escape paths, lock accounting on all four exit paths (including owner-cancelled-mid-fetch, verified by probe), and test determinism.
- Full suites locally: `Altinn.App.Core.Tests` 2876/2876, `Altinn.App.Api.Tests` 485/485 (includes PublicApi snapshot), `Altinn.App.Clients.Fiks.Tests` 178/178, SourceGenerator suites green. `Altinn.App.Integration.Tests` fails locally with mass 502s **on unmodified `origin/main` too** (localtest proxy cannot reach app processes in this environment) — environmental, deferring to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when retrieving Maskinporten issuer metadata, including clearer handling of fallback versus successful cached values.
  - Prevented multiple simultaneous requests during cold starts (single-flight), reducing unnecessary traffic.
  - Added controlled, fail-fast fallback caching when metadata fetches fail, with automatic recovery via background refresh.
  - Ensured correct behaviour when cancellation occurs during cold start, without incorrectly caching failures.
  - Improved timeout handling for metadata requests.

- **Tests**
  - Added behavioural coverage for concurrent requests, outages, recovery, cancellation, and background refresh scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->