### PR TITLE
refactor(releaser): centralize publication policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -142,6 +142,8 @@ src/test/K6/**/yarn.lock                                                  @altin
 src/tools/health/**/go.mod                                                @altinn/team-altinn-studio-kjoring
 src/tools/health/**/go.sum                                                @altinn/team-altinn-studio-kjoring
 src/tools/releaser/**/go.mod                                              @altinn/team-altinn-studio-kjoring
+src/tools/releaser/internal/component.go                                  @altinn/team-altinn-studio-kjoring
+src/tools/releaser/internal/release_policy.go                             @altinn/team-altinn-studio-kjoring
 src/tools/releaser/internal/release_trigger.go                            @altinn/team-altinn-studio-kjoring
 
 # Squad Flyt

--- a/.github/scripts/codeowners-generate.mjs
+++ b/.github/scripts/codeowners-generate.mjs
@@ -135,6 +135,8 @@ const GROUPS = [
       '.github/workflows/template-runtime-construct-environments.yaml',
       '.github/workflows/template-studio-construct-environments.yaml',
       '.github/workflows/validate-renovate.yaml',
+      'src/tools/releaser/internal/component.go',
+      'src/tools/releaser/internal/release_policy.go',
       'src/tools/releaser/internal/release_trigger.go',
     ],
   },

--- a/.github/workflows/release-components.yaml
+++ b/.github/workflows/release-components.yaml
@@ -35,6 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       component: ${{ steps.resolve.outputs.component }}
+      publisher: ${{ steps.resolve.outputs.publisher }}
+      environment: ${{ steps.resolve.outputs.environment }}
       base-branch: ${{ steps.resolve.outputs.base-branch }}
       commit: ${{ steps.resolve.outputs.commit }}
       release-version: ${{ steps.resolve.outputs.release-version }}
@@ -74,12 +76,16 @@ jobs:
             -selected-version "$SELECTED_VERSION" > "$result_file"
 
           component="$(jq -r '.release.component // ""' "$result_file")"
+          publisher="$(jq -r '.release.publisher // ""' "$result_file")"
+          environment="$(jq -r '.release.environment // ""' "$result_file")"
           base_branch="$(jq -r '.release.baseBranch // ""' "$result_file")"
           commit="$(jq -r '.release.commit // ""' "$result_file")"
           release_version="$(jq -r '.release.releaseVersion // ""' "$result_file")"
 
           {
             echo "component=$component"
+            echo "publisher=$publisher"
+            echo "environment=$environment"
             echo "base-branch=$base_branch"
             echo "commit=$commit"
             echo "release-version=$release_version"
@@ -92,50 +98,24 @@ jobs:
           fi
         working-directory: src/tools/releaser
 
-  resolve-environment:
-    name: Resolve release environment
-    if: needs.resolve-trigger.outputs.component != ''
-    needs: resolve-trigger
-    runs-on: ubuntu-latest
-    outputs:
-      environment: ${{ steps.context.outputs.environment }}
-    steps:
-      - name: Resolve environment
-        id: context
-        env:
-          RELEASE_VERSION: ${{ needs.resolve-trigger.outputs.release-version }}
-        run: |
-          environment="prod"
-          if [[ "$RELEASE_VERSION" == *"-preview."* ]]; then
-            environment="dev"
-          elif [[ "$RELEASE_VERSION" == *"-rc."* ]]; then
-            environment="staging"
-          fi
-
-          echo "environment=$environment" >> "$GITHUB_OUTPUT"
-
   release-app:
     name: Release app
-    if: needs.resolve-trigger.outputs.component == 'app'
-    needs:
-      - resolve-trigger
-      - resolve-environment
+    if: needs.resolve-trigger.outputs.publisher == 'app'
+    needs: resolve-trigger
     permissions:
       contents: write
       id-token: write
     uses: ./.github/workflows/release-app.yaml
     with:
       base-branch: ${{ needs.resolve-trigger.outputs.base-branch }}
-      environment: ${{ needs.resolve-environment.outputs.environment }}
+      environment: ${{ needs.resolve-trigger.outputs.environment }}
       commit: ${{ needs.resolve-trigger.outputs.commit }}
       release-version: ${{ needs.resolve-trigger.outputs.release-version }}
 
   release-studioctl:
     name: Release studioctl
-    if: needs.resolve-trigger.outputs.component == 'studioctl'
-    needs:
-      - resolve-trigger
-      - resolve-environment
+    if: needs.resolve-trigger.outputs.publisher == 'studioctl'
+    needs: resolve-trigger
     permissions:
       contents: write
     uses: ./.github/workflows/release-studioctl.yaml
@@ -149,11 +129,9 @@ jobs:
     if: >-
       always() &&
       needs.resolve-trigger.result == 'success' &&
-      needs.resolve-environment.result == 'success' &&
-      needs.resolve-trigger.outputs.component != ''
+      needs.resolve-trigger.outputs.publisher != ''
     needs:
       - resolve-trigger
-      - resolve-environment
       - release-app
       - release-studioctl
     runs-on: ubuntu-latest
@@ -162,9 +140,10 @@ jobs:
         env:
           APP_RESULT: ${{ needs.release-app.result }}
           COMPONENT: ${{ needs.resolve-trigger.outputs.component }}
+          PUBLISHER: ${{ needs.resolve-trigger.outputs.publisher }}
           STUDIOCTL_RESULT: ${{ needs.release-studioctl.result }}
         run: |
           if [[ "$APP_RESULT" == "skipped" && "$STUDIOCTL_RESULT" == "skipped" ]]; then
-            echo "No publisher job is configured for resolved component: $COMPONENT" >&2
+            echo "No publisher job is configured for $COMPONENT publisher: $PUBLISHER" >&2
             exit 1
           fi

--- a/src/tools/releaser/README.md
+++ b/src/tools/releaser/README.md
@@ -37,9 +37,10 @@ Context: on `main`
      and starts the newer line at `<channel>.1`.
 3. Approve and merge the prep PR.
 4. CI detects the changelog promotion in the canonical `main` push and runs automatically, including for PRs
-   from forks. It calls:
-   - `go run . workflow -component <component> -base-branch main`
-5. Workflow resolves the latest prerelease from the component changelog, builds artifacts (if applicable), creates tag `<component>/v...`, and creates a draft prerelease.
+   from forks. The dispatcher resolves and passes an immutable component, version, commit, and branch plan to the
+   selected publisher.
+5. The publisher verifies that plan, builds artifacts (if applicable), creates tag `<component>/v...`, and creates a
+   draft prerelease.
 
 ## Stable releases
 
@@ -101,6 +102,8 @@ prerelease, stabilization, and patch release flows.
 - Manual workflow dispatch is a recovery path. Select the component, enter the exact promoted version and full
   commit SHA, and dispatch from `main` or the matching `release/<component>/vX.Y` branch. A matching existing draft
   release is updated in place so retries can continue after a later publication step fails.
-- Release publication depends on the unified CI workflow routing the component to its reusable publisher workflow.
+- The Go trigger policy is the publication source of truth. The component registry selects the reusable publisher;
+  version policy maps `preview` releases to the `dev` environment, `rc` releases to `staging`, and stable releases to
+  `prod`. Unknown prerelease channels fail closed during trigger resolution.
 - Manual dispatch validates the exact selected version against the selected commit and branch; publishers never
   select a newer version or move their checkout while executing a release plan.

--- a/src/tools/releaser/internal/component.go
+++ b/src/tools/releaser/internal/component.go
@@ -24,11 +24,11 @@ type ComponentBuilder interface {
 
 // Component represents a releasable component in the repository.
 type Component struct {
-	Builder             ComponentBuilder
-	Name                string
-	ChangelogPath       string
-	SourcePath          string
-	HasReleasePublisher bool
+	Builder       ComponentBuilder
+	Name          string
+	ChangelogPath string
+	SourcePath    string
+	Publisher     ReleasePublisher
 }
 
 // Component registry.
@@ -36,25 +36,25 @@ type Component struct {
 //nolint:gochecknoglobals // registry pattern
 var components = map[string]*Component{
 	"studioctl": {
-		Name:                "studioctl",
-		ChangelogPath:       "src/cli/CHANGELOG.md",
-		SourcePath:          "src/cli",
-		Builder:             nil, // registered by the releaser CLI
-		HasReleasePublisher: true,
+		Name:          "studioctl",
+		ChangelogPath: "src/cli/CHANGELOG.md",
+		SourcePath:    "src/cli",
+		Builder:       nil, // registered by the releaser CLI
+		Publisher:     ReleasePublisherStudioctl,
 	},
 	"fileanalyzers": {
-		Name:                "fileanalyzers",
-		ChangelogPath:       "src/App/fileanalyzers/CHANGELOG.md",
-		SourcePath:          "src/App/fileanalyzers",
-		Builder:             nil, // YAML handles dotnet pack/push
-		HasReleasePublisher: false,
+		Name:          "fileanalyzers",
+		ChangelogPath: "src/App/fileanalyzers/CHANGELOG.md",
+		SourcePath:    "src/App/fileanalyzers",
+		Builder:       nil, // YAML handles dotnet pack/push
+		Publisher:     ReleasePublisherNone,
 	},
 	"app": {
-		Name:                "app",
-		ChangelogPath:       "src/App/backend/CHANGELOG.md",
-		SourcePath:          "src/App/backend",
-		Builder:             nil, // registered by the releaser CLI
-		HasReleasePublisher: true,
+		Name:          "app",
+		ChangelogPath: "src/App/backend/CHANGELOG.md",
+		SourcePath:    "src/App/backend",
+		Builder:       nil, // registered by the releaser CLI
+		Publisher:     ReleasePublisherApp,
 	},
 }
 

--- a/src/tools/releaser/internal/release_policy.go
+++ b/src/tools/releaser/internal/release_policy.go
@@ -1,0 +1,54 @@
+package internal
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"altinn.studio/releaser/internal/version"
+)
+
+// ReleasePublisher identifies a statically wired reusable publisher workflow.
+type ReleasePublisher string
+
+// Supported release publishers.
+const (
+	ReleasePublisherNone      ReleasePublisher = ""
+	ReleasePublisherApp       ReleasePublisher = "app"
+	ReleasePublisherStudioctl ReleasePublisher = "studioctl"
+)
+
+// ReleaseEnvironment identifies the protected GitHub environment for publication.
+type ReleaseEnvironment string
+
+// Supported release environments.
+const (
+	ReleaseEnvironmentDev     ReleaseEnvironment = "dev"
+	ReleaseEnvironmentStaging ReleaseEnvironment = "staging"
+	ReleaseEnvironmentProd    ReleaseEnvironment = "prod"
+)
+
+var (
+	errReleaseChannelUnsupported   = errors.New("unsupported prerelease channel")
+	errReleasePublisherUnavailable = errors.New("component has no release publisher")
+)
+
+func resolveReleaseEnvironment(releaseVersion string) (ReleaseEnvironment, error) {
+	parsed, err := version.Parse(normalizeVersionPrefix(releaseVersion))
+	if err != nil {
+		return "", fmt.Errorf("parse release version: %w", err)
+	}
+	if !parsed.IsPrerelease {
+		return ReleaseEnvironmentProd, nil
+	}
+
+	channel, _, _ := strings.Cut(parsed.Prerelease, ".")
+	switch channel {
+	case "preview":
+		return ReleaseEnvironmentDev, nil
+	case "rc":
+		return ReleaseEnvironmentStaging, nil
+	default:
+		return "", fmt.Errorf("%w: %s", errReleaseChannelUnsupported, channel)
+	}
+}

--- a/src/tools/releaser/internal/release_policy_internal_test.go
+++ b/src/tools/releaser/internal/release_policy_internal_test.go
@@ -1,0 +1,64 @@
+package internal
+
+import (
+	"errors"
+	"testing"
+
+	"altinn.studio/releaser/internal/version"
+)
+
+func TestResolveReleaseEnvironment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		wantErr error
+		name    string
+		version string
+		want    ReleaseEnvironment
+	}{
+		{
+			name:    "stable",
+			version: "v1.2.3",
+			want:    ReleaseEnvironmentProd,
+		},
+		{
+			name:    "preview",
+			version: "1.2.3-preview.4",
+			want:    ReleaseEnvironmentDev,
+		},
+		{
+			name:    "release candidate",
+			version: "v1.2.3-rc.2",
+			want:    ReleaseEnvironmentStaging,
+		},
+		{
+			name:    "unsupported prerelease channel",
+			version: "v1.2.3-alpha.1",
+			wantErr: errReleaseChannelUnsupported,
+		},
+		{
+			name:    "invalid version",
+			version: "not-a-version",
+			wantErr: version.ErrInvalidFormat,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := resolveReleaseEnvironment(tc.version)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("resolveReleaseEnvironment() error = %v, want %v", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveReleaseEnvironment() error = %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("resolveReleaseEnvironment() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/src/tools/releaser/internal/release_trigger.go
+++ b/src/tools/releaser/internal/release_trigger.go
@@ -35,10 +35,12 @@ type ReleaseTriggerRequest struct {
 
 // ReleasePlan is the immutable release context emitted to CI.
 type ReleasePlan struct {
-	Component      string `json:"component"`
-	BaseBranch     string `json:"baseBranch"`
-	Commit         string `json:"commit"`
-	ReleaseVersion string `json:"releaseVersion"`
+	Component      string             `json:"component"`
+	Publisher      ReleasePublisher   `json:"publisher"`
+	Environment    ReleaseEnvironment `json:"environment"`
+	BaseBranch     string             `json:"baseBranch"`
+	Commit         string             `json:"commit"`
+	ReleaseVersion string             `json:"releaseVersion"`
 }
 
 // ReleaseTriggerResult either contains one complete release plan or represents a no-op.
@@ -100,13 +102,14 @@ func resolveReleaseTriggerWithDeps(
 			return ReleaseTriggerResult{}, fmt.Errorf("load %s changelog at %s: %w", component.Name, commit, err)
 		}
 		selectedVersion := normalizeVersionPrefix(req.SelectedVersion)
-		if err := validateWorkflowReleasePlan(component, req.RefName, selectedVersion); err != nil {
-			return ReleaseTriggerResult{}, fmt.Errorf("validate manual release plan: %w", err)
+		result, err := releaseTriggerResult(component, req.RefName, commit, selectedVersion)
+		if err != nil {
+			return ReleaseTriggerResult{}, fmt.Errorf("build manual release plan: %w", err)
 		}
 		if !cl.HasVersion(selectedVersion) {
 			return ReleaseTriggerResult{}, fmt.Errorf("%w: %s", errReleaseTriggerVersionMissing, selectedVersion)
 		}
-		return releaseTriggerResult(component.Name, req.RefName, commit, selectedVersion), nil
+		return result, nil
 	case "push":
 		return resolvePushReleaseTrigger(ctx, req, git)
 	default:
@@ -160,10 +163,15 @@ func resolvePushReleaseTrigger(
 		return ReleaseTriggerResult{Release: nil}, nil
 	case 1:
 		promotion := promotedComponents[0]
-		if _, err := validateReleaseTriggerComponent(promotion.component, req.RefName); err != nil {
+		component, err := validateReleaseTriggerComponent(promotion.component, req.RefName)
+		if err != nil {
 			return ReleaseTriggerResult{}, err
 		}
-		return releaseTriggerResult(promotion.component, req.RefName, req.Commit, promotion.version), nil
+		result, err := releaseTriggerResult(component, req.RefName, req.Commit, promotion.version)
+		if err != nil {
+			return ReleaseTriggerResult{}, fmt.Errorf("build push release plan: %w", err)
+		}
+		return result, nil
 	default:
 		return ReleaseTriggerResult{}, fmt.Errorf(
 			"%w: %s",
@@ -188,7 +196,7 @@ func releaseTriggerPromotions(
 	promotedComponents := make([]releaseTriggerPromotion, 0, 1)
 	for _, name := range componentNames {
 		component := components[name]
-		if !component.HasReleasePublisher {
+		if component.Publisher == ReleasePublisherNone {
 			continue
 		}
 		if _, changed := changedFiles[component.ChangelogPath]; !changed {
@@ -255,13 +263,29 @@ func changedFileSet(output string) map[string]struct{} {
 	return files
 }
 
-func releaseTriggerResult(component, baseBranch, commit, releaseVersion string) ReleaseTriggerResult {
+func releaseTriggerResult(
+	component *Component,
+	baseBranch, commit, releaseVersion string,
+) (ReleaseTriggerResult, error) {
+	if err := validateWorkflowReleasePlan(component, baseBranch, releaseVersion); err != nil {
+		return ReleaseTriggerResult{}, fmt.Errorf("validate release plan: %w", err)
+	}
+	if component.Publisher == ReleasePublisherNone {
+		return ReleaseTriggerResult{}, fmt.Errorf("%w: %s", errReleasePublisherUnavailable, component.Name)
+	}
+	environment, err := resolveReleaseEnvironment(releaseVersion)
+	if err != nil {
+		return ReleaseTriggerResult{}, fmt.Errorf("resolve release environment: %w", err)
+	}
+
 	return ReleaseTriggerResult{Release: &ReleasePlan{
-		Component:      component,
+		Component:      component.Name,
+		Publisher:      component.Publisher,
+		Environment:    environment,
 		BaseBranch:     baseBranch,
 		Commit:         commit,
 		ReleaseVersion: releaseVersion,
-	}}
+	}}, nil
 }
 
 func validateReleaseTriggerComponent(component, baseBranch string) (*Component, error) {

--- a/src/tools/releaser/internal/release_trigger_internal_test.go
+++ b/src/tools/releaser/internal/release_trigger_internal_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	triggerBeforeSHA = "abcdef0123456789abcdef0123456789abcdef01"
-	triggerHeadSHA   = "0123456789abcdef0123456789abcdef01234567"
-	triggerVersion   = "v1.0.0"
+	triggerBeforeSHA     = "abcdef0123456789abcdef0123456789abcdef01"
+	triggerHeadSHA       = "0123456789abcdef0123456789abcdef01234567"
+	triggerVersion       = "v1.0.0-preview.1"
+	triggerStableVersion = "v1.0.0"
 
 	triggerBaseChangelog = `# Changelog
 
@@ -26,7 +27,7 @@ const (
 
 ## [Unreleased]
 
-## [1.0.0] - 2026-08-06
+## [1.0.0-preview.1] - 2026-08-06
 
 ### Added
 
@@ -40,7 +41,7 @@ const (
 
 - Arrived after the promotion
 
-## [1.0.0] - 2026-08-06
+## [1.0.0-preview.1] - 2026-08-06
 
 ### Added
 
@@ -268,7 +269,7 @@ func TestResolveReleaseTriggerManual(t *testing.T) {
 			if err != nil {
 				t.Fatalf("resolveReleaseTriggerWithDeps() error = %v", err)
 			}
-			want := releaseTriggerResult(tc.component, tc.refName, triggerHeadSHA, tc.version)
+			want := expectedReleaseTriggerResult(tc.component, tc.refName, tc.version)
 			if !reflect.DeepEqual(got, want) {
 				t.Fatalf("resolveReleaseTriggerWithDeps() = %+v, want %+v", got, want)
 			}
@@ -346,7 +347,7 @@ func TestResolveReleaseTriggerManualCanRecoverOlderVersion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveReleaseTriggerWithDeps() error = %v", err)
 	}
-	want := releaseTriggerResult("app", "main", triggerHeadSHA, selectedVersion)
+	want := expectedReleaseTriggerResult("app", "main", selectedVersion)
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("resolveReleaseTriggerWithDeps() = %+v, want %+v", got, want)
 	}
@@ -396,14 +397,21 @@ func TestResolveReleaseTriggerPush(t *testing.T) {
 			refName:    "main",
 			changed:    []string{appPath},
 			changelogs: map[string]triggerChangelogPair{appPath: promotion},
-			want:       releaseTriggerResult("app", "main", triggerHeadSHA, triggerVersion),
+			want:       expectedReleaseTriggerResult("app", "main", triggerVersion),
 		},
 		{
-			name:       "studioctl promotion on release branch",
-			refName:    "release/studioctl/v1.2",
-			changed:    []string{studioctlPath},
-			changelogs: map[string]triggerChangelogPair{studioctlPath: promotion},
-			want:       releaseTriggerResult("studioctl", "release/studioctl/v1.2", triggerHeadSHA, triggerVersion),
+			name:    "studioctl promotion on release branch",
+			refName: "release/studioctl/v1.0",
+			changed: []string{studioctlPath},
+			changelogs: map[string]triggerChangelogPair{studioctlPath: {
+				base: triggerStabilizationBase,
+				head: triggerStabilizedChangelog,
+			}},
+			want: expectedReleaseTriggerResult(
+				"studioctl",
+				"release/studioctl/v1.0",
+				triggerStableVersion,
+			),
 		},
 		{
 			name:       "ordinary changelog update is a no-op",
@@ -430,7 +438,7 @@ func TestResolveReleaseTriggerPush(t *testing.T) {
 				appPath:       promotion,
 				studioctlPath: ordinary,
 			},
-			want: releaseTriggerResult("app", "main", triggerHeadSHA, triggerVersion),
+			want: expectedReleaseTriggerResult("app", "main", triggerVersion),
 		},
 		{
 			name:    "promotion remains detectable beside a later entry for the same component",
@@ -439,7 +447,7 @@ func TestResolveReleaseTriggerPush(t *testing.T) {
 			changelogs: map[string]triggerChangelogPair{
 				appPath: {base: triggerBaseChangelog, head: triggerPromotedWithNewEntry},
 			},
-			want: releaseTriggerResult("app", "main", triggerHeadSHA, triggerVersion),
+			want: expectedReleaseTriggerResult("app", "main", triggerVersion),
 		},
 		{
 			name:    "multiple promotions fail closed",
@@ -485,7 +493,11 @@ func TestResolveReleaseTriggerPush(t *testing.T) {
 			changelogs: map[string]triggerChangelogPair{
 				appPath: {base: triggerStabilizationBase, head: triggerStabilizedChangelog},
 			},
-			want: releaseTriggerResult("app", "release/app/v1.0", triggerHeadSHA, triggerVersion),
+			want: expectedReleaseTriggerResult(
+				"app",
+				"release/app/v1.0",
+				triggerStableVersion,
+			),
 		},
 		{
 			name:    "component without a publisher is ignored",
@@ -618,6 +630,24 @@ func TestResolveReleaseTriggerPushRequiredInputs(t *testing.T) {
 			t.Fatalf("resolveReleaseTriggerWithDeps() = %+v, want %+v", got, want)
 		}
 	})
+}
+
+func expectedReleaseTriggerResult(
+	componentName, baseBranch, releaseVersion string,
+) ReleaseTriggerResult {
+	component := components[componentName]
+	environment, err := resolveReleaseEnvironment(releaseVersion)
+	if err != nil {
+		panic(err)
+	}
+	return ReleaseTriggerResult{Release: &ReleasePlan{
+		Component:      component.Name,
+		Publisher:      component.Publisher,
+		Environment:    environment,
+		BaseBranch:     baseBranch,
+		Commit:         triggerHeadSHA,
+		ReleaseVersion: releaseVersion,
+	}}
 }
 
 func triggerReleasedChangelog(version string) string {


### PR DESCRIPTION
## Description

Stacked on #19829.

Make the Go trigger result the single publication-policy decision:

- replace the publisher-enabled boolean with an explicit reusable publisher identity in the component registry
- add publisher and protected environment to the immutable release plan
- map `preview` to `dev`, `rc` to `staging`, and stable versions to `prod`
- fail closed for unsupported prerelease channels instead of defaulting them to production
- route reusable workflows by the resolved publisher and remove the later shell environment resolver
- validate the version/branch combination while building the trigger plan
- add Kjøring CODEOWNERS coverage for the component registry and release policy source files

The publisher receives one complete plan rather than re-deriving component or environment context in a later job.

## Verification

- [x] Related issues are connected (stacked on #19829)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

```console
$ make fmt && make lint && make test && make test-e2e && make build
# exit 0; 0 lint issues; unit and e2e tests pass with -race

$ releaser resolve-trigger # historical app promotion 90141dd... against 15ca1f9...
{"release":{"component":"app","publisher":"app","environment":"dev","baseBranch":"main","commit":"90141dd581695cdcedaacbf9bbc6b949f65bde2f","releaseVersion":"v9.0.0-preview.3"}}

$ releaser resolve-trigger # historical studioctl promotion 4c679a6... against 5c5c58d...
{"release":{"component":"studioctl","publisher":"studioctl","environment":"dev","baseBranch":"main","commit":"4c679a67fcca0180088ad1436200677b2b42fa03","releaseVersion":"v0.1.0-preview.16"}}

$ npm run codeowners:validate
# exit 0
```
