### PR TITLE
chore(deps): pin supported GitHub Actions to exact versions

### DIFF
--- a/.github/actions/app-build-frontend/action.yaml
+++ b/.github/actions/app-build-frontend/action.yaml
@@ -23,7 +23,7 @@ runs:
       shell: bash
 
     - name: Save frontend build
-      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       with:
         name: app-frontend-dist
         path: src/App/frontend/dist

--- a/.github/actions/app-run-local-env/action.yaml
+++ b/.github/actions/app-run-local-env/action.yaml
@@ -38,7 +38,7 @@ runs:
         studioctl env up --detach
 
     - name: Download the built frontend
-      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
         name: app-frontend-dist
         path: src/App/frontend/dist
@@ -73,7 +73,7 @@ runs:
 
     - name: Start app processes
       if: ${{ inputs.run-localtest == 'true' && inputs.app-run-targets-json != '' }}
-      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       env:
         APP_RUN_TARGETS_JSON: ${{ inputs.app-run-targets-json }}
         SKIP_APP_BUILD: ${{ inputs.skip-app-build }}

--- a/.github/workflows/app-backend-tests.yml
+++ b/.github/workflows/app-backend-tests.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Download built frontend
         if: matrix.os.id == 'ubuntu-latest'
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: app-frontend-dist
           path: src/App/frontend/dist

--- a/.github/workflows/app-frontend-cypress.yml
+++ b/.github/workflows/app-frontend-cypress.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Build app run targets
         id: app-run-targets
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const fs = require('fs/promises');
@@ -126,7 +126,7 @@ jobs:
           tar -czf app-process-build.tar.gz "${build_dirs[@]}"
 
       - name: Upload app process outputs
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: app-process-build
           path: app-process-build.tar.gz
@@ -157,7 +157,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Download app process outputs
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: app-process-build
           path: /tmp/app-process-build
@@ -221,7 +221,7 @@ jobs:
             npx cypress "${cypress_args[@]}"
           fi
 
-      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: failure()
         with:
           name: app-frontend-logs
@@ -253,7 +253,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Download app process outputs
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: app-process-build
           path: /tmp/app-process-build
@@ -281,7 +281,7 @@ jobs:
           CYPRESS_CACHE_FOLDER: ${{ github.workspace }}/.cache/Cypress
         run: npx cypress run --browser "${CHROME_PATH:-chrome}" --spec test/e2e/integration --env environment=localtest
 
-      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: failure()
         with:
           name: app-frontend-external-logs

--- a/.github/workflows/app-frontend-k6-browser.yml
+++ b/.github/workflows/app-frontend-k6-browser.yml
@@ -72,7 +72,7 @@ jobs:
         run: sudo chown -R runner:runner k6-browser-screenshots/ || echo "No screenshots to fix ownership"
 
       - name: Upload screenshots
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: always()
         with:
           name: k6-browser-screenshots

--- a/.github/workflows/app-frontend-lighthouse-ci.yml
+++ b/.github/workflows/app-frontend-lighthouse-ci.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Comment PR with Lighthouse Report
         if: github.event_name == 'pull_request' && steps.lighthouse-compare.outputs.markdown != ''
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           COMPARE_MARKDOWN: ${{ steps.lighthouse-compare.outputs.markdown }}
         with:

--- a/.github/workflows/cli-build-test.yaml
+++ b/.github/workflows/cli-build-test.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Upload release artifacts
         if: always()
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: studioctl-release-artifacts
           path: build/release/

--- a/.github/workflows/designer-frontend-playwright-staging.yml
+++ b/.github/workflows/designer-frontend-playwright-staging.yml
@@ -57,7 +57,7 @@ jobs:
           yarn playwright:test:all
 
       - name: Store artifacts
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: failure()
         with:
           name: playwright-screenshots

--- a/.github/workflows/designer-frontend-resourceadm-playwright-staging.yml
+++ b/.github/workflows/designer-frontend-resourceadm-playwright-staging.yml
@@ -59,7 +59,7 @@ jobs:
           yarn resourceadm:playwright:test:all
 
       - name: Store artifacts
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: failure()
         with:
           name: playwright-resourceadm-screenshots

--- a/.github/workflows/designer-frontend-resourceadm-run-playwright-on-pr.yml
+++ b/.github/workflows/designer-frontend-resourceadm-run-playwright-on-pr.yml
@@ -62,7 +62,7 @@ jobs:
           yarn resourceadm:playwright:test:all
 
       - name: Store artifacts
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: failure()
         with:
           name: playwright-resourceadm-screenshots

--- a/.github/workflows/designer-frontend-run-playwright-on-pr.yaml
+++ b/.github/workflows/designer-frontend-run-playwright-on-pr.yaml
@@ -84,7 +84,7 @@ jobs:
           yarn playwright:test:all
 
       - name: Store artifacts
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: failure()
         with:
           name: playwright-screenshots

--- a/.github/workflows/designer-frontend-unit-tests.yml
+++ b/.github/workflows/designer-frontend-unit-tests.yml
@@ -77,7 +77,7 @@ jobs:
           yarn test:ci
 
       - name: 'Upload coverage reports to Codecov'
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/.github/workflows/designer-scan.yml
+++ b/.github/workflows/designer-scan.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Build the Docker image
       run: docker build --file ./src/Designer/Dockerfile --tag altinn-designer:${{github.sha}} .
 
-    - uses: Azure/container-scan@f9af925b897d8af5f7e0026b8bca9346261abc93 # v0
+    - uses: Azure/container-scan@f9af925b897d8af5f7e0026b8bca9346261abc93 # v0.1
       env:
         # See https://github.com/goodwithtech/dockle/issues/188
         DOCKLE_HOST: "unix:///var/run/docker.sock"

--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const defaultTypes = {

--- a/.github/workflows/releaser-build-test.yml
+++ b/.github/workflows/releaser-build-test.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload e2e test logs
         if: always()
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: releaser-e2e-test-logs
           path: src/tools/releaser/test/e2e/_logs/

--- a/.github/workflows/repositories-scan.yml
+++ b/.github/workflows/repositories-scan.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Build the Docker image
       run: docker build ./gitea --tag altinn-repos:${{github.sha}}
 
-    - uses: Azure/container-scan@f9af925b897d8af5f7e0026b8bca9346261abc93 # v0
+    - uses: Azure/container-scan@f9af925b897d8af5f7e0026b8bca9346261abc93 # v0.1
       env:
         # See https://github.com/goodwithtech/dockle/issues/188
         DOCKLE_HOST: "unix:///var/run/docker.sock"

--- a/.github/workflows/runtime-operator-build.yml
+++ b/.github/workflows/runtime-operator-build.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Upload test logs
         if: always()
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: runtime-operator-test-logs
           path: src/Runtime/operator/test/logs/

--- a/.github/workflows/runtime-pdf3-build.yml
+++ b/.github/workflows/runtime-pdf3-build.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Upload test logs
         if: failure()
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: runtime-pdf3-test-logs
           path: src/Runtime/pdf3/test/logs/

--- a/.github/workflows/storybook-to-github-pages.yaml
+++ b/.github/workflows/storybook-to-github-pages.yaml
@@ -28,7 +28,7 @@ jobs:
         run: yarn build-storybook
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           name: github-pages-storybook
           path: src/Designer/frontend/libs/studio-components-legacy/storybook-static


### PR DESCRIPTION
## Description

Converts 25 GitHub Action version comments from floating major tags to the exact upstream versions that already resolve to their pinned SHAs.

The SHA references are unchanged, so workflow execution is unchanged. Exact version metadata lets Renovate handle future releases as semver updates instead of digest-only movements of mutable major tags.

Five `Azure/static-web-apps-deploy` references intentionally remain on `#v1`: official upstream publishes only `v1` and `v0.0.1-preview`, so no exact stable semver tag exists. The pinned `v1` SHA is correct and must not be mislabeled as `v1.0.0`. The stacked policy PR #19750 makes timestamp-less digest movements fail closed.

This is the first PR in a two-PR stack. The follow-up policy PR removes the repository-wide minimum-release-age exemption for digest updates.

## Verification

- [x] Related issues are connected via #19750
- [ ] **Your** code builds clean without any errors or warnings (not run; changes are comments only)
- [x] Manual testing done: verified removed and added `uses` references are identical when version comments are ignored
- [x] Relevant automated test added (not applicable)
- [x] `git diff --check`
- [x] Verified the only remaining SHA-pinned floating Action comments are the five documented `Azure/static-web-apps-deploy #v1` references
- [x] Independently verified every changed SHA against its official exact upstream tag, including peeled annotated tags
