### PR TITLE
test(app-backend): stabilize projected volume reload tests

### DIFF
--- a/src/App/backend/test/Altinn.App.Api.Tests/Extensions/WebHostBuilderExtensionsTests.cs
+++ b/src/App/backend/test/Altinn.App.Api.Tests/Extensions/WebHostBuilderExtensionsTests.cs
@@ -107,7 +107,8 @@ public sealed class WebHostBuilderExtensionsTests
         projectedVolume.WriteVersion(
             KubernetesProjectedVolume.InitialVersionDirectoryName,
             fileName,
-            CreateRuntimeSettingsJson("before")
+            CreateRuntimeSettingsJson("before"),
+            KubernetesProjectedVolume.InitialVersionLastWriteTimeUtc
         );
         projectedVolume.CreateSymlinks(KubernetesProjectedVolume.InitialVersionDirectoryName, fileName);
 
@@ -125,7 +126,8 @@ public sealed class WebHostBuilderExtensionsTests
         projectedVolume.WriteVersion(
             KubernetesProjectedVolume.UpdatedVersionDirectoryName,
             fileName,
-            CreateRuntimeSettingsJson("after")
+            CreateRuntimeSettingsJson("after"),
+            KubernetesProjectedVolume.UpdatedVersionLastWriteTimeUtc
         );
         projectedVolume.SwapDataSymlink(KubernetesProjectedVolume.UpdatedVersionDirectoryName);
 

--- a/src/App/backend/test/Altinn.App.Core.Tests/Features/Maskinporten/Extensions/WebHostBuilderExtensionsTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Features/Maskinporten/Extensions/WebHostBuilderExtensionsTests.cs
@@ -101,7 +101,8 @@ public sealed class WebHostBuilderExtensionsTests
         projectedVolume.WriteVersion(
             KubernetesProjectedVolume.InitialVersionDirectoryName,
             SettingsFileName,
-            CreateSettingsJson("client-before")
+            CreateSettingsJson("client-before"),
+            KubernetesProjectedVolume.InitialVersionLastWriteTimeUtc
         );
         projectedVolume.CreateSymlinks(KubernetesProjectedVolume.InitialVersionDirectoryName, SettingsFileName);
 
@@ -122,7 +123,8 @@ public sealed class WebHostBuilderExtensionsTests
         projectedVolume.WriteVersion(
             KubernetesProjectedVolume.UpdatedVersionDirectoryName,
             SettingsFileName,
-            CreateSettingsJson("client-after")
+            CreateSettingsJson("client-after"),
+            KubernetesProjectedVolume.UpdatedVersionLastWriteTimeUtc
         );
         projectedVolume.SwapDataSymlink(KubernetesProjectedVolume.UpdatedVersionDirectoryName);
 

--- a/src/App/backend/test/Altinn.App.Tests.Common/KubernetesProjectedVolume.cs
+++ b/src/App/backend/test/Altinn.App.Tests.Common/KubernetesProjectedVolume.cs
@@ -7,9 +7,12 @@ internal sealed class KubernetesProjectedVolume
 {
     // Kubernetes writes Secret/projected volume payloads into timestamped hidden directories and keeps the
     // visible files pointing through ..data. Updates are published by renaming the ..data_tmp symlink over ..data.
-    // The exact timestamp-like directory names below are representative fixtures; the symlink swap is the behavior under test.
+    // The exact timestamps below are representative fixtures. PollingFileChangeToken compares target mtimes, so the
+    // version files need distinct mtimes for the symlink swap to be observable on filesystems with coarse timestamps.
     public const string InitialVersionDirectoryName = "..2026_06_15_10_00_00.000000001";
     public const string UpdatedVersionDirectoryName = "..2026_06_15_10_00_10.000000002";
+    public static DateTime InitialVersionLastWriteTimeUtc { get; } = new(2026, 6, 15, 10, 0, 0, DateTimeKind.Utc);
+    public static DateTime UpdatedVersionLastWriteTimeUtc { get; } = new(2026, 6, 15, 10, 0, 10, DateTimeKind.Utc);
 
     private const string DataSymlinkName = "..data";
 
@@ -21,11 +24,13 @@ internal sealed class KubernetesProjectedVolume
 
     public string Path { get; }
 
-    public void WriteVersion(string versionDirectoryName, string fileName, string content)
+    public void WriteVersion(string versionDirectoryName, string fileName, string content, DateTime lastWriteTimeUtc)
     {
         string versionDirectory = System.IO.Path.Join(Path, versionDirectoryName);
         Directory.CreateDirectory(versionDirectory);
-        File.WriteAllText(System.IO.Path.Join(versionDirectory, fileName), content);
+        string filePath = System.IO.Path.Join(versionDirectory, fileName);
+        File.WriteAllText(filePath, content);
+        File.SetLastWriteTimeUtc(filePath, lastWriteTimeUtc);
     }
 
     public void CreateSymlinks(string versionDirectoryName, string fileName)


### PR DESCRIPTION
## Description

Make the Kubernetes projected-volume fixture assign deterministic, distinct mtimes to its initial and updated payload files.

.NET's `PollingFileChangeToken` detects a symlinked target change by comparing the resolved target's `LastWriteTimeUtc`. The fixture created both target files back-to-back, allowing Linux to assign identical mtimes; the `..data` symlink swap then remained invisible for the entire 30-second timeout. This caused the flaky failure observed in [PR #19727](https://github.com/Altinn/altinn-studio/actions/runs/30926705352/job/92052026097?pr=19727).

The fixture timestamps now match its representative version directory names and remain ten seconds apart without adding a real-time delay.

## Verification

- [x] Related issues are connected (CI failure linked above)
- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

Commands and results:

- Forced both fixture versions to the same mtime before the fix: reproduced the exact 30-second timeout.
- `dotnet csharpier check` for all three changed files: passed.
- Formerly flaky Maskinporten reload test, five consecutive runs: passed 5/5.
- Companion API projected-volume reload test: passed.
- `dotnet build solutions/All.slnx -v q --no-restore`: passed with the repository's existing NuGet vulnerability warnings (40 warnings, 0 errors).
- `dotnet test solutions/All.slnx -v m --no-restore --no-build --filter "Category!=Integration"`: passed (3,875 tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved Kubernetes projected-volume test coverage by using explicit UTC timestamps for initial and updated configuration files.
  * Strengthened change-detection validation when configuration versions are written and updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->