### PR TITLE
chore: release studioctl v0.1.0-preview.20

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -9,6 +9,8 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+## [0.1.0-preview.20] - 2026-08-07
+
 ### Added
 
 - Accept Studio repository URLs, with or without `.git`, in `studioctl app clone` and select the environment from the URL.


### PR DESCRIPTION
## Description

Prepare release v0.1.0-preview.20

- [Added] Accept Studio repository URLs, with or without `.git`, in `studioctl app clone` and select the environment from the URL.
- [Changed] Wait up to 30 seconds for an app to become reachable through Localtest when using `studioctl run`; use `--startup-timeout` to choose a different limit.
- [Fixed] Explain access errors during `studioctl app upgrade`
- [Fixed] Explain whether app endpoint discovery or Localtest Storage was still incomplete when `studioctl run` reaches its startup timeout.
- [Fixed] Detect apps started directly with `dotnet run` sooner by checking process endpoints every five seconds while retaining the ten-second container check interval.
- [Fixed] Discover apps launched by `studioctl run` from their registered process without relying on process-name or command-line matching.

@coderabbitai ignore

**Full Changelog**: https://github.com/Altinn/altinn-studio/compare/studioctl/v0.1.0-preview.19...studioctl/v0.1.0-preview.20