### PR TITLE
docs: clarify changelog audience

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,9 @@ Other top-level dirs: `charts/` (Helm), `infra/` (deployment infra), `docs/` (AD
 
 ## Conventions across the repo
 
+- **Changelogs:** Changelog entries are release notes for product users. Describe only user-facing
+  functionality in clear language, and omit implementation details that do not affect product use.
+  Technical language is appropriate when it helps users understand or adopt the change.
 - **Docs:** `AGENTS.md` is the source of truth for agent guidance in a directory. Where a `CLAUDE.md`
   exists alongside it, that file just links to the `AGENTS.md` (`@AGENTS.md`) so Claude Code loads it.
   Never leave a directory with only a `CLAUDE.md` — always create the `AGENTS.md` and point `CLAUDE.md`

--- a/src/App/backend/CHANGELOG.md
+++ b/src/App/backend/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to Altinn app backend packages will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Entries should describe only user-facing functionality in clear, user-friendly language; omit implementation details that do not affect how people use the product.
 Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]

--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to studioctl will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Entries should describe only user-facing functionality in clear, user-friendly language; omit implementation details that do not affect how people use the product.
 Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]


### PR DESCRIPTION
## Description

Clarify that changelog entries are release notes for product users: they should describe user-facing functionality in clear language and omit implementation details that do not affect product use. Technical terminology remains appropriate when it helps users understand or adopt a change.

Add the guidance to both existing changelogs and to the repository-wide agent conventions.

## Verification

- [x] Related issues are connected (not applicable)
- [x] `go run . validate-changelogs`
- [x] `yarn docs:validate`
- [x] `git diff --check`
- [x] Manual testing done (reviewed the rendered Markdown changes)
- [x] Relevant automated test added (not applicable; documentation-only change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog guidance across the project to focus entries on user-facing functionality and benefits.
  * Clarified that implementation details should be omitted unless they help users understand or adopt a change.
  * Added guidance to use clear, user-friendly language, with technical terminology included only where relevant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->