### PR TITLE
fix(cli): preserve subform metadata during v9 upgrades

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -22,7 +22,7 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ### Fixed
 
-- Preserve subform metadata when `studioctl app upgrade v9` migrates and removes `layout-sets.json`.
+- Keep subforms identifiable when running `studioctl app upgrade v9`.
 
 ## [0.1.0-preview.18] - 2026-07-24
 

--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -20,6 +20,10 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 - Stage every change from `studioctl app upgrade` in one `git add -A` pass once the upgrade is done. Previously, some migration steps staged their changes, while others did not.
 - Point `studioctl app upgrade v9` removed-API warnings at the offending call rather than the start of the enclosing expression.
 
+### Fixed
+
+- Preserve subform metadata when `studioctl app upgrade v9` migrates and removes `layout-sets.json`.
+
 ## [0.1.0-preview.18] - 2026-07-24
 
 ### Added

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/LayoutSetsMigration/LayoutSetsToTaskUiMigrator.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/LayoutSetsMigration/LayoutSetsToTaskUiMigrator.cs
@@ -74,7 +74,7 @@ internal sealed class LayoutSetsToTaskUiMigrator
                 }
 
                 touchedFolders.Add(destinationId);
-                UpsertDefaultDataType(destinationPath, plan.DataType);
+                UpsertLayoutSetMetadata(destinationPath, plan.DataType, plan.Type);
             }
 
             if (plan.DestinationIds.Count > 1 && !plan.DestinationIds.Contains(plan.SourceId, StringComparer.Ordinal))
@@ -167,7 +167,8 @@ internal sealed class LayoutSetsToTaskUiMigrator
                     sourceId,
                     sourcePath,
                     ResolveDestinationFolderIds(sourceId, setObject["tasks"] as JsonArray),
-                    setObject["dataType"]?.GetValue<string>()
+                    setObject["dataType"]?.GetValue<string>(),
+                    setObject["type"]?.GetValue<string>()
                 )
             );
         }
@@ -230,9 +231,9 @@ internal sealed class LayoutSetsToTaskUiMigrator
         return taskIds;
     }
 
-    private void UpsertDefaultDataType(string folderPath, string? dataType)
+    private void UpsertLayoutSetMetadata(string folderPath, string? dataType, string? type)
     {
-        if (string.IsNullOrWhiteSpace(dataType))
+        if (string.IsNullOrWhiteSpace(dataType) && string.IsNullOrWhiteSpace(type))
         {
             return;
         }
@@ -250,7 +251,16 @@ internal sealed class LayoutSetsToTaskUiMigrator
             settings = [];
         }
 
-        settings["defaultDataType"] = dataType;
+        if (!string.IsNullOrWhiteSpace(dataType))
+        {
+            settings["defaultDataType"] = dataType;
+        }
+
+        if (!string.IsNullOrWhiteSpace(type))
+        {
+            settings["type"] = type;
+        }
+
         var options = new JsonSerializerOptions { WriteIndented = true };
         File.WriteAllText(settingsPath, settings.ToJsonString(options));
     }
@@ -286,5 +296,6 @@ internal sealed record LayoutSetMigrationPlan(
     string SourceId,
     string SourcePath,
     List<string> DestinationIds,
-    string? DataType
+    string? DataType,
+    string? Type
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Preserve the Designer-specific `type` metadata when `studioctl app upgrade v9` migrates layout sets into task-folder `Settings.json` files. Without this, deleting `layout-sets.json` also removes the marker Studio Designer needs to recognize subforms that have not yet been connected to a Subform component.

The migration now carries `type` into every destination folder alongside `defaultDataType`, while leaving layout sets without a type unchanged.

Closes #19382.

## Verification

- [x] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

Manual verification:

1. Copied `src/test/apps/subform-test` to a disposable directory.
2. Added a legacy `layout-sets.json` with two layout sets marked as `type: subform` and one regular task layout set.
3. Ran the complete v9 upgrade through the locally built studioctl server; it completed with exit code 0.
4. Confirmed both subform `Settings.json` files contained `"type": "subform"`, the regular task did not gain a `type`, and `layout-sets.json` was removed.

The studioctl server project built successfully, but the build reported the existing NU1902 warning for AngleSharp 1.4.0, so the warning-free build checkbox remains unchecked. No automated test was added; this change was verified against the test app as described above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved subform metadata when upgrading applications to version 9.
  * Retained existing layout settings when optional data type or type information is not provided during migration.

* **Documentation**
  * Added an unreleased changelog entry describing the metadata preservation fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->