### PR TITLE
perf(studioctl): discover direct app runs sooner

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -17,6 +17,7 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 - Explain access errors during `studioctl app upgrade`
 - Explain whether app endpoint discovery or Localtest Storage was still incomplete when `studioctl run` reaches its startup timeout.
+- Detect apps started directly with `dotnet run` sooner by checking for new app endpoints every five seconds instead of every ten seconds.
 
 ## [0.1.0-preview.19] - 2026-08-06
 

--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -17,7 +17,7 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 - Explain access errors during `studioctl app upgrade`
 - Explain whether app endpoint discovery or Localtest Storage was still incomplete when `studioctl run` reaches its startup timeout.
-- Detect apps started directly with `dotnet run` sooner by checking for new app endpoints every five seconds instead of every ten seconds.
+- Detect apps started directly with `dotnet run` sooner by checking process endpoints every five seconds while retaining the ten-second container check interval.
 
 ## [0.1.0-preview.19] - 2026-08-06
 

--- a/src/cli/studioctl-server/Discovery/AppRegistry.cs
+++ b/src/cli/studioctl-server/Discovery/AppRegistry.cs
@@ -6,7 +6,7 @@ namespace Altinn.Studio.StudioctlServer.Discovery;
 internal sealed class AppRegistry : BackgroundService
 {
     private const int MaxConcurrentProbes = 8;
-    private static readonly TimeSpan _pollInterval = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan _pollInterval = TimeSpan.FromSeconds(5);
     private static readonly TimeSpan _startupPollInterval = TimeSpan.FromMilliseconds(500);
 
     private readonly IReadOnlyList<IAppDiscovery> _discoveries;

--- a/src/cli/studioctl-server/Discovery/AppRegistry.cs
+++ b/src/cli/studioctl-server/Discovery/AppRegistry.cs
@@ -6,10 +6,10 @@ namespace Altinn.Studio.StudioctlServer.Discovery;
 internal sealed class AppRegistry : BackgroundService
 {
     private const int MaxConcurrentProbes = 8;
-    private static readonly TimeSpan _pollInterval = TimeSpan.FromSeconds(5);
     private static readonly TimeSpan _startupPollInterval = TimeSpan.FromMilliseconds(500);
 
-    private readonly IReadOnlyList<IAppDiscovery> _discoveries;
+    private readonly DiscoveryState[] _discoveries;
+    private readonly TimeSpan _passivePollInterval;
     private readonly AppMetadataProbe _probe;
     private readonly LocaltestStorageProbe _storageProbe;
     private readonly ILogger<AppRegistry> _logger;
@@ -27,7 +27,8 @@ internal sealed class AppRegistry : BackgroundService
         ILogger<AppRegistry> logger
     )
     {
-        _discoveries = [.. discoveries];
+        _discoveries = [.. discoveries.Select(static (discovery, index) => new DiscoveryState(index, discovery))];
+        _passivePollInterval = _discoveries.Min(static discovery => discovery.Discovery.PassivePollInterval);
         _probe = probe;
         _storageProbe = storageProbe;
         _logger = logger;
@@ -176,7 +177,8 @@ internal sealed class AppRegistry : BackgroundService
 
         try
         {
-            await Refresh(cancellationToken);
+            var forceRefresh = message is not TimerTick || _pendingStarts.Count > 0;
+            await Refresh(now, forceRefresh, cancellationToken);
             _lastRefreshFailed = false;
         }
         catch (Exception ex) when (ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
@@ -189,14 +191,14 @@ internal sealed class AppRegistry : BackgroundService
             PrunePendingStarts(DateTimeOffset.UtcNow);
         }
 
-        return now >= nextPoll ? now + _pollInterval : nextPoll;
+        return now >= nextPoll ? now + _passivePollInterval : nextPoll;
     }
 
-    private async Task Refresh(CancellationToken cancellationToken)
+    private async Task Refresh(DateTimeOffset now, bool forceRefresh, CancellationToken cancellationToken)
     {
         var previous = Volatile.Read(ref _apps);
 
-        var apps = await DiscoverApps(cancellationToken);
+        var apps = await DiscoverApps(now, forceRefresh, cancellationToken);
         if (!previous.SequenceEqual(apps))
         {
             Volatile.Write(ref _apps, apps);
@@ -209,10 +211,14 @@ internal sealed class AppRegistry : BackgroundService
 
     private void RemoveChangedCallback(Action callback) => _changed -= callback;
 
-    private async Task<DiscoveredApp[]> DiscoverApps(CancellationToken cancellationToken)
+    private async Task<DiscoveredApp[]> DiscoverApps(
+        DateTimeOffset now,
+        bool forceRefresh,
+        CancellationToken cancellationToken
+    )
     {
-        var probeResults = new ConcurrentBag<ProbeResult>();
-        var discoveryItems = _discoveries.Select(static (discovery, index) => new DiscoveryItem(index, discovery));
+        var discoveryResults = new ConcurrentBag<DiscoveryResult>();
+        var discoveryItems = _discoveries.Where(discovery => forceRefresh || now >= discovery.NextPoll);
         var discoveryOptions = new ParallelOptions { CancellationToken = cancellationToken };
 
         await Parallel.ForEachAsync(
@@ -221,6 +227,7 @@ internal sealed class AppRegistry : BackgroundService
             async (discoveryItem, discoveryCancellationToken) =>
             {
                 var candidates = await discoveryItem.Discovery.Discover(discoveryCancellationToken);
+                var probeResults = new ConcurrentBag<CandidateProbeResult>();
                 var candidateItems = candidates.Select(
                     static (candidate, index) => new CandidateItem(index, candidate)
                 );
@@ -237,20 +244,36 @@ internal sealed class AppRegistry : BackgroundService
                     {
                         var app = await ProbeCandidate(candidateItem.Candidate, probeCancellationToken);
                         if (app is not null)
-                            probeResults.Add(new ProbeResult(discoveryItem.Index, candidateItem.Index, app));
+                            probeResults.Add(new CandidateProbeResult(candidateItem.Index, app));
                     }
+                );
+
+                discoveryResults.Add(
+                    new DiscoveryResult(
+                        discoveryItem.Index,
+                        [
+                            .. probeResults
+                                .OrderBy(static result => result.CandidateIndex)
+                                .Select(static result => result.App),
+                        ]
+                    )
                 );
             }
         );
 
-        var apps = new Dictionary<AppKey, DiscoveredApp>();
-        foreach (
-            var result in probeResults
-                .OrderBy(static result => result.DiscoveryIndex)
-                .ThenBy(static result => result.CandidateIndex)
-        )
+        foreach (var result in discoveryResults)
         {
-            apps[AppKey.From(result.App)] = result.App;
+            var discovery = _discoveries[result.DiscoveryIndex];
+            discovery.Apps = result.Apps;
+            if (now >= discovery.NextPoll)
+                discovery.NextPoll = now + discovery.Discovery.PassivePollInterval;
+        }
+
+        var apps = new Dictionary<AppKey, DiscoveredApp>();
+        foreach (var discovery in _discoveries)
+        {
+            foreach (var app in discovery.Apps)
+                apps[AppKey.From(app)] = app;
         }
 
         return [.. apps.Values];
@@ -390,13 +413,27 @@ internal sealed class AppRegistry : BackgroundService
 
     private sealed record AppStartedMessage(AppStartWaiter Waiter) : AppRegistryMessage;
 
-    private sealed record DiscoveryItem(int Index, IAppDiscovery Discovery);
-
     private sealed record CandidateItem(int Index, AppDiscoveryCandidate Candidate);
 
-    private sealed record ProbeResult(int DiscoveryIndex, int CandidateIndex, DiscoveredApp App);
+    private sealed record CandidateProbeResult(int CandidateIndex, DiscoveredApp App);
+
+    private sealed record DiscoveryResult(int DiscoveryIndex, DiscoveredApp[] Apps);
 
     private sealed record AppStoppedMessage(string? AppId) : AppRegistryMessage;
+
+    private sealed class DiscoveryState
+    {
+        public DiscoveryState(int index, IAppDiscovery discovery)
+        {
+            Index = index;
+            Discovery = discovery;
+        }
+
+        public int Index { get; }
+        public IAppDiscovery Discovery { get; }
+        public DateTimeOffset NextPoll { get; set; } = DateTimeOffset.MinValue;
+        public DiscoveredApp[] Apps { get; set; } = [];
+    }
 
     private sealed class AppStartWaiter
     {

--- a/src/cli/studioctl-server/Discovery/Container/ContainerDiscovery.cs
+++ b/src/cli/studioctl-server/Discovery/Container/ContainerDiscovery.cs
@@ -9,6 +9,8 @@ internal sealed class ContainerDiscovery : IAppDiscovery
     private static readonly TimeSpan _timeout = TimeSpan.FromSeconds(3);
     private static readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web);
 
+    public TimeSpan PassivePollInterval => TimeSpan.FromSeconds(10);
+
     private readonly string? _studioctlPath;
     private readonly ILogger<ContainerDiscovery> _logger;
 

--- a/src/cli/studioctl-server/Discovery/IAppDiscovery.cs
+++ b/src/cli/studioctl-server/Discovery/IAppDiscovery.cs
@@ -2,5 +2,7 @@ namespace Altinn.Studio.StudioctlServer.Discovery;
 
 internal interface IAppDiscovery
 {
+    TimeSpan PassivePollInterval { get; }
+
     Task<IReadOnlyList<AppDiscoveryCandidate>> Discover(CancellationToken cancellationToken);
 }

--- a/src/cli/studioctl-server/Discovery/Process/ProcessDiscovery.cs
+++ b/src/cli/studioctl-server/Discovery/Process/ProcessDiscovery.cs
@@ -4,6 +4,8 @@ namespace Altinn.Studio.StudioctlServer.Discovery.Process;
 
 internal sealed class ProcessDiscovery : IAppDiscovery
 {
+    public TimeSpan PassivePollInterval => TimeSpan.FromSeconds(5);
+
     private readonly PortListeners _portListeners;
 
     public ProcessDiscovery(PortListeners portListeners)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Reduce studioctl-server's passive process discovery interval from 10 to 5 seconds. Passive process discovery is what picks up apps started directly with `dotnet run`; a 10-second cadence can require two probe cycles and produce the reported 20+ second delay.

Container runtime discovery remains at 10 seconds to avoid doubling background Docker/Podman work on developer laptops. Each discovery source now declares its passive cadence, and the registry retains its latest result between due polls. The eager cadence used by `studioctl run` remains 500 ms and forces both process and container discovery while an app-start waiter exists.

I evaluated a 2-second process interval but rejected it because it produced about 30 process scans per minute. Five seconds cuts the worst two-cycle direct-process discovery delay from roughly 20 to 10 seconds without increasing passive container-runtime queries.

This is the top PR in the studioctl startup/discovery stack.

## Verification

- [x] Related issues are connected (not applicable; based on direct user feedback)
- [x] **Your** code builds clean without any errors
- [x] Manual testing done (required)
- [ ] Relevant automated test added (the existing full CLI suites cover the changed registry; no wall-clock timing test was added)
 
```text
$ dotnet run --no-build
App listening:                        11:21:16.732
studioctl-server discovered endpoint: 11:21:18.849
Observed discovery latency:           2.117s
Subsequent passive process probes:    exactly 5s apart

$ make build
success

$ make lint
0 issues.

$ make test
Go packages: passed with race detector
Studioctl.Tests: Passed 135, Failed 0

$ dotnet csharpier check studioctl-server/Discovery
Checked 10 files.
```

A full `studioctl run -d --json --skip-build` startup was also measured at 1.187 seconds, confirming eager discovery remains fast.
