### PR TITLE
fix: handle BOM in custom template JSON

### DIFF
--- a/src/Designer/backend/src/Designer/Services/Implementation/CustomTemplateService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/CustomTemplateService.cs
@@ -270,7 +270,9 @@ public class CustomTemplateService : ICustomTemplateService
             }
         }
 
-        string templateContent = Encoding.UTF8.GetString(Convert.FromBase64String(file.Content));
+        using var stream = new MemoryStream(Convert.FromBase64String(file.Content));
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        string templateContent = await reader.ReadToEndAsync();
         var validationResult = await ValidateManifestJsonAsync(templateContent);
 
         if (validationResult.Count > 0)

--- a/src/Designer/backend/tests/Designer.Tests/Services/CustomTemplate/ApplyTemplateToRepositoryTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/CustomTemplate/ApplyTemplateToRepositoryTests.cs
@@ -61,6 +61,33 @@ public class ApplyTemplateToRepositoryTests : IDisposable
     }
 
     [Fact]
+    public async Task GetCustomTemplateById_WithUtf8Bom_ReturnsTemplate()
+    {
+        // Arrange
+        string templateOwner = "als";
+        string templateId = "bom-template";
+        var template = new CustomTemplateModel
+        {
+            Id = templateId,
+            Owner = templateOwner,
+            Name = "BOM template",
+            Description = "A template saved with a UTF-8 BOM.",
+        };
+        MockTemplateJsonFile(templateOwner, templateId, template, includeUtf8Bom: true);
+
+        var sut = CreateService();
+
+        // Act
+        CustomTemplateModel result = await sut.GetCustomTemplateById(templateOwner, templateId);
+
+        // Assert
+        Assert.Equal(template.Id, result.Id);
+        Assert.Equal(template.Owner, result.Owner);
+        Assert.Equal(template.Name, result.Name);
+        Assert.Equal(template.Description, result.Description);
+    }
+
+    [Fact]
     public async Task ApplyTemplateToRepository_WithFilesAndRemovePaths_CopiesAndDeletes()
     {
         // Arrange
@@ -567,10 +594,20 @@ public class ApplyTemplateToRepositoryTests : IDisposable
             .ReturnsAsync(commitSha);
     }
 
-    private void MockTemplateJsonFile(string owner, string templateId, CustomTemplateModel template)
+    private void MockTemplateJsonFile(
+        string owner,
+        string templateId,
+        CustomTemplateModel template,
+        bool includeUtf8Bom = false
+    )
     {
         string templateJson = JsonSerializer.Serialize(template, CustomTemplateService.JsonOptions);
-        string base64Content = Convert.ToBase64String(Encoding.UTF8.GetBytes(templateJson));
+        byte[] templateBytes = Encoding.UTF8.GetBytes(templateJson);
+        if (includeUtf8Bom)
+        {
+            templateBytes = [.. Encoding.UTF8.GetPreamble(), .. templateBytes];
+        }
+        string base64Content = Convert.ToBase64String(templateBytes);
 
         _giteaClientMock
             .Setup(x => x.GetLatestCommitOnBranch(owner, $"{owner}-content", null, default))


### PR DESCRIPTION
## Description

Custom `template.json` files are retrieved from Gitea as base64-encoded bytes. Decoding a UTF-8 BOM directly with `Encoding.UTF8.GetString` leaves a leading `U+FEFF`, which causes template schema validation to fail before deserialization.

This change reads the decoded template through an encoding-aware `StreamReader` before validation and deserialization. A regression test verifies that a BOM-prefixed custom template can be loaded.

Part of #19682.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

Confirmed the regression test failed in NJsonSchema with `JsonReaderException` before the implementation change and passed afterward.

```text
dotnet csharpier check .
Checked 1424 files

dotnet test tests/Designer.Tests/Designer.Tests.csproj --no-restore \
  --filter "FullyQualifiedName~ApplyTemplateToRepositoryTests"
Passed: 11, Failed: 0

dotnet build Designer.sln --no-restore
Build succeeded. 0 Warning(s), 0 Error(s)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom template loading to correctly handle templates containing a UTF-8 byte-order mark (BOM).
  * Prevented affected template content from failing during validation or deserialisation.

* **Tests**
  * Added coverage confirming that templates with UTF-8 BOM content are loaded successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->