### PR TITLE
fix(studioctl-server): remove hidden 100s cap on host-bridge requests

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -17,6 +17,10 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 - Point `studioctl app upgrade v9` removed-API warnings at the offending call rather than the start of the enclosing expression.
 
+### Fixed
+
+- Remove the hidden 100-second cap on requests tunneled through the host bridge: `studioctl-server` left `HttpClient.Timeout` at its default, so any app request running longer — such as a workflow-engine service-task callback with a generous per-step `MaxExecutionTime` (e.g. long-running AI or external-system tasks) — was aborted at exactly 100s (the app saw 499/`TaskCanceledException`) and the step failed despite being within its budget. The bridge now relies on the tunnel's own per-request cancellation, matching how the workflow engine itself disables the client timeout so the step budget is the single source of truth.
+
 ## [0.1.0-preview.18] - 2026-07-24
 
 ### Added

--- a/src/cli/studioctl-server/HostBridge/HostBridgeConnector.cs
+++ b/src/cli/studioctl-server/HostBridge/HostBridgeConnector.cs
@@ -28,6 +28,12 @@ internal sealed class HostBridgeConnector : BackgroundService
     )
     {
         DefaultRequestHeaders = { UserAgent = { ProductInfoHeaderValue.Parse(StudioctlUserAgent.Value) } },
+        // Each bridged request is cancelled through the tunnel (PendingRequest.Cancel), so that is the
+        // single budget for in-flight requests. HttpClient's default 100s Timeout would silently cap
+        // long-running requests — e.g. workflow-engine service-task callbacks, which carry their own
+        // per-step MaxExecutionTime budget and legitimately run for many minutes. ConnectTimeout above
+        // still bounds connection establishment.
+        Timeout = Timeout.InfiniteTimeSpan,
     };
 
     private readonly HostBridgeOptions _options;


### PR DESCRIPTION
## Description

`studioctl-server`'s HostBridge `HttpClient` kept its default 100-second `Timeout`, silently aborting any tunneled app request that ran longer.

Workflow-engine **service-task callbacks** are the prime victim: the engine grants each step a per-step `MaxExecutionTime` (#19571) and deliberately disables its own `HttpClient` timeout so that budget is the single source of truth (`AppCommand.cs`). But locally, every callback travels engine -> localtest ingress -> host bridge -> app, and the bridge cut the request at exactly 100s. The app logged `499`/`TaskCanceledException`, the step burned its retries and dead-lettered even though it was well within its budget.

Observed running an AI-enrichment service task (~2 min LLM run, step `maxExecutionTime: 01:00:00` correctly on the wire) on app-lib `9.0.0-preview.3` via `studioctl env up`; with this fix the same workflow completes.

## Fix

Each bridged request already carries its own cancellation through the tunnel (`PendingRequest.Cancel`), so set `Timeout = Timeout.InfiniteTimeSpan` and let the tunnel/step budget be the only in-flight limit — the same pattern the workflow engine uses for its callback client. `ConnectTimeout` (5s) still bounds connection establishment.

## Verification

- Reproduced: ai service task callback aborted at 100 014 ms with 499, three attempts, workflow dead-lettered.
- With fix (locally built `studioctl-server` + engine resume): callback ran ~110s to completion, workflow chain `data -> pdf -> ai -> end` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Long-running requests through the host bridge are no longer cancelled automatically after 100 seconds.
  * Requests now remain active until the tunnel or request itself is cancelled, while connection establishment continues to observe its existing timeout.

* **Documentation**
  * Updated the unreleased changelog to document the improved request timeout behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->