### PR TITLE
fix: update stale CODEOWNERS paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,7 +22,6 @@ app-libs/**/package.json                                                  @altin
 src/App/frontend/**/docker-compose.yml                                    @altinn/team-altinn-studio-utforming
 src/App/frontend/**/package.json                                          @altinn/team-altinn-studio-utforming
 src/Designer/frontend/**/package.json                                     @altinn/team-altinn-studio-utforming
-src/Designer/frontend/**/yarn.lock                                        @altinn/team-altinn-studio-utforming
 
 # Team Access Info
 .github/workflows/designer-frontend-resourceadm-playwright-staging.yml    @altinn/team-access-info
@@ -31,14 +30,14 @@ src/Designer/frontend/resourceadm/**/package.json                         @altin
 
 # AI
 .github/workflows/deploy-studio-mcp-server.yaml                           @ErlingHauan
-.github/workflows/mcp-build.yaml                                          @ErlingHauan
-.github/workflows/mcp-test.yaml                                           @ErlingHauan
+.github/workflows/mcp-build-test.yaml                                     @ErlingHauan
 src/AI/agents/**/docker-compose.*.yml                                     @ErlingHauan
 src/AI/agents/**/docker-compose.yaml                                      @ErlingHauan
 src/AI/agents/**/dockerfile*                                              @ErlingHauan
 src/AI/agents/**/pyproject.toml                                           @ErlingHauan
 src/AI/agents/**/requirements-dev.txt                                     @ErlingHauan
 src/AI/agents/**/requirements.txt                                         @ErlingHauan
+src/AI/agents/**/uv.lock                                                  @ErlingHauan
 src/AI/augmenter-agent/**/*.csproj                                        @ErlingHauan
 src/AI/augmenter-agent/**/docker-compose.yaml                             @ErlingHauan
 src/AI/augmenter-agent/**/dockerfile*                                     @ErlingHauan

--- a/.github/scripts/codeowners-generate.mjs
+++ b/.github/scripts/codeowners-generate.mjs
@@ -68,8 +68,7 @@ const GROUPS = [
     roots: ['src/AI/agents', 'src/AI/augmenter-agent', 'src/AI/mcp'],
     extraPaths: [
       '.github/workflows/deploy-studio-mcp-server.yaml',
-      '.github/workflows/mcp-build.yaml',
-      '.github/workflows/mcp-test.yaml',
+      '.github/workflows/mcp-build-test.yaml',
     ],
   },
   {


### PR DESCRIPTION
## Description

Updates stale AI workflow paths in the CODEOWNERS generator and regenerates `.github/CODEOWNERS`.

The existing mismatch was surfaced when #19727 touched the renamed workflow, but is unrelated to the Renovate update and is therefore submitted separately against `main`. Regeneration also reconciles the already removed Designer frontend lockfile and the new AI agents lockfile.

## Verification

- [x] `node .github/scripts/codeowners-generate.mjs --check`
- [x] `git diff --check`
- [x] Manual testing done by reproducing the failed validator before the change and confirming it passes after generation
- [ ] Relevant automated test added (the existing generated-file validation covers this change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership rules for MCP workflow files and AI agent lockfiles.
  * Removed an outdated lockfile ownership entry.
  * Consolidated MCP build and test workflow ownership under a single workflow rule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->