### PR TITLE
chore(cli): pin durable-yield workflow-engine image

### DIFF
--- a/src/Runtime/workflow-engine-app/README.md
+++ b/src/Runtime/workflow-engine-app/README.md
@@ -56,7 +56,7 @@ No Docker Compose setup needed — tests use Testcontainers for PostgreSQL and W
 
 ```yaml
 image: ghcr.io/altinn/altinn-studio/runtime-workflow-engine-app
-tag: "693d3e6cd3"
+tag: "5e537dc6d3"
 ```
 
 > Passing `--dev-workflow-engine` instead **disables** that container and routes the engine binding to a local host process (so you can run it yourself with `dotnet run`). In that mode the pinned tag is not used — only the default `studioctl env up` consumes it.

--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -16,6 +16,7 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ### Changed
 
+- Update the workflow-engine image used by `studioctl env up` to a version with durable-yield support: service tasks can wait for external outcomes (for example a delivery confirmation) without occupying a worker or being treated as failures.
 - Refuse to start `studioctl app upgrade` when the git repository has local changes, so the upgrade lands as one clean reviewable changeset.
 - Rename `OrganisationLookup` components and their data model bindings to `OrganizationLookup` when running `studioctl app upgrade v9`.
 - Stage every change from `studioctl app upgrade` in one `git add -A` pass once the upgrade is done. Previously, some migration steps staged their changes, while others did not.

--- a/src/cli/internal/config/config.yaml
+++ b/src/cli/internal/config/config.yaml
@@ -12,7 +12,7 @@ images:
       tag: "694406e93c"
     workflow-engine:
       image: ghcr.io/altinn/altinn-studio/runtime-workflow-engine-app
-      tag: "693d3e6cd3"
+      tag: "5e537dc6d3"
     workflow-engine-db:
       image: postgres
       tag: "18.3"


### PR DESCRIPTION
## Description

Bumps the `runtime-workflow-engine-app` image pin in studioctl (`src/cli/internal/config/config.yaml`) from `693d3e6cd3` to `5e537dc6d3` — the post-merge build of #19622 (durable yield). Plain `studioctl env up` (non-DevMode) now runs an engine that speaks the durable-yield wire contract (`Waiting` status, `defer` callback block, `command.waitBudget`, nudge endpoint). Also updates the README example that quotes the pin.

The image is already published to GHCR by the [deploy workflow run](https://github.com/Altinn/altinn-studio/actions/runs/31086879280) for the merge commit, and the same build is deployed to the runtime environments.

Part of #19685.

## Verification

- [x] `go build ./...` + config package tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the workflow-engine environment used by `studioctl env up`.
  * Service tasks can now support durable yields while awaiting outcomes from external systems.

* **Improvements**
  * Refreshed the workflow-engine image to include the latest runtime capabilities and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->