### PR TITLE
chore(deps): update crate-ci/typos action to v1.48.0

### DIFF
--- a/.github/workflows/runtime-workflow-engine-app-tests.yaml
+++ b/.github/workflows/runtime-workflow-engine-app-tests.yaml
@@ -39,7 +39,7 @@ jobs:
           fetch-depth: 0
 
       - name: Spell check
-        uses: crate-ci/typos@7c572958218557a3272c2d6719629443b5cc26fd # v1.45.2
+        uses: crate-ci/typos@bee27e3a4fd1ea2111cf90ab89cd076c870fce14 # v1.48.0
         with:
           config: src/Runtime/workflow-engine-app/typos.toml
           files: src/Runtime/workflow-engine-app

--- a/.github/workflows/runtime-workflow-engine-tests.yaml
+++ b/.github/workflows/runtime-workflow-engine-tests.yaml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 0
 
       - name: Spell check
-        uses: crate-ci/typos@7c572958218557a3272c2d6719629443b5cc26fd # v1.45.2
+        uses: crate-ci/typos@bee27e3a4fd1ea2111cf90ab89cd076c870fce14 # v1.48.0
         with:
           config: src/Runtime/workflow-engine/typos.toml
           files: src/Runtime/workflow-engine


### PR DESCRIPTION
## What changed

- update the pinned `crate-ci/typos` action from v1.45.2 to v1.48.0
- keep both workflow-engine spell-check workflows on the same immutable commit pin

## Why

This picks up the latest dictionary updates while preserving the repository's commit-SHA pinning convention.

## Verification

- parsed both workflow files as YAML
- ran `actionlint` against both workflow files
- ran `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the spell-checking workflow to use a newer version of the spelling validation tool.
  - Improved compatibility with the latest available spelling rules and checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->