### PR TITLE
ci(releaser): serialize component publication

### DIFF
--- a/.github/workflows/release-app.yaml
+++ b/.github/workflows/release-app.yaml
@@ -18,6 +18,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: release-app-${{ inputs.base-branch }}
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Build, release and publish app

--- a/.github/workflows/release-app.yaml
+++ b/.github/workflows/release-app.yaml
@@ -20,6 +20,7 @@ on:
 
 concurrency:
   group: release-app-${{ inputs.base-branch }}
+  queue: max
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/release-studioctl.yaml
+++ b/.github/workflows/release-studioctl.yaml
@@ -13,6 +13,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: release-studioctl-${{ inputs.base-branch }}
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Build and release studioctl

--- a/.github/workflows/release-studioctl.yaml
+++ b/.github/workflows/release-studioctl.yaml
@@ -15,6 +15,7 @@ on:
 
 concurrency:
   group: release-studioctl-${{ inputs.base-branch }}
+  queue: max
   cancel-in-progress: false
 
 jobs:

--- a/src/tools/releaser/README.md
+++ b/src/tools/releaser/README.md
@@ -105,5 +105,7 @@ prerelease, stabilization, and patch release flows.
 - The Go trigger policy is the publication source of truth. The component registry selects the reusable publisher;
   version policy maps `preview` releases to the `dev` environment, `rc` releases to `staging`, and stable releases to
   `prod`. Unknown prerelease channels fail closed during trigger resolution.
+- Publisher workflows serialize releases for the same component and base branch without cancelling an in-progress
+  publication. Different components and release lines can still publish independently.
 - Manual dispatch validates the exact selected version against the selected commit and branch; publishers never
   select a newer version or move their checkout while executing a release plan.

--- a/src/tools/releaser/README.md
+++ b/src/tools/releaser/README.md
@@ -105,7 +105,8 @@ prerelease, stabilization, and patch release flows.
 - The Go trigger policy is the publication source of truth. The component registry selects the reusable publisher;
   version policy maps `preview` releases to the `dev` environment, `rc` releases to `staging`, and stable releases to
   `prod`. Unknown prerelease channels fail closed during trigger resolution.
-- Publisher workflows serialize releases for the same component and base branch without cancelling an in-progress
-  publication. Different components and release lines can still publish independently.
+- Publisher workflows serialize releases for the same component and base branch with GitHub's maximum pending queue,
+  without cancelling an in-progress publication. Different components and release lines can still publish
+  independently.
 - Manual dispatch validates the exact selected version against the selected commit and branch; publishers never
   select a newer version or move their checkout while executing a release plan.


### PR DESCRIPTION
## Description

Stacked on #19830.

Serialize publisher workflows by component and canonical base branch:

- use distinct concurrency groups for app and studioctl release publishers
- retain up to GitHub's maximum 100 pending runs with `queue: max`
- never cancel an in-progress publication
- allow different components and release lines to publish independently

The explicit queue is important: GitHub's default single pending slot replaces an older pending run, which could silently skip a release because trigger detection is scoped to each push range.

## Verification

- [x] Related issues are connected (stacked on #19830)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

```console
$ make fmt && make lint && make test && make test-e2e && make build
# exit 0; 0 lint issues; unit and e2e tests pass with -race

$ actionlint -ignore 'unexpected key "queue"' \
    .github/workflows/release-components.yaml \
    .github/workflows/release-app.yaml \
    .github/workflows/release-studioctl.yaml \
    .github/workflows/releaser-build-test.yml
# exit 0

$ npm run codeowners:validate
# exit 0

$ git diff --check origin/main...HEAD
# exit 0
```

`actionlint` 1.7.12 predates the `concurrency.queue` schema, so only that known syntax diagnostic is suppressed. The key and `max` behavior were checked against the current official GitHub Actions concurrency documentation: https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency
