### PR TITLE
feat: enforce clean git state before running v9 upgrade script to ensure clean changeset

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -16,6 +16,7 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ### Changed
 
+- Refuse to start `studioctl app upgrade` when the git repository has local changes, so the upgrade lands as one clean reviewable changeset.
 - Rename `OrganisationLookup` components and their data model bindings to `OrganizationLookup` when running `studioctl app upgrade v9`.
 - Stage every change from `studioctl app upgrade` in one `git add -A` pass once the upgrade is done. Previously, some migration steps staged their changes, while others did not.
 - Point `studioctl app upgrade v9` removed-API warnings at the offending call rather than the start of the enclosing expression.

--- a/src/cli/studioctl-server/Studioctl/AppUpgradeService.cs
+++ b/src/cli/studioctl-server/Studioctl/AppUpgradeService.cs
@@ -41,6 +41,12 @@ internal sealed class AppUpgradeService : IDisposable
         if (!Directory.Exists(projectFolder))
             return AppUpgradeResult.Invalid($"projectFolder does not exist: {projectFolder}");
 
+        // We want to enforce a clean directory, so git diff will only show what the update did
+        if (GitOperations.HasLocalChanges(projectFolder))
+            return AppUpgradeResult.Invalid(
+                "The git repository has local changes. Commit or stash them before upgrading."
+            );
+
         await _upgradeLock.WaitAsync(cancellationToken);
         try
         {

--- a/src/cli/studioctl-server/Studioctl/AppUpgradeService.cs
+++ b/src/cli/studioctl-server/Studioctl/AppUpgradeService.cs
@@ -48,10 +48,13 @@ internal sealed class AppUpgradeService : IDisposable
             var error = new StringWriter(CultureInfo.InvariantCulture);
             try
             {
-                // We want to enforce a clean directory, so git diff will only show what the update did
-                if (GitOperations.HasLocalChanges(projectFolder, output))
+                // We want to enforce a clean directory, so git diff will only show what the update did. An
+                // unreadable repository is refused too - we cannot tell its changes apart from the upgrade's.
+                if (!GitOperations.IsWorkingTreeClean(projectFolder, out var gitError))
                     return AppUpgradeResult.Invalid(
-                        "The git repository has local changes. Commit or stash them before upgrading."
+                        gitError is null
+                            ? "The git repository has local changes. Commit or stash them before upgrading."
+                            : $"Could not determine whether the git repository has local changes: {gitError}. Fix the repository before upgrading."
                     );
 
                 var exitCode = await RunUpgradeAsync(

--- a/src/cli/studioctl-server/Studioctl/AppUpgradeService.cs
+++ b/src/cli/studioctl-server/Studioctl/AppUpgradeService.cs
@@ -41,12 +41,6 @@ internal sealed class AppUpgradeService : IDisposable
         if (!Directory.Exists(projectFolder))
             return AppUpgradeResult.Invalid($"projectFolder does not exist: {projectFolder}");
 
-        // We want to enforce a clean directory, so git diff will only show what the update did
-        if (GitOperations.HasLocalChanges(projectFolder))
-            return AppUpgradeResult.Invalid(
-                "The git repository has local changes. Commit or stash them before upgrading."
-            );
-
         await _upgradeLock.WaitAsync(cancellationToken);
         try
         {
@@ -54,6 +48,12 @@ internal sealed class AppUpgradeService : IDisposable
             var error = new StringWriter(CultureInfo.InvariantCulture);
             try
             {
+                // We want to enforce a clean directory, so git diff will only show what the update did
+                if (GitOperations.HasLocalChanges(projectFolder, output))
+                    return AppUpgradeResult.Invalid(
+                        "The git repository has local changes. Commit or stash them before upgrading."
+                    );
+
                 var exitCode = await RunUpgradeAsync(
                     request with
                     {

--- a/src/cli/studioctl-server/Studioctl/Upgrade/GitOperations.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/GitOperations.cs
@@ -8,25 +8,28 @@ namespace Altinn.Studio.Cli.Upgrade;
 internal static class GitOperations
 {
     /// <summary>
-    /// Whether the repository containing <paramref name="path"/> has local changes — staged, unstaged or
-    /// untracked. Failures are reported to <paramref name="output"/> and treated as no local changes, so a
-    /// repository we cannot read never blocks the caller.
+    /// Whether the working tree of the repository containing <paramref name="path"/> is confirmed clean — no
+    /// staged, unstaged or untracked changes. A path deliberately outside git counts as clean. Anything we
+    /// cannot confirm is not clean: local changes leave <paramref name="error"/> <c>null</c>, while a
+    /// repository we cannot read reports the git failure in <paramref name="error"/>.
     /// </summary>
-    public static bool HasLocalChanges(string path, TextWriter output)
+    public static bool IsWorkingTreeClean(string path, out string? error)
     {
+        error = null;
+
         try
         {
             using var repo = TryOpenRepository(path);
             if (repo is null)
             {
-                return false;
+                return true;
             }
 
-            return repo.RetrieveStatus().IsDirty;
+            return !repo.RetrieveStatus().IsDirty;
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            output.WriteLine($"Warning: Failed to check for local git changes: {ex.Message}");
+            error = ex.Message;
             return false;
         }
     }

--- a/src/cli/studioctl-server/Studioctl/Upgrade/GitOperations.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/GitOperations.cs
@@ -8,6 +8,29 @@ namespace Altinn.Studio.Cli.Upgrade;
 internal static class GitOperations
 {
     /// <summary>
+    /// Whether the repository containing <paramref name="path"/> has local changes — staged, unstaged or
+    /// untracked.
+    /// </summary>
+    public static bool HasLocalChanges(string path)
+    {
+        try
+        {
+            var repoPath = Repository.Discover(path);
+            if (string.IsNullOrEmpty(repoPath))
+            {
+                return false;
+            }
+
+            using var repo = new Repository(repoPath);
+            return repo.RetrieveStatus().IsDirty;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Stages every change in the repository containing <paramref name="path"/> — the equivalent of
     /// <c>git add -A</c>. Failures are reported to <paramref name="output"/> and never fail the caller.
     /// </summary>

--- a/src/cli/studioctl-server/Studioctl/Upgrade/GitOperations.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/GitOperations.cs
@@ -9,23 +9,24 @@ internal static class GitOperations
 {
     /// <summary>
     /// Whether the repository containing <paramref name="path"/> has local changes — staged, unstaged or
-    /// untracked.
+    /// untracked. Failures are reported to <paramref name="output"/> and treated as no local changes, so a
+    /// repository we cannot read never blocks the caller.
     /// </summary>
-    public static bool HasLocalChanges(string path)
+    public static bool HasLocalChanges(string path, TextWriter output)
     {
         try
         {
-            var repoPath = Repository.Discover(path);
-            if (string.IsNullOrEmpty(repoPath))
+            using var repo = TryOpenRepository(path);
+            if (repo is null)
             {
                 return false;
             }
 
-            using var repo = new Repository(repoPath);
             return repo.RetrieveStatus().IsDirty;
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
+            output.WriteLine($"Warning: Failed to check for local git changes: {ex.Message}");
             return false;
         }
     }
@@ -38,14 +39,13 @@ internal static class GitOperations
     {
         try
         {
-            var repoPath = Repository.Discover(path);
-            if (string.IsNullOrEmpty(repoPath))
+            using var repo = TryOpenRepository(path);
+            if (repo is null)
             {
                 output.WriteLine("Not a git repository - leaving changes unstaged");
                 return;
             }
 
-            using var repo = new Repository(repoPath);
             Commands.Stage(repo, "*");
 
             using var stagedChanges = repo.Diff.Compare<TreeChanges>(repo.Head.Tip?.Tree, DiffTargets.Index);
@@ -57,5 +57,15 @@ internal static class GitOperations
         {
             output.WriteLine($"Warning: Failed to stage changes: {ex.Message}");
         }
+    }
+
+    /// <summary>
+    /// Opens the repository containing <paramref name="path"/>, or <c>null</c> when <paramref name="path"/> is
+    /// not inside a git repository.
+    /// </summary>
+    private static Repository? TryOpenRepository(string path)
+    {
+        var repoPath = Repository.Discover(path);
+        return string.IsNullOrEmpty(repoPath) ? null : new Repository(repoPath);
     }
 }


### PR DESCRIPTION
# Description

`studioctl app upgrade` now refuses to start when the app's git repository has local changes,
asking the user to commit or stash first. This makes the changeset show only what the upgrade did, with no user edits mixed in.

`GitOperations.HasLocalChanges` reports staged, unstaged and untracked changes for the whole repository (the same scope `StageAllChanges` stages). Ignored files are not counted, so build output like `bin/`, `obj/` and `node_modules/` never blocks an upgrade.

## Things to consider
We currently check for changes in the whole repository. If you are inside the altinn-studio monorepo, with local changes to the update script, and try to run it one of the test apps in the same repo, the script will not run. If this is problematic we can add an --allow-dirty option to the script.


## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * App upgrades now refuse to start when the project repository contains staged, unstaged or untracked changes.
  * Repository access or inspection failures are reported before the upgrade begins, preventing upgrades when the repository state cannot be verified.
  * Users should commit or stash local changes before retrying an upgrade.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->