### PR TITLE
fix: allow concurrent reads in party client test interceptor

### DIFF
--- a/src/App/backend/test/Altinn.App.Api.Tests/Mocks/AltinnPartyClientInterceptorTests.cs
+++ b/src/App/backend/test/Altinn.App.Api.Tests/Mocks/AltinnPartyClientInterceptorTests.cs
@@ -1,0 +1,30 @@
+using System.Net;
+using Altinn.App.Tests.Common.Mocks;
+
+namespace Altinn.App.Api.Tests.Mocks;
+
+public class AltinnPartyClientInterceptorTests
+{
+    [Fact]
+    public async Task GetParty_AllowsConcurrentReads()
+    {
+        using var client = new HttpClient(new AltinnPartyClientInterceptor())
+        {
+            BaseAddress = new Uri("https://platform.altinn.no/"),
+        };
+
+        using var firstResponse = await client.GetAsync(
+            "register/api/v1/parties/500600",
+            HttpCompletionOption.ResponseHeadersRead
+        );
+        var firstResponseStream = await firstResponse.Content.ReadAsStreamAsync();
+        using var secondResponse = await client.GetAsync(
+            "register/api/v1/parties/500600",
+            HttpCompletionOption.ResponseHeadersRead
+        );
+
+        Assert.Equal(HttpStatusCode.OK, firstResponse.StatusCode);
+        Assert.False(firstResponseStream.CanWrite);
+        Assert.Equal(HttpStatusCode.OK, secondResponse.StatusCode);
+    }
+}

--- a/src/App/backend/test/Altinn.App.Tests.Common/Mocks/AltinnPartyClientInterceptor.cs
+++ b/src/App/backend/test/Altinn.App.Tests.Common/Mocks/AltinnPartyClientInterceptor.cs
@@ -69,9 +69,6 @@ public class AltinnPartyClientInterceptor : HttpMessageHandler
             };
         }
 
-        return new HttpResponseMessage(HttpStatusCode.OK)
-        {
-            Content = new StreamContent(new FileStream(file, FileMode.Open)),
-        };
+        return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(File.OpenRead(file)) };
     }
 }

--- a/src/App/backend/test/Altinn.App.Tests.Common/Mocks/AltinnPartyClientInterceptor.cs
+++ b/src/App/backend/test/Altinn.App.Tests.Common/Mocks/AltinnPartyClientInterceptor.cs
@@ -69,6 +69,7 @@ public class AltinnPartyClientInterceptor : HttpMessageHandler
             };
         }
 
-        return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(File.OpenRead(file)) };
+        var stream = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read);
+        return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(stream) };
     }
 }


### PR DESCRIPTION
## Description

Fixes the Windows test flake observed in [this Actions job](https://github.com/Altinn/altinn-studio/actions/runs/31099907529/job/92611104699?pr=19811), where concurrent test requests could not open the same party fixture file.

`AltinnPartyClientInterceptor` now opens party fixture files read-only with shared-read access. A regression test keeps one response open while requesting the same party again.

## Verification

- [x] Related issues are connected (not applicable; linked failing job above)
- [ ] **Your** code builds clean without any errors or warnings (build succeeds; existing NuGet audit warnings remain)
- [x] Manual testing done (reproduced from the Actions failure and verified the concurrent-read scenario)
- [x] Relevant automated test added

Commands run:

```console
dotnet build solutions/All.slnx -v m --no-restore
dotnet test solutions/All.slnx -v m --no-restore --no-build --filter "Category!=Integration"
```

All test projects passed: 3,923 tests total.
