### PR TITLE
fix: prefer stable v9 app packages

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -24,6 +24,7 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 ### Fixed
 
 - Keep subforms identifiable when running `studioctl app upgrade v9`.
+- Prefer the latest stable v9 app packages in `studioctl app upgrade v9`, falling back to the latest preview until a stable version is available.
 
 ## [0.1.0-preview.18] - 2026-07-24
 

--- a/src/cli/studioctl-server-tests/Upgrade/v8Tov9/V9PackageVersionResolverTests.cs
+++ b/src/cli/studioctl-server-tests/Upgrade/v8Tov9/V9PackageVersionResolverTests.cs
@@ -1,0 +1,28 @@
+using Altinn.Studio.Cli.Upgrade.v8Tov9;
+
+namespace Studioctl.Tests.Upgrade.v8Tov9;
+
+public sealed class V9PackageVersionResolverTests
+{
+    [Fact]
+    public void ResolveLatestTargetVersion_PrefersLatestStableVersion()
+    {
+        string[] apiVersions = ["9.0.0", "9.0.1", "9.1.0-preview.1"];
+        string[] coreVersions = ["9.0.0", "9.0.1", "9.1.0-preview.1"];
+
+        var version = V9PackageVersionResolver.ResolveLatestTargetVersion(apiVersions, coreVersions, 9);
+
+        Assert.Equal("9.0.1", version);
+    }
+
+    [Fact]
+    public void ResolveLatestTargetVersion_NoStableVersion_ReturnsLatestCommonPrerelease()
+    {
+        string[] apiVersions = ["9.0.0-preview.1", "9.0.0-preview.2", "9.0.0-preview.3"];
+        string[] coreVersions = ["9.0.0-preview.1", "9.0.0-preview.2"];
+
+        var version = V9PackageVersionResolver.ResolveLatestTargetVersion(apiVersions, coreVersions, 9);
+
+        Assert.Equal("9.0.0-preview.2", version);
+    }
+}

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/V9PackageVersionResolver.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/V9PackageVersionResolver.cs
@@ -29,7 +29,8 @@ internal static class V9PackageVersionResolver
             .Select(NuGetPackageVersion.TryParse)
             .OfType<NuGetPackageVersion>()
             .Where(v => v.Major == targetMajorVersion)
-            .OrderDescending()
+            .OrderBy(v => v.Prerelease.Count > 0)
+            .ThenByDescending(v => v)
             .FirstOrDefault();
 
         if (latest is null)


### PR DESCRIPTION
## Description

Make `studioctl app upgrade v9` prefer the latest stable version shared by `Altinn.App.Api` and `Altinn.App.Core`. When no stable v9 version exists, it continues to select the latest shared prerelease.

This prevents a numerically newer preview, such as `9.1.0-preview.1`, from superseding the latest stable v9 package, such as `9.0.1`.

Adds resolver regression tests for both the stable-first policy and the prerelease fallback, plus a user-facing changelog entry.

## Verification

- [ ] Related issues are connected (not applicable; no issue)
- [ ] **Your** code builds clean without any errors or warnings (build succeeds; existing NuGet vulnerability advisories remain)
- [ ] Manual testing done (the behavior is covered directly by resolver tests)
- [x] Relevant automated test added

Commands run from `src/cli`:

```text
make build
make lint-fix
make fmt
make lint
make test
dotnet build studioctl-server/studioctl-server.csproj --no-restore
```

Results:

```text
make build: passed
make lint-fix: 0 issues
make fmt: passed
make lint: 0 issues
make test: Go race tests passed; 135 .NET tests passed
dotnet build: succeeded with 0 errors and the existing AngleSharp NU1902 advisory warning
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - `studioctl app upgrade v9` now prioritises the latest stable app package versions.
  - Automatically falls back to the latest preview version when no stable version is available.

- **Documentation**
  - Added changelog details describing the updated upgrade version selection.

- **Tests**
  - Added coverage for stable-version selection and preview fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->