### PR TITLE
chore(renovate): group Go module updates repository-wide

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -111,6 +111,12 @@
       "commitMessageSuffix": " (pdf3)"
     },
     {
+      "description": "Keep Go module updates in repository-wide groups",
+      "matchManagers": ["gomod"],
+      "additionalBranchPrefix": "",
+      "commitMessageSuffix": ""
+    },
+    {
       "matchFileNames": ["src/App/**"],
       "matchPackageNames": [
         "/dotnet(-|\\/)sdk/",


### PR DESCRIPTION
## Description

Resets path-specific branch prefixes and commit-message suffixes for the `gomod` manager after the repository path rules are applied. Go dependency updates will use the repository-wide Renovate groups, while npm, NuGet, Docker, and other managers retain their existing path-specific behavior.

This avoids splitting related Go module updates across the global and `pdf3/` branches and makes it easier to keep nested Go modules tidy in the same review. Related to #19800.

## Verification

- [x] `jq empty renovate.json`
- [x] `npx --yes --package renovate renovate-config-validator renovate.json`
- [x] `git diff --check`
- [x] Manual review confirmed the override follows the existing empty-prefix/empty-suffix pattern
- [ ] Relevant automated test added (not applicable for Renovate configuration)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency management for Go modules to preserve repository-wide grouping and consistent update handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->