### PR TITLE
chore(app-backend): bump build-and-test job timeout to 25 minutes

### DIFF
--- a/.github/workflows/app-backend-tests.yml
+++ b/.github/workflows/app-backend-tests.yml
@@ -41,7 +41,7 @@ jobs:
             workingDir: src\App\backend\
     name: Build and test
     runs-on: ${{ matrix.os.runner }}
-    timeout-minutes: 15
+    timeout-minutes: 25
     env:
       DOTNET_HOSTBUILDER__RELOADCONFIGONCHANGE: false
     steps:


### PR DESCRIPTION
## What

Bumps the `Build and test` job timeout in `app-backend-tests.yml` from 15 to 25 minutes.

## Why

The last ten **successful** ubuntu (`self-hosted-single`) runs of this job took 12.2–14.7 minutes against the 15-minute cap — two finished with 18 seconds of headroom:

```
12.2  13.8  12.5  14.7  12.9  14.7  13.4  14.4  14.3  14.3   (minutes)
```

Whether a run survives is luck of the runner draw. A slow draw gets cancelled mid-suite with every completed test passing — most recently [#19673 attempt 1](https://github.com/Altinn/altinn-studio/actions/runs/30443771568) (killed at 15m19s, 3014/3014 unit tests green, integration tests passing one by one when the axe fell), and it has bitten before that too.

25 minutes gives ~10 minutes of headroom over the worst observed legitimate duration. The cost is that a genuinely hung job occupies the shared runner 10 minutes longer before being killed — acceptable against spurious cancellations of green runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the backend analysis workflow timeout to allow longer-running checks to complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->