### PR TITLE
chore(pdf3): remove redundant Yarn version metadata

### DIFF
--- a/src/Runtime/pdf3/package.json
+++ b/src/Runtime/pdf3/package.json
@@ -1,6 +1,5 @@
 {
   "name": "pdf3",
-  "packageManager": "yarn@4.16.0",
   "devDependencies": {
     "@types/k6": "^1.3.1"
   }


### PR DESCRIPTION
## Description

Removes the redundant `packageManager` property from `src/Runtime/pdf3/package.json`. pdf3 only keeps this manifest for the `@types/k6` development dependency and does not need its own Yarn version pin. It will use the repository Yarn configuration instead, avoiding isolated Renovate PRs for this metadata.

Supersedes #19765.

## Verification

- [x] Related issues are connected: #19765
- [x] `corepack yarn --version` resolves to the repository-pinned Yarn 4.17.1
- [x] `corepack yarn install --immutable` succeeds from `src/Runtime/pdf3` without lockfile changes
- [x] `git diff --check` passes
- [ ] Relevant automated test added (not applicable for removing package-manager metadata)