### PR TITLE
feat: Stage all changes after update script completes

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -16,6 +16,7 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 ### Changed
 
 - Point `studioctl app upgrade v9` removed-API warnings at the offending call rather than the start of the enclosing expression.
+- Stage every change from `studioctl app upgrade` in one `git add -A` pass once the upgrade is done. Previously some migration steps staged their changes, while others did not.
 
 ## [0.1.0-preview.18] - 2026-07-24
 

--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -15,8 +15,8 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ### Changed
 
+- Stage every change from `studioctl app upgrade` in one `git add -A` pass once the upgrade is done. Previously, some migration steps staged their changes, while others did not.
 - Point `studioctl app upgrade v9` removed-API warnings at the offending call rather than the start of the enclosing expression.
-- Stage every change from `studioctl app upgrade` in one `git add -A` pass once the upgrade is done. Previously some migration steps staged their changes, while others did not.
 
 ## [0.1.0-preview.18] - 2026-07-24
 

--- a/src/cli/studioctl-server/Studioctl/AppUpgradeService.cs
+++ b/src/cli/studioctl-server/Studioctl/AppUpgradeService.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Altinn.Studio.Cli.Upgrade;
 using Altinn.Studio.Cli.Upgrade.Backend.v7Tov8.BackendUpgrade;
 using Altinn.Studio.Cli.Upgrade.Frontend.Fev3Tov4.FrontendUpgrade;
 using Altinn.Studio.Cli.Upgrade.v8Tov9;
@@ -56,6 +57,8 @@ internal sealed class AppUpgradeService : IDisposable
                     error,
                     cancellationToken
                 );
+
+                GitOperations.StageAllChanges(projectFolder, output);
 
                 return AppUpgradeResult.Completed(exitCode, output.ToString(), error.ToString());
             }

--- a/src/cli/studioctl-server/Studioctl/AppUpgradeService.cs
+++ b/src/cli/studioctl-server/Studioctl/AppUpgradeService.cs
@@ -58,7 +58,10 @@ internal sealed class AppUpgradeService : IDisposable
                     cancellationToken
                 );
 
-                GitOperations.StageAllChanges(projectFolder, output);
+                if (!V8Tov9Upgrade.IsError(exitCode))
+                {
+                    GitOperations.StageAllChanges(projectFolder, output);
+                }
 
                 return AppUpgradeResult.Completed(exitCode, output.ToString(), error.ToString());
             }

--- a/src/cli/studioctl-server/Studioctl/Upgrade/GitOperations.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/GitOperations.cs
@@ -25,12 +25,12 @@ internal static class GitOperations
             using var repo = new Repository(repoPath);
             Commands.Stage(repo, "*");
 
-            var stagedCount = repo.Diff.Compare<TreeChanges>(repo.Head.Tip?.Tree, DiffTargets.Index).Count();
+            var stagedCount = repo.Diff.Compare<TreeChanges>(repo.Head.Tip?.Tree, DiffTargets.Index).Count;
             output.WriteLine(
                 $"Staged the {stagedCount} updated file(s) - run 'git status' for overview and 'git diff --cached' to review them"
             );
         }
-        catch (LibGit2SharpException ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             output.WriteLine($"Warning: Failed to stage changes: {ex.Message}");
         }

--- a/src/cli/studioctl-server/Studioctl/Upgrade/GitOperations.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/GitOperations.cs
@@ -25,9 +25,9 @@ internal static class GitOperations
             using var repo = new Repository(repoPath);
             Commands.Stage(repo, "*");
 
-            var stagedCount = repo.Diff.Compare<TreeChanges>(repo.Head.Tip?.Tree, DiffTargets.Index).Count;
+            using var stagedChanges = repo.Diff.Compare<TreeChanges>(repo.Head.Tip?.Tree, DiffTargets.Index);
             output.WriteLine(
-                $"Staged the {stagedCount} updated file(s) - run 'git status' for overview and 'git diff --cached' to review them"
+                $"Staged the {stagedChanges.Count} updated file(s) - run 'git status' for overview and 'git diff --cached' to review them"
             );
         }
         catch (Exception ex) when (ex is not OperationCanceledException)

--- a/src/cli/studioctl-server/Studioctl/Upgrade/GitOperations.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/GitOperations.cs
@@ -3,114 +3,34 @@ using LibGit2Sharp;
 namespace Altinn.Studio.Cli.Upgrade;
 
 /// <summary>
-/// Helper class for git operations using LibGit2Sharp.
-/// Stages file changes so that moves are detected as renames by git.
+/// Git helpers on top of LibGit2Sharp.
 /// </summary>
-internal sealed class GitOperations : IDisposable
+internal static class GitOperations
 {
-    private readonly Repository _repo;
-    private readonly string _repoRoot;
-
-    private GitOperations(Repository repo, string repoRoot)
-    {
-        _repo = repo;
-        _repoRoot = repoRoot;
-    }
-
     /// <summary>
-    /// Tries to create a GitOperations instance for the given path.
-    /// Returns null if the path is not inside a git repository.
+    /// Stages every change in the repository containing <paramref name="path"/> — the equivalent of
+    /// <c>git add -A</c>. Failures are reported to <paramref name="output"/> and never fail the caller.
     /// </summary>
-    public static GitOperations? TryCreate(string path)
+    public static void StageAllChanges(string path, TextWriter output)
     {
-        var repoPath = Repository.Discover(path);
-        if (string.IsNullOrEmpty(repoPath))
+        try
         {
-            return null;
-        }
+            var repoPath = Repository.Discover(path);
+            if (string.IsNullOrEmpty(repoPath))
+            {
+                output.WriteLine("Not a git repository - leaving changes unstaged");
+                return;
+            }
 
-        var repo = new Repository(repoPath);
-        var workingDir = repo.Info.WorkingDirectory;
-        if (string.IsNullOrEmpty(workingDir))
+            using var repo = new Repository(repoPath);
+            Commands.Stage(repo, "*");
+
+            var stagedCount = repo.Diff.Compare<TreeChanges>(repo.Head.Tip?.Tree, DiffTargets.Index).Count();
+            output.WriteLine($"Staged the {stagedCount} updated file(s) - run 'git status' for overview and 'git diff --cached' to review them");
+        }
+        catch (LibGit2SharpException ex)
         {
-            repo.Dispose();
-            return null;
+            output.WriteLine($"Warning: Failed to stage changes: {ex.Message}");
         }
-
-        var repoRoot = workingDir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        return new GitOperations(repo, repoRoot);
-    }
-
-    /// <summary>
-    /// Moves a directory and stages the changes as a rename in git.
-    /// </summary>
-    public void MoveDirectory(string sourcePath, string destinationPath)
-    {
-        var sourceFiles = Directory
-            .GetFiles(sourcePath, "*", SearchOption.AllDirectories)
-            .Select(f => GetRelativePath(f))
-            .ToList();
-
-        Directory.Move(sourcePath, destinationPath);
-
-        foreach (var relativePath in sourceFiles)
-        {
-            Commands.Remove(_repo, relativePath, removeFromWorkingDirectory: false);
-        }
-
-        var newFiles = Directory
-            .GetFiles(destinationPath, "*", SearchOption.AllDirectories)
-            .Select(f => GetRelativePath(f));
-        Commands.Stage(_repo, newFiles);
-    }
-
-    /// <summary>
-    /// Deletes a directory and stages the removal in git.
-    /// </summary>
-    public void DeleteDirectory(string path)
-    {
-        var files = Directory.GetFiles(path, "*", SearchOption.AllDirectories).Select(f => GetRelativePath(f)).ToList();
-
-        Directory.Delete(path, recursive: true);
-
-        foreach (var relativePath in files)
-        {
-            Commands.Remove(_repo, relativePath, removeFromWorkingDirectory: false);
-        }
-    }
-
-    /// <summary>
-    /// Stages all files in a directory as additions.
-    /// </summary>
-    public void StageDirectory(string path)
-    {
-        var files = Directory.GetFiles(path, "*", SearchOption.AllDirectories).Select(f => GetRelativePath(f));
-        Commands.Stage(_repo, files);
-    }
-
-    /// <summary>
-    /// Stages a single file.
-    /// </summary>
-    public void StageFile(string path)
-    {
-        Commands.Stage(_repo, GetRelativePath(path));
-    }
-
-    /// <summary>
-    /// Stages a file removal.
-    /// </summary>
-    public void StageRemoval(string path)
-    {
-        Commands.Remove(_repo, GetRelativePath(path), removeFromWorkingDirectory: false);
-    }
-
-    private string GetRelativePath(string absolutePath)
-    {
-        return Path.GetRelativePath(_repoRoot, absolutePath).Replace('\\', '/');
-    }
-
-    public void Dispose()
-    {
-        _repo.Dispose();
     }
 }

--- a/src/cli/studioctl-server/Studioctl/Upgrade/GitOperations.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/GitOperations.cs
@@ -26,7 +26,9 @@ internal static class GitOperations
             Commands.Stage(repo, "*");
 
             var stagedCount = repo.Diff.Compare<TreeChanges>(repo.Head.Tip?.Tree, DiffTargets.Index).Count();
-            output.WriteLine($"Staged the {stagedCount} updated file(s) - run 'git status' for overview and 'git diff --cached' to review them");
+            output.WriteLine(
+                $"Staged the {stagedCount} updated file(s) - run 'git status' for overview and 'git diff --cached' to review them"
+            );
         }
         catch (LibGit2SharpException ex)
         {

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/IndexMigration/IndexCshtmlMigrator.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/IndexMigration/IndexCshtmlMigrator.cs
@@ -105,7 +105,6 @@ internal sealed class IndexCshtmlMigrator
     private async Task<int> PerformMigration(CategorizationResult categorizationResult)
     {
         var createdFiles = new List<string>();
-        var generatedConfig = false;
 
         var hasInlineContent = categorizationResult.KnownCustomizations.Any(c =>
             c.CustomizationType == CustomizationType.InlineStylesheet
@@ -145,7 +144,6 @@ internal sealed class IndexCshtmlMigrator
             if (config.HasContent)
             {
                 await configGenerator.WriteToFile(_configOutputPath);
-                generatedConfig = true;
                 var urlCount = config.Stylesheets.Count + config.Scripts.Count;
                 UpgradeConsole.WriteLine($"Generated assets.json with {urlCount} external URL(s)");
             }
@@ -164,7 +162,6 @@ internal sealed class IndexCshtmlMigrator
             }
 
             CleanupEmptyDirectories();
-            StageMigrationChanges(createdFiles, generatedConfig);
 
             return 0;
         }
@@ -185,33 +182,6 @@ internal sealed class IndexCshtmlMigrator
                 File.Delete(_configOutputPath);
             }
             return 1;
-        }
-    }
-
-    private void StageMigrationChanges(IEnumerable<string> createdFiles, bool generatedConfig)
-    {
-        using var git = GitOperations.TryCreate(_projectFolder);
-        if (git is null)
-        {
-            return;
-        }
-
-        foreach (var file in createdFiles)
-        {
-            if (File.Exists(file))
-            {
-                git.StageFile(file);
-            }
-        }
-
-        if (generatedConfig && File.Exists(_configOutputPath))
-        {
-            git.StageFile(_configOutputPath);
-        }
-
-        if (!File.Exists(_indexCshtmlPath))
-        {
-            git.StageRemoval(_indexCshtmlPath);
         }
     }
 

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/LayoutSetsMigration/LayoutSetsToTaskUiMigrator.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/LayoutSetsMigration/LayoutSetsToTaskUiMigrator.cs
@@ -1,24 +1,16 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using Altinn.Studio.Cli.Upgrade;
 using Altinn.Studio.Cli.Upgrade.JsonWhitespaceRestoration;
 
 namespace Altinn.Studio.Cli.Upgrade.v8Tov9.LayoutSetsMigration;
 
-internal sealed class LayoutSetsToTaskUiMigrator : IDisposable
+internal sealed class LayoutSetsToTaskUiMigrator
 {
     private readonly string _projectFolder;
-    private readonly GitOperations? _git;
 
     public LayoutSetsToTaskUiMigrator(string projectFolder)
     {
         _projectFolder = projectFolder;
-        _git = GitOperations.TryCreate(projectFolder);
-    }
-
-    public void Dispose()
-    {
-        _git?.Dispose();
     }
 
     public MigrationResult Migrate()
@@ -71,13 +63,12 @@ internal sealed class LayoutSetsToTaskUiMigrator : IDisposable
                 {
                     if (plan.DestinationIds.Count == 1)
                     {
-                        MoveDirectory(plan.SourcePath, destinationPath);
+                        Directory.Move(plan.SourcePath, destinationPath);
                         renamedFolderCount++;
                     }
                     else
                     {
                         CopyDirectory(plan.SourcePath, destinationPath);
-                        _git?.StageDirectory(destinationPath);
                         copiedFolderCount++;
                     }
                 }
@@ -88,7 +79,7 @@ internal sealed class LayoutSetsToTaskUiMigrator : IDisposable
 
             if (plan.DestinationIds.Count > 1 && !plan.DestinationIds.Contains(plan.SourceId, StringComparer.Ordinal))
             {
-                DeleteDirectory(plan.SourcePath);
+                Directory.Delete(plan.SourcePath, recursive: true);
                 deletedSourceFolderCount++;
             }
         }
@@ -99,13 +90,10 @@ internal sealed class LayoutSetsToTaskUiMigrator : IDisposable
             var globalSettingsPath = Path.Combine(uiPath, "Settings.json");
             var options = new JsonSerializerOptions { WriteIndented = true };
             File.WriteAllText(globalSettingsPath, uiSettingsObject.ToJsonString(options));
-            _git?.StageFile(globalSettingsPath);
             migratedGlobalSettings = true;
         }
 
         // Restore whitespace-only changes to preserve original formatting in Settings.json files.
-        // UpsertDefaultDataType intentionally leaves files unstaged so the processor can diff
-        // the working directory against the index (which has the original formatting).
         try
         {
             var whitespaceRestorer = new WhitespaceRestorationProcessor(uiPath);
@@ -116,18 +104,7 @@ internal sealed class LayoutSetsToTaskUiMigrator : IDisposable
             // Non-fatal: whitespace restoration is best-effort
         }
 
-        // Stage settings files after whitespace restoration has cleaned them up
-        foreach (var destinationId in touchedFolders)
-        {
-            var settingsPath = Path.Combine(uiPath, destinationId, "Settings.json");
-            if (File.Exists(settingsPath))
-            {
-                _git?.StageFile(settingsPath);
-            }
-        }
-
         File.Delete(layoutSetsPath);
-        _git?.StageRemoval(layoutSetsPath);
 
         return new MigrationResult
         {
@@ -138,30 +115,6 @@ internal sealed class LayoutSetsToTaskUiMigrator : IDisposable
             DeletedSourceFolderCount = deletedSourceFolderCount,
             MigratedGlobalSettings = migratedGlobalSettings,
         };
-    }
-
-    private void MoveDirectory(string sourcePath, string destinationPath)
-    {
-        if (_git is not null)
-        {
-            _git.MoveDirectory(sourcePath, destinationPath);
-        }
-        else
-        {
-            Directory.Move(sourcePath, destinationPath);
-        }
-    }
-
-    private void DeleteDirectory(string path)
-    {
-        if (_git is not null)
-        {
-            _git.DeleteDirectory(path);
-        }
-        else
-        {
-            Directory.Delete(path, recursive: true);
-        }
     }
 
     /// <summary>
@@ -300,8 +253,6 @@ internal sealed class LayoutSetsToTaskUiMigrator : IDisposable
         settings["defaultDataType"] = dataType;
         var options = new JsonSerializerOptions { WriteIndented = true };
         File.WriteAllText(settingsPath, settings.ToJsonString(options));
-        // Don't stage here — leave in working dir so the whitespace restoration
-        // processor can detect and revert formatting-only changes against the index.
     }
 
     private static void CopyDirectory(string sourceDir, string destinationDir)

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/V8Tov9Upgrade.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/V8Tov9Upgrade.cs
@@ -658,7 +658,7 @@ internal static class V8Tov9Upgrade
         try
         {
             await UpgradeConsole.Out.WriteLineAsync("Migrating layout-sets.json to task-folder UI settings...");
-            using var migrator = new LayoutSetsToTaskUiMigrator(projectFolder);
+            var migrator = new LayoutSetsToTaskUiMigrator(projectFolder);
             var result = migrator.Migrate();
 
             if (!result.LayoutSetsDeleted)

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/V8Tov9Upgrade.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/V8Tov9Upgrade.cs
@@ -873,15 +873,18 @@ internal static class V8Tov9Upgrade
     private const int ExitManualActionRequired = 3;
 
     /// <summary>
+    /// Whether an exit code reports a hard error. Any non-zero that isn't the manual-action signal counts
+    /// as one, so an unexpected/future non-zero code can never be swallowed into success.
+    /// </summary>
+    public static bool IsError(int code) => code != ExitSuccess && code != ExitManualActionRequired;
+
+    /// <summary>
     /// Aggregates two job exit codes by severity: a genuine error must never be masked by a
     /// manual-action or success result, and manual-action outranks success. (Numeric order does not
     /// track severity, so this cannot be a plain <see cref="Math.Max(int,int)"/>.)
     /// </summary>
     private static int CombineExitCodes(int current, int next)
     {
-        // Any non-zero that isn't the manual-action signal counts as a hard error and dominates, so an
-        // unexpected/future non-zero code can never be swallowed into success.
-        static bool IsError(int code) => code != ExitSuccess && code != ExitManualActionRequired;
         if (IsError(current) || IsError(next))
             return ExitError;
         if (current == ExitManualActionRequired || next == ExitManualActionRequired)


### PR DESCRIPTION
## Description

`studioctl app upgrade` staged some of the files it changed but not others: the
layout-sets and `Index.cshtml` migrations staged their own output, while every
other migration step left its changes in the working tree. The resulting diff
was split across staged and unstaged, which made it hard to review.

Staging now happens in one `git add -A` pass in `AppUpgradeService`, after all
migrations are done, and reports what it did:

>     Staged the 6 updated file(s) - run 'git status' for overview and 'git diff --cached' to review them

With the change, most of the code in GitOperations could be removed, as we only need git to stage all files at the end.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - `studioctl app upgrade` now stages all changes together after an upgrade completes.
  - Upgrade-generated files, updates, moves and deletions are now included consistently in staged changes.
  - Version control issues during upgrades are handled more gracefully, with warnings reported instead of unnecessarily interrupting the process.

- **Documentation**
  - Updated the CLI changelog to describe the improved staging behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->