### PR TITLE
fix: handle BOM when adding default Maskinporten scopes

### DIFF
--- a/src/Designer/backend/src/Designer/Helpers/PackageVersionHelper.cs
+++ b/src/Designer/backend/src/Designer/Helpers/PackageVersionHelper.cs
@@ -1,5 +1,6 @@
 ﻿#nullable disable
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Xml.Linq;
 using System.Xml.XPath;
@@ -19,12 +20,13 @@ public static class PackageVersionHelper
     }
 
     public static bool TryGetPackageVersionFromCsprojContent(
-        string csprojContent,
+        byte[] csprojContent,
         IReadOnlyList<string> packageNames,
         out SemanticVersion version
     )
     {
-        return TryGetPackageVersionFromCsprojXml(XDocument.Parse(csprojContent), packageNames, out version);
+        using var stream = new MemoryStream(csprojContent, writable: false);
+        return TryGetPackageVersionFromCsprojXml(XDocument.Load(stream), packageNames, out version);
     }
 
     private static bool TryGetPackageVersionFromCsprojXml(

--- a/src/Designer/backend/src/Designer/Services/Implementation/ReleaseService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/ReleaseService.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Net;
-using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -267,7 +266,7 @@ public class ReleaseService : IReleaseService
 
         try
         {
-            string csprojContent = Encoding.UTF8.GetString(Convert.FromBase64String(appCsproj.Content));
+            byte[] csprojContent = Convert.FromBase64String(appCsproj.Content);
             string[] packageNames = ["Altinn.App.Api", "Altinn.App.Api.Experimental"];
 
             return PackageVersionHelper.TryGetPackageVersionFromCsprojContent(

--- a/src/Designer/backend/tests/Designer.Tests/Services/ReleaseServiceTest.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/ReleaseServiceTest.cs
@@ -279,7 +279,7 @@ public class ReleaseServiceTest
         );
     }
 
-    private void SetupAppLibVersion(string version)
+    private void SetupAppLibVersion(string version, bool includeUtf8Bom = false)
     {
         string csprojContent = $"""
             <Project Sdk="Microsoft.NET.Sdk.Web">
@@ -288,12 +288,15 @@ public class ReleaseServiceTest
               </ItemGroup>
             </Project>
             """;
+        byte[] csprojBytes = Encoding.UTF8.GetBytes(csprojContent);
+        if (includeUtf8Bom)
+        {
+            csprojBytes = [.. Encoding.UTF8.GetPreamble(), .. csprojBytes];
+        }
 
         _giteaClient
             .Setup(c => c.GetFileAsync(_org, _app, "App/App.csproj", It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(
-                new FileSystemObject { Content = Convert.ToBase64String(Encoding.UTF8.GetBytes(csprojContent)) }
-            );
+            .ReturnsAsync(new FileSystemObject { Content = Convert.ToBase64String(csprojBytes) });
     }
 
     private void VerifyWarningLog()
@@ -546,7 +549,7 @@ public class ReleaseServiceTest
     }
 
     [Fact]
-    public async Task CreateAsync_WithAppLibVersion9PreviewAndNullAppScopes_AddsDefaultMaskinportenScopes()
+    public async Task CreateAsync_WithUtf8BomAppLibVersion9PreviewAndNullAppScopes_AddsDefaultMaskinportenScopes()
     {
         // Arrange
         ReleaseEntity releaseEntity = new()
@@ -597,7 +600,7 @@ public class ReleaseServiceTest
         _azureDevOpsBuildClient
             .Setup(b => b.QueueAsync(It.IsAny<QueueBuildParameters>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(GetBuild());
-        SetupAppLibVersion("9.0.0-preview.1");
+        SetupAppLibVersion("9.0.0-preview.1", includeUtf8Bom: true);
 
         ReleaseService releaseService = CreateReleaseService();
 


### PR DESCRIPTION
## Description

Default Maskinporten scopes for v9 apps are added during release creation after reading the `Altinn.App.Api` version from `App/App.csproj`.

Gitea returns the project file as base64-encoded bytes. Decoding those bytes directly to a string preserves a UTF-8 byte order mark as `U+FEFF`, which causes `XDocument.Parse` to throw before the package version can be read. The exception is handled as an unknown/non-v9 app, so the release is successfully queued without the mandatory default scopes.

This change:

- passes the decoded project-file bytes to `PackageVersionHelper`;
- parses them with `XDocument.Load(Stream)`, allowing the XML reader to handle the BOM and encoding;
- adds a release-service regression test using a BOM-prefixed v9 preview project file.

This is a regression fix for the behavior introduced in #18782. An audit found no other Designer path that decodes base64 repository content and then passes it to `XDocument.Parse`.

## Verification

- [x] Related issues are connected (not applicable; regression in #18782)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

Reproduced the failure against a BOM-prefixed v9 preview `App.csproj`, confirmed the regression test failed before the implementation change, and passed afterward.

```text
dotnet csharpier check .
Checked 1424 files

dotnet test tests/Designer.Tests/Designer.Tests.csproj --no-restore \
  --filter "FullyQualifiedName~ReleaseServiceTest|FullyQualifiedName~PackageVersionHelperTests"
Passed: 15, Failed: 0

dotnet build Designer.sln --no-restore
Build succeeded. 0 Warning(s), 0 Error(s)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of project files containing a UTF-8 byte-order mark during release processing.
  * Package version detection now works reliably when project content includes encoded metadata.

* **Tests**
  * Added coverage for release scenarios involving UTF-8 byte-order marks and preview package versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->