### PR TITLE
fix: handle BOM in organization content JSON

### DIFF
--- a/src/Designer/backend/src/Designer/Services/Implementation/GiteaContentLibraryService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/GiteaContentLibraryService.cs
@@ -154,8 +154,9 @@ public class GiteaContentLibraryService : IGiteaContentLibraryService
         {
             return string.Empty;
         }
-        byte[] binaryData = Convert.FromBase64String(file.Content);
-        return Encoding.UTF8.GetString(binaryData);
+        using var stream = new MemoryStream(Convert.FromBase64String(file.Content));
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        return await reader.ReadToEndAsync();
     }
 
     private static string StaticContentTextResourceFilePath(string languageCode)

--- a/src/Designer/backend/tests/Designer.Tests/Services/GiteaContentLibraryServiceTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/GiteaContentLibraryServiceTests.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
@@ -141,16 +143,25 @@ public class GiteaContentLibraryServiceTests
         );
     }
 
-    [Fact]
-    public async Task GetCodeList_ShouldReturnCodeList()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task GetCodeList_WithOptionalUtf8Bom_ShouldReturnCodeList(bool includeUtf8Bom)
     {
         // Arrange
         const string CodeListId = "codeListString";
         string filePath = CodeListUtils.FilePathWithTextResources(CodeListId);
+        byte[] codeListBytes = Encoding.UTF8.GetBytes(
+            TestDataHelper.GetFileFromRepo(OrgName, RepoName, Developer, filePath)
+        );
+        if (includeUtf8Bom)
+        {
+            codeListBytes = [.. Encoding.UTF8.GetPreamble(), .. codeListBytes];
+        }
         FileSystemObject codeListFileObject = new()
         {
             Name = CodeListId,
-            Content = TestDataHelper.GetFileAsBase64StringFromRepo(OrgName, RepoName, Developer, filePath),
+            Content = Convert.ToBase64String(codeListBytes),
         };
         _giteaClientMock
             .Setup(service =>


### PR DESCRIPTION
## Description

Organization code lists and text resources are retrieved from Gitea as base64-encoded bytes. Decoding a UTF-8 BOM directly with `Encoding.UTF8.GetString` leaves a leading `U+FEFF`, which `System.Text.Json` rejects.

This change reads the decoded content through an encoding-aware `StreamReader`, allowing both BOM-prefixed and BOM-less JSON to be deserialized. The code-list test now covers both encodings through the shared file-loading path.

Part of #19682.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

Confirmed the BOM test failed with `JsonException` before the implementation change and passed afterward.

```text
dotnet csharpier check .
Checked 1424 files

dotnet test tests/Designer.Tests/Designer.Tests.csproj --no-restore \
  --filter "FullyQualifiedName~GiteaContentLibraryServiceTests"
Passed: 14, Failed: 0

dotnet build Designer.sln --no-restore
Build succeeded. 0 Warning(s), 0 Error(s)
```
