### PR TITLE
fix(deps): enforce release age for digest updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,11 +23,6 @@
   "postUpdateOptions": ["gomodTidy"],
   "packageRules": [
     {
-      "description": "Disable minimum release age checks for digest updates",
-      "matchUpdateTypes": ["digest"],
-      "minimumReleaseAge": null
-    },
-    {
       "matchManagers": ["gomod", "pep621"],
       "groupName": "{{manager}} non-major dependencies",
       "matchPackageNames": ["*"],


### PR DESCRIPTION
## Description

Follows the exact GitHub Action version metadata cleanup merged in #19749.

The repository-wide `minimumReleaseAge: null` exception for digest updates was introduced in #17688 as a workaround for Renovate's missing release timestamps on digest-only updates. This PR removes that broad exception.

Updates to Actions with exact semver metadata are normal version updates, so Renovate can use their release timestamps and enforce the inherited three-day minimum release age.

True digest-only movements—such as an existing tag being repointed, a container image being rebuilt under the same tag, or an Action that publishes only a floating major tag—do not always have a release timestamp. Those updates will remain pending rather than bypassing the quarantine. This fail-closed behavior is intentional; any necessary exceptions should be narrow and documented per dependency.

Renovate limitation discussed in: https://github.com/renovatebot/renovate/discussions/39781

## Verification

- [x] Related work is connected via #17688 and #19749
- [ ] **Your** code builds clean without any errors or warnings (not run; this changes Renovate policy only)
- [x] Manual testing done: reviewed the resolved policy and expected fail-closed behavior
- [x] Relevant automated test added (not applicable)
- [x] `npx --yes --package renovate -- renovate-config-validator --strict`
- [x] `git diff --check`
- [x] Independent reviewer verified the policy diff and inherited three-day strict configuration
