### PR TITLE
feat: Improve information about failing request  in unknown error page

### DIFF
--- a/src/App/frontend/src/features/instantiate/containers/UnknownError.test.tsx
+++ b/src/App/frontend/src/features/instantiate/containers/UnknownError.test.tsx
@@ -2,12 +2,31 @@ import React from 'react';
 
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { AxiosError, AxiosResponse } from 'axios';
 
 import { UnknownError } from 'src/features/instantiate/containers/UnknownError';
 import { renderWithMinimalProviders } from 'src/test/renderWithProviders';
 
 // Need to unmock axios to get actual implementation of isAxiosError
 jest.unmock('axios');
+
+const failedInstantiationBody = {
+  title: 'Instance initialization failed.',
+  status: 500,
+};
+
+function makeInstantiationError(): AxiosError {
+  const error = new Error('Request failed with status code 500') as AxiosError;
+  error.name = 'AxiosError';
+  error.isAxiosError = true;
+  error.config = {
+    method: 'post',
+    baseURL: '/ttd/component-library',
+    url: '/instances?instanceOwnerPartyId=501337&language=nb',
+  } as AxiosError['config'];
+  error.response = { status: 500, data: failedInstantiationBody } as AxiosResponse;
+  return error;
+}
 
 describe('Unknown error', () => {
   afterEach(() => {
@@ -40,5 +59,31 @@ describe('Unknown error', () => {
     await user.click(copyButton);
     expect(writeTextMock).toHaveBeenCalledWith(expect.stringContaining('Error test message'));
     expect(copyButton).toHaveAccessibleName('Kopiert');
+  });
+
+  it('should show the failing request and the response body for an axios error', async () => {
+    const user = userEvent.setup({ delay: null });
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    await renderWithMinimalProviders({
+      renderer: () => <UnknownError error={makeInstantiationError()} />,
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Vis detaljer om feilen' }));
+
+    expect(screen.getByText('POST')).toBeInTheDocument();
+    expect(screen.getByText('/instances?instanceOwnerPartyId=501337&language=nb')).toBeInTheDocument();
+    expect(screen.getByText('500')).toBeInTheDocument();
+    expect(screen.getByText(/"title": "Instance initialization failed\."/)).toBeInTheDocument();
+
+    const writeTextMock = jest.spyOn(navigator.clipboard, 'writeText').mockResolvedValue();
+    await user.click(screen.getByRole('button', { name: 'Kopier' }));
+
+    const copiedJson = JSON.parse(writeTextMock.mock.calls[0][0]);
+    expect(copiedJson).toMatchObject({
+      method: 'POST',
+      url: '/instances?instanceOwnerPartyId=501337&language=nb',
+      responseStatus: 500,
+      responseData: failedInstantiationBody,
+    });
   });
 });

--- a/src/App/frontend/src/features/instantiate/containers/UnknownErrorDetails.module.css
+++ b/src/App/frontend/src/features/instantiate/containers/UnknownErrorDetails.module.css
@@ -3,3 +3,9 @@
   gap: 16px;
   flex-direction: column;
 }
+
+.detailValue {
+  /* Keep newlines in json bodies and stack traces, but let long lines wrap instead of overflowing */
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}

--- a/src/App/frontend/src/features/instantiate/containers/UnknownErrorDetails.tsx
+++ b/src/App/frontend/src/features/instantiate/containers/UnknownErrorDetails.tsx
@@ -6,7 +6,7 @@ import type { AxiosError } from 'axios';
 
 import classes from 'src/features/instantiate/containers/UnknownErrorDetails.module.css';
 import { Lang } from 'src/features/language/Lang';
-import { getAxiosErrorDetails } from 'src/utils/axiosErrorDetails';
+import { formatResponseBody, getAxiosErrorDetails } from 'src/utils/axiosErrorDetails';
 
 interface UnknownErrorDetailsProps {
   error: Error | AxiosError;
@@ -19,8 +19,7 @@ export function UnknownErrorDetails({ error, className }: UnknownErrorDetailsPro
   const [axiosError] = useState(() => getAxiosErrorDetails(error));
   const [location] = useState(window?.location.href);
 
-  // Axios parses json responses, so the body is usually an object rather than a string
-  const responseBody = JSON.stringify(axiosError?.responseData, null, 2);
+  const responseBody = formatResponseBody(axiosError?.responseData);
 
   async function handleCopyErrorClicked() {
     const errorInfo = {

--- a/src/App/frontend/src/features/instantiate/containers/UnknownErrorDetails.tsx
+++ b/src/App/frontend/src/features/instantiate/containers/UnknownErrorDetails.tsx
@@ -2,10 +2,11 @@ import React, { useState } from 'react';
 
 import { AccordionItem, Button, Flex } from '@app/form-component';
 import { CheckmarkCircleIcon } from '@navikt/aksel-icons';
-import { type AxiosError, isAxiosError } from 'axios';
+import type { AxiosError } from 'axios';
 
 import classes from 'src/features/instantiate/containers/UnknownErrorDetails.module.css';
 import { Lang } from 'src/features/language/Lang';
+import { getAxiosErrorDetails } from 'src/utils/axiosErrorDetails';
 
 interface UnknownErrorDetailsProps {
   error: Error | AxiosError;
@@ -15,16 +16,11 @@ interface UnknownErrorDetailsProps {
 export function UnknownErrorDetails({ error, className }: UnknownErrorDetailsProps) {
   const [now] = useState(new Date());
   const [copied, setCopied] = useState(false);
-  const [axiosError] = useState(() => {
-    if (isAxiosError(error)) {
-      return {
-        responseStatus: error.response?.status,
-        responseData: error.response?.data,
-      };
-    }
-    return null;
-  });
+  const [axiosError] = useState(() => getAxiosErrorDetails(error));
   const [location] = useState(window?.location.href);
+
+  // Axios parses json responses, so the body is usually an object rather than a string
+  const responseBody = JSON.stringify(axiosError?.responseData, null, 2);
 
   async function handleCopyErrorClicked() {
     const errorInfo = {
@@ -87,12 +83,34 @@ export function UnknownErrorDetails({ error, className }: UnknownErrorDetailsPro
           value={now.toISOString()}
         />
 
+        {axiosError?.url && (
+          <DetailItem
+            name='Request url'
+            value={axiosError.url}
+          />
+        )}
+
+        {axiosError?.method && (
+          <DetailItem
+            name='Request method'
+            value={axiosError.method}
+          />
+        )}
+
         {axiosError && (
           <DetailItem
             name='Response status'
             value={axiosError.responseStatus ? axiosError.responseStatus.toString() : ''}
           />
         )}
+
+        {responseBody && (
+          <DetailItem
+            name='Response body'
+            value={responseBody}
+          />
+        )}
+
         {error.stack && (
           <DetailItem
             name='Stacktrace'
@@ -110,7 +128,7 @@ function DetailItem({ name, value }: { name: string; value: string }) {
       <div>
         <strong>{name}:</strong>
       </div>
-      <div>{value}</div>
+      <div className={classes.detailValue}>{value}</div>
     </div>
   );
 }

--- a/src/App/frontend/src/utils/axiosErrorDetails.test.ts
+++ b/src/App/frontend/src/utils/axiosErrorDetails.test.ts
@@ -1,0 +1,40 @@
+import type { AxiosError, AxiosResponse } from 'axios';
+
+import { getAxiosErrorDetails } from 'src/utils/axiosErrorDetails';
+
+describe('getAxiosErrorDetails', () => {
+  it('should return null for errors that are not from axios', () => {
+    expect(getAxiosErrorDetails(new Error('boom'))).toBeNull();
+    expect(getAxiosErrorDetails(undefined)).toBeNull();
+    expect(getAxiosErrorDetails('boom')).toBeNull();
+  });
+
+  it('should extract method, url, status and body from an axios error', () => {
+    const error = new Error('Request failed with status code 500') as AxiosError;
+    error.isAxiosError = true;
+    error.config = {
+      method: 'post',
+      url: '/instances?instanceOwnerPartyId=501337&language=nb',
+    } as AxiosError['config'];
+    error.response = { status: 500, data: { title: 'Instance initialization failed.' } } as AxiosResponse;
+
+    expect(getAxiosErrorDetails(error)).toEqual({
+      method: 'POST',
+      url: '/instances?instanceOwnerPartyId=501337&language=nb',
+      responseStatus: 500,
+      responseData: { title: 'Instance initialization failed.' },
+    });
+  });
+
+  it('should handle a missing config and response', () => {
+    const error = new Error('Network Error') as AxiosError;
+    error.isAxiosError = true;
+
+    expect(getAxiosErrorDetails(error)).toEqual({
+      method: undefined,
+      url: undefined,
+      responseStatus: undefined,
+      responseData: undefined,
+    });
+  });
+});

--- a/src/App/frontend/src/utils/axiosErrorDetails.test.ts
+++ b/src/App/frontend/src/utils/axiosErrorDetails.test.ts
@@ -1,6 +1,6 @@
 import type { AxiosError, AxiosResponse } from 'axios';
 
-import { getAxiosErrorDetails } from 'src/utils/axiosErrorDetails';
+import { formatResponseBody, getAxiosErrorDetails } from 'src/utils/axiosErrorDetails';
 
 describe('getAxiosErrorDetails', () => {
   it('should return null for errors that are not from axios', () => {
@@ -36,5 +36,23 @@ describe('getAxiosErrorDetails', () => {
       responseStatus: undefined,
       responseData: undefined,
     });
+  });
+});
+
+describe('formatResponseBody', () => {
+  it('should format responseBody property', () => {
+    expect(formatResponseBody({ title: 'Boom' })).toBe('{\n  "title": "Boom"\n}');
+  });
+
+  it('should return text bodies as-is, without json escaping', () => {
+    expect(formatResponseBody('<html>\n<body>502 Bad Gateway</body>\n</html>')).toBe(
+      '<html>\n<body>502 Bad Gateway</body>\n</html>',
+    );
+  });
+
+  it('should return undefined when there is nothing to show', () => {
+    expect(formatResponseBody(undefined)).toBeUndefined();
+    expect(formatResponseBody(null)).toBeUndefined();
+    expect(formatResponseBody('')).toBeUndefined();
   });
 });

--- a/src/App/frontend/src/utils/axiosErrorDetails.ts
+++ b/src/App/frontend/src/utils/axiosErrorDetails.ts
@@ -1,0 +1,28 @@
+import type { AxiosError } from 'axios';
+
+import { isAxiosError } from 'src/utils/isAxiosError';
+
+export interface AxiosErrorDetails {
+  method: string | undefined;
+  url: string | undefined;
+  responseStatus: number | undefined;
+  responseData: unknown;
+}
+
+/**
+ * Extracts the request/response info for a failed request.
+ * Returns null for errors that did not come from axios.
+ */
+export function getAxiosErrorDetails(error: unknown): AxiosErrorDetails | null {
+  if (!isAxiosError(error)) {
+    return null;
+  }
+
+  const { config, response } = error as AxiosError;
+  return {
+    method: config?.method?.toUpperCase(),
+    url: config?.url,
+    responseStatus: response?.status,
+    responseData: response?.data,
+  };
+}

--- a/src/App/frontend/src/utils/axiosErrorDetails.ts
+++ b/src/App/frontend/src/utils/axiosErrorDetails.ts
@@ -1,5 +1,3 @@
-import type { AxiosError } from 'axios';
-
 import { isAxiosError } from 'src/utils/isAxiosError';
 
 export interface AxiosErrorDetails {
@@ -18,11 +16,32 @@ export function getAxiosErrorDetails(error: unknown): AxiosErrorDetails | null {
     return null;
   }
 
-  const { config, response } = error as AxiosError;
+  const { config, response } = error;
   return {
     method: config?.method?.toUpperCase(),
     url: config?.url,
     responseStatus: response?.status,
     responseData: response?.data,
   };
+}
+
+/**
+ * Formats a response body for display. Axios parses json responses, so the body is usually an object,
+ * but it can also be a raw string (for instance an html error page from a gateway) or missing entirely.
+ * Returns undefined when there is nothing (useful) to show.
+ */
+export function formatResponseBody(responseData: unknown): string | undefined {
+  if (responseData == null) {
+    return undefined;
+  }
+
+  if (typeof responseData === 'string') {
+    return responseData.trim();
+  }
+
+  try {
+    return JSON.stringify(responseData, null, 2) ?? undefined;
+  } catch {
+    return undefined;
+  }
 }

--- a/src/App/frontend/src/utils/axiosErrorDetails.ts
+++ b/src/App/frontend/src/utils/axiosErrorDetails.ts
@@ -36,7 +36,7 @@ export function formatResponseBody(responseData: unknown): string | undefined {
   }
 
   if (typeof responseData === 'string') {
-    return responseData.trim();
+    return responseData.trim() || undefined;
   }
 
   try {


### PR DESCRIPTION
If a unknown error happens due to a failing request, we want to display the url of the request and it's response.

Before : 
<img width="809" height="687" alt="image" src="https://github.com/user-attachments/assets/66bf192e-c5d6-4b78-b801-ec013691fd90" />


After (shows request url, request method and response body)
<img width="667" height="1130" alt="image" src="https://github.com/user-attachments/assets/73a4cf38-14e2-4e8a-a3ec-7b0e5af4a52f" />


## Description

<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Error details now include Axios request information (URL and HTTP method), response status, and a formatted response body when available.
  * Copying error details now outputs a JSON payload containing the request and response data.

* **Bug Fixes**
  * Error details rendering now consistently formats and displays Axios response bodies, with improved handling for missing request/response fields.

* **Documentation / Tests**
  * Added unit tests for Axios error detail extraction and response body formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->