### PR TITLE
feat(studioctl): clone apps from repository URLs

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -9,6 +9,10 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+### Added
+
+- Accept Studio repository URLs, with or without `.git`, in `studioctl app clone` and select the environment from the URL.
+
 ### Changed
 
 - Wait up to 30 seconds for an app to become reachable through Localtest when using `studioctl run`; use `--startup-timeout` to choose a different limit.

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -48,6 +48,8 @@ studioctl app run
 ```
 
 `studioctl auth login` opens Designer for Ansattporten login and stores a Designer API key locally.
+`studioctl app clone` also accepts Studio repository URLs, with or without the `.git` extension, and
+selects the environment from the URL (for example `https://dev.altinn.studio/repos/<org>/<repo>.git`).
 For agents and automations, pass an existing Studio/Designer API key on standard input:
 
 ```sh
@@ -62,7 +64,7 @@ studioctl auth login --env dev --with-token < token.txt
 
 - `studioctl auth login`: login with Ansattporten or `--with-token` for `prod`, `dev`, `staging`, or `local`
 - `studioctl apps search`: search app repositories in Altinn Studio
-- `studioctl app clone`: clone `org/repo` from the selected Altinn Studio environment
+- `studioctl app clone`: clone `org/repo` or a Studio repository URL from the selected or inferred environment
 - `studioctl app run`: run app locally
 - `studioctl app env`: print local app harness environment as KEY=value text (`--json` for JSON output)
 - `studioctl env up`: start localtest

--- a/src/cli/internal/auth/credentials.go
+++ b/src/cli/internal/auth/credentials.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -161,6 +162,17 @@ func (c *Credentials) EnvNames() []string {
 func HostForEnv(env string) string {
 	if host, ok := knownEnvHosts[env]; ok {
 		return host
+	}
+	return ""
+}
+
+// EnvForHost returns the known environment for a Studio host.
+// Returns an empty string if the host is unknown.
+func EnvForHost(host string) string {
+	for env, knownHost := range knownEnvHosts {
+		if strings.EqualFold(host, knownHost) {
+			return env
+		}
 	}
 	return ""
 }

--- a/src/cli/internal/auth/credentials_test.go
+++ b/src/cli/internal/auth/credentials_test.go
@@ -122,6 +122,19 @@ func TestEnvironmentDefaults(t *testing.T) {
 	if got := auth.SchemeForEnv("prod"); got != testHTTPS {
 		t.Errorf("expected prod scheme https, got %s", got)
 	}
+	for env, host := range map[string]string{
+		"prod":    "altinn.studio",
+		"dev":     "dev.altinn.studio",
+		"local":   "studio.localhost",
+		"staging": "staging.altinn.studio",
+	} {
+		if got := auth.EnvForHost(host); got != env {
+			t.Errorf("EnvForHost(%q) = %q, want %q", host, got, env)
+		}
+	}
+	if got := auth.EnvForHost("example.com"); got != "" {
+		t.Errorf("EnvForHost(unknown) = %q, want empty", got)
+	}
 }
 
 func TestEnvCredentialsSchemeOrDefault(t *testing.T) {

--- a/src/cli/internal/cmd/app.go
+++ b/src/cli/internal/cmd/app.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net/url"
 	"strings"
 
 	containerruntime "altinn.studio/devenv/pkg/container"
@@ -34,9 +35,15 @@ type AppCommand struct {
 	service *appsvc.Service
 }
 
-const appLogsSubcommand = "logs"
+const (
+	appLogsSubcommand = "logs"
+	cloneEnvFlagName  = "env"
+)
 
-var errAppUpgradeFailed = errors.New("upgrade failed")
+var (
+	errAppUpgradeFailed         = errors.New("upgrade failed")
+	errCloneEnvironmentMismatch = errors.New("repository URL environment conflicts with --env")
+)
 
 type appBuildOutput struct {
 	ImageTag   string `json:"imageTag"`
@@ -50,6 +57,12 @@ type appBuildFlags struct {
 	imageTag   string
 	push       bool
 	jsonOutput bool
+}
+
+type cloneSource struct {
+	org  string
+	repo string
+	env  string
 }
 
 func (o appBuildOutput) PrintImage(out *ui.Output) error {
@@ -522,7 +535,7 @@ func (c *AppCommand) appUpgradeUsage() string {
 func (c *AppCommand) runClone(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("app clone", flag.ContinueOnError)
 	var env string
-	fs.StringVar(&env, "env", auth.DefaultEnv, "Environment name (prod, dev, staging)")
+	fs.StringVar(&env, cloneEnvFlagName, auth.DefaultEnv, "Environment name (prod, dev, staging, local)")
 
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -534,19 +547,34 @@ func (c *AppCommand) runClone(ctx context.Context, args []string) error {
 	remaining := fs.Args()
 	if len(remaining) == 0 {
 		return fmt.Errorf(
-			"%w: usage: %s app clone [--env ENV] <org>/<repo> [destination]",
+			"%w: usage: %s app clone [--env ENV] <org>/<repo|repository-url> [destination]",
 			ErrMissingArgument,
 			osutil.CurrentBin(),
 		)
 	}
+	if len(remaining) > 2 || (len(remaining) == 2 && isCloneFlag(remaining[1])) {
+		return fmt.Errorf(
+			"%w: flags must be specified before the repository; expected at most one destination",
+			ErrInvalidFlagValue,
+		)
+	}
 
-	repoArg := remaining[0]
-	org, repo, parseErr := parseOrgRepo(repoArg)
+	source, parseErr := parseCloneSource(remaining[0])
 	if parseErr != nil {
 		return parseErr
 	}
+	envSet := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == cloneEnvFlagName {
+			envSet = true
+		}
+	})
+	env, err := resolveCloneEnvironment(env, envSet, source.env)
+	if err != nil {
+		return err
+	}
 
-	dest := repo
+	dest := source.repo
 	if len(remaining) > 1 {
 		dest = remaining[1]
 	}
@@ -559,16 +587,16 @@ func (c *AppCommand) runClone(ctx context.Context, args []string) error {
 		return fmt.Errorf("resolve host: %w", err)
 	}
 
-	c.out.Verbosef("Cloning %s/%s from %s...", org, repo, host)
+	c.out.Verbosef("Cloning %s/%s from %s...", source.org, source.repo, host)
 
 	result, err := c.service.Clone(ctx, appsvc.CloneRequest{
 		Env:         env,
-		Org:         org,
-		Repo:        repo,
+		Org:         source.org,
+		Repo:        source.repo,
 		Destination: dest,
 	})
 	if err != nil {
-		return mapCloneError(err, env, org, repo, host, dest)
+		return mapCloneError(err, env, source.org, source.repo, host, dest)
 	}
 
 	c.out.Successf("Cloned to %s", result.AbsPath)
@@ -577,6 +605,80 @@ func (c *AppCommand) runClone(ctx context.Context, args []string) error {
 	c.out.Printlnf("  cd %s && %s env up", dest, osutil.CurrentBin())
 
 	return nil
+}
+
+func isCloneFlag(value string) bool {
+	return value == "-env" || value == "--env" ||
+		strings.HasPrefix(value, "-env=") || strings.HasPrefix(value, "--env=") ||
+		value == "-h" || value == "--help"
+}
+
+func parseCloneSource(value string) (cloneSource, error) {
+	repositoryURL, err := url.Parse(value)
+	if err != nil {
+		return cloneSource{}, invalidCloneSource(value)
+	}
+	if !repositoryURL.IsAbs() && repositoryURL.Host == "" {
+		org, repo, parseErr := parseOrgRepo(value)
+		return cloneSource{org: org, repo: repo, env: ""}, parseErr
+	}
+	return parseStudioRepositoryURL(repositoryURL, value)
+}
+
+func parseStudioRepositoryURL(repositoryURL *url.URL, value string) (cloneSource, error) {
+	if repositoryURL.User != nil || repositoryURL.RawQuery != "" || repositoryURL.Fragment != "" ||
+		repositoryURL.Port() != "" {
+		return cloneSource{}, invalidCloneSource(value)
+	}
+	env := auth.EnvForHost(repositoryURL.Hostname())
+	if env == "" || !strings.EqualFold(repositoryURL.Host, auth.HostForEnv(env)) ||
+		!strings.EqualFold(repositoryURL.Scheme, auth.SchemeForEnv(env)) {
+		return cloneSource{}, invalidCloneSource(value)
+	}
+
+	parts := strings.Split(repositoryURL.EscapedPath(), "/")
+	if len(parts) != 4 || parts[0] != "" || parts[1] != "repos" {
+		return cloneSource{}, invalidCloneSource(value)
+	}
+	org, repo, err := parseStudioRepositoryPath(parts[2], parts[3])
+	if err != nil {
+		return cloneSource{}, invalidCloneSource(value)
+	}
+
+	return cloneSource{org: org, repo: repo, env: env}, nil
+}
+
+func parseStudioRepositoryPath(escapedOrg, escapedRepo string) (string, string, error) {
+	org, orgErr := url.PathUnescape(escapedOrg)
+	repo, repoErr := url.PathUnescape(strings.TrimSuffix(escapedRepo, ".git"))
+	if orgErr != nil || repoErr != nil || org == "" || repo == "" ||
+		strings.Contains(org, "/") || strings.Contains(repo, "/") {
+		return "", "", ErrInvalidRepoFormat
+	}
+	return org, repo, nil
+}
+
+func resolveCloneEnvironment(flagEnv string, envSet bool, inferredEnv string) (string, error) {
+	if inferredEnv == "" {
+		return flagEnv, nil
+	}
+	if envSet && flagEnv != inferredEnv {
+		return "", fmt.Errorf(
+			"%w: --env %s, URL environment %s",
+			errCloneEnvironmentMismatch,
+			flagEnv,
+			inferredEnv,
+		)
+	}
+	return inferredEnv, nil
+}
+
+func invalidCloneSource(value string) error {
+	return fmt.Errorf(
+		"%w: %q (expected org/repo or a Studio repository URL ending in /repos/org/repo[.git])",
+		ErrInvalidRepoFormat,
+		value,
+	)
 }
 
 func mapCloneError(err error, env, org, repo, host, dest string) error {

--- a/src/cli/internal/cmd/app.go
+++ b/src/cli/internal/cmd/app.go
@@ -547,7 +547,7 @@ func (c *AppCommand) runClone(ctx context.Context, args []string) error {
 	remaining := fs.Args()
 	if len(remaining) == 0 {
 		return fmt.Errorf(
-			"%w: usage: %s app clone [--env ENV] <org>/<repo|repository-url> [destination]",
+			"%w: usage: %s app clone [--env ENV] <org/repo|repository-url> [destination]",
 			ErrMissingArgument,
 			osutil.CurrentBin(),
 		)

--- a/src/cli/internal/cmd/app_internal_test.go
+++ b/src/cli/internal/cmd/app_internal_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -169,6 +170,160 @@ func TestParseAppUpgradeFlagsRejectsUnsupportedKind(t *testing.T) {
 	_, _, err := (&AppCommand{}).parseAppUpgradeFlags([]string{"backend-v9"})
 	if err == nil {
 		t.Fatal("parseAppUpgradeFlags() error = nil, want error")
+	}
+}
+
+func TestParseCloneSource(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		wantOrg  string
+		wantRepo string
+		wantEnv  string
+	}{
+		{name: "org and repo", input: "ttd/my-app", wantOrg: "ttd", wantRepo: "my-app"},
+		{
+			name:     "production browser URL",
+			input:    "https://altinn.studio/repos/ttd/my-app",
+			wantOrg:  "ttd",
+			wantRepo: "my-app",
+			wantEnv:  "prod",
+		},
+		{
+			name:     "production clone URL",
+			input:    "https://altinn.studio/repos/ttd/my-app.git",
+			wantOrg:  "ttd",
+			wantRepo: "my-app",
+			wantEnv:  "prod",
+		},
+		{
+			name:     "development URL",
+			input:    "https://dev.altinn.studio/repos/ttd/my-app.git",
+			wantOrg:  "ttd",
+			wantRepo: "my-app",
+			wantEnv:  "dev",
+		},
+		{
+			name:     "staging URL",
+			input:    "https://staging.altinn.studio/repos/ttd/my-app",
+			wantOrg:  "ttd",
+			wantRepo: "my-app",
+			wantEnv:  "staging",
+		},
+		{
+			name:     "local URL",
+			input:    "http://studio.localhost/repos/ttd/my-app.git",
+			wantOrg:  "ttd",
+			wantRepo: "my-app",
+			wantEnv:  "local",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseCloneSource(tt.input)
+			if err != nil {
+				t.Fatalf("parseCloneSource() error = %v", err)
+			}
+			if got.org != tt.wantOrg || got.repo != tt.wantRepo || got.env != tt.wantEnv {
+				t.Errorf(
+					"parseCloneSource() = %+v, want org=%q repo=%q env=%q",
+					got,
+					tt.wantOrg,
+					tt.wantRepo,
+					tt.wantEnv,
+				)
+			}
+		})
+	}
+}
+
+func TestParseCloneSourceRejectsInvalidURLs(t *testing.T) {
+	t.Parallel()
+
+	inputs := []string{
+		"https://example.com/repos/ttd/my-app",
+		"http://altinn.studio/repos/ttd/my-app",
+		"https://altinn.studio/ttd/my-app",
+		"https://altinn.studio/repos/ttd/my-app/extra",
+		"https://altinn.studio/repos/ttd/.git",
+		"https://altinn.studio/repos/ttd/my-app?ref=main",
+		"https://altinn.studio:/repos/ttd/my-app",
+	}
+
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+
+			if _, err := parseCloneSource(input); err == nil {
+				t.Errorf("parseCloneSource(%q) error = nil, want error", input)
+			}
+		})
+	}
+}
+
+func TestRunCloneRejectsFlagsAfterRepository(t *testing.T) {
+	t.Parallel()
+
+	inputs := [][]string{
+		{"https://altinn.studio/repos/ttd/my-app", "--env", "prod"},
+		{"https://altinn.studio/repos/ttd/my-app", "--env=prod"},
+		{"ttd/my-app", "destination", "extra"},
+	}
+
+	for _, input := range inputs {
+		t.Run(strings.Join(input, " "), func(t *testing.T) {
+			t.Parallel()
+
+			err := (&AppCommand{}).runClone(t.Context(), input)
+			if !errors.Is(err, ErrInvalidFlagValue) {
+				t.Errorf("runClone() error = %v, want ErrInvalidFlagValue", err)
+			}
+		})
+	}
+}
+
+func TestIsCloneFlagAllowsHyphenPrefixedDestination(t *testing.T) {
+	t.Parallel()
+
+	if isCloneFlag("-scratch") {
+		t.Error("isCloneFlag(-scratch) = true, want false")
+	}
+}
+
+func TestResolveCloneEnvironment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		flagEnv     string
+		inferredEnv string
+		want        string
+		envSet      bool
+		wantErr     bool
+	}{
+		{name: "default", flagEnv: "prod", want: "prod"},
+		{name: "inferred", flagEnv: "prod", inferredEnv: "dev", want: "dev"},
+		{name: "matching explicit", flagEnv: "dev", inferredEnv: "dev", envSet: true, want: "dev"},
+		{name: "conflicting explicit", flagEnv: "prod", inferredEnv: "dev", envSet: true, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := resolveCloneEnvironment(tt.flagEnv, tt.envSet, tt.inferredEnv)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("resolveCloneEnvironment() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("resolveCloneEnvironment() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Description

Allow `studioctl app clone` to accept canonical Altinn Studio repository URLs in addition to `org/repo` identifiers.

- Accept repository URLs with and without the `.git` suffix.
- Infer `prod`, `dev`, `staging`, or `local` from the URL host and use that environment's stored credentials.
- Reject malformed Studio URLs and an explicit `--env` that conflicts with the URL.
- Keep the existing repository lookup, Git clone, and credential-helper flow after normalizing the input.
- Document the new input form in the CLI README and changelog.

## Verification

- [x] Related issues are connected (not applicable)
- [x] **Your** code builds clean without any errors or warnings from the changed Go code
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

Commands:

```console
$ make lint
0 issues.

$ make test
# Go race-enabled suite: passed
# studioctl-server: 136 passed, 0 failed

$ make build
go build -ldflags "-X altinn.studio/studioctl/internal/cmd.version=0.1.0-preview.0" -o build/studioctl ./cmd/studioctl

$ ./build/studioctl app clone https://altinn.studio/repos/xmrsa/ra0764-01 /data/home/code/apps/ra0764-url-no-git-debug
Cloned to /data/home/code/apps/ra0764-url-no-git-debug

$ ./build/studioctl app clone https://altinn.studio/repos/xmrsa/ra0764-01.git /data/home/code/apps/ra0764-url-git-debug
Cloned to /data/home/code/apps/ra0764-url-git-debug

$ ./build/studioctl app clone --env dev https://altinn.studio/repos/xmrsa/ra0764-01 /data/home/code/apps/ra0764-url-conflict-debug
repository URL environment conflicts with --env: --env dev, URL environment prod
```

The .NET test restore emits existing NuGet vulnerability advisories for dependencies already present on `main`; all tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `studioctl app clone` accepts Studio repository URLs with or without `.git`.
  * The environment is inferred automatically from the repository URL, including `local`.
  * Explicit environment selections are checked against the URL.

* **Bug Fixes**
  * Improved validation and error messages for invalid URLs, misplaced flags, and conflicting environment options.

* **Documentation**
  * Updated cloning guidance and command references for Studio repository URLs and environment inference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->