### PR TITLE
fix(renovate): keep React updates in one PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -166,7 +166,9 @@
         "@types/react-dom"
       ],
       "groupName": "React ecosystem",
-      "groupSlug": "react-ecosystem"
+      "groupSlug": "react-ecosystem",
+      "additionalBranchPrefix": "",
+      "commitMessageSuffix": ""
     }
   ],
   "schedule": []


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Follow-up to #19729, which added a repository-wide Renovate group for `react`, `react-dom`, `@types/react`, and `@types/react-dom`.

That rule grouped the package names, but Renovate merges all matching package rules. React dependencies in App frontend and App libraries therefore retained the earlier App-specific `additionalBranchPrefix` and `commitMessageSuffix`. The result was two separate update branches and pull requests:

- #19731 updated App frontend and App libraries on `renovate/app/patch-react-ecosystem`.
- #19757 updated Studio Designer on `renovate/patch-react-ecosystem`.

Explicitly reset both string options in the final React rule. This gives every eligible React dependency the same branch configuration, allowing Renovate to put App and Designer updates in one repository-wide pull request.

Renovate documents that all matching package rules are merged and later rules override only options they specify: https://docs.renovatebot.com/configuration-options/#packagerules

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

Verified that `renovate.json` parses as valid JSON and that the complete branch diff passes `git diff --check`. The observed branch names in #19731 and #19757 confirm that the inherited `additionalBranchPrefix` caused the split. No product build, manual test, or automated test was run for this Renovate configuration-only change.
