### PR TITLE
fix(studioctl): explain app startup timeout phase

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -16,6 +16,7 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 ### Fixed
 
 - Explain access errors during `studioctl app upgrade`
+- Explain whether app endpoint discovery or Localtest Storage was still incomplete when `studioctl run` reaches its startup timeout.
 
 ## [0.1.0-preview.19] - 2026-08-06
 

--- a/src/cli/internal/cmd/run.go
+++ b/src/cli/internal/cmd/run.go
@@ -815,7 +815,7 @@ func registerPortAppWithStartupMonitor(
 
 func portAppRegistrationTimeoutError(appID string, port int, startupTimeout time.Duration) error {
 	return fmt.Errorf(
-		"%w: app %s was not discovered on port %d within %s",
+		"%w: app %s did not become reachable through Localtest on port %d within %s",
 		errAppStartupTimedOut,
 		appID,
 		port,
@@ -892,7 +892,7 @@ func (c *RunCommand) registerProcessAndWaitForApp(
 
 func registerProcessAppWithStartupMonitor(
 	ctx context.Context,
-	client *studioctlserver.Client,
+	client appStartupClient,
 	appID string,
 	processID int,
 	runInfo studioctlserver.AppRegistration,
@@ -929,7 +929,7 @@ func applyAppRunInfo(registration *studioctlserver.AppRegistration, runInfo stud
 
 func registerAppWithStartupMonitor(
 	ctx context.Context,
-	client *studioctlserver.Client,
+	client appStartupClient,
 	registration studioctlserver.AppRegistration,
 	monitor readinessMonitor,
 	startupTimeout time.Duration,
@@ -939,7 +939,7 @@ func registerAppWithStartupMonitor(
 	defer cancel()
 
 	if err := monitor(waitCtx); err != nil {
-		return "", startupMonitorError(ctx, waitCtx, err, timeoutErr)
+		return "", startupMonitorError(ctx, waitCtx, client, registration, err, timeoutErr)
 	}
 
 	registrationDone := make(chan appRegistrationResult, 1)
@@ -952,32 +952,24 @@ func registerAppWithStartupMonitor(
 	defer ticker.Stop()
 
 	for {
-		if err := startupContextError(ctx, waitCtx, timeoutErr); err != nil {
-			return "", err
+		if ctx.Err() != nil {
+			return "", errAppRunStopped
+		}
+		if waitCtx.Err() != nil {
+			return "", appStartupTimeoutError(ctx, client, registration, timeoutErr)
 		}
 
 		select {
 		case result := <-registrationDone:
-			if result.err == nil {
-				return result.baseURL, nil
-			}
-			if errors.Is(result.err, studioctlserver.ErrAppEndpointNotFound) ||
-				errors.Is(result.err, context.DeadlineExceeded) ||
-				waitCtx.Err() != nil {
-				return "", timeoutErr
-			}
-			if ctx.Err() != nil {
-				return "", errAppRunStopped
-			}
-			return "", startupOperationError(ctx, "register app with studioctl-server", result.err)
+			return resolveAppRegistrationResult(ctx, waitCtx, client, registration, result, timeoutErr)
 		case <-ticker.C:
 			if err := monitor(waitCtx); err != nil {
-				return "", startupMonitorError(ctx, waitCtx, err, timeoutErr)
+				return "", startupMonitorError(ctx, waitCtx, client, registration, err, timeoutErr)
 			}
 		case <-ctx.Done():
 			return "", errAppRunStopped
 		case <-waitCtx.Done():
-			return "", timeoutErr
+			return "", appStartupTimeoutError(ctx, client, registration, timeoutErr)
 		}
 	}
 }
@@ -987,29 +979,107 @@ type appRegistrationResult struct {
 	baseURL string
 }
 
-func startupMonitorError(ctx, waitCtx context.Context, err, timeoutErr error) error {
+func resolveAppRegistrationResult(
+	ctx context.Context,
+	waitCtx context.Context,
+	client appStartupClient,
+	registration studioctlserver.AppRegistration,
+	result appRegistrationResult,
+	timeoutErr error,
+) (string, error) {
+	if result.err == nil {
+		return result.baseURL, nil
+	}
+	if errors.Is(result.err, studioctlserver.ErrAppEndpointNotFound) ||
+		errors.Is(result.err, context.DeadlineExceeded) ||
+		waitCtx.Err() != nil {
+		return "", appStartupTimeoutError(ctx, client, registration, timeoutErr)
+	}
+	if ctx.Err() != nil {
+		return "", errAppRunStopped
+	}
+	return "", startupOperationError(ctx, "register app with studioctl-server", result.err)
+}
+
+func startupMonitorError(
+	ctx context.Context,
+	waitCtx context.Context,
+	client appStartupClient,
+	registration studioctlserver.AppRegistration,
+	err error,
+	timeoutErr error,
+) error {
 	if ctx.Err() != nil {
 		return errAppRunStopped
 	}
 	if waitCtx.Err() != nil {
-		return timeoutErr
+		return appStartupTimeoutError(ctx, client, registration, timeoutErr)
 	}
 	return err
 }
 
-func startupContextError(ctx, waitCtx context.Context, timeoutErr error) error {
+type appStartupClient interface {
+	RegisterApp(ctx context.Context, registration studioctlserver.AppRegistration) (string, error)
+	Status(ctx context.Context) (*studioctlserver.Status, error)
+}
+
+func appStartupTimeoutError(
+	ctx context.Context,
+	client appStartupClient,
+	registration studioctlserver.AppRegistration,
+	timeoutErr error,
+) error {
 	if ctx.Err() != nil {
 		return errAppRunStopped
 	}
-	if waitCtx.Err() != nil {
-		return timeoutErr
+	status, err := client.Status(ctx)
+	if ctx.Err() != nil {
+		return errAppRunStopped
 	}
-	return nil
+	if err != nil {
+		return fmt.Errorf("%w: could not inspect studioctl-server status: %w", timeoutErr, err)
+	}
+	return appStartupTimeoutErrorFromStatus(registration, status, timeoutErr)
+}
+
+func appStartupTimeoutErrorFromStatus(
+	registration studioctlserver.AppRegistration,
+	status *studioctlserver.Status,
+	timeoutErr error,
+) error {
+	for _, app := range status.Apps {
+		if !appMatchesRegistration(app, registration) {
+			continue
+		}
+		return fmt.Errorf(
+			"%w: endpoint %s was discovered, but Localtest Storage did not return metadata for %s",
+			timeoutErr,
+			app.BaseURL,
+			registration.AppID,
+		)
+	}
+	return fmt.Errorf("%w: no matching app metadata endpoint was discovered", timeoutErr)
+}
+
+func appMatchesRegistration(
+	app studioctlserver.DiscoveredApp,
+	registration studioctlserver.AppRegistration,
+) bool {
+	if !strings.EqualFold(app.AppID, registration.AppID) {
+		return false
+	}
+	if registration.ProcessID > 0 && (app.ProcessID == nil || *app.ProcessID != registration.ProcessID) {
+		return false
+	}
+	if registration.ContainerID != "" && app.ContainerID != registration.ContainerID {
+		return false
+	}
+	return registration.HostPort <= 0 || (app.HostPort != nil && *app.HostPort == registration.HostPort)
 }
 
 func processAppRegistrationTimeoutError(appID string, processID int, startupTimeout time.Duration) error {
 	return fmt.Errorf(
-		"%w: app %s was not discovered in process %d within %s",
+		"%w: app %s did not become reachable through Localtest from process %d within %s",
 		errAppStartupTimedOut,
 		appID,
 		processID,

--- a/src/cli/internal/cmd/run_internal_test.go
+++ b/src/cli/internal/cmd/run_internal_test.go
@@ -21,10 +21,16 @@ import (
 	repocontext "altinn.studio/studioctl/internal/context"
 	"altinn.studio/studioctl/internal/envtopology"
 	"altinn.studio/studioctl/internal/osutil"
+	"altinn.studio/studioctl/internal/studioctlserver"
 	"altinn.studio/studioctl/internal/ui"
 )
 
-var errRemoveFailed = errors.New("remove failed")
+var (
+	errRemoveFailed          = errors.New("remove failed")
+	errStatusUnavailable     = errors.New("status unavailable")
+	errUnexpectedRegisterApp = errors.New("unexpected RegisterApp call")
+	errUnexpectedStatus      = errors.New("unexpected Status call")
+)
 
 func TestFollowContainer_ContextCancelledReturnsRunStopped(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
@@ -79,10 +85,196 @@ func TestStartupMonitorError_ContextCancelledReturnsRunStopped(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
-	err := startupMonitorError(ctx, t.Context(), context.Canceled, errAppStartupTimedOut)
+	err := startupMonitorError(
+		ctx,
+		t.Context(),
+		appStartupClientStub{},
+		studioctlserver.AppRegistration{},
+		context.Canceled,
+		errAppStartupTimedOut,
+	)
 	if !errors.Is(err, errAppRunStopped) {
 		t.Fatalf("startupMonitorError() error = %v, want errAppRunStopped", err)
 	}
+}
+
+func TestRegisterAppWithStartupMonitor_MonitorDeadlineReportsDiscoveryStatus(t *testing.T) {
+	t.Parallel()
+
+	statusCalled := false
+	client := appStartupClientStub{
+		statusFunc: func(context.Context) (*studioctlserver.Status, error) {
+			statusCalled = true
+			return &studioctlserver.Status{}, nil
+		},
+	}
+	registration := studioctlserver.AppRegistration{AppID: "ttd/app", ProcessID: 42}
+	timeoutErr := processAppRegistrationTimeoutError("ttd/app", 42, 10*time.Millisecond)
+	monitor := func(ctx context.Context) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	_, err := registerAppWithStartupMonitor(
+		t.Context(),
+		client,
+		registration,
+		monitor,
+		10*time.Millisecond,
+		timeoutErr,
+	)
+
+	if !statusCalled {
+		t.Fatal("Status() was not called after monitor reached the startup deadline")
+	}
+	if !errors.Is(err, errAppStartupTimedOut) {
+		t.Fatalf("registerAppWithStartupMonitor() error = %v, want errAppStartupTimedOut", err)
+	}
+	if !strings.Contains(err.Error(), "no matching app metadata endpoint was discovered") {
+		t.Fatalf("registerAppWithStartupMonitor() error = %v, want missing endpoint detail", err)
+	}
+}
+
+func TestAppStartupTimeoutError_ContextCancelledDuringStatusReturnsRunStopped(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	client := appStartupClientStub{
+		statusFunc: func(context.Context) (*studioctlserver.Status, error) {
+			cancel()
+			return nil, context.Canceled
+		},
+	}
+
+	err := appStartupTimeoutError(
+		ctx,
+		client,
+		studioctlserver.AppRegistration{},
+		errAppStartupTimedOut,
+	)
+	if !errors.Is(err, errAppRunStopped) {
+		t.Fatalf("appStartupTimeoutError() error = %v, want errAppRunStopped", err)
+	}
+}
+
+func TestAppStartupTimeoutError_StatusFailurePreservesTimeoutAndContext(t *testing.T) {
+	t.Parallel()
+
+	client := appStartupClientStub{
+		statusFunc: func(context.Context) (*studioctlserver.Status, error) {
+			return nil, errStatusUnavailable
+		},
+	}
+	timeoutErr := processAppRegistrationTimeoutError("ttd/app", 42, 30*time.Second)
+
+	err := appStartupTimeoutError(
+		t.Context(),
+		client,
+		studioctlserver.AppRegistration{AppID: "ttd/app", ProcessID: 42},
+		timeoutErr,
+	)
+
+	if !errors.Is(err, errAppStartupTimedOut) {
+		t.Fatalf("appStartupTimeoutError() error = %v, want errAppStartupTimedOut", err)
+	}
+	if !errors.Is(err, errStatusUnavailable) {
+		t.Fatalf("appStartupTimeoutError() error = %v, want errStatusUnavailable", err)
+	}
+	if !strings.Contains(err.Error(), "could not inspect studioctl-server status: status unavailable") {
+		t.Fatalf("appStartupTimeoutError() error = %v, want Status failure context", err)
+	}
+}
+
+func TestAppStartupTimeoutErrorFromStatusReportsLocaltestStorage(t *testing.T) {
+	t.Parallel()
+
+	processID := 42
+	hostPort := 5100
+	registration := studioctlserver.AppRegistration{
+		AppID:          "ttd/app",
+		ContainerID:    "",
+		HostPort:       hostPort,
+		ProcessID:      processID,
+		TimeoutSeconds: 30,
+	}
+	status := &studioctlserver.Status{Apps: []studioctlserver.DiscoveredApp{{
+		ProcessID:   &processID,
+		HostPort:    &hostPort,
+		AppID:       "TTD/APP",
+		BaseURL:     "http://127.0.0.1:5100/",
+		Source:      "process",
+		Description: "Altinn.Application.dll",
+		Name:        "Altinn.Application.dll",
+		ContainerID: "",
+	}}}
+
+	timeoutErr := processAppRegistrationTimeoutError("ttd/app", processID, 30*time.Second)
+	err := appStartupTimeoutErrorFromStatus(registration, status, timeoutErr)
+	if !errors.Is(err, errAppStartupTimedOut) {
+		t.Fatalf("appStartupTimeoutErrorFromStatus() error = %v, want errAppStartupTimedOut", err)
+	}
+	if !strings.Contains(err.Error(), "endpoint http://127.0.0.1:5100/ was discovered") {
+		t.Fatalf("appStartupTimeoutErrorFromStatus() error = %v, want discovered endpoint", err)
+	}
+	if !strings.Contains(err.Error(), "Localtest Storage did not return metadata for ttd/app") {
+		t.Fatalf("appStartupTimeoutErrorFromStatus() error = %v, want Localtest Storage detail", err)
+	}
+	if strings.Contains(err.Error(), "was not discovered") {
+		t.Fatalf("appStartupTimeoutErrorFromStatus() error = %v, contains contradictory discovery detail", err)
+	}
+}
+
+func TestAppStartupTimeoutErrorFromStatusReportsMissingMatchingEndpoint(t *testing.T) {
+	t.Parallel()
+
+	otherProcessID := 41
+	registration := studioctlserver.AppRegistration{
+		AppID:          "ttd/app",
+		ContainerID:    "",
+		HostPort:       0,
+		ProcessID:      42,
+		TimeoutSeconds: 30,
+	}
+	status := &studioctlserver.Status{Apps: []studioctlserver.DiscoveredApp{{
+		ProcessID:   &otherProcessID,
+		HostPort:    nil,
+		AppID:       "ttd/app",
+		BaseURL:     "http://127.0.0.1:5100/",
+		Source:      "process",
+		Description: "Altinn.Application.dll",
+		Name:        "Altinn.Application.dll",
+		ContainerID: "",
+	}}}
+
+	err := appStartupTimeoutErrorFromStatus(registration, status, errAppStartupTimedOut)
+	if !errors.Is(err, errAppStartupTimedOut) {
+		t.Fatalf("appStartupTimeoutErrorFromStatus() error = %v, want errAppStartupTimedOut", err)
+	}
+	if !strings.Contains(err.Error(), "no matching app metadata endpoint was discovered") {
+		t.Fatalf("appStartupTimeoutErrorFromStatus() error = %v, want missing endpoint detail", err)
+	}
+}
+
+type appStartupClientStub struct {
+	registerAppFunc func(context.Context, studioctlserver.AppRegistration) (string, error)
+	statusFunc      func(context.Context) (*studioctlserver.Status, error)
+}
+
+func (s appStartupClientStub) RegisterApp(
+	ctx context.Context,
+	registration studioctlserver.AppRegistration,
+) (string, error) {
+	if s.registerAppFunc == nil {
+		return "", errUnexpectedRegisterApp
+	}
+	return s.registerAppFunc(ctx, registration)
+}
+
+func (s appStartupClientStub) Status(ctx context.Context) (*studioctlserver.Status, error) {
+	if s.statusFunc == nil {
+		return nil, errUnexpectedStatus
+	}
+	return s.statusFunc(ctx)
 }
 
 func TestRunJSONRequiresDetach(t *testing.T) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When startup times out, query studioctl-server status and explain which phase failed:

- the app endpoint was discovered, but Localtest Storage did not return its metadata; or
- no endpoint matching the registered process/container was discovered.

The matching uses app ID plus the available process ID, container ID, or host port, so another running copy cannot produce a misleading diagnosis. Cancellation is re-checked after the diagnostic status request so Ctrl-C remains a normal stopped-run result. If the status request itself fails, the failure is included without losing the startup-timeout error classification.

This is PR 3 of the studioctl startup/discovery stack.

## Verification

- [x] Related issues are connected (not applicable; based on direct user feedback)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

```text
$ studioctl run -d -p /data/home/code/.worktrees/testprefix-startup-timeout --startup-timeout 1s
...
app did not become reachable through localtest: app ttd/testprefix did not become reachable through Localtest from process 170782 within 1s: no matching app metadata endpoint was discovered

$ make lint
0 issues.

$ make test
Go packages: passed with race detector
Studioctl.Tests: Passed 135, Failed 0
```

Unit coverage includes both diagnostic outcomes, monitor-driven deadlines, cancellation during the status request, contradictory-message prevention, and status-request failures.
