### PR TITLE
fix(localtest): fetch requested app metadata directly

### DIFF
--- a/src/Runtime/localtest/src/Controllers/Storage/ApplicationsController.cs
+++ b/src/Runtime/localtest/src/Controllers/Storage/ApplicationsController.cs
@@ -83,6 +83,7 @@ public class ApplicationsController : ControllerBase
     /// </summary>
     /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
     /// <param name="app">Application identifier which is unique within an organisation.</param>
+    /// <param name="cancellationToken">A token that is cancelled when the request is aborted.</param>
     /// <returns>The metadata for the identified application.</returns>
     [AllowAnonymous]
     [HttpGet("{org}/{app}")]
@@ -90,11 +91,11 @@ public class ApplicationsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [Produces("application/json")]
-    public async Task<ActionResult<Application>> GetOne(string org, string app)
+    public async Task<ActionResult<Application>> GetOne(string org, string app, CancellationToken cancellationToken)
     {
         string appId = $"{org}/{app}";
 
-        Application result = await repository.FindOne(appId, org);
+        Application result = await repository.FindOne(appId, org, cancellationToken);
 
         if (result == null)
         {

--- a/src/Runtime/localtest/src/Services/Storage/Implementation/ApplicationRepository.cs
+++ b/src/Runtime/localtest/src/Services/Storage/Implementation/ApplicationRepository.cs
@@ -40,12 +40,12 @@ namespace LocalTest.Services.Storage.Implementation
 
         public async Task<Application> FindOne(string appId, string org, CancellationToken cancellationToken = default)
         {
-            var applications = await _localApp.GetApplications();
-            if (applications.ContainsKey(appId))
+            var application = await _localApp.GetApplicationMetadata(appId, cancellationToken);
+            if (application != null && string.Equals(application.Id, appId, StringComparison.OrdinalIgnoreCase))
             {
-                return applications[appId];
+                return application;
             }
-            throw new Exception($"applicationmetadata for '{appId} not found'");
+            throw new Exception($"applicationmetadata for '{appId}' not found");
         }
 
         public Task<Dictionary<string, Dictionary<string, string>>> GetAppTitles(List<string> appIds)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Localtest Storage previously enumerated metadata from every discovered app before resolving one requested app. A slow or unresponsive endpoint could therefore delay registration for an otherwise healthy app.

This change fetches only the requested app's metadata, rejects stale/mismatched metadata by validating the returned app ID case-insensitively, and propagates HTTP request cancellation to the app lookup.

The existing not-found behavior is intentionally preserved. This is the bottom PR in the studioctl startup/discovery stack.

## Verification

- [x] Related issues are connected (not applicable; based on direct user feedback)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (no existing Localtest test project; a new project was removed following review)

```text
$ dotnet restore
All projects are up-to-date for restore.

$ dotnet build --configuration Debug --no-restore
Build succeeded.
    0 Warning(s)
    0 Error(s)
```

The source-built Localtest image was also exercised with an app launched through studioctl.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Application lookups now support request cancellation, improving responsiveness when requests are stopped.
  * Application metadata is validated more reliably, including case-insensitive ID matching.
  * Missing applications are handled consistently instead of returning incorrect results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->