### PR TITLE
fix(app-frontend): prevent focus cleanup navigation race

### DIFF
--- a/src/App/frontend/src/hooks/useNavigatePage.ts
+++ b/src/App/frontend/src/hooks/useNavigatePage.ts
@@ -17,6 +17,7 @@ import {
 import { useAllNavigationParams, useAllNavigationParamsAsRef, useNavigationParam } from 'src/hooks/navigation';
 import { useAsRef } from 'src/hooks/useAsRef';
 import { useLocalStorageState } from 'src/hooks/useLocalStorageState';
+import { cancelFocusComponentUrlCleanup } from 'src/layout/focusComponent';
 import { TaskKeys } from 'src/routesBuilder';
 import { ProcessTaskType } from 'src/types';
 import { computeStartUrl } from 'src/utils/computeStartUrl';
@@ -49,6 +50,7 @@ const useOurNavigate = () => {
         setReturnToView?.(undefined);
         setSummaryNodeOfOrigin?.(undefined);
       }
+      cancelFocusComponentUrlCleanup();
       navigate(path, theirOptions);
     },
     [navigate, setReturnToView, setSummaryNodeOfOrigin],

--- a/src/App/frontend/src/index.tsx
+++ b/src/App/frontend/src/index.tsx
@@ -7,7 +7,7 @@ const isRedirectingFromHashRoute = executeHashRouterRedirect();
 
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import { RouterProvider } from 'react-router';
+import { RouterProvider } from 'react-router/dom';
 
 import '@digdir/designsystemet-css';
 import '@digdir/designsystemet-css/theme';

--- a/src/App/frontend/src/layout/focusComponent.test.tsx
+++ b/src/App/frontend/src/layout/focusComponent.test.tsx
@@ -1,6 +1,5 @@
-import React, { useEffect, useRef } from 'react';
-import { createBrowserRouter, MemoryRouter, useNavigate } from 'react-router';
-import { RouterProvider } from 'react-router/dom';
+import React, { useRef } from 'react';
+import { MemoryRouter } from 'react-router';
 
 import { act, render, screen, waitFor } from '@testing-library/react';
 
@@ -27,7 +26,6 @@ describe('focusComponent', () => {
   afterEach(() => {
     act(() => setFocusComponentRequest(undefined));
     setFocusComponentUrlCleanup(undefined);
-    window.history.replaceState({}, '', '/');
     jest.restoreAllMocks();
   });
 
@@ -127,38 +125,5 @@ describe('focusComponent', () => {
 
     await waitFor(() => expect(screen.getByLabelText('Name')).toHaveFocus());
     expect(cleanup).toHaveBeenCalledTimes(1);
-  });
-
-  it('does not let focus URL cleanup overwrite immediate page navigation', async () => {
-    const consoleError = jest.spyOn(console, 'error').mockImplementation();
-
-    function FocusAndNavigate() {
-      const ref = useRef<HTMLDivElement | null>(null);
-      const navigate = useNavigate();
-      const request = useFocusComponentRequest('node-a');
-      useHandleFocusComponent('node-a', ref);
-      useEffect(() => {
-        if (request) {
-          navigate('/summary');
-        }
-      }, [navigate, request]);
-      return (
-        <>
-          <FocusComponentRequestFromUrl />
-          <div ref={ref}>
-            <input aria-label='Name' />
-          </div>
-        </>
-      );
-    }
-
-    window.history.replaceState({}, '', '/form?focusComponentId=node-a');
-    const router = createBrowserRouter([{ path: '*', Component: FocusAndNavigate }]);
-
-    render(<RouterProvider router={router} />);
-
-    await waitFor(() => expect(window.location.pathname).toBe('/summary'));
-    expect(window.location.search).toBe('');
-    expect(consoleError).not.toHaveBeenCalled();
   });
 });

--- a/src/App/frontend/src/layout/focusComponent.test.tsx
+++ b/src/App/frontend/src/layout/focusComponent.test.tsx
@@ -1,5 +1,6 @@
-import React, { useRef } from 'react';
-import { MemoryRouter } from 'react-router';
+import React, { useEffect, useRef } from 'react';
+import { createMemoryRouter, MemoryRouter, useNavigate } from 'react-router';
+import { RouterProvider } from 'react-router/dom';
 
 import { act, render, screen, waitFor } from '@testing-library/react';
 
@@ -13,6 +14,33 @@ import {
 } from 'src/layout/focusComponent';
 
 describe('focusComponent', () => {
+  function SimpleFocusTarget() {
+    const ref = useRef<HTMLDivElement | null>(null);
+    useHandleFocusComponent('node-a', ref);
+    return (
+      <div ref={ref}>
+        <input aria-label='Name' />
+      </div>
+    );
+  }
+  function createFocusRouter(extra?: React.ReactNode) {
+    return createMemoryRouter(
+      [
+        {
+          path: '*',
+          element: (
+            <>
+              <FocusComponentRequestFromUrl />
+              <SimpleFocusTarget />
+              {extra}
+            </>
+          ),
+        },
+      ],
+      { initialEntries: ['/form?focusComponentId=node-a'] },
+    );
+  }
+
   beforeEach(() => {
     setFocusComponentRequest(undefined);
     setFocusComponentUrlCleanup(undefined);
@@ -111,19 +139,45 @@ describe('focusComponent', () => {
 
     expect(cleanup).not.toHaveBeenCalled();
 
-    function FocusTarget() {
-      const ref = useRef<HTMLDivElement | null>(null);
-      useHandleFocusComponent('node-a', ref);
-      return (
-        <div ref={ref}>
-          <input aria-label='Name' />
-        </div>
-      );
-    }
-
-    render(<FocusTarget />);
+    render(<SimpleFocusTarget />);
 
     await waitFor(() => expect(screen.getByLabelText('Name')).toHaveFocus());
     expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not let focus URL cleanup overwrite immediate page navigation', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation();
+
+    function NavigateWhenFocused() {
+      const request = useFocusComponentRequest('node-a');
+      const navigate = useNavigate();
+      useEffect(() => {
+        if (request) {
+          navigate('/summary');
+        }
+      }, [navigate, request]);
+      return null;
+    }
+
+    const router = createFocusRouter(<NavigateWhenFocused />);
+
+    render(<RouterProvider router={router} />);
+
+    await waitFor(() => expect(router.state.location.pathname).toBe('/summary'));
+    expect(router.state.location.search).toBe('');
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it('cleans focus URL parameters synchronously after focusing', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation();
+    const router = createFocusRouter();
+    const navigate = jest.spyOn(router, 'navigate');
+
+    render(<RouterProvider router={router} />);
+
+    await waitFor(() => expect(router.state.location.search).toBe(''));
+    expect(router.state.location.pathname).toBe('/form');
+    expect(navigate).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ flushSync: true }));
+    expect(consoleError).not.toHaveBeenCalled();
   });
 });

--- a/src/App/frontend/src/layout/focusComponent.test.tsx
+++ b/src/App/frontend/src/layout/focusComponent.test.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import { createBrowserRouter, createMemoryRouter, MemoryRouter, useNavigate } from 'react-router';
+import { createBrowserRouter, MemoryRouter, useNavigate } from 'react-router';
 import { RouterProvider } from 'react-router/dom';
 
 import { act, render, screen, waitFor } from '@testing-library/react';
@@ -14,33 +14,6 @@ import {
 } from 'src/layout/focusComponent';
 
 describe('focusComponent', () => {
-  function SimpleFocusTarget() {
-    const ref = useRef<HTMLDivElement | null>(null);
-    useHandleFocusComponent('node-a', ref);
-    return (
-      <div ref={ref}>
-        <input aria-label='Name' />
-      </div>
-    );
-  }
-  function focusRoutes(extra?: React.ReactNode) {
-    return [
-      {
-        path: '*',
-        element: (
-          <>
-            <FocusComponentRequestFromUrl />
-            <SimpleFocusTarget />
-            {extra}
-          </>
-        ),
-      },
-    ];
-  }
-  function createFocusRouter(extra?: React.ReactNode) {
-    return createMemoryRouter(focusRoutes(extra), { initialEntries: ['/form?focusComponentId=node-a'] });
-  }
-
   beforeEach(() => {
     setFocusComponentRequest(undefined);
     setFocusComponentUrlCleanup(undefined);
@@ -140,7 +113,17 @@ describe('focusComponent', () => {
 
     expect(cleanup).not.toHaveBeenCalled();
 
-    render(<SimpleFocusTarget />);
+    function FocusTarget() {
+      const ref = useRef<HTMLDivElement | null>(null);
+      useHandleFocusComponent('node-a', ref);
+      return (
+        <div ref={ref}>
+          <input aria-label='Name' />
+        </div>
+      );
+    }
+
+    render(<FocusTarget />);
 
     await waitFor(() => expect(screen.getByLabelText('Name')).toHaveFocus());
     expect(cleanup).toHaveBeenCalledTimes(1);
@@ -149,38 +132,33 @@ describe('focusComponent', () => {
   it('does not let focus URL cleanup overwrite immediate page navigation', async () => {
     const consoleError = jest.spyOn(console, 'error').mockImplementation();
 
-    function NavigateWhenFocused() {
-      const request = useFocusComponentRequest('node-a');
+    function FocusAndNavigate() {
+      const ref = useRef<HTMLDivElement | null>(null);
       const navigate = useNavigate();
+      const request = useFocusComponentRequest('node-a');
+      useHandleFocusComponent('node-a', ref);
       useEffect(() => {
         if (request) {
           navigate('/summary');
         }
       }, [navigate, request]);
-      return null;
+      return (
+        <>
+          <FocusComponentRequestFromUrl />
+          <div ref={ref}>
+            <input aria-label='Name' />
+          </div>
+        </>
+      );
     }
 
     window.history.replaceState({}, '', '/form?focusComponentId=node-a');
-    const router = createBrowserRouter(focusRoutes(<NavigateWhenFocused />));
+    const router = createBrowserRouter([{ path: '*', Component: FocusAndNavigate }]);
 
     render(<RouterProvider router={router} />);
 
-    await waitFor(() => expect(router.state.location.pathname).toBe('/summary'));
-    expect(window.location.pathname).toBe('/summary');
-    expect(router.state.location.search).toBe('');
-    expect(consoleError).not.toHaveBeenCalled();
-  });
-
-  it('cleans focus URL parameters synchronously after focusing', async () => {
-    const consoleError = jest.spyOn(console, 'error').mockImplementation();
-    const router = createFocusRouter();
-    const navigate = jest.spyOn(router, 'navigate');
-
-    render(<RouterProvider router={router} />);
-
-    await waitFor(() => expect(router.state.location.search).toBe(''));
-    expect(router.state.location.pathname).toBe('/form');
-    expect(navigate).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ flushSync: true }));
+    await waitFor(() => expect(window.location.pathname).toBe('/summary'));
+    expect(window.location.search).toBe('');
     expect(consoleError).not.toHaveBeenCalled();
   });
 });

--- a/src/App/frontend/src/layout/focusComponent.test.tsx
+++ b/src/App/frontend/src/layout/focusComponent.test.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import { createMemoryRouter, MemoryRouter, useNavigate } from 'react-router';
+import { createBrowserRouter, createMemoryRouter, MemoryRouter, useNavigate } from 'react-router';
 import { RouterProvider } from 'react-router/dom';
 
 import { act, render, screen, waitFor } from '@testing-library/react';
@@ -23,22 +23,22 @@ describe('focusComponent', () => {
       </div>
     );
   }
+  function focusRoutes(extra?: React.ReactNode) {
+    return [
+      {
+        path: '*',
+        element: (
+          <>
+            <FocusComponentRequestFromUrl />
+            <SimpleFocusTarget />
+            {extra}
+          </>
+        ),
+      },
+    ];
+  }
   function createFocusRouter(extra?: React.ReactNode) {
-    return createMemoryRouter(
-      [
-        {
-          path: '*',
-          element: (
-            <>
-              <FocusComponentRequestFromUrl />
-              <SimpleFocusTarget />
-              {extra}
-            </>
-          ),
-        },
-      ],
-      { initialEntries: ['/form?focusComponentId=node-a'] },
-    );
+    return createMemoryRouter(focusRoutes(extra), { initialEntries: ['/form?focusComponentId=node-a'] });
   }
 
   beforeEach(() => {
@@ -54,6 +54,7 @@ describe('focusComponent', () => {
   afterEach(() => {
     act(() => setFocusComponentRequest(undefined));
     setFocusComponentUrlCleanup(undefined);
+    window.history.replaceState({}, '', '/');
     jest.restoreAllMocks();
   });
 
@@ -159,11 +160,13 @@ describe('focusComponent', () => {
       return null;
     }
 
-    const router = createFocusRouter(<NavigateWhenFocused />);
+    window.history.replaceState({}, '', '/form?focusComponentId=node-a');
+    const router = createBrowserRouter(focusRoutes(<NavigateWhenFocused />));
 
     render(<RouterProvider router={router} />);
 
     await waitFor(() => expect(router.state.location.pathname).toBe('/summary'));
+    expect(window.location.pathname).toBe('/summary');
     expect(router.state.location.search).toBe('');
     expect(consoleError).not.toHaveBeenCalled();
   });

--- a/src/App/frontend/src/layout/focusComponent.ts
+++ b/src/App/frontend/src/layout/focusComponent.ts
@@ -31,6 +31,10 @@ export function setFocusComponentUrlCleanup(cleanup: (() => void) | undefined) {
   cleanupFocusComponentUrl = cleanup;
 }
 
+export function cancelFocusComponentUrlCleanup() {
+  cleanupFocusComponentUrl = undefined;
+}
+
 export function useFocusComponentRequest(nodeId: string): FocusComponentRequest | undefined {
   return useSyncExternalStore(
     (listener) => {
@@ -103,7 +107,7 @@ export function FocusComponentRequestFromUrl() {
       }, focusQueryCleanupOptions);
     });
 
-    return () => setFocusComponentUrlCleanup(undefined);
+    return cancelFocusComponentUrlCleanup;
   }, [setSearchParams]);
 
   return null;

--- a/src/App/frontend/src/layout/focusComponent.ts
+++ b/src/App/frontend/src/layout/focusComponent.ts
@@ -6,6 +6,11 @@ import { SearchParams } from 'src/core/routing/types';
 import { replaceAndPreventResetOptions } from 'src/features/navigation/navigationOptions';
 import { useQueryKey } from 'src/hooks/navigation';
 
+const focusQueryCleanupOptions = {
+  ...replaceAndPreventResetOptions,
+  flushSync: true,
+};
+
 export type FocusComponentRequest = {
   nodeId: string;
   errorBinding: string | null;
@@ -54,9 +59,13 @@ export function useHandleFocusComponent(nodeId: string, containerDivRef: React.R
           field.focus();
         }
       } finally {
-        if (pathnameWas === window.location.pathname) {
-          cleanupFocusComponentUrl?.();
-        }
+        const cleanup = cleanupFocusComponentUrl;
+        // React cannot flush a router update from an effect. Finish the effect first so the cleanup can be synchronous.
+        queueMicrotask(() => {
+          if (cleanup === cleanupFocusComponentUrl && pathnameWas === window.location.pathname) {
+            cleanup?.();
+          }
+        });
       }
 
       return () => cancelAnimationFrame(animationFrame);
@@ -91,7 +100,7 @@ export function FocusComponentRequestFromUrl() {
         nextParams.delete(SearchParams.FocusComponentId);
         nextParams.delete(SearchParams.FocusErrorBinding);
         return nextParams;
-      }, replaceAndPreventResetOptions);
+      }, focusQueryCleanupOptions);
     });
 
     return () => setFocusComponentUrlCleanup(undefined);


### PR DESCRIPTION
## Description

Fixes a routing race exposed by the external Cypress run on #19702.

Following an error link navigates to a form field with `focusComponentId` query parameters. The focus effect removes those parameters through a router update. If page navigation starts while that cleanup is queued or pending, the cleanup could win and return the app to the form page.

This change:

- commits focus-query cleanup synchronously outside the React effect
- invalidates queued or pending focus cleanup at the central page-navigation boundary
- uses React Router's DOM provider so synchronous router updates are supported

The ordering is deterministic: cleanup either commits before page-navigation intent, or navigation invalidates it and becomes the newer React Router navigation.

## Verification

- [ ] Related issues are connected (not applicable)
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (covered by deterministic router reproduction)
- [ ] Relevant automated test added (the existing external Cypress scenario is the permanent regression)

A temporary production-faithful browser-router harness using `getContext` and a loader reproduced the failure at `/form` before the fix and completed at `/summary` after navigation-intent cancellation. The temporary harness was removed to avoid duplicating the existing Cypress regression.

Commands run:

- `yarn prettier --check src/index.tsx src/layout/focusComponent.ts src/hooks/useNavigatePage.ts`
- `yarn eslint src/index.tsx src/layout/focusComponent.ts src/hooks/useNavigatePage.ts`
- `yarn test src/layout/focusComponent.test.tsx --runInBand`
- `yarn tsc`
- `yarn build`

The final unpushed diff was independently reviewed before push; no substantive findings remained.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved focus behaviour when navigating between pages.
  - Prevented outdated focus-related URL parameters from being removed after a subsequent navigation.
  - Ensured focus cleanup is handled at the correct point during route changes, providing more reliable page transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->