### PR TITLE
chore(renovate): keep React upgrades synchronized

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -160,6 +160,18 @@
         "src/App/codelists/**"
       ],
       "enabled": false
+    },
+    {
+      "description": "Upgrade React consistently across the entire repository",
+      "matchManagers": ["npm"],
+      "matchPackageNames": [
+        "react",
+        "react-dom",
+        "@types/react",
+        "@types/react-dom"
+      ],
+      "groupName": "React ecosystem",
+      "groupSlug": "react-ecosystem"
     }
   ],
   "schedule": []


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Group `react`, `react-dom`, `@types/react`, and `@types/react-dom` Renovate updates across the entire repository.

These dependencies need to move together across Studio Designer, App frontend, and the shared App libraries. Allowing App-scoped Renovate pull requests to update only part of the Yarn workspace can leave incompatible React versions and make package resolution fail. As we've seen happen/fail in for example #19720.

The rule is intentionally repository-wide and is placed last so it takes precedence over broader dependency grouping rules.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

Verified that `renovate.json` parses as valid JSON and that the committed diff passes `git diff --check`. A product build, manual test, and automated test were not applicable/run for this Renovate configuration-only change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Grouped React, React DOM, and related TypeScript type-package updates into a single Renovate update, simplifying dependency maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->