### PR TITLE
fix(deps): require manual Helm compatibility updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,6 +35,12 @@
       "groupSlug": "{{manager}}-minor-patch"
     },
     {
+      "description": "Helm Go dependency updates are done manually because even patch releases can change Kubernetes client minor versions",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["helm.sh/helm/v3"],
+      "enabled": false
+    },
+    {
       "description": "Group Kubernetes, Flux, and cluster tooling Go dependency patches so related release trains move together",
       "matchManagers": ["gomod"],
       "matchPackageNames": [


### PR DESCRIPTION
## Description

Disables automated Go dependency updates for Helm so each update receives an explicit Kubernetes compatibility review.

Helm 3.21.1 → 3.21.3 demonstrated why this is necessary: although it is a Helm patch update, it advances the compiled Kubernetes client modules from the 0.35 line to 0.36 (Kubernetes 1.35 → 1.36).

This policy change is separate from the dependency repair in #19704, following review feedback there.

It cannot be folded into the existing compatible Kubernetes patch rule: that rule intentionally allows patch updates, while Helm patch releases can themselves advance the Kubernetes client minor line. Adding Helm to that rule would regroup the unsafe update without blocking it.

## Verification

- [x] Related Renovate PR: #19700
- [x] Related fixup PR: #19704
- [x] renovate-config-validator --strict renovate.json
- [x] Diff reviewed against current upstream main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated updates for Helm v3 Go dependencies are now disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->