### PR TITLE
fix(workflow-engine): remove cancellation watcher test race

### DIFF
--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Core.Tests/CancellationWatcherServiceTests.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Core.Tests/CancellationWatcherServiceTests.cs
@@ -10,6 +10,8 @@ namespace WorkflowEngine.Core.Tests;
 [Collection("BackgroundServiceTests")]
 public class CancellationWatcherServiceTests
 {
+    private static readonly TimeSpan GateTimeout = TimeSpan.FromSeconds(5);
+
     private static Workflow DummyWorkflow() =>
         new()
         {
@@ -53,6 +55,8 @@ public class CancellationWatcherServiceTests
         var workflow = DummyWorkflow();
         var id = Guid.NewGuid();
         using var workflowCts = new CancellationTokenSource();
+        var cancellationObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var registration = workflowCts.Token.Register(() => cancellationObserved.TrySetResult());
         tracker.TryAdd(id, workflowCts, workflow);
 
         // When polled, return the workflow as pending cancellation
@@ -71,8 +75,7 @@ public class CancellationWatcherServiceTests
 
         try
         {
-            // Wait for at least one poll cycle
-            await Task.Delay(200, TestContext.Current.CancellationToken);
+            await cancellationObserved.Task.WaitAsync(GateTimeout, TestContext.Current.CancellationToken);
 
             Assert.True(workflowCts.IsCancellationRequested);
             Assert.NotNull(workflow.CancellationRequestedAt);
@@ -131,6 +134,8 @@ public class CancellationWatcherServiceTests
         var workflow = DummyWorkflow();
         var id = Guid.NewGuid();
         using var workflowCts = new CancellationTokenSource();
+        var cancellationObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var registration = workflowCts.Token.Register(() => cancellationObserved.TrySetResult());
         tracker.TryAdd(id, workflowCts, workflow);
 
         var callCount = 0;
@@ -158,8 +163,7 @@ public class CancellationWatcherServiceTests
 
         try
         {
-            // Wait for multiple poll cycles
-            await Task.Delay(300, TestContext.Current.CancellationToken);
+            await cancellationObserved.Task.WaitAsync(GateTimeout, TestContext.Current.CancellationToken);
 
             Assert.True(callCount >= 2, $"Expected at least 2 calls but got {callCount}");
             Assert.True(workflowCts.IsCancellationRequested);


### PR DESCRIPTION
## Description

Fixes the flaky `CancellationWatcherServiceTests.SurvivesTransientErrors` failure observed in [PR #19727's workflow-engine job](https://github.com/Altinn/altinn-studio/actions/runs/30926708834/job/92050790113?pr=19727).

The test waited for a fixed 300 ms before checking both the repository call count and the workflow cancellation token. On the second poll, the mock increments `callCount` before it returns the pending cancellation to `CancellationWatcherService`. Under runner contention, the test continuation could run in that gap: `callCount >= 2` passed while `workflowCts.IsCancellationRequested` was still false.

Wait for the workflow cancellation token itself through a `TaskCompletionSource` gate instead. The five-second timeout is only a failure ceiling. The same event-driven synchronization is applied to the other cancellation-positive test in the class, which had the same fixed-delay weakness. Production code is unchanged.

## Verification

- [x] Related issues are connected (not applicable; linked failed job above)
- [ ] **Your** code builds clean without any errors or warnings (build passes; 31 pre-existing NuGet vulnerability warnings remain)
- [x] Manual testing done (50/50 fresh-process stress iterations of `SurvivesTransientErrors` passed)
- [x] Relevant automated test added (the existing cancellation watcher tests now synchronize on the asserted event)

Commands run:

- `CI=true dotnet build WorkflowEngine.slnx --no-restore` — passed with 0 errors and 31 existing package advisory warnings.
- `dotnet test tests/WorkflowEngine.Core.Tests/WorkflowEngine.Core.Tests.csproj --filter 'FullyQualifiedName~CancellationWatcherServiceTests'` — 3/3 passed.
- Repeated `SurvivesTransientErrors` in 50 fresh `dotnet test --no-build` processes — 50/50 passed.
- `dotnet test WorkflowEngine.slnx --no-build --blame-hang --blame-hang-timeout 5m` — Data 66/66, Models 60/60, Resilience 51/51, and Core 164/164 passed. Repository and Integration fixtures could not start because this guest has no usable Docker socket; they failed in Testcontainers setup before test execution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cancellation test reliability by waiting for workflow cancellation signals rather than relying on fixed delays.
  * Added a shared five-second timeout to prevent tests from waiting indefinitely.
  * Retained coverage for cancellation handling and transient-error retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->