### PR TITLE
fix(deps): align .NET servicing dependencies

### DIFF
--- a/src/Runtime/gateway/Directory.Packages.props
+++ b/src/Runtime/gateway/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="Azure.Monitor.Query.Logs" Version="1.0.0" />
     <PackageVersion Include="Azure.ResourceManager.OperationalInsights" Version="1.3.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.16.0" />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.19.2" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />

--- a/src/Runtime/kubernetes-wrapper/src/Dockerfile
+++ b/src/Runtime/kubernetes-wrapper/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0.301-alpine3.23@sha256:940f919ae84dd92ccd4aab7686fa5b777870b006c9360351039e16bcaad73d89 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0.302-alpine3.23@sha256:d8ee39817ca03a3757288e83c37ed73cc969a286c603b827c7cbe33add1c2d1c AS build
 WORKDIR /src
 
 # Copy restore inputs and restore as distinct layer
@@ -15,7 +15,7 @@ COPY src/. ./src/
 RUN dotnet publish ./src/Altinn.Studio.KubernetesWrapper.csproj -c Release -o /app/out --no-restore /p:CSharpier_Bypass=true
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.7-alpine3.23@sha256:60eb031b554df75a4b9f358290a2fa15d8961a3bc79b47bb34a00e31f7b78c69 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0.10-alpine3.23@sha256:27b6b84beeede74fd16886177d360799c8e4299ceadfbd64eef57bafead7878a AS final
 WORKDIR /app
 COPY --from=build /app/out .
 ENTRYPOINT ["dotnet", "Altinn.Studio.KubernetesWrapper.dll"]

--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -15,7 +15,6 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ### Changed
 
-- Build studioctl with .NET SDK 10.0.302.
 - Point `studioctl app upgrade v9` removed-API warnings at the offending call rather than the start of the enclosing expression.
 
 ## [0.1.0-preview.18] - 2026-07-24

--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -15,6 +15,7 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ### Changed
 
+- Build studioctl with .NET SDK 10.0.302.
 - Point `studioctl app upgrade v9` removed-API warnings at the offending call rather than the start of the enclosing expression.
 
 ## [0.1.0-preview.18] - 2026-07-24


### PR DESCRIPTION
## Description

Completes the .NET servicing updates in #19634:

- aligns the Gateway's central Microsoft.IdentityModel.JsonWebTokens pin with JwtBearer 10.0.10
- aligns the Kubernetes wrapper build/runtime images with SDK 10.0.302 and ASP.NET 10.0.10, including immutable digests

The studioctl SDK bump is an internal build detail, so it intentionally has no changelog entry. The original Renovate PR needs the skip-changelog label.

## Verification

- [x] Related PR: #19634
- [x] Gateway restore and build pass
- [x] Gateway fixture: 29/29 integration tests pass
- [x] Kubernetes wrapper tests pass
- [x] Kubernetes wrapper Docker image builds with the updated pinned images

The builds still report the pre-existing Microsoft.OpenApi NU1903 warning; this fixup does not introduce it.
