### PR TITLE
refactor:  Make instance-selection follow route module pattern from react router

### DIFF
--- a/src/App/frontend/eslint.config.mjs
+++ b/src/App/frontend/eslint.config.mjs
@@ -249,6 +249,13 @@ export default defineConfig([
     },
   },
   {
+    // Route modules must default-export their component - that is React Router's Route Module API.
+    files: ['src/routes/**/*.route.tsx'],
+    rules: {
+      'import/no-default-export': ['off'],
+    },
+  },
+  {
     files: ['src/routes/**/*.{ts,tsx}', 'src/router.tsx'],
     ignores: ['src/routes/**/*.test.ts'],
     rules: {

--- a/src/App/frontend/src/components/message/ErrorReport.tsx
+++ b/src/App/frontend/src/components/message/ErrorReport.tsx
@@ -144,7 +144,8 @@ export function ErrorReportList({ formErrors, taskErrors }: ErrorReportListProps
 }
 
 /**
- * @see instanceSelectionLoader Contains somewhat similar error handling logic in the route loader.
+ * @see src/routes/instance-selection/instance-selection.loader.ts Contains somewhat similar error
+ * handling logic in the route loader.
  */
 export function ErrorListFromInstantiation({ error }: { error: unknown }) {
   const selectedParty = useSelectedParty();

--- a/src/App/frontend/src/router.tsx
+++ b/src/App/frontend/src/router.tsx
@@ -17,12 +17,12 @@ import { statelessIndexLoader } from 'src/routes/index/stateless-index.loader';
 import { instanceLoader } from 'src/routes/instance/instance.loader';
 import { Component as InstanceRoute, ErrorBoundary as InstanceErrorBoundary } from 'src/routes/instance/instance.route';
 import { instanceIndexLoader } from 'src/routes/instance/instance-index.loader';
-import { instanceSelectionLoader } from 'src/routes/instance-selection/instance-selection.loader';
-import { Component as InstanceSelectionRoute } from 'src/routes/instance-selection/instance-selection.route';
+import * as instanceSelectionRoute from 'src/routes/instance-selection/instance-selection.route';
 import { Component as PageRoute } from 'src/routes/page/page.route';
 import { partySelectionLoader } from 'src/routes/party-selection/party-selection.loader';
 import { Component as PartySelectionRoute } from 'src/routes/party-selection/party-selection.route';
 import { Component as ProcessEndRoute } from 'src/routes/process-end/process-end.route';
+import { convertRouteModule } from 'src/routes/routeModule';
 import { taskLoader } from 'src/routes/task/task.loader';
 import { Component as TaskRoute } from 'src/routes/task/task.route';
 import { taskIndexLoader } from 'src/routes/task/task-index.loader';
@@ -39,8 +39,7 @@ export function createRouter({ queryClient, apiClients }: { queryClient: QueryCl
         children: [
           {
             path: routes.instanceSelection,
-            Component: InstanceSelectionRoute,
-            loader: instanceSelectionLoader,
+            ...convertRouteModule(instanceSelectionRoute),
           },
           {
             path: routes.partySelection,

--- a/src/App/frontend/src/routes/instance-selection/instance-selection.loader.test.ts
+++ b/src/App/frontend/src/routes/instance-selection/instance-selection.loader.test.ts
@@ -11,7 +11,7 @@ import { partyApi } from 'src/core/api-client/party.api';
 import { GlobalData } from 'src/GlobalData';
 import { apiClientsContext } from 'src/routerContexts/apiClientRouterContext';
 import { queryClientContext } from 'src/routerContexts/reactQueryRouterContext';
-import { instanceSelectionLoader } from 'src/routes/instance-selection/instance-selection.loader';
+import { clientLoader } from 'src/routes/instance-selection/instance-selection.loader';
 import { createLoaderFunctionArgs } from 'src/test/routerUtils';
 import type { InstanceSelectionLoaderResult } from 'src/routes/instance-selection/instance-selection.loader';
 
@@ -48,7 +48,7 @@ function createLoaderArgs(): LoaderFunctionArgs {
   return createLoaderFunctionArgs({ context });
 }
 
-describe('instanceSelectionLoader', () => {
+describe('instance-selection clientLoader', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     GlobalData.setSelectedParty(mockParty);
@@ -65,7 +65,7 @@ describe('instanceSelectionLoader', () => {
     ];
     jest.mocked(instanceApi.getActiveInstances).mockResolvedValue(activeInstances);
 
-    const result = await instanceSelectionLoader(createLoaderArgs());
+    const result = await clientLoader(createLoaderArgs());
 
     expect(result).toBeNull();
     expect(instanceApi.create).not.toHaveBeenCalled();
@@ -75,7 +75,7 @@ describe('instanceSelectionLoader', () => {
     jest.mocked(instanceApi.getActiveInstances).mockResolvedValue([]);
     jest.mocked(instanceApi.create).mockResolvedValue(mockInstance);
 
-    await instanceSelectionLoader(createLoaderArgs());
+    await clientLoader(createLoaderArgs());
 
     expect(instanceApi.create).toHaveBeenCalledWith({ instanceOwnerPartyId: mockParty.partyId });
     expect(redirect).toHaveBeenCalledWith(expect.stringContaining('some-instance-guid'));
@@ -95,7 +95,7 @@ describe('instanceSelectionLoader', () => {
     jest.mocked(instanceApi.getActiveInstances).mockResolvedValue([]);
     jest.mocked(instanceApi.create).mockRejectedValue(error);
 
-    const result = (await instanceSelectionLoader(createLoaderArgs())) as InstanceSelectionLoaderResult;
+    const result = (await clientLoader(createLoaderArgs())) as InstanceSelectionLoaderResult;
 
     expect(result).not.toBeNull();
     expect(result).toHaveProperty('error', 'forbidden-validation');
@@ -113,7 +113,7 @@ describe('instanceSelectionLoader', () => {
     jest.mocked(instanceApi.getActiveInstances).mockResolvedValue([]);
     jest.mocked(instanceApi.create).mockRejectedValue(error);
 
-    const result = await instanceSelectionLoader(createLoaderArgs());
+    const result = await clientLoader(createLoaderArgs());
 
     expect(result).not.toBeNull();
     expect(result).toHaveProperty('error', 'forbidden');
@@ -125,7 +125,7 @@ describe('instanceSelectionLoader', () => {
     jest.mocked(instanceApi.getActiveInstances).mockResolvedValue([]);
     jest.mocked(instanceApi.create).mockRejectedValue(error);
 
-    const result = await instanceSelectionLoader(createLoaderArgs());
+    const result = await clientLoader(createLoaderArgs());
 
     expect(result).not.toBeNull();
     expect(result).toHaveProperty('error', 'instantiation-failed');
@@ -139,7 +139,7 @@ describe('instanceSelectionLoader', () => {
     const originalSelectedParty = window.altinnAppGlobalData.selectedParty;
     window.altinnAppGlobalData.selectedParty = undefined;
 
-    await instanceSelectionLoader(createLoaderArgs());
+    await clientLoader(createLoaderArgs());
 
     window.altinnAppGlobalData.selectedParty = originalSelectedParty;
 

--- a/src/App/frontend/src/routes/instance-selection/instance-selection.loader.ts
+++ b/src/App/frontend/src/routes/instance-selection/instance-selection.loader.ts
@@ -17,9 +17,7 @@ export type InstanceSelectionLoaderError =
 
 export type InstanceSelectionLoaderResult = null | InstanceSelectionLoaderError;
 
-export async function instanceSelectionLoader({
-  context,
-}: LoaderFunctionArgs): Promise<InstanceSelectionLoaderResult | Response> {
+export async function clientLoader({ context }: LoaderFunctionArgs): Promise<InstanceSelectionLoaderResult | Response> {
   const queryClient = context.get(queryClientContext);
   const { partyApi, instanceApi } = context.get(apiClientsContext);
   prefetchPartiesAllowedToInstantiate({ queryClient, partyApi });

--- a/src/App/frontend/src/routes/instance-selection/instance-selection.route.tsx
+++ b/src/App/frontend/src/routes/instance-selection/instance-selection.route.tsx
@@ -5,9 +5,12 @@ import { DisplayError } from 'src/core/errorHandling/DisplayError';
 import { InstantiateValidationError } from 'src/features/instantiate/containers/InstantiateValidationError';
 import { MissingRolesError } from 'src/features/instantiate/containers/MissingRolesError';
 import { InstanceSelectionWrapper } from 'src/features/instantiate/selection/InstanceSelection';
+import { clientLoader } from 'src/routes/instance-selection/instance-selection.loader';
 import type { InstanceSelectionLoaderResult } from 'src/routes/instance-selection/instance-selection.loader';
 
-export const Component = () => {
+export { clientLoader };
+
+export default function InstanceSelection() {
   const loaderData = useLoaderData<InstanceSelectionLoaderResult>();
 
   if (loaderData?.error === 'forbidden') {
@@ -23,4 +26,4 @@ export const Component = () => {
   }
 
   return <InstanceSelectionWrapper />;
-};
+}

--- a/src/App/frontend/src/routes/routeModule.test.ts
+++ b/src/App/frontend/src/routes/routeModule.test.ts
@@ -1,0 +1,56 @@
+import { convertRouteModule } from 'src/routes/routeModule';
+
+describe('convertRouteModule', () => {
+  const Component = () => null;
+
+  it('should map the default export to Component', () => {
+    const converted = convertRouteModule({ default: Component });
+
+    expect(converted.Component).toBe(Component);
+  });
+
+  it('should map clientLoader to loader and clientAction to action', () => {
+    const clientLoader = () => null;
+    const clientAction = () => null;
+
+    const converted = convertRouteModule({ default: Component, clientLoader, clientAction });
+
+    expect(converted.loader).toBe(clientLoader);
+    expect(converted.action).toBe(clientAction);
+  });
+
+  it('should leave loader and action undefined when the module exports neither', () => {
+    const converted = convertRouteModule({ default: Component });
+
+    expect(converted.loader).toBeUndefined();
+    expect(converted.action).toBeUndefined();
+  });
+
+  it('should pass the remaining route module exports through untouched', () => {
+    const ErrorBoundary = () => null;
+    const HydrateFallback = () => null;
+    const shouldRevalidate = () => true;
+    const handle = { some: 'value' };
+
+    const converted = convertRouteModule({
+      default: Component,
+      ErrorBoundary,
+      HydrateFallback,
+      shouldRevalidate,
+      handle,
+    });
+
+    expect(converted.ErrorBoundary).toBe(ErrorBoundary);
+    expect(converted.HydrateFallback).toBe(HydrateFallback);
+    expect(converted.shouldRevalidate).toBe(shouldRevalidate);
+    expect(converted.handle).toBe(handle);
+  });
+
+  it('should not leak the route module export names onto the route object', () => {
+    const converted = convertRouteModule({ default: Component, clientLoader: () => null });
+
+    expect(converted).not.toHaveProperty('default');
+    expect(converted).not.toHaveProperty('clientLoader');
+    expect(converted).not.toHaveProperty('clientAction');
+  });
+});

--- a/src/App/frontend/src/routes/routeModule.test.ts
+++ b/src/App/frontend/src/routes/routeModule.test.ts
@@ -46,11 +46,28 @@ describe('convertRouteModule', () => {
     expect(converted.handle).toBe(handle);
   });
 
-  it('should not leak the route module export names onto the route object', () => {
-    const converted = convertRouteModule({ default: Component, clientLoader: () => null });
+  it('should copy nothing but the supported route object fields', () => {
+    // The route module export names are renamed rather than copied, and `path`, `index` and `children`
+    // must stay with the router configuration. A route module has no business exporting the latter, but
+    // a module namespace object is structurally assignable to RouteModule, so TypeScript cannot say so.
+    const routeModule = {
+      default: Component,
+      clientLoader: () => null,
+      path: 'somewhere-else',
+      index: true,
+      children: [],
+    };
 
-    expect(converted).not.toHaveProperty('default');
-    expect(converted).not.toHaveProperty('clientLoader');
-    expect(converted).not.toHaveProperty('clientAction');
+    const converted = convertRouteModule(routeModule);
+
+    expect(Object.keys(converted).sort()).toEqual([
+      'Component',
+      'ErrorBoundary',
+      'HydrateFallback',
+      'action',
+      'handle',
+      'loader',
+      'shouldRevalidate',
+    ]);
   });
 });

--- a/src/App/frontend/src/routes/routeModule.ts
+++ b/src/App/frontend/src/routes/routeModule.ts
@@ -17,7 +17,7 @@ type ConvertedRouteModule = Omit<NonIndexRouteObject, 'path' | 'index' | 'childr
 
 /**
  * Maps a route module onto the route object shape `createBrowserRouter` expects. React Router's Vite
- * plugin reads the route module exports directly, so this conversion goes away once we adopt it.
+ * plugin reads the route module exports directly, so this conversion goes away if we decide to adopt it sometime in the future.
  *
  * @see https://reactrouter.com/upgrading/router-provider
  */

--- a/src/App/frontend/src/routes/routeModule.ts
+++ b/src/App/frontend/src/routes/routeModule.ts
@@ -1,0 +1,31 @@
+import type { NonIndexRouteObject } from 'react-router';
+
+/**
+ * The part of React Router's Route Module API we use. A route module exports its component as the
+ * default export and its data functions as `clientLoader`/`clientAction`.
+ *
+ * @see https://reactrouter.com/start/framework/route-module
+ */
+type RouteModule = {
+  default: NonIndexRouteObject['Component'];
+  clientLoader?: NonIndexRouteObject['loader'];
+  clientAction?: NonIndexRouteObject['action'];
+} & Pick<NonIndexRouteObject, 'ErrorBoundary' | 'HydrateFallback' | 'shouldRevalidate' | 'handle'>;
+
+/** Everything a route module contributes. `path`, `index` and `children` stay in the router config. */
+type ConvertedRouteModule = Omit<NonIndexRouteObject, 'path' | 'index' | 'children'>;
+
+/**
+ * Maps a route module onto the route object shape `createBrowserRouter` expects. React Router's Vite
+ * plugin reads the route module exports directly, so this conversion goes away once we adopt it.
+ *
+ * @see https://reactrouter.com/upgrading/router-provider
+ */
+export function convertRouteModule({
+  default: Component,
+  clientLoader,
+  clientAction,
+  ...rest
+}: RouteModule): ConvertedRouteModule {
+  return { ...rest, loader: clientLoader, action: clientAction, Component };
+}

--- a/src/App/frontend/src/routes/routeModule.ts
+++ b/src/App/frontend/src/routes/routeModule.ts
@@ -21,11 +21,14 @@ type ConvertedRouteModule = Omit<NonIndexRouteObject, 'path' | 'index' | 'childr
  *
  * @see https://reactrouter.com/upgrading/router-provider
  */
-export function convertRouteModule({
-  default: Component,
-  clientLoader,
-  clientAction,
-  ...rest
-}: RouteModule): ConvertedRouteModule {
-  return { ...rest, loader: clientLoader, action: clientAction, Component };
+export function convertRouteModule(routeModule: RouteModule): ConvertedRouteModule {
+  return {
+    Component: routeModule.default,
+    loader: routeModule.clientLoader,
+    action: routeModule.clientAction,
+    ErrorBoundary: routeModule.ErrorBoundary,
+    HydrateFallback: routeModule.HydrateFallback,
+    shouldRevalidate: routeModule.shouldRevalidate,
+    handle: routeModule.handle,
+  };
 }


### PR DESCRIPTION
## Description

Proof of concept for following the Route Module format used in React Router **framework mode**.
The change matches to two first steps from the migration guide at 
([upgrade guide](https://reactrouter.com/upgrading/router-provider)), except that we are not applying lazy loading in step 2 (that would be a big change).
It follows the format specified at 
[Route Module API](https://reactrouter.com/start/framework/route-module).
This is a pure refactor, and should not change any behaviour.
I don't know if we will ever use React Router in framework mode, but the changes in this PR will make such a migration easier (and easer to experiment with), and I think it's nice to follow these React Router conventions.
The changes are applied to **one route only**
(`instance-selection` in the app frontend) so we can review the shape before applying it to other routes.

**What a route module looks like here** — `instance-selection.route.tsx` exports `clientLoader` plus a
default component; `router.tsx` spreads it through a small `convert` helper:

```tsx
{ path: routes.instanceSelection, ...convertRouteModule(instanceSelectionRoute) },
```

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)