### PR TITLE
fix(studioctl): allow slower app startup

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -9,6 +9,10 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+### Changed
+
+- Wait up to 30 seconds for an app to become reachable through Localtest when using `studioctl run`; use `--startup-timeout` to choose a different limit.
+
 ### Fixed
 
 - Explain access errors during `studioctl app upgrade`

--- a/src/cli/internal/cmd/run.go
+++ b/src/cli/internal/cmd/run.go
@@ -38,7 +38,7 @@ const (
 	foregroundContainerCleanupTimeout = 15 * time.Second
 	dotnetShutdownTimeout             = 10 * time.Second
 	studioctlServerCleanupTimeout     = 2 * time.Second
-	defaultAppStartupTimeout          = 15 * time.Second
+	defaultAppStartupTimeout          = 30 * time.Second
 	appStartupPollInterval            = 500 * time.Millisecond
 	maxAppLogCreateAttempts           = 3
 )

--- a/src/cli/internal/cmd/run_internal_test.go
+++ b/src/cli/internal/cmd/run_internal_test.go
@@ -125,6 +125,9 @@ func TestParseRunFlagsUsesProcessMode(t *testing.T) {
 	if !flags.randomHostPort {
 		t.Fatal("randomHostPort = false, want true")
 	}
+	if flags.startupTimeout != 30*time.Second {
+		t.Fatalf("startupTimeout = %s, want 30s", flags.startupTimeout)
+	}
 }
 
 func TestParseRunFlagsCanDisableRandomHostPort(t *testing.T) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Increase the default app startup timeout from 15 to 30 seconds. User reports show valid apps can take more than 20 seconds to become visible through Localtest, especially around build, restore, startup, discovery, and metadata probing.

The existing `--startup-timeout` override remains available for faster or slower environments. This deliberately changes only the default; the following PRs address the discovery path and diagnostics.

This is PR 2 of the studioctl startup/discovery stack.

## Verification

- [x] Related issues are connected (not applicable; based on direct user feedback)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

```text
$ ./build/studioctl run --help
  --startup-timeout DURATION
                       Wait duration for app startup (default 30s)

$ ./build/studioctl app run --help
  --startup-timeout DURATION
                       Wait duration for app startup (default 30s)

$ make test
Go packages: passed with race detector
Studioctl.Tests: Passed 135, Failed 0
```

NuGet restore printed the repository's existing package-advisory warnings; this change introduced no compiler or lint warnings.
