### PR TITLE
chore: replace Accordion with Details component

### DIFF
--- a/src/Designer/frontend/libs/studio-components/src/components/StudioDetails/StudioDetails.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioDetails/StudioDetails.tsx
@@ -2,8 +2,21 @@ import type { ReactElement } from 'react';
 import { Details } from '@digdir/designsystemet-react';
 import type { DetailsProps } from '@digdir/designsystemet-react';
 
-export type StudioDetailsProps = DetailsProps;
+export type StudioDetailsProps = Omit<DetailsProps, 'onToggle'> & {
+  /** Omit when the open state is controlled elsewhere. Example: PageAccordion.tsx */
+  onToggle?: (event: Event) => void;
+};
 
-export function StudioDetails({ children, ...rest }: StudioDetailsProps): ReactElement {
-  return <Details {...rest}>{children}</Details>;
+const ignoreToggle = (): void => undefined;
+
+export function StudioDetails({
+  children,
+  onToggle = ignoreToggle,
+  ...rest
+}: StudioDetailsProps): ReactElement {
+  return (
+    <Details {...(rest as DetailsProps)} onToggle={onToggle}>
+      {children}
+    </Details>
+  );
 }

--- a/src/Designer/frontend/packages/ux-editor-v3/src/components/Elements/DefaultToolbar.module.css
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/components/Elements/DefaultToolbar.module.css
@@ -1,12 +1,7 @@
-.accordionItem > div {
-  border-bottom: none !important;
+.detailsElement {
+  border-top: none;
 }
 
-.accordionHeader > button {
-  border: none;
-  padding: var(--fds-spacing-3) var(--fds-spacing-5);
-}
-
-.accordionContent {
-  padding: 0;
+.detailsContent {
+  margin-inline: 0;
 }

--- a/src/Designer/frontend/packages/ux-editor-v3/src/components/Elements/DefaultToolbar.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/components/Elements/DefaultToolbar.tsx
@@ -5,7 +5,7 @@ import classes from './DefaultToolbar.module.css';
 import { useTranslation } from 'react-i18next';
 import { schemaComponents, textComponents, advancedItems } from '../../data/formItemConfig';
 import type { KeyValuePairs } from 'app-shared/types/KeyValuePairs';
-import { Accordion } from '@digdir/designsystemet-react';
+import { StudioDetails } from '@studio/components';
 import {
   getCollapsableMenuTitleByType,
   getComponentTitleByComponentType,
@@ -39,26 +39,23 @@ export function DefaultToolbar() {
     <>
       {Object.values(CollapsableMenus).map((key: CollapsableMenus) => {
         return (
-          <Accordion key={key} color='subtle'>
-            <Accordion.Item
-              defaultOpen={key === CollapsableMenus.Components}
-              className={classes.accordionItem}
-            >
-              <Accordion.Header className={classes.accordionHeader}>
-                {getCollapsableMenuTitleByType(key, t)}
-              </Accordion.Header>
-              <Accordion.Content className={classes.accordionContent}>
-                {allComponentLists[key].map((component: IToolbarElement) => (
-                  <ToolbarItem
-                    text={getComponentTitleByComponentType(component.type, t) || component.label}
-                    icon={component.icon}
-                    componentType={component.type}
-                    key={component.type}
-                  />
-                ))}
-              </Accordion.Content>
-            </Accordion.Item>
-          </Accordion>
+          <StudioDetails
+            key={key}
+            defaultOpen={key === CollapsableMenus.Components}
+            className={classes.detailsElement}
+          >
+            <StudioDetails.Summary>{getCollapsableMenuTitleByType(key, t)}</StudioDetails.Summary>
+            <StudioDetails.Content className={classes.detailsContent}>
+              {allComponentLists[key].map((component: IToolbarElement) => (
+                <ToolbarItem
+                  text={getComponentTitleByComponentType(component.type, t) || component.label}
+                  icon={component.icon}
+                  componentType={component.type}
+                  key={component.type}
+                />
+              ))}
+            </StudioDetails.Content>
+          </StudioDetails>
         );
       })}
     </>

--- a/src/Designer/frontend/packages/ux-editor-v3/src/components/Properties/Properties.module.css
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/components/Properties/Properties.module.css
@@ -2,3 +2,7 @@
   background: var(--fds-semantic-surface-neutral-subtle);
   flex: var(--properties-width-fraction);
 }
+
+.accordionContent {
+  margin-inline: 0;
+}

--- a/src/Designer/frontend/packages/ux-editor-v3/src/components/Properties/Properties.test.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/components/Properties/Properties.test.tsx
@@ -1,5 +1,5 @@
 import { Properties } from './Properties';
-import { render as rtlRender, screen, waitFor } from '@testing-library/react';
+import { render as rtlRender, screen, waitFor, within } from '@testing-library/react';
 import { FormItemContext } from '../../containers/FormItemContext';
 import userEvent from '@testing-library/user-event';
 import { formItemContextProviderMock } from '../../testing/formItemContextMocks';
@@ -31,54 +31,52 @@ jest.mock('./Calculations', () => ({
   Calculations: () => <div data-testid={calculationsTestId} />,
 }));
 
+const getAccordionSummary = (name: string): HTMLElement => screen.getByText(name);
+
+const getAccordion = (name: string): HTMLElement =>
+  screen.getAllByRole('group').find((accordion) => within(accordion).queryByText(name));
+
+const expectToggleAccordion = async (name: string) => {
+  await user.click(getAccordionSummary(name));
+  expect(getAccordion(name)).toHaveAttribute('open');
+  await user.click(getAccordionSummary(name));
+  expect(getAccordion(name)).not.toHaveAttribute('open');
+};
+
 describe('Properties', () => {
   describe('Content', () => {
     it('Closes content on load', () => {
       render();
-      const button = screen.queryByRole('button', { name: contentText });
-      expect(button).toHaveAttribute('aria-expanded', 'false');
+      expect(getAccordion(contentText)).not.toHaveAttribute('open');
     });
 
     it('Toggles content when clicked', async () => {
       render();
-      const button = screen.queryByRole('button', { name: contentText });
-      await user.click(button);
-      expect(button).toHaveAttribute('aria-expanded', 'true');
-      await user.click(button);
-      expect(button).toHaveAttribute('aria-expanded', 'false');
+      await expectToggleAccordion(contentText);
     });
 
     it('Opens content when a component is selected', async () => {
       const { rerender } = render();
       rerender(getComponent({ formItemId: 'test' }));
-      const button = screen.queryByRole('button', { name: contentText });
-      await waitFor(() => expect(button).toHaveAttribute('aria-expanded', 'true'));
+      await waitFor(() => expect(getAccordion(contentText)).toHaveAttribute('open'));
     });
   });
 
   describe('Dynamics', () => {
     it('Closes dynamics on load', () => {
       render();
-      const button = screen.queryByRole('button', { name: dynamicsText });
-      expect(button).toHaveAttribute('aria-expanded', 'false');
+      expect(getAccordion(dynamicsText)).not.toHaveAttribute('open');
     });
 
     it('Toggles dynamics when clicked', async () => {
       render();
-      const button = screen.queryByRole('button', { name: dynamicsText });
-      await user.click(button);
-      expect(button).toHaveAttribute('aria-expanded', 'true');
-      await user.click(button);
-      expect(button).toHaveAttribute('aria-expanded', 'false');
+      await expectToggleAccordion(dynamicsText);
     });
 
     it('Shows new dynamics by default', async () => {
       const { rerender } = render();
       rerender(getComponent({ formItemId: 'test' }));
-      const dynamicsButton = screen.queryByRole('button', {
-        name: dynamicsText,
-      });
-      await user.click(dynamicsButton);
+      await user.click(getAccordionSummary(dynamicsText));
       const newDynamics = screen.getByTestId(expressionsTestId);
       expect(newDynamics).toBeInTheDocument();
     });
@@ -87,17 +85,12 @@ describe('Properties', () => {
   describe('Calculations', () => {
     it('Closes calculations on load', () => {
       render();
-      const button = screen.queryByRole('button', { name: calculationsText });
-      expect(button).toHaveAttribute('aria-expanded', 'false');
+      expect(getAccordion(calculationsText)).not.toHaveAttribute('open');
     });
 
     it('Toggles calculations when clicked', async () => {
       render();
-      const button = screen.queryByRole('button', { name: calculationsText });
-      await user.click(button);
-      expect(button).toHaveAttribute('aria-expanded', 'true');
-      await user.click(button);
-      expect(button).toHaveAttribute('aria-expanded', 'false');
+      await expectToggleAccordion(calculationsText);
     });
   });
 

--- a/src/Designer/frontend/packages/ux-editor-v3/src/components/Properties/Properties.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/components/Properties/Properties.tsx
@@ -2,7 +2,7 @@ import { useRef, useState, useEffect } from 'react';
 import { Calculations } from './Calculations';
 import { Content } from './Content';
 import { useTranslation } from 'react-i18next';
-import { Accordion } from '@digdir/designsystemet-react';
+import { StudioDetails } from '@studio/components';
 import { useFormItemContext } from '../../containers/FormItemContext';
 import classes from './Properties.module.css';
 import { Dynamics } from './Dynamics';
@@ -31,30 +31,27 @@ export const Properties = () => {
 
   return (
     <div className={classes.root}>
-      <Accordion color='subtle'>
-        <Accordion.Item open={openList.includes('content')}>
-          <Accordion.Header onHeaderClick={() => toggleOpen('content')}>
-            {t('right_menu.content')}
-          </Accordion.Header>
-          <Accordion.Content>
-            <Content />
-          </Accordion.Content>
-        </Accordion.Item>
-        <Accordion.Item open={openList.includes('dynamics')}>
-          <Accordion.Header onHeaderClick={() => toggleOpen('dynamics')}>
-            {t('right_menu.dynamics')}
-          </Accordion.Header>
-          <Accordion.Content>{formId && <Dynamics />}</Accordion.Content>
-        </Accordion.Item>
-        <Accordion.Item open={openList.includes('calculations')}>
-          <Accordion.Header onHeaderClick={(e) => toggleOpen('calculations')}>
-            {t('right_menu.calculations')}
-          </Accordion.Header>
-          <Accordion.Content>
-            <Calculations />
-          </Accordion.Content>
-        </Accordion.Item>
-      </Accordion>
+      <StudioDetails open={openList.includes('content')} onToggle={() => toggleOpen('content')}>
+        <StudioDetails.Summary>{t('right_menu.content')}</StudioDetails.Summary>
+        <StudioDetails.Content className={classes.accordionContent}>
+          <Content />
+        </StudioDetails.Content>
+      </StudioDetails>
+      <StudioDetails open={openList.includes('dynamics')} onToggle={() => toggleOpen('dynamics')}>
+        <StudioDetails.Summary>{t('right_menu.dynamics')}</StudioDetails.Summary>
+        <StudioDetails.Content className={classes.accordionContent}>
+          {formId && <Dynamics />}
+        </StudioDetails.Content>
+      </StudioDetails>
+      <StudioDetails
+        open={openList.includes('calculations')}
+        onToggle={() => toggleOpen('calculations')}
+      >
+        <StudioDetails.Summary>{t('right_menu.calculations')}</StudioDetails.Summary>
+        <StudioDetails.Content className={classes.accordionContent}>
+          <Calculations />
+        </StudioDetails.Content>
+      </StudioDetails>
     </div>
   );
 };

--- a/src/Designer/frontend/packages/ux-editor-v3/src/containers/DesignView/DesignView.test.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/containers/DesignView/DesignView.test.tsx
@@ -45,7 +45,7 @@ describe('DesignView', () => {
     await render();
 
     formLayoutSettingsMock.pages.order.forEach((page) => {
-      const accordionButton = screen.getByRole('button', { name: page });
+      const accordionButton = screen.getByText(page);
       expect(accordionButton).toBeInTheDocument();
     });
   });
@@ -54,7 +54,7 @@ describe('DesignView', () => {
     const user = userEvent.setup();
     await render();
 
-    const accordionButton1 = screen.getByRole('button', { name: mockPageName1 });
+    const accordionButton1 = screen.getByText(mockPageName1);
     await user.click(accordionButton1);
 
     expect(mockSetSearchParams).toHaveBeenCalledTimes(1);
@@ -65,7 +65,7 @@ describe('DesignView', () => {
     const user = userEvent.setup();
     await render();
 
-    const accordionButton2 = screen.getByRole('button', { name: mockPageName2 });
+    const accordionButton2 = screen.getByText(mockPageName2);
     await user.click(accordionButton2);
 
     expect(mockSetSearchParams).toHaveBeenCalledTimes(1);

--- a/src/Designer/frontend/packages/ux-editor-v3/src/containers/DesignView/DesignView.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/containers/DesignView/DesignView.tsx
@@ -5,7 +5,6 @@ import { useFormLayoutsQuery } from '../../hooks/queries/useFormLayoutsQuery';
 import classes from './DesignView.module.css';
 import { useTranslation } from 'react-i18next';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
-import { Accordion } from '@digdir/designsystemet-react';
 import type { IFormLayouts } from '../../types/global';
 import type { FormLayoutPage } from '../../types/FormLayoutPage';
 import { FormLayoutActions } from '../../features/formDesigner/formLayout/formLayoutSlice';
@@ -146,9 +145,7 @@ export const DesignView = (): ReactNode => {
     <div className={classes.root}>
       <div>
         <div className={classes.wrapper}>
-          <div className={classes.accordionWrapper}>
-            <Accordion color='neutral'>{displayPageAccordions}</Accordion>
-          </div>
+          <div className={classes.accordionWrapper}>{displayPageAccordions}</div>
         </div>
         <ReceiptContent
           receiptName={receiptName}

--- a/src/Designer/frontend/packages/ux-editor-v3/src/containers/DesignView/PageAccordion/PageAccordion.module.css
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/containers/DesignView/PageAccordion/PageAccordion.module.css
@@ -1,26 +1,6 @@
-.navigationMenu {
-  display: flex;
-  justify-content: flex-start;
-  align-items: stretch;
-  padding-block: 12px;
-  margin-left: 10px;
-  background-color: var(--background-color);
-}
-
-.accordionHeader {
-  flex: 1;
-}
-
-.accordionHeader button {
-  border: none;
-  background-color: var(--background-color);
-}
-
-.accordionContent {
-  padding: 0;
-}
-
 .accordionItem {
+  display: grid;
+  grid-template-columns: 1fr auto;
   border-top: 1px solid var(--fds-semantic-border-neutral-subtle);
 }
 
@@ -29,7 +9,32 @@
   border-bottom: none;
 }
 
-.accordionHeaderRow {
+.details {
+  grid-column: 1 / -1;
+  grid-row: 1;
+  min-width: 0;
+}
+
+.accordionHeader {
+  --dsc-details-summary-background: var(--background-color);
+  --dsc-details-summary-background--hover: var(--background-color);
+  --dsc-details-summary-background--open: var(--background-color);
+}
+
+.accordionContent {
+  margin-inline: 0;
+  padding: 0;
+}
+
+.navigationMenu {
+  grid-column: 2;
+  grid-row: 1;
+  align-self: start;
+  z-index: 1;
   display: flex;
+  justify-content: flex-start;
+  align-items: stretch;
+  padding-block: 12px;
+  margin-left: 10px;
   background-color: var(--background-color);
 }

--- a/src/Designer/frontend/packages/ux-editor-v3/src/containers/DesignView/PageAccordion/PageAccordion.module.css
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/containers/DesignView/PageAccordion/PageAccordion.module.css
@@ -12,7 +12,7 @@
 .details {
   grid-column: 1 / -1;
   grid-row: 1;
-  min-width: 0;
+  border-top: none;
 }
 
 .accordionHeader {

--- a/src/Designer/frontend/packages/ux-editor-v3/src/containers/DesignView/PageAccordion/PageAccordion.test.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/containers/DesignView/PageAccordion/PageAccordion.test.tsx
@@ -57,7 +57,7 @@ describe('PageAccordion', () => {
     const user = userEvent.setup();
     await render();
 
-    const accordionButton = screen.getByRole('button', { name: mockPageName1 });
+    const accordionButton = screen.getByText(mockPageName1);
     await user.click(accordionButton);
 
     expect(mockOnClick).toHaveBeenCalledTimes(1);

--- a/src/Designer/frontend/packages/ux-editor-v3/src/containers/DesignView/PageAccordion/PageAccordion.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/containers/DesignView/PageAccordion/PageAccordion.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { MouseEvent, ReactNode } from 'react';
 import { useCallback } from 'react';
 import classes from './PageAccordion.module.css';
 import cn from 'classnames';
@@ -63,10 +63,17 @@ export const PageAccordion = ({
     }
   }, [deleteLayout, layoutOrder, pageName, selectedLayout, setSearchParams, t]);
 
+  // The open state is driven entirely by isOpen, so the native toggle is prevented to stop
+  // Details from opening and closing the panel on its own before React updates.
+  const handleSummaryClick = (event: MouseEvent<HTMLElement>): void => {
+    event.preventDefault();
+    onClick();
+  };
+
   return (
     <div className={cn(classes.accordionItem, pageIsReceipt && classes.receiptItem)}>
       <StudioDetails open={isOpen} onToggle={onClick} className={classes.details}>
-        <StudioDetails.Summary className={classes.accordionHeader}>
+        <StudioDetails.Summary onClick={handleSummaryClick} className={classes.accordionHeader}>
           {pageName}
         </StudioDetails.Summary>
         <StudioDetails.Content

--- a/src/Designer/frontend/packages/ux-editor-v3/src/containers/DesignView/PageAccordion/PageAccordion.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/containers/DesignView/PageAccordion/PageAccordion.tsx
@@ -63,8 +63,6 @@ export const PageAccordion = ({
     }
   }, [deleteLayout, layoutOrder, pageName, selectedLayout, setSearchParams, t]);
 
-  // The open state is driven entirely by isOpen, so the native toggle is prevented to stop
-  // Details from opening and closing the panel on its own before React updates.
   const handleSummaryClick = (event: MouseEvent<HTMLElement>): void => {
     event.preventDefault();
     onClick();
@@ -72,7 +70,7 @@ export const PageAccordion = ({
 
   return (
     <div className={cn(classes.accordionItem, pageIsReceipt && classes.receiptItem)}>
-      <StudioDetails open={isOpen} onToggle={onClick} className={classes.details}>
+      <StudioDetails open={isOpen} className={classes.details}>
         <StudioDetails.Summary onClick={handleSummaryClick} className={classes.accordionHeader}>
           {pageName}
         </StudioDetails.Summary>

--- a/src/Designer/frontend/packages/ux-editor-v3/src/containers/DesignView/PageAccordion/PageAccordion.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/containers/DesignView/PageAccordion/PageAccordion.tsx
@@ -2,7 +2,6 @@ import type { ReactNode } from 'react';
 import { useCallback } from 'react';
 import classes from './PageAccordion.module.css';
 import cn from 'classnames';
-import { Accordion } from '@digdir/designsystemet-react';
 import { NavigationMenu } from './NavigationMenu';
 import { pageAccordionContentId } from '@studio/testing/testids';
 import { TrashIcon } from '@studio/icons';
@@ -12,7 +11,7 @@ import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmen
 import { useAppContext } from '../../../hooks/useAppContext';
 import { firstAvailableLayout } from '../../../utils/formLayoutsUtils';
 import { useFormLayoutSettingsQuery } from '../../../hooks/queries/useFormLayoutSettingsQuery';
-import { StudioButton } from '@studio/components';
+import { StudioButton, StudioDetails } from '@studio/components';
 import { useDeleteLayout } from './useDeleteLayout';
 
 export type PageAccordionProps = {
@@ -65,32 +64,29 @@ export const PageAccordion = ({
   }, [deleteLayout, layoutOrder, pageName, selectedLayout, setSearchParams, t]);
 
   return (
-    <Accordion.Item
-      className={cn(classes.accordionItem, pageIsReceipt && classes.receiptItem)}
-      open={isOpen}
-    >
-      <div className={classes.accordionHeaderRow}>
-        <Accordion.Header className={classes.accordionHeader} level={3} onHeaderClick={onClick}>
+    <div className={cn(classes.accordionItem, pageIsReceipt && classes.receiptItem)}>
+      <StudioDetails open={isOpen} onToggle={onClick} className={classes.details}>
+        <StudioDetails.Summary className={classes.accordionHeader}>
           {pageName}
-        </Accordion.Header>
-        <div className={classes.navigationMenu}>
-          <NavigationMenu pageName={pageName} pageIsReceipt={pageIsReceipt} />
-          <StudioButton
-            color='danger'
-            icon={<TrashIcon aria-hidden />}
-            onClick={handleConfirmDelete}
-            title={t('general.delete_item', { item: pageName })}
-            variant='tertiary'
-            disabled={isPending}
-          />
-        </div>
+        </StudioDetails.Summary>
+        <StudioDetails.Content
+          data-testid={pageAccordionContentId(pageName)}
+          className={classes.accordionContent}
+        >
+          {children}
+        </StudioDetails.Content>
+      </StudioDetails>
+      <div className={classes.navigationMenu}>
+        <NavigationMenu pageName={pageName} pageIsReceipt={pageIsReceipt} />
+        <StudioButton
+          color='danger'
+          icon={<TrashIcon aria-hidden />}
+          onClick={handleConfirmDelete}
+          title={t('general.delete_item', { item: pageName })}
+          variant='tertiary'
+          disabled={isPending}
+        />
       </div>
-      <Accordion.Content
-        data-testid={pageAccordionContentId(pageName)}
-        className={classes.accordionContent}
-      >
-        {children}
-      </Accordion.Content>
-    </Accordion.Item>
+    </div>
   );
 };

--- a/src/Designer/frontend/packages/ux-editor-v3/src/containers/DesignView/ReceiptContent/ReceiptContent.test.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/containers/DesignView/ReceiptContent/ReceiptContent.test.tsx
@@ -67,7 +67,7 @@ describe('ReceiptContent', () => {
     const addButton = screen.getByRole('button', { name: textMock('receipt.create') });
     expect(addButton).toBeInTheDocument();
 
-    const receiptAccordion = screen.queryByRole('button', { name: mockReceiptName });
+    const receiptAccordion = screen.queryByText(mockReceiptName);
     expect(receiptAccordion).not.toBeInTheDocument();
   });
 
@@ -77,7 +77,7 @@ describe('ReceiptContent', () => {
     const addButton = screen.queryByRole('button', { name: textMock('receipt.create') });
     expect(addButton).not.toBeInTheDocument();
 
-    const receiptAccordion = screen.getByRole('button', { name: mockReceiptName });
+    const receiptAccordion = screen.getByText(mockReceiptName);
     expect(receiptAccordion).toBeInTheDocument();
   });
 
@@ -85,7 +85,7 @@ describe('ReceiptContent', () => {
     const user = userEvent.setup();
     await render();
 
-    const receiptButton = screen.getByRole('button', { name: mockReceiptName });
+    const receiptButton = screen.getByText(mockReceiptName);
     await user.click(receiptButton);
 
     expect(mockOnClickAccordion).toHaveBeenCalledTimes(1);
@@ -95,7 +95,7 @@ describe('ReceiptContent', () => {
     const user = userEvent.setup();
     await render({ selectedAccordion: mockPageName1 });
 
-    const receiptButton = screen.getByRole('button', { name: mockReceiptName });
+    const receiptButton = screen.getByText(mockReceiptName);
     await user.click(receiptButton);
 
     expect(mockOnClickAccordion).toHaveBeenCalledTimes(1);

--- a/src/Designer/frontend/packages/ux-editor-v3/src/containers/DesignView/ReceiptContent/ReceiptContent.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/containers/DesignView/ReceiptContent/ReceiptContent.tsx
@@ -2,7 +2,6 @@ import type { ReactNode } from 'react';
 import classes from './ReceiptContent.module.css';
 import type { FormLayoutPage } from '../../../types/FormLayoutPage';
 import { PageAccordion } from '../PageAccordion';
-import { Accordion } from '@digdir/designsystemet-react';
 import { useTranslation } from 'react-i18next';
 import { FormTree } from '../FormTree';
 import { StudioButton } from '@studio/components';
@@ -62,16 +61,14 @@ export const ReceiptContent = ({
     return (
       <div className={classes.wrapper}>
         <div className={classes.accordionWrapper}>
-          <Accordion color='neutral'>
-            <PageAccordion
-              pageName={receiptName}
-              isOpen={receiptName === selectedAccordion}
-              onClick={onClickAccordion}
-              pageIsReceipt
-            >
-              <FormTree layout={layout} />
-            </PageAccordion>
-          </Accordion>
+          <PageAccordion
+            pageName={receiptName}
+            isOpen={receiptName === selectedAccordion}
+            onClick={onClickAccordion}
+            pageIsReceipt
+          >
+            <FormTree layout={layout} />
+          </PageAccordion>
         </div>
       </div>
     );

--- a/src/Designer/frontend/packages/ux-editor-v4/src/components/Elements/DefaultToolbar.module.css
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/components/Elements/DefaultToolbar.module.css
@@ -1,12 +1,7 @@
-.accordionItem > div {
-  border-bottom: none !important;
+.detailsElement {
+  border-top: none;
 }
 
-.accordionHeader > button {
-  border: none;
-  padding: var(--ds-size-6) var(--ds-size-6);
-}
-
-.accordionContent {
-  padding: 0;
+.detailsContent {
+  margin-inline: 0;
 }

--- a/src/Designer/frontend/packages/ux-editor-v4/src/components/Elements/DefaultToolbar.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/components/Elements/DefaultToolbar.tsx
@@ -5,10 +5,10 @@ import classes from './DefaultToolbar.module.css';
 import { useTranslation } from 'react-i18next';
 import { schemaComponents, textComponents, advancedItems } from '../../data/formItemConfig';
 import type { KeyValuePairs } from 'app-shared/types/KeyValuePairs';
-import { Accordion } from '@digdir/designsystemet-react';
 import { getCollapsableMenuTitleByType } from '../../utils/language';
 import { ToolbarItem } from './ToolbarItem';
 import { useComponentTitle } from '@altinn/ux-editor-v4/hooks';
+import { StudioDetails } from '@studio/components';
 
 export const DefaultToolbar = () => {
   const { t } = useTranslation();
@@ -25,26 +25,23 @@ export const DefaultToolbar = () => {
 
   return Object.values(CollapsableMenus).map((key: CollapsableMenus) => {
     return (
-      <Accordion key={key}>
-        <Accordion.Item
-          defaultOpen={key === CollapsableMenus.Components}
-          className={classes.accordionItem}
-        >
-          <Accordion.Header className={classes.accordionHeader} level={3}>
-            {getCollapsableMenuTitleByType(key, t)}
-          </Accordion.Header>
-          <Accordion.Content className={classes.accordionContent}>
-            {allComponentLists[key].map((component: IToolbarElement) => (
-              <ToolbarItem
-                componentTitle={getComponentTitle(component)}
-                icon={component.icon}
-                componentType={component.type}
-                key={component.type}
-              />
-            ))}
-          </Accordion.Content>
-        </Accordion.Item>
-      </Accordion>
+      <StudioDetails
+        key={key}
+        defaultOpen={key === CollapsableMenus.Components}
+        className={classes.detailsElement}
+      >
+        <StudioDetails.Summary>{getCollapsableMenuTitleByType(key, t)}</StudioDetails.Summary>
+        <StudioDetails.Content className={classes.detailsContent}>
+          {allComponentLists[key].map((component: IToolbarElement) => (
+            <ToolbarItem
+              componentTitle={getComponentTitle(component)}
+              icon={component.icon}
+              componentType={component.type}
+              key={component.type}
+            />
+          ))}
+        </StudioDetails.Content>
+      </StudioDetails>
     );
   });
 };

--- a/src/Designer/frontend/packages/ux-editor-v4/src/components/Properties/ComponentConfigPanel/ComponentConfigPanel.module.css
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/components/Properties/ComponentConfigPanel/ComponentConfigPanel.module.css
@@ -1,8 +1,7 @@
-.accordionContent {
-  padding: var(--fds-spacing-5) 0;
-  background-color: var(--fds-semantic-surface-neutral-default);
-}
-
 .unknownComponentAlert {
   padding: var(--fds-spacing-5);
+}
+
+.accordionContent {
+  margin-inline: 0;
 }

--- a/src/Designer/frontend/packages/ux-editor-v4/src/components/Properties/ComponentConfigPanel/ComponentConfigPanel.test.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/components/Properties/ComponentConfigPanel/ComponentConfigPanel.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { UserEvent } from '@testing-library/user-event';
 import { textMock } from '@studio/testing/mocks/i18nMock';
@@ -54,12 +54,18 @@ const editFormComponentSpy = jest.spyOn(
 
 const expressionsTestId = 'expressions';
 
+const getAccordionSummary = (name: string): HTMLElement => screen.getByText(name);
+
+const getAccordion = (name: string): HTMLElement =>
+  screen.getAllByRole('group').find((accordion) => within(accordion).queryByText(name));
+
 const expectToggleAccordion = async (name: string, user: UserEvent) => {
-  const button = screen.getByRole('button', { name });
-  await user.click(button);
-  expect(button).toHaveAttribute('aria-expanded', 'true');
-  await user.click(button);
-  expect(button).toHaveAttribute('aria-expanded', 'false');
+  const summary = getAccordionSummary(name);
+  const accordion = getAccordion(name);
+  await user.click(summary);
+  expect(accordion).toHaveAttribute('open');
+  await user.click(summary);
+  expect(accordion).not.toHaveAttribute('open');
 };
 
 describe('ComponentConfigPanel', () => {
@@ -132,18 +138,10 @@ describe('ComponentConfigPanel', () => {
     it('has all accordion items closed by default', async () => {
       const { rerender } = renderComponentConfig();
       rerender(getComponent());
-      const textAccordion = screen.getByRole('button', { name: textMock('right_menu.text') });
-      expect(textAccordion).toHaveAttribute('aria-expanded', 'false');
-      const dataModelBindingsAccordion = screen.getByRole('button', {
-        name: textMock('right_menu.data_model_bindings'),
-      });
-      expect(dataModelBindingsAccordion).toHaveAttribute('aria-expanded', 'false');
-      const contentAccordion = screen.getByRole('button', { name: textMock('right_menu.content') });
-      expect(contentAccordion).toHaveAttribute('aria-expanded', 'false');
-      const dynamicsAccordion = screen.getByRole('button', {
-        name: textMock('right_menu.dynamics'),
-      });
-      expect(dynamicsAccordion).toHaveAttribute('aria-expanded', 'false');
+      expect(getAccordion(textMock('right_menu.text'))).not.toHaveAttribute('open');
+      expect(getAccordion(textMock('right_menu.data_model_bindings'))).not.toHaveAttribute('open');
+      expect(getAccordion(textMock('right_menu.content'))).not.toHaveAttribute('open');
+      expect(getAccordion(textMock('right_menu.dynamics'))).not.toHaveAttribute('open');
     });
   });
 
@@ -194,10 +192,10 @@ describe('ComponentConfigPanel', () => {
 
     it('should not render summary overrides accordion when formItem is not a Summary2 component', () => {
       renderComponentConfig();
-      const button = screen.queryByRole('button', {
-        name: textMock('ux_editor.component_properties.summary.override.title'),
-      });
-      expect(button).not.toBeInTheDocument();
+      const summary = screen.queryByText(
+        textMock('ux_editor.component_properties.summary.override.title'),
+      );
+      expect(summary).not.toBeInTheDocument();
     });
   });
 
@@ -211,9 +209,7 @@ describe('ComponentConfigPanel', () => {
 
     it('Sets accordion title to include images when component is image', async () => {
       renderComponentConfig({ formItem: componentMocks[ComponentType.Image] });
-      const accordionTitle = screen.queryByRole('button', {
-        name: textMock('right_menu.text_and_image'),
-      });
+      const accordionTitle = screen.queryByText(textMock('right_menu.text_and_image'));
       expect(accordionTitle).toBeInTheDocument();
     });
   });
@@ -230,8 +226,7 @@ describe('ComponentConfigPanel', () => {
   describe('Content', () => {
     it('Closes content on load', () => {
       renderComponentConfig();
-      const button = screen.queryByRole('button', { name: textMock('right_menu.content') });
-      expect(button).toHaveAttribute('aria-expanded', 'false');
+      expect(getAccordion(textMock('right_menu.content'))).not.toHaveAttribute('open');
     });
 
     it('Toggles content when clicked', async () => {
@@ -245,8 +240,7 @@ describe('ComponentConfigPanel', () => {
   describe('Dynamics', () => {
     it('Closes dynamics on load', () => {
       renderComponentConfig();
-      const button = screen.queryByRole('button', { name: textMock('right_menu.dynamics') });
-      expect(button).toHaveAttribute('aria-expanded', 'false');
+      expect(getAccordion(textMock('right_menu.dynamics'))).not.toHaveAttribute('open');
     });
 
     it('Toggles dynamics when clicked', async () => {

--- a/src/Designer/frontend/packages/ux-editor-v4/src/components/Properties/ComponentConfigPanel/ComponentConfigPanel.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/components/Properties/ComponentConfigPanel/ComponentConfigPanel.tsx
@@ -1,8 +1,7 @@
 import { Text } from '../Text';
 import { useFormItemContext } from '../../../containers/FormItemContext';
-import { Accordion } from '@digdir/designsystemet-react';
 import { ComponentType } from 'app-shared/types/ComponentType';
-import { StudioSpinner } from '@studio/components';
+import { StudioSpinner, StudioDetails } from '@studio/components';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Summary2Override } from '../../config/componentSpecificContent/Summary2/Override/Summary2Override';
@@ -61,75 +60,75 @@ export const ComponentConfigPanel = ({ selectedItem }: ComponentConfigPanelProps
   return (
     <>
       <ComponentConfigHeader />
-      <Accordion>
-        {formItem.type === ComponentType.Summary2 && (
-          <Accordion.Item
-            open={openList.includes('summary2overrides')}
-            key={`${formItemId}-summary2overrides`}
-          >
-            <Accordion.Header onHeaderClick={() => toggleOpen('summary2overrides')}>
-              {t('ux_editor.component_properties.summary.override.title')}
-            </Accordion.Header>
-            <Accordion.Content>
-              <Summary2Override component={formItem} onChange={handleUpdate} />
-            </Accordion.Content>
-          </Accordion.Item>
-        )}
-        {hasTextProperties && (
-          <Accordion.Item
-            open={openList.includes('text')}
-            key={`${formItemId}-textResourceBindings`}
-          >
-            <Accordion.Header
-              aria-label={t('right_menu.text_label')}
-              onHeaderClick={() => toggleOpen('text')}
-            >
-              {t(formItem.type === 'Image' ? 'right_menu.text_and_image' : 'right_menu.text')}
-            </Accordion.Header>
-            <Accordion.Content className={classes.accordionContent}>
-              <Text />
-            </Accordion.Content>
-          </Accordion.Item>
-        )}
-        {hasDataModelBindingProperties && (
-          <Accordion.Item
-            open={openList.includes('dataModel')}
-            key={`${formItemId}-dataModelBindings`}
-          >
-            <Accordion.Header onHeaderClick={() => toggleOpen('dataModel')}>
-              {t('right_menu.data_model_bindings')}
-            </Accordion.Header>
-            <Accordion.Content className={classes.accordionContent}>
-              <DataModelBindings />
-            </Accordion.Content>
-          </Accordion.Item>
-        )}
-        {hasOtherProperties && (
-          <Accordion.Item open={openList.includes('content')} key={`${formItemId}-content`}>
-            <Accordion.Header onHeaderClick={() => toggleOpen('content')}>
-              {t('right_menu.content')}
-            </Accordion.Header>
-            <Accordion.Content className={classes.accordionContent}>
-              <EditFormComponent
-                editFormId={formItemId}
-                component={formItem}
-                handleComponentUpdate={async (updatedComponent, mutateOptions) => {
-                  handleUpdate(updatedComponent);
-                  debounceSave(formItemId, updatedComponent, mutateOptions);
-                }}
-              />
-            </Accordion.Content>
-          </Accordion.Item>
-        )}
-        <Accordion.Item open={openList.includes('dynamics')} key={`${formItemId}-dynamics`}>
-          <Accordion.Header onHeaderClick={() => toggleOpen('dynamics')}>
-            {t('right_menu.dynamics')}
-          </Accordion.Header>
-          <Accordion.Content>
-            <Expressions />
-          </Accordion.Content>
-        </Accordion.Item>
-      </Accordion>
+      {formItem.type === ComponentType.Summary2 && (
+        <StudioDetails
+          onToggle={() => toggleOpen('summary2overrides')}
+          open={openList.includes('summary2overrides')}
+          key={`${formItemId}-summary2overrides`}
+        >
+          <StudioDetails.Summary>
+            {t('ux_editor.component_properties.summary.override.title')}
+          </StudioDetails.Summary>
+          <StudioDetails.Content className={classes.accordionContent}>
+            <Summary2Override component={formItem} onChange={handleUpdate} />
+          </StudioDetails.Content>
+        </StudioDetails>
+      )}
+      {hasTextProperties && (
+        <StudioDetails
+          onToggle={() => toggleOpen('text')}
+          open={openList.includes('text')}
+          key={`${formItemId}-textResourceBindings`}
+        >
+          <StudioDetails.Summary aria-label={t('right_menu.text_label')}>
+            {t(formItem.type === 'Image' ? 'right_menu.text_and_image' : 'right_menu.text')}
+          </StudioDetails.Summary>
+          <StudioDetails.Content className={classes.accordionContent}>
+            <Text />
+          </StudioDetails.Content>
+        </StudioDetails>
+      )}
+      {hasDataModelBindingProperties && (
+        <StudioDetails
+          onToggle={() => toggleOpen('dataModel')}
+          open={openList.includes('dataModel')}
+          key={`${formItemId}-dataModelBindings`}
+        >
+          <StudioDetails.Summary>{t('right_menu.data_model_bindings')}</StudioDetails.Summary>
+          <StudioDetails.Content className={classes.accordionContent}>
+            <DataModelBindings />
+          </StudioDetails.Content>
+        </StudioDetails>
+      )}
+      {hasOtherProperties && (
+        <StudioDetails
+          onToggle={() => toggleOpen('content')}
+          open={openList.includes('content')}
+          key={`${formItemId}-content`}
+        >
+          <StudioDetails.Summary>{t('right_menu.content')}</StudioDetails.Summary>
+          <StudioDetails.Content className={classes.accordionContent}>
+            <EditFormComponent
+              editFormId={formItemId}
+              component={formItem}
+              handleComponentUpdate={async (updatedComponent, mutateOptions) => {
+                handleUpdate(updatedComponent);
+                debounceSave(formItemId, updatedComponent, mutateOptions);
+              }}
+            />
+          </StudioDetails.Content>
+        </StudioDetails>
+      )}
+      <StudioDetails
+        onToggle={() => toggleOpen('dynamics')}
+        open={openList.includes('dynamics')}
+        key={`${formItemId}-dynamics`}
+      >
+        <StudioDetails.Summary>{t('right_menu.dynamics')}</StudioDetails.Summary>
+        <StudioDetails.Content className={classes.accordionContent}>
+          <Expressions />
+        </StudioDetails.Content>
+      </StudioDetails>
     </>
   );
 };

--- a/src/Designer/frontend/packages/ux-editor-v4/src/components/Properties/ComponentConfigPanel/ComponentConfigPanel.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/components/Properties/ComponentConfigPanel/ComponentConfigPanel.tsx
@@ -125,7 +125,7 @@ export const ComponentConfigPanel = ({ selectedItem }: ComponentConfigPanelProps
         key={`${formItemId}-dynamics`}
       >
         <StudioDetails.Summary>{t('right_menu.dynamics')}</StudioDetails.Summary>
-        <StudioDetails.Content className={classes.accordionContent}>
+        <StudioDetails.Content>
           <Expressions />
         </StudioDetails.Content>
       </StudioDetails>

--- a/src/Designer/frontend/packages/ux-editor-v4/src/components/Properties/PageConfigPanel/PageConfigPanel.module.css
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/components/Properties/PageConfigPanel/PageConfigPanel.module.css
@@ -1,6 +1,6 @@
 .pdf,
 .text {
-  padding: var(--fds-spacing-5) 0;
+  margin-inline: 0;
 }
 
 .mainConfig {

--- a/src/Designer/frontend/packages/ux-editor-v4/src/components/Properties/PageConfigPanel/PageConfigPanel.test.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/components/Properties/PageConfigPanel/PageConfigPanel.test.tsx
@@ -56,8 +56,9 @@ describe('PageConfigPanel', () => {
   it('render all accordion items when layout is selected', async () => {
     const newSelectedPage = layout1NameMock;
     renderPageConfigPanel(newSelectedPage);
-    screen.getByRole('button', { name: textMock('right_menu.text') });
-    screen.getByRole('button', { name: textMock('right_menu.dynamics') });
+    screen.getByText(textMock('right_menu.text'));
+    screen.getByText(textMock('right_menu.dynamics'));
+    screen.getByText(textMock('right_menu.pdf'));
   });
 
   it('render warning when layout is selected and has duplicated ids', () => {

--- a/src/Designer/frontend/packages/ux-editor-v4/src/components/Properties/PageConfigPanel/PageConfigPanel.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/components/Properties/PageConfigPanel/PageConfigPanel.tsx
@@ -68,7 +68,7 @@ export const PageConfigPanel = ({ selectedItem }: PageConfigPanelProps) => {
         </StudioDetails>
         <StudioDetails>
           <StudioDetails.Summary>{t('right_menu.dynamics')}</StudioDetails.Summary>
-          <StudioDetails.Content className={classes.dynamics}>
+          <StudioDetails.Content>
             <HiddenExpressionOnLayout />
           </StudioDetails.Content>
         </StudioDetails>

--- a/src/Designer/frontend/packages/ux-editor-v4/src/components/Properties/PageConfigPanel/PageConfigPanel.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/components/Properties/PageConfigPanel/PageConfigPanel.tsx
@@ -1,5 +1,5 @@
 import { Fragment } from 'react';
-import { Accordion } from '@digdir/designsystemet-react';
+import { StudioDetails } from '@studio/components';
 import { FileIcon } from '@studio/icons';
 import { useText, useFormLayouts } from '../../../hooks';
 import { useTextResourcesSelector } from 'app-shared/hooks';
@@ -60,26 +60,24 @@ export const PageConfigPanel = ({ selectedItem }: PageConfigPanelProps) => {
           <EditPageId layoutName={selectedItem.id} />
           <NameConfig selectedItem={selectedItem} />
         </div>
-        <Accordion>
-          <Accordion.Item>
-            <Accordion.Header>{t('right_menu.text')}</Accordion.Header>
-            <Accordion.Content className={classes.text}>
-              <NameConfig selectedItem={selectedItem} />
-            </Accordion.Content>
-          </Accordion.Item>
-          <Accordion.Item>
-            <Accordion.Header>{t('right_menu.dynamics')}</Accordion.Header>
-            <Accordion.Content>
-              <HiddenExpressionOnLayout />
-            </Accordion.Content>
-          </Accordion.Item>
-          <Accordion.Item>
-            <Accordion.Header>{t('right_menu.pdf')}</Accordion.Header>
-            <Accordion.Content className={classes.pdf}>
-              <PdfConfig />
-            </Accordion.Content>
-          </Accordion.Item>
-        </Accordion>
+        <StudioDetails>
+          <StudioDetails.Summary>{t('right_menu.text')}</StudioDetails.Summary>
+          <StudioDetails.Content className={classes.text}>
+            <NameConfig selectedItem={selectedItem} />
+          </StudioDetails.Content>
+        </StudioDetails>
+        <StudioDetails>
+          <StudioDetails.Summary>{t('right_menu.dynamics')}</StudioDetails.Summary>
+          <StudioDetails.Content className={classes.dynamics}>
+            <HiddenExpressionOnLayout />
+          </StudioDetails.Content>
+        </StudioDetails>
+        <StudioDetails>
+          <StudioDetails.Summary>{t('right_menu.pdf')}</StudioDetails.Summary>
+          <StudioDetails.Content className={classes.pdf}>
+            <PdfConfig />
+          </StudioDetails.Content>
+        </StudioDetails>
       </Fragment>
       <PageConfigWarningModal open={hasDuplicatedIdsInAllLayouts} />
     </>

--- a/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/DesignView.test.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/DesignView.test.tsx
@@ -39,7 +39,7 @@ describe('DesignView', () => {
     renderDesignView({});
 
     formLayoutSettingsMock.pages.order.forEach((page) => {
-      const accordionButton = screen.getByRole('button', { name: page });
+      const accordionButton = screen.getByText(page);
       expect(accordionButton).toBeInTheDocument();
     });
   });
@@ -92,7 +92,7 @@ describe('DesignView', () => {
     const user = userEvent.setup();
     renderDesignView({});
 
-    const accordionButton1 = screen.getByRole('button', { name: mockPageName1 });
+    const accordionButton1 = screen.getByText(mockPageName1);
     await user.click(accordionButton1);
 
     expect(appContextMock.setSelectedFormLayoutName).toHaveBeenCalledTimes(1);
@@ -103,7 +103,7 @@ describe('DesignView', () => {
     const user = userEvent.setup();
     renderDesignView({});
 
-    const accordionButton2 = screen.getByRole('button', { name: mockPageName2 });
+    const accordionButton2 = screen.getByText(mockPageName2);
     await user.click(accordionButton2);
 
     expect(appContextMock.setSelectedFormLayoutName).toHaveBeenCalledTimes(1);
@@ -138,7 +138,7 @@ describe('DesignView', () => {
       layoutSettings: { ...formLayoutSettingsMock, pages: { order: [], pdfLayoutName } },
       externalLayout: { [pdfLayoutName]: layout1Mock },
     });
-    const pdfAccordionButton = screen.getByRole('button', { name: pdfLayoutName });
+    const pdfAccordionButton = screen.getByText(pdfLayoutName);
     expect(pdfAccordionButton).toBeInTheDocument();
     consoleWarnSpy.mockRestore();
   });
@@ -164,7 +164,7 @@ describe('DesignView', () => {
     const user = userEvent.setup();
     appContextMock.selectedFormLayoutName = layout2NameMock;
     renderDesignView({ pagesModel: groupsPagesModelMock });
-    const accordionButton = screen.getByRole('button', { name: layout1NameMock });
+    const accordionButton = screen.getByText(layout1NameMock);
     await user.click(accordionButton);
     expect(appContextMock.setSelectedFormLayoutName).toHaveBeenCalledTimes(1);
     expect(appContextMock.setSelectedFormLayoutName).toHaveBeenCalledWith(layout1NameMock);
@@ -174,7 +174,7 @@ describe('DesignView', () => {
     const user = userEvent.setup();
     appContextMock.selectedFormLayoutName = layout1NameMock;
     renderDesignView({ pagesModel: groupsPagesModelMock });
-    const accordionButton = screen.getByRole('button', { name: layout1NameMock });
+    const accordionButton = screen.getByText(layout1NameMock);
     await user.click(accordionButton);
     expect(appContextMock.setSelectedFormLayoutName).toHaveBeenCalledTimes(1);
     expect(appContextMock.setSelectedFormLayoutName).toHaveBeenCalledWith(undefined);

--- a/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/DesignView.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/DesignView.tsx
@@ -3,7 +3,6 @@ import { useMemo } from 'react';
 import classes from './DesignView.module.css';
 import { useTranslation } from 'react-i18next';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
-import { Accordion } from '@digdir/designsystemet-react';
 import { useFormLayoutSettingsQuery } from '../../hooks/queries/useFormLayoutSettingsQuery';
 import { PageAccordion } from './PageAccordion';
 import { useAppContext, useFormLayouts } from '../../hooks';
@@ -171,9 +170,7 @@ export const DesignView = (): ReactNode => {
               isAddPagePending={isAddPageMutationPending}
             />
           ) : (
-            pagesModel?.pages?.length > 0 && (
-              <Accordion>{displayPageAccordions(pagesModel)}</Accordion>
-            )
+            pagesModel?.pages?.length > 0 && displayPageAccordions(pagesModel)
           )}
         </div>
       </div>

--- a/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/PageAccordion/PageAccordion.module.css
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/PageAccordion/PageAccordion.module.css
@@ -1,4 +1,4 @@
-.accordionItem {
+.detailsWrapper {
   display: grid;
   grid-template-columns: 1fr auto;
 }
@@ -9,13 +9,13 @@
   border-top: none;
 }
 
-.accordionHeaderWarning {
+.detailsWarning {
   --dsc-details-summary-background: var(--ds-color-danger-surface-tinted);
   --dsc-details-summary-background--hover: var(--ds-color-danger-surface-tinted);
   --dsc-details-summary-background--open: var(--ds-color-danger-surface-tinted);
 }
 
-.accordionContent {
+.detailsContent {
   margin: 0;
 }
 
@@ -30,5 +30,5 @@
 }
 
 .pdfIcon {
-  font-size: var(--fds-sizing-6);
+  font-size: var(--ds-size-7);
 }

--- a/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/PageAccordion/PageAccordion.module.css
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/PageAccordion/PageAccordion.module.css
@@ -1,44 +1,34 @@
-.navigationMenu {
-  display: flex;
-  align-items: center;
-  padding: var(--fds-spacing-1);
+.accordionItem {
+  display: grid;
+  grid-template-columns: 1fr auto;
 }
 
-.accordionSelected {
-  background-color: var(--fds-semantic-surface-action-first-no_fill-hover);
+.details {
+  grid-column: 1 / -1;
+  grid-row: 1;
+  min-width: 0;
 }
 
-.accordionHeader,
 .accordionHeaderWarning {
-  flex: 1;
-}
-
-.accordionHeaderWarning button {
-  background-color: var(--fds-semantic-surface-danger-subtle) !important;
+  --dsc-details-summary-background: var(--fds-semantic-surface-danger-subtle);
+  --dsc-details-summary-background--hover: var(--fds-semantic-surface-danger-subtle);
+  --dsc-details-summary-background--open: var(--fds-semantic-surface-danger-subtle);
 }
 
 .accordionContent {
-  padding: 0;
-  background-color: var(--fds-semantic-surface-neutral-default);
+  margin: 0;
 }
 
-.accordionItem:not(:first-child) {
-  border-top: 1px solid var(--fds-semantic-border-neutral-subtle);
-}
-
-.headerContent button {
-  border: none;
-  padding: var(--ds-size-6) var(--ds-size-6);
-}
-
-.accordionHeaderRow {
+.navigationMenu {
+  grid-column: 2;
+  grid-row: 1;
+  align-self: start;
+  z-index: 1;
   display: flex;
+  align-items: center;
+  padding: var(--ds-size-1);
 }
 
 .pdfIcon {
   font-size: var(--fds-sizing-6);
-}
-
-.customNavigationMenu {
-  background-color: var(--fds-semantic-surface-neutral-neutral);
 }

--- a/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/PageAccordion/PageAccordion.module.css
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/PageAccordion/PageAccordion.module.css
@@ -6,13 +6,13 @@
 .details {
   grid-column: 1 / -1;
   grid-row: 1;
-  min-width: 0;
+  border-top: none;
 }
 
 .accordionHeaderWarning {
-  --dsc-details-summary-background: var(--fds-semantic-surface-danger-subtle);
-  --dsc-details-summary-background--hover: var(--fds-semantic-surface-danger-subtle);
-  --dsc-details-summary-background--open: var(--fds-semantic-surface-danger-subtle);
+  --dsc-details-summary-background: var(--ds-color-danger-surface-tinted);
+  --dsc-details-summary-background--hover: var(--ds-color-danger-surface-tinted);
+  --dsc-details-summary-background--open: var(--ds-color-danger-surface-tinted);
 }
 
 .accordionContent {

--- a/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/PageAccordion/PageAccordion.test.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/PageAccordion/PageAccordion.test.tsx
@@ -44,7 +44,7 @@ describe('PageAccordion', () => {
     const user = userEvent.setup();
     await render();
 
-    const accordionButton = screen.getByRole('button', { name: mockPageName1 });
+    const accordionButton = screen.getByText(mockPageName1);
     await user.click(accordionButton);
 
     expect(mockOnClick).toHaveBeenCalledTimes(1);
@@ -149,20 +149,17 @@ describe('PageAccordion', () => {
     await render({ props: { isInvalid: true } });
     const headerContainer = screen.getByTestId(`accordion-header-${mockPageName1}`);
     expect(headerContainer).toHaveClass('accordionHeaderWarning');
-    expect(headerContainer).not.toHaveClass('accordionHeader');
   });
 
   it('render warning class to header when hasDuplicatedIds is true', async () => {
     await render({ props: { hasDuplicatedIds: true } });
     const headerContainer = screen.getByTestId(`accordion-header-${mockPageName1}`);
     expect(headerContainer).toHaveClass('accordionHeaderWarning');
-    expect(headerContainer).not.toHaveClass('accordionHeader');
   });
 
-  it('Applies normal header class when neither isInvalid nor hasDuplicatedIds is true', async () => {
+  it('does not render warning class when neither isInvalid nor hasDuplicatedIds is true', async () => {
     await render({ props: { isInvalid: false, hasDuplicatedIds: false } });
     const headerContainer = screen.getByTestId(`accordion-header-${mockPageName1}`);
-    expect(headerContainer).toHaveClass('accordionHeader');
     expect(headerContainer).not.toHaveClass('accordionHeaderWarning');
   });
 });

--- a/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/PageAccordion/PageAccordion.test.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/PageAccordion/PageAccordion.test.tsx
@@ -148,19 +148,19 @@ describe('PageAccordion', () => {
   it('render warning class to header when isInvalid is true', async () => {
     await render({ props: { isInvalid: true } });
     const headerContainer = screen.getByTestId(`accordion-header-${mockPageName1}`);
-    expect(headerContainer).toHaveClass('accordionHeaderWarning');
+    expect(headerContainer).toHaveClass('detailsWarning');
   });
 
   it('render warning class to header when hasDuplicatedIds is true', async () => {
     await render({ props: { hasDuplicatedIds: true } });
     const headerContainer = screen.getByTestId(`accordion-header-${mockPageName1}`);
-    expect(headerContainer).toHaveClass('accordionHeaderWarning');
+    expect(headerContainer).toHaveClass('detailsWarning');
   });
 
   it('does not render warning class when neither isInvalid nor hasDuplicatedIds is true', async () => {
     await render({ props: { isInvalid: false, hasDuplicatedIds: false } });
     const headerContainer = screen.getByTestId(`accordion-header-${mockPageName1}`);
-    expect(headerContainer).not.toHaveClass('accordionHeaderWarning');
+    expect(headerContainer).not.toHaveClass('detailsWarning');
   });
 });
 

--- a/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/PageAccordion/PageAccordion.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/PageAccordion/PageAccordion.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { MouseEvent, ReactNode } from 'react';
 import classes from './PageAccordion.module.css';
 import { NavigationMenu } from './NavigationMenu';
 import { accordionHeaderId, pageAccordionContentId } from '@studio/testing/testids';
@@ -61,6 +61,13 @@ export const PageAccordion = ({
   const { mutate: deletePage, isPending } = useDeletePageMutation(org, app, layoutSet);
   const { mutate: changePageGroups } = useChangePageGroupOrder(org, app, layoutSet);
 
+  // The open state is driven entirely by isOpen, so the native toggle is prevented to stop
+  // Details from opening and closing the panel on its own before React updates.
+  const handleSummaryClick = (event: MouseEvent<HTMLElement>): void => {
+    event.preventDefault();
+    onClick();
+  };
+
   const isUsingGroups = isPagesModelWithGroups(pages);
   const handleConfirmDelete = () => {
     if (!confirm(t('ux_editor.page_delete_text'))) return;
@@ -77,12 +84,12 @@ export const PageAccordion = ({
       deletePage(pageId);
     }
   };
-
   return (
     <div className={classes.accordionItem}>
       <StudioDetails open={isOpen} onToggle={onClick} className={classes.details}>
         <StudioDetails.Summary
           data-testid={accordionHeaderId(pageId)}
+          onClick={handleSummaryClick}
           className={isInvalid || hasDuplicatedIds ? classes.accordionHeaderWarning : undefined}
         >
           {pageName || pageId}

--- a/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/PageAccordion/PageAccordion.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/PageAccordion/PageAccordion.tsx
@@ -61,8 +61,6 @@ export const PageAccordion = ({
   const { mutate: deletePage, isPending } = useDeletePageMutation(org, app, layoutSet);
   const { mutate: changePageGroups } = useChangePageGroupOrder(org, app, layoutSet);
 
-  // The open state is driven entirely by isOpen, so the native toggle is prevented to stop
-  // Details from opening and closing the panel on its own before React updates.
   const handleSummaryClick = (event: MouseEvent<HTMLElement>): void => {
     event.preventDefault();
     onClick();
@@ -87,7 +85,7 @@ export const PageAccordion = ({
 
   return (
     <div className={classes.detailsWrapper}>
-      <StudioDetails open={isOpen} onToggle={onClick} className={classes.details}>
+      <StudioDetails open={isOpen} className={classes.details}>
         <StudioDetails.Summary
           data-testid={accordionHeaderId(pageId)}
           onClick={handleSummaryClick}

--- a/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/PageAccordion/PageAccordion.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/PageAccordion/PageAccordion.tsx
@@ -84,19 +84,20 @@ export const PageAccordion = ({
       deletePage(pageId);
     }
   };
+
   return (
-    <div className={classes.accordionItem}>
+    <div className={classes.detailsWrapper}>
       <StudioDetails open={isOpen} onToggle={onClick} className={classes.details}>
         <StudioDetails.Summary
           data-testid={accordionHeaderId(pageId)}
           onClick={handleSummaryClick}
-          className={isInvalid || hasDuplicatedIds ? classes.accordionHeaderWarning : undefined}
+          className={isInvalid || hasDuplicatedIds ? classes.detailsWarning : undefined}
         >
           {pageName || pageId}
         </StudioDetails.Summary>
         <StudioDetails.Content
           data-testid={pageAccordionContentId(pageId)}
-          className={classes.accordionContent}
+          className={classes.detailsContent}
         >
           {children}
         </StudioDetails.Content>

--- a/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/PageAccordion/PageAccordion.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/PageAccordion/PageAccordion.tsx
@@ -1,13 +1,12 @@
 import type { ReactNode } from 'react';
 import classes from './PageAccordion.module.css';
-import { Accordion } from '@digdir/designsystemet-react';
 import { NavigationMenu } from './NavigationMenu';
 import { accordionHeaderId, pageAccordionContentId } from '@studio/testing/testids';
 import { FilePdfIcon, TrashIcon } from '@studio/icons';
 import { useTranslation } from 'react-i18next';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useAppContext } from '../../../hooks';
-import { StudioButton } from '@studio/components';
+import { StudioButton, StudioDetails } from '@studio/components';
 import { useDeletePageMutation } from '../../../hooks/mutations/useDeletePageMutation';
 import { usePagesQuery } from '../../../hooks/queries/usePagesQuery';
 import { useChangePageGroupOrder } from '../../../hooks/mutations/useChangePageGroupOrder';
@@ -15,7 +14,6 @@ import { getUpdatedGroupsExcludingPage } from '../../../utils/designViewUtils/de
 import { isPagesModelWithGroups } from 'app-shared/types/api/dto/PagesModel';
 import { useTextResourceValue } from '../../../components/TextResource/hooks/useTextResourceValue';
 
-import cn from 'classnames';
 import useUxEditorParams from '@altinn/ux-editor-v4/hooks/useUxEditorParams';
 
 export type PageAccordionProps = {
@@ -81,36 +79,32 @@ export const PageAccordion = ({
   };
 
   return (
-    <Accordion.Item open={isOpen} className={classes.accordionItem}>
-      <div className={classes.accordionHeaderRow}>
-        <div
+    <div className={classes.accordionItem}>
+      <StudioDetails open={isOpen} onToggle={onClick} className={classes.details}>
+        <StudioDetails.Summary
           data-testid={accordionHeaderId(pageId)}
-          className={
-            isInvalid || hasDuplicatedIds ? classes.accordionHeaderWarning : classes.accordionHeader
-          }
+          className={isInvalid || hasDuplicatedIds ? classes.accordionHeaderWarning : undefined}
         >
-          <Accordion.Header level={3} onHeaderClick={onClick} className={classes.headerContent}>
-            {pageName || pageId}
-          </Accordion.Header>
-        </div>
-        <div className={cn(classes.navigationMenu, { [classes.accordionSelected]: isOpen })}>
-          {pageIsPdf && <FilePdfIcon className={classes.pdfIcon} />}
-          {showNavigationMenu && <NavigationMenu pageName={pageId} />}
-          <StudioButton
-            icon={<TrashIcon aria-hidden />}
-            onClick={handleConfirmDelete}
-            title={t('general.delete_item', { item: pageName || pageId })}
-            variant='tertiary'
-            disabled={isPending}
-          />
-        </div>
+          {pageName || pageId}
+        </StudioDetails.Summary>
+        <StudioDetails.Content
+          data-testid={pageAccordionContentId(pageId)}
+          className={classes.accordionContent}
+        >
+          {children}
+        </StudioDetails.Content>
+      </StudioDetails>
+      <div className={classes.navigationMenu}>
+        {pageIsPdf && <FilePdfIcon className={classes.pdfIcon} />}
+        {showNavigationMenu && <NavigationMenu pageName={pageId} />}
+        <StudioButton
+          icon={<TrashIcon aria-hidden />}
+          onClick={handleConfirmDelete}
+          title={t('general.delete_item', { item: pageName || pageId })}
+          variant='tertiary'
+          disabled={isPending}
+        />
       </div>
-      <Accordion.Content
-        data-testid={pageAccordionContentId(pageId)}
-        className={classes.accordionContent}
-      >
-        {children}
-      </Accordion.Content>
-    </Accordion.Item>
+    </div>
   );
 };

--- a/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/PageGroupAccordion.module.css
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/PageGroupAccordion.module.css
@@ -35,7 +35,7 @@
   font-size: var(--ds-size-5);
 }
 
-.groupPageAccordionWrapper {
+.pageAccordionWrapper {
   margin: auto;
   width: 90%;
 }

--- a/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/PageGroupAccordion.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/PageGroupAccordion.tsx
@@ -29,7 +29,6 @@ import { useChangePageGroupOrder } from '../../hooks/mutations/useChangePageGrou
 import { useAppContext } from '../../hooks';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { pageGroupAccordionHeader } from '@studio/testing/testids';
-import { Accordion } from '@digdir/designsystemet-react';
 import cn from 'classnames';
 import { ItemType } from '../../../../ux-editor-v4/src/components/Properties/ItemType';
 import { usePagesQuery } from '../../hooks/queries/usePagesQuery';
@@ -162,7 +161,7 @@ export const PageGroupAccordion = ({
           const layout = layouts?.[page.id];
           const isInvalidLayout = layout ? duplicatedIdsExistsInLayout(layout) : false;
           return (
-            <Accordion key={page.id} className={classes.groupPageAccordionWrapper}>
+            <div key={page.id} className={classes.pageAccordionWrapper}>
               <PageAccordion
                 pageId={page.id}
                 isOpen={page.id === selectedFormLayoutName}
@@ -179,7 +178,7 @@ export const PageGroupAccordion = ({
                   />
                 )}
               </PageAccordion>
-            </Accordion>
+            </div>
           );
         })}
         <StudioButton

--- a/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/PdfLayout/PdfLayoutAccordion.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/PdfLayout/PdfLayoutAccordion.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { PageAccordion } from '@altinn/ux-editor-v4/containers/DesignView/PageAccordion';
 import { duplicatedIdsExistsInLayout } from '@altinn/ux-editor-v4/utils/formLayoutUtils';
 import { FormLayout } from '@altinn/ux-editor-v4/containers/DesignView/FormLayout';
-import { Accordion } from '@digdir/designsystemet-react';
 import { useFormLayouts } from '@altinn/ux-editor-v4/hooks';
 import { mapFormLayoutsToFormLayoutPages } from '@altinn/ux-editor-v4/utils/formLayoutsUtils';
 
@@ -24,23 +23,21 @@ export const PdfLayoutAccordion = ({
   if (!pdfLayoutData) return null;
 
   return (
-    <Accordion>
-      <PageAccordion
-        pageId={pdfLayoutData.page}
-        isOpen={pdfLayoutData.page === selectedFormLayoutName}
-        onClick={onAccordionClick}
-        isInvalid={duplicatedIdsExistsInLayout(pdfLayoutData.data)}
-        hasDuplicatedIds={hasDuplicatedIds}
-        showNavigationMenu={false}
-        pageIsPdf={true}
-      >
-        {pdfLayoutData.page === selectedFormLayoutName && (
-          <FormLayout
-            layout={pdfLayoutData.data}
-            isInvalid={duplicatedIdsExistsInLayout(pdfLayoutData.data)}
-          />
-        )}
-      </PageAccordion>
-    </Accordion>
+    <PageAccordion
+      pageId={pdfLayoutData.page}
+      isOpen={pdfLayoutData.page === selectedFormLayoutName}
+      onClick={onAccordionClick}
+      isInvalid={duplicatedIdsExistsInLayout(pdfLayoutData.data)}
+      hasDuplicatedIds={hasDuplicatedIds}
+      showNavigationMenu={false}
+      pageIsPdf={true}
+    >
+      {pdfLayoutData.page === selectedFormLayoutName && (
+        <FormLayout
+          layout={pdfLayoutData.data}
+          isInvalid={duplicatedIdsExistsInLayout(pdfLayoutData.data)}
+        />
+      )}
+    </PageAccordion>
   );
 };

--- a/src/Designer/frontend/packages/ux-editor/src/components/Elements/DefaultToolbar.module.css
+++ b/src/Designer/frontend/packages/ux-editor/src/components/Elements/DefaultToolbar.module.css
@@ -1,12 +1,7 @@
-.accordionItem > div {
-  border-bottom: none !important;
+.detailsElement {
+  border-top: none;
 }
 
-.accordionHeader > button {
-  border: none;
-  padding: var(--ds-size-6) var(--ds-size-6);
-}
-
-.accordionContent {
-  padding: 0;
+.detailsContent {
+  margin-inline: 0;
 }

--- a/src/Designer/frontend/packages/ux-editor/src/components/Elements/DefaultToolbar.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/components/Elements/DefaultToolbar.tsx
@@ -5,10 +5,10 @@ import classes from './DefaultToolbar.module.css';
 import { useTranslation } from 'react-i18next';
 import { schemaComponents, textComponents, advancedItems } from '../../data/formItemConfig';
 import type { KeyValuePairs } from 'app-shared/types/KeyValuePairs';
-import { Accordion } from '@digdir/designsystemet-react';
 import { getCollapsableMenuTitleByType } from '../../utils/language';
 import { ToolbarItem } from './ToolbarItem';
 import { useComponentTitle } from '@altinn/ux-editor/hooks';
+import { StudioDetails } from '@studio/components';
 
 export const DefaultToolbar = () => {
   const { t } = useTranslation();
@@ -25,26 +25,23 @@ export const DefaultToolbar = () => {
 
   return Object.values(CollapsableMenus).map((key: CollapsableMenus) => {
     return (
-      <Accordion key={key}>
-        <Accordion.Item
-          defaultOpen={key === CollapsableMenus.Components}
-          className={classes.accordionItem}
-        >
-          <Accordion.Header className={classes.accordionHeader} level={3}>
-            {getCollapsableMenuTitleByType(key, t)}
-          </Accordion.Header>
-          <Accordion.Content className={classes.accordionContent}>
-            {allComponentLists[key].map((component: IToolbarElement) => (
-              <ToolbarItem
-                componentTitle={getComponentTitle(component)}
-                icon={component.icon}
-                componentType={component.type}
-                key={component.type}
-              />
-            ))}
-          </Accordion.Content>
-        </Accordion.Item>
-      </Accordion>
+      <StudioDetails
+        key={key}
+        defaultOpen={key === CollapsableMenus.Components}
+        className={classes.detailsElement}
+      >
+        <StudioDetails.Summary>{getCollapsableMenuTitleByType(key, t)}</StudioDetails.Summary>
+        <StudioDetails.Content className={classes.detailsContent}>
+          {allComponentLists[key].map((component: IToolbarElement) => (
+            <ToolbarItem
+              componentTitle={getComponentTitle(component)}
+              icon={component.icon}
+              componentType={component.type}
+              key={component.type}
+            />
+          ))}
+        </StudioDetails.Content>
+      </StudioDetails>
     );
   });
 };

--- a/src/Designer/frontend/packages/ux-editor/src/components/Properties/ComponentConfigPanel/ComponentConfigPanel.module.css
+++ b/src/Designer/frontend/packages/ux-editor/src/components/Properties/ComponentConfigPanel/ComponentConfigPanel.module.css
@@ -1,8 +1,7 @@
-.accordionContent {
-  padding: var(--fds-spacing-5) 0;
-  background-color: var(--fds-semantic-surface-neutral-default);
-}
-
 .unknownComponentAlert {
   padding: var(--fds-spacing-5);
+}
+
+.accordionContent {
+  margin-inline: 0;
 }

--- a/src/Designer/frontend/packages/ux-editor/src/components/Properties/ComponentConfigPanel/ComponentConfigPanel.test.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/components/Properties/ComponentConfigPanel/ComponentConfigPanel.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { UserEvent } from '@testing-library/user-event';
 import { textMock } from '@studio/testing/mocks/i18nMock';
@@ -54,12 +54,18 @@ const editFormComponentSpy = jest.spyOn(
 
 const expressionsTestId = 'expressions';
 
+const getAccordionSummary = (name: string): HTMLElement => screen.getByText(name);
+
+const getAccordion = (name: string): HTMLElement =>
+  screen.getAllByRole('group').find((accordion) => within(accordion).queryByText(name));
+
 const expectToggleAccordion = async (name: string, user: UserEvent) => {
-  const button = screen.getByRole('button', { name });
-  await user.click(button);
-  expect(button).toHaveAttribute('aria-expanded', 'true');
-  await user.click(button);
-  expect(button).toHaveAttribute('aria-expanded', 'false');
+  const summary = getAccordionSummary(name);
+  const accordion = getAccordion(name);
+  await user.click(summary);
+  expect(accordion).toHaveAttribute('open');
+  await user.click(summary);
+  expect(accordion).not.toHaveAttribute('open');
 };
 
 describe('ComponentConfigPanel', () => {
@@ -132,18 +138,10 @@ describe('ComponentConfigPanel', () => {
     it('has all accordion items closed by default', async () => {
       const { rerender } = renderComponentConfig();
       rerender(getComponent());
-      const textAccordion = screen.getByRole('button', { name: textMock('right_menu.text') });
-      expect(textAccordion).toHaveAttribute('aria-expanded', 'false');
-      const dataModelBindingsAccordion = screen.getByRole('button', {
-        name: textMock('right_menu.data_model_bindings'),
-      });
-      expect(dataModelBindingsAccordion).toHaveAttribute('aria-expanded', 'false');
-      const contentAccordion = screen.getByRole('button', { name: textMock('right_menu.content') });
-      expect(contentAccordion).toHaveAttribute('aria-expanded', 'false');
-      const dynamicsAccordion = screen.getByRole('button', {
-        name: textMock('right_menu.dynamics'),
-      });
-      expect(dynamicsAccordion).toHaveAttribute('aria-expanded', 'false');
+      expect(getAccordion(textMock('right_menu.text'))).not.toHaveAttribute('open');
+      expect(getAccordion(textMock('right_menu.data_model_bindings'))).not.toHaveAttribute('open');
+      expect(getAccordion(textMock('right_menu.content'))).not.toHaveAttribute('open');
+      expect(getAccordion(textMock('right_menu.dynamics'))).not.toHaveAttribute('open');
     });
   });
 
@@ -194,10 +192,10 @@ describe('ComponentConfigPanel', () => {
 
     it('should not render summary overrides accordion when formItem is not a Summary2 component', () => {
       renderComponentConfig();
-      const button = screen.queryByRole('button', {
-        name: textMock('ux_editor.component_properties.summary.override.title'),
-      });
-      expect(button).not.toBeInTheDocument();
+      const summary = screen.queryByText(
+        textMock('ux_editor.component_properties.summary.override.title'),
+      );
+      expect(summary).not.toBeInTheDocument();
     });
   });
 
@@ -211,9 +209,7 @@ describe('ComponentConfigPanel', () => {
 
     it('Sets accordion title to include images when component is image', async () => {
       renderComponentConfig({ formItem: componentMocks[ComponentType.Image] });
-      const accordionTitle = screen.queryByRole('button', {
-        name: textMock('right_menu.text_and_image'),
-      });
+      const accordionTitle = screen.queryByText(textMock('right_menu.text_and_image'));
       expect(accordionTitle).toBeInTheDocument();
     });
   });
@@ -230,8 +226,7 @@ describe('ComponentConfigPanel', () => {
   describe('Content', () => {
     it('Closes content on load', () => {
       renderComponentConfig();
-      const button = screen.queryByRole('button', { name: textMock('right_menu.content') });
-      expect(button).toHaveAttribute('aria-expanded', 'false');
+      expect(getAccordion(textMock('right_menu.content'))).not.toHaveAttribute('open');
     });
 
     it('Toggles content when clicked', async () => {
@@ -245,8 +240,7 @@ describe('ComponentConfigPanel', () => {
   describe('Dynamics', () => {
     it('Closes dynamics on load', () => {
       renderComponentConfig();
-      const button = screen.queryByRole('button', { name: textMock('right_menu.dynamics') });
-      expect(button).toHaveAttribute('aria-expanded', 'false');
+      expect(getAccordion(textMock('right_menu.dynamics'))).not.toHaveAttribute('open');
     });
 
     it('Toggles dynamics when clicked', async () => {

--- a/src/Designer/frontend/packages/ux-editor/src/components/Properties/ComponentConfigPanel/ComponentConfigPanel.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/components/Properties/ComponentConfigPanel/ComponentConfigPanel.tsx
@@ -1,8 +1,7 @@
 import { Text } from '../Text';
 import { useFormItemContext } from '../../../containers/FormItemContext';
-import { Accordion } from '@digdir/designsystemet-react';
 import { ComponentType } from 'app-shared/types/ComponentType';
-import { StudioSpinner } from '@studio/components';
+import { StudioSpinner, StudioDetails } from '@studio/components';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Summary2Override } from '../../config/componentSpecificContent/Summary2/Override/Summary2Override';
@@ -61,75 +60,75 @@ export const ComponentConfigPanel = ({ selectedItem }: ComponentConfigPanelProps
   return (
     <>
       <ComponentConfigHeader />
-      <Accordion>
-        {formItem.type === ComponentType.Summary2 && (
-          <Accordion.Item
-            open={openList.includes('summary2overrides')}
-            key={`${formItemId}-summary2overrides`}
-          >
-            <Accordion.Header onHeaderClick={() => toggleOpen('summary2overrides')}>
-              {t('ux_editor.component_properties.summary.override.title')}
-            </Accordion.Header>
-            <Accordion.Content>
-              <Summary2Override component={formItem} onChange={handleUpdate} />
-            </Accordion.Content>
-          </Accordion.Item>
-        )}
-        {hasTextProperties && (
-          <Accordion.Item
-            open={openList.includes('text')}
-            key={`${formItemId}-textResourceBindings`}
-          >
-            <Accordion.Header
-              aria-label={t('right_menu.text_label')}
-              onHeaderClick={() => toggleOpen('text')}
-            >
-              {t(formItem.type === 'Image' ? 'right_menu.text_and_image' : 'right_menu.text')}
-            </Accordion.Header>
-            <Accordion.Content className={classes.accordionContent}>
-              <Text />
-            </Accordion.Content>
-          </Accordion.Item>
-        )}
-        {hasDataModelBindingProperties && (
-          <Accordion.Item
-            open={openList.includes('dataModel')}
-            key={`${formItemId}-dataModelBindings`}
-          >
-            <Accordion.Header onHeaderClick={() => toggleOpen('dataModel')}>
-              {t('right_menu.data_model_bindings')}
-            </Accordion.Header>
-            <Accordion.Content className={classes.accordionContent}>
-              <DataModelBindings />
-            </Accordion.Content>
-          </Accordion.Item>
-        )}
-        {hasOtherProperties && (
-          <Accordion.Item open={openList.includes('content')} key={`${formItemId}-content`}>
-            <Accordion.Header onHeaderClick={() => toggleOpen('content')}>
-              {t('right_menu.content')}
-            </Accordion.Header>
-            <Accordion.Content className={classes.accordionContent}>
-              <EditFormComponent
-                editFormId={formItemId}
-                component={formItem}
-                handleComponentUpdate={async (updatedComponent, mutateOptions) => {
-                  handleUpdate(updatedComponent);
-                  debounceSave(formItemId, updatedComponent, mutateOptions);
-                }}
-              />
-            </Accordion.Content>
-          </Accordion.Item>
-        )}
-        <Accordion.Item open={openList.includes('dynamics')} key={`${formItemId}-dynamics`}>
-          <Accordion.Header onHeaderClick={() => toggleOpen('dynamics')}>
-            {t('right_menu.dynamics')}
-          </Accordion.Header>
-          <Accordion.Content>
-            <Expressions />
-          </Accordion.Content>
-        </Accordion.Item>
-      </Accordion>
+      {formItem.type === ComponentType.Summary2 && (
+        <StudioDetails
+          onToggle={() => toggleOpen('summary2overrides')}
+          open={openList.includes('summary2overrides')}
+          key={`${formItemId}-summary2overrides`}
+        >
+          <StudioDetails.Summary>
+            {t('ux_editor.component_properties.summary.override.title')}
+          </StudioDetails.Summary>
+          <StudioDetails.Content className={classes.accordionContent}>
+            <Summary2Override component={formItem} onChange={handleUpdate} />
+          </StudioDetails.Content>
+        </StudioDetails>
+      )}
+      {hasTextProperties && (
+        <StudioDetails
+          onToggle={() => toggleOpen('text')}
+          open={openList.includes('text')}
+          key={`${formItemId}-textResourceBindings`}
+        >
+          <StudioDetails.Summary aria-label={t('right_menu.text_label')}>
+            {t(formItem.type === 'Image' ? 'right_menu.text_and_image' : 'right_menu.text')}
+          </StudioDetails.Summary>
+          <StudioDetails.Content className={classes.accordionContent}>
+            <Text />
+          </StudioDetails.Content>
+        </StudioDetails>
+      )}
+      {hasDataModelBindingProperties && (
+        <StudioDetails
+          onToggle={() => toggleOpen('dataModel')}
+          open={openList.includes('dataModel')}
+          key={`${formItemId}-dataModelBindings`}
+        >
+          <StudioDetails.Summary>{t('right_menu.data_model_bindings')}</StudioDetails.Summary>
+          <StudioDetails.Content className={classes.accordionContent}>
+            <DataModelBindings />
+          </StudioDetails.Content>
+        </StudioDetails>
+      )}
+      {hasOtherProperties && (
+        <StudioDetails
+          onToggle={() => toggleOpen('content')}
+          open={openList.includes('content')}
+          key={`${formItemId}-content`}
+        >
+          <StudioDetails.Summary>{t('right_menu.content')}</StudioDetails.Summary>
+          <StudioDetails.Content className={classes.accordionContent}>
+            <EditFormComponent
+              editFormId={formItemId}
+              component={formItem}
+              handleComponentUpdate={async (updatedComponent, mutateOptions) => {
+                handleUpdate(updatedComponent);
+                debounceSave(formItemId, updatedComponent, mutateOptions);
+              }}
+            />
+          </StudioDetails.Content>
+        </StudioDetails>
+      )}
+      <StudioDetails
+        onToggle={() => toggleOpen('dynamics')}
+        open={openList.includes('dynamics')}
+        key={`${formItemId}-dynamics`}
+      >
+        <StudioDetails.Summary>{t('right_menu.dynamics')}</StudioDetails.Summary>
+        <StudioDetails.Content className={classes.accordionContent}>
+          <Expressions />
+        </StudioDetails.Content>
+      </StudioDetails>
     </>
   );
 };

--- a/src/Designer/frontend/packages/ux-editor/src/components/Properties/ComponentConfigPanel/ComponentConfigPanel.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/components/Properties/ComponentConfigPanel/ComponentConfigPanel.tsx
@@ -125,7 +125,7 @@ export const ComponentConfigPanel = ({ selectedItem }: ComponentConfigPanelProps
         key={`${formItemId}-dynamics`}
       >
         <StudioDetails.Summary>{t('right_menu.dynamics')}</StudioDetails.Summary>
-        <StudioDetails.Content className={classes.accordionContent}>
+        <StudioDetails.Content>
           <Expressions />
         </StudioDetails.Content>
       </StudioDetails>

--- a/src/Designer/frontend/packages/ux-editor/src/components/Properties/PageConfigPanel/PageConfigPanel.module.css
+++ b/src/Designer/frontend/packages/ux-editor/src/components/Properties/PageConfigPanel/PageConfigPanel.module.css
@@ -1,6 +1,6 @@
 .pdf,
 .text {
-  padding: var(--fds-spacing-5) 0;
+  margin-inline: 0;
 }
 
 .mainConfig {

--- a/src/Designer/frontend/packages/ux-editor/src/components/Properties/PageConfigPanel/PageConfigPanel.test.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/components/Properties/PageConfigPanel/PageConfigPanel.test.tsx
@@ -52,8 +52,9 @@ describe('PageConfigPanel', () => {
   it('render all accordion items when layout is selected', async () => {
     const newSelectedPage = layout1NameMock;
     renderPageConfigPanel(newSelectedPage);
-    screen.getByRole('button', { name: textMock('right_menu.text') });
-    screen.getByRole('button', { name: textMock('right_menu.dynamics') });
+    screen.getByText(textMock('right_menu.text'));
+    screen.getByText(textMock('right_menu.dynamics'));
+    screen.getByText(textMock('right_menu.pdf'));
   });
 
   it('render warning when layout is selected and has duplicated ids', () => {

--- a/src/Designer/frontend/packages/ux-editor/src/components/Properties/PageConfigPanel/PageConfigPanel.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/components/Properties/PageConfigPanel/PageConfigPanel.tsx
@@ -68,7 +68,7 @@ export const PageConfigPanel = ({ selectedItem }: PageConfigPanelProps) => {
         </StudioDetails>
         <StudioDetails>
           <StudioDetails.Summary>{t('right_menu.dynamics')}</StudioDetails.Summary>
-          <StudioDetails.Content className={classes.dynamics}>
+          <StudioDetails.Content>
             <HiddenExpressionOnLayout />
           </StudioDetails.Content>
         </StudioDetails>

--- a/src/Designer/frontend/packages/ux-editor/src/components/Properties/PageConfigPanel/PageConfigPanel.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/components/Properties/PageConfigPanel/PageConfigPanel.tsx
@@ -1,5 +1,5 @@
 import { Fragment } from 'react';
-import { Accordion } from '@digdir/designsystemet-react';
+import { StudioDetails } from '@studio/components';
 import { FileIcon } from '@studio/icons';
 import { useText, useFormLayouts } from '../../../hooks';
 import { useTextResourcesSelector } from 'app-shared/hooks';
@@ -60,26 +60,24 @@ export const PageConfigPanel = ({ selectedItem }: PageConfigPanelProps) => {
           <EditPageId layoutName={selectedItem.id} />
           <NameConfig selectedItem={selectedItem} />
         </div>
-        <Accordion>
-          <Accordion.Item>
-            <Accordion.Header>{t('right_menu.text')}</Accordion.Header>
-            <Accordion.Content className={classes.text}>
-              <NameConfig selectedItem={selectedItem} />
-            </Accordion.Content>
-          </Accordion.Item>
-          <Accordion.Item>
-            <Accordion.Header>{t('right_menu.dynamics')}</Accordion.Header>
-            <Accordion.Content>
-              <HiddenExpressionOnLayout />
-            </Accordion.Content>
-          </Accordion.Item>
-          <Accordion.Item>
-            <Accordion.Header>{t('right_menu.pdf')}</Accordion.Header>
-            <Accordion.Content className={classes.pdf}>
-              <PdfConfig />
-            </Accordion.Content>
-          </Accordion.Item>
-        </Accordion>
+        <StudioDetails>
+          <StudioDetails.Summary>{t('right_menu.text')}</StudioDetails.Summary>
+          <StudioDetails.Content className={classes.text}>
+            <NameConfig selectedItem={selectedItem} />
+          </StudioDetails.Content>
+        </StudioDetails>
+        <StudioDetails>
+          <StudioDetails.Summary>{t('right_menu.dynamics')}</StudioDetails.Summary>
+          <StudioDetails.Content className={classes.dynamics}>
+            <HiddenExpressionOnLayout />
+          </StudioDetails.Content>
+        </StudioDetails>
+        <StudioDetails>
+          <StudioDetails.Summary>{t('right_menu.pdf')}</StudioDetails.Summary>
+          <StudioDetails.Content className={classes.pdf}>
+            <PdfConfig />
+          </StudioDetails.Content>
+        </StudioDetails>
       </Fragment>
       <PageConfigWarningModal open={hasDuplicatedIdsInAllLayouts} />
     </>

--- a/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/DesignView.test.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/DesignView.test.tsx
@@ -39,7 +39,7 @@ describe('DesignView', () => {
     renderDesignView({});
 
     formLayoutSettingsMock.pages.order.forEach((page) => {
-      const accordionButton = screen.getByRole('button', { name: page });
+      const accordionButton = screen.getByText(page);
       expect(accordionButton).toBeInTheDocument();
     });
   });
@@ -92,7 +92,7 @@ describe('DesignView', () => {
     const user = userEvent.setup();
     renderDesignView({});
 
-    const accordionButton1 = screen.getByRole('button', { name: mockPageName1 });
+    const accordionButton1 = screen.getByText(mockPageName1);
     await user.click(accordionButton1);
 
     expect(appContextMock.setSelectedFormLayoutName).toHaveBeenCalledTimes(1);
@@ -103,7 +103,7 @@ describe('DesignView', () => {
     const user = userEvent.setup();
     renderDesignView({});
 
-    const accordionButton2 = screen.getByRole('button', { name: mockPageName2 });
+    const accordionButton2 = screen.getByText(mockPageName2);
     await user.click(accordionButton2);
 
     expect(appContextMock.setSelectedFormLayoutName).toHaveBeenCalledTimes(1);
@@ -138,7 +138,7 @@ describe('DesignView', () => {
       layoutSettings: { ...formLayoutSettingsMock, pages: { order: [], pdfLayoutName } },
       externalLayout: { [pdfLayoutName]: layout1Mock },
     });
-    const pdfAccordionButton = screen.getByRole('button', { name: pdfLayoutName });
+    const pdfAccordionButton = screen.getByText(pdfLayoutName);
     expect(pdfAccordionButton).toBeInTheDocument();
     consoleWarnSpy.mockRestore();
   });
@@ -164,7 +164,7 @@ describe('DesignView', () => {
     const user = userEvent.setup();
     appContextMock.selectedFormLayoutName = layout2NameMock;
     renderDesignView({ pagesModel: groupsPagesModelMock });
-    const accordionButton = screen.getByRole('button', { name: layout1NameMock });
+    const accordionButton = screen.getByText(layout1NameMock);
     await user.click(accordionButton);
     expect(appContextMock.setSelectedFormLayoutName).toHaveBeenCalledTimes(1);
     expect(appContextMock.setSelectedFormLayoutName).toHaveBeenCalledWith(layout1NameMock);
@@ -174,7 +174,7 @@ describe('DesignView', () => {
     const user = userEvent.setup();
     appContextMock.selectedFormLayoutName = layout1NameMock;
     renderDesignView({ pagesModel: groupsPagesModelMock });
-    const accordionButton = screen.getByRole('button', { name: layout1NameMock });
+    const accordionButton = screen.getByText(layout1NameMock);
     await user.click(accordionButton);
     expect(appContextMock.setSelectedFormLayoutName).toHaveBeenCalledTimes(1);
     expect(appContextMock.setSelectedFormLayoutName).toHaveBeenCalledWith(undefined);

--- a/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/DesignView.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/DesignView.tsx
@@ -3,7 +3,6 @@ import { useMemo } from 'react';
 import classes from './DesignView.module.css';
 import { useTranslation } from 'react-i18next';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
-import { Accordion } from '@digdir/designsystemet-react';
 import { useFormLayoutSettingsQuery } from '../../hooks/queries/useFormLayoutSettingsQuery';
 import { PageAccordion } from './PageAccordion';
 import { useAppContext, useFormLayouts } from '../../hooks';
@@ -176,9 +175,7 @@ const DesignViewLoadedContent = ({
               isAddPagePending={isAddPageMutationPending}
             />
           ) : (
-            pagesModel?.pages?.length > 0 && (
-              <Accordion>{displayPageAccordions(pagesModel)}</Accordion>
-            )
+            pagesModel?.pages?.length > 0 && displayPageAccordions(pagesModel)
           )}
         </div>
       </div>

--- a/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/PageAccordion.module.css
+++ b/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/PageAccordion.module.css
@@ -1,44 +1,34 @@
-.navigationMenu {
-  display: flex;
-  align-items: center;
-  padding: var(--fds-spacing-1);
+.accordionItem {
+  display: grid;
+  grid-template-columns: 1fr auto;
 }
 
-.accordionSelected {
-  background-color: var(--fds-semantic-surface-action-first-no_fill-hover);
+.details {
+  grid-column: 1 / -1;
+  grid-row: 1;
+  min-width: 0;
 }
 
-.accordionHeader,
 .accordionHeaderWarning {
-  flex: 1;
-}
-
-.accordionHeaderWarning button {
-  background-color: var(--fds-semantic-surface-danger-subtle) !important;
+  --dsc-details-summary-background: var(--fds-semantic-surface-danger-subtle);
+  --dsc-details-summary-background--hover: var(--fds-semantic-surface-danger-subtle);
+  --dsc-details-summary-background--open: var(--fds-semantic-surface-danger-subtle);
 }
 
 .accordionContent {
-  padding: 0;
-  background-color: var(--fds-semantic-surface-neutral-default);
+  margin: 0;
 }
 
-.accordionItem:not(:first-child) {
-  border-top: 1px solid var(--fds-semantic-border-neutral-subtle);
-}
-
-.headerContent button {
-  border: none;
-  padding: var(--ds-size-6) var(--ds-size-6);
-}
-
-.accordionHeaderRow {
+.navigationMenu {
+  grid-column: 2;
+  grid-row: 1;
+  align-self: start;
+  z-index: 1;
   display: flex;
+  align-items: center;
+  padding: var(--ds-size-1);
 }
 
 .pdfIcon {
   font-size: var(--fds-sizing-6);
-}
-
-.customNavigationMenu {
-  background-color: var(--fds-semantic-surface-neutral-neutral);
 }

--- a/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/PageAccordion.module.css
+++ b/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/PageAccordion.module.css
@@ -1,4 +1,4 @@
-.accordionItem {
+.detailsWrapper {
   display: grid;
   grid-template-columns: 1fr auto;
 }
@@ -6,16 +6,16 @@
 .details {
   grid-column: 1 / -1;
   grid-row: 1;
-  min-width: 0;
+  border-top: none;
 }
 
-.accordionHeaderWarning {
-  --dsc-details-summary-background: var(--fds-semantic-surface-danger-subtle);
-  --dsc-details-summary-background--hover: var(--fds-semantic-surface-danger-subtle);
-  --dsc-details-summary-background--open: var(--fds-semantic-surface-danger-subtle);
+.detailsWarning {
+  --dsc-details-summary-background: var(--ds-color-danger-surface-tinted);
+  --dsc-details-summary-background--hover: var(--ds-color-danger-surface-tinted);
+  --dsc-details-summary-background--open: var(--ds-color-danger-surface-tinted);
 }
 
-.accordionContent {
+.detailsContent {
   margin: 0;
 }
 
@@ -30,5 +30,5 @@
 }
 
 .pdfIcon {
-  font-size: var(--fds-sizing-6);
+  font-size: var(--ds-size-7);
 }

--- a/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/PageAccordion.test.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/PageAccordion.test.tsx
@@ -44,7 +44,7 @@ describe('PageAccordion', () => {
     const user = userEvent.setup();
     await render();
 
-    const accordionButton = screen.getByRole('button', { name: mockPageName1 });
+    const accordionButton = screen.getByText(mockPageName1);
     await user.click(accordionButton);
 
     expect(mockOnClick).toHaveBeenCalledTimes(1);
@@ -149,20 +149,17 @@ describe('PageAccordion', () => {
     await render({ props: { isInvalid: true } });
     const headerContainer = screen.getByTestId(`accordion-header-${mockPageName1}`);
     expect(headerContainer).toHaveClass('accordionHeaderWarning');
-    expect(headerContainer).not.toHaveClass('accordionHeader');
   });
 
   it('render warning class to header when hasDuplicatedIds is true', async () => {
     await render({ props: { hasDuplicatedIds: true } });
     const headerContainer = screen.getByTestId(`accordion-header-${mockPageName1}`);
     expect(headerContainer).toHaveClass('accordionHeaderWarning');
-    expect(headerContainer).not.toHaveClass('accordionHeader');
   });
 
-  it('Applies normal header class when neither isInvalid nor hasDuplicatedIds is true', async () => {
+  it('does not render warning class when neither isInvalid nor hasDuplicatedIds is true', async () => {
     await render({ props: { isInvalid: false, hasDuplicatedIds: false } });
     const headerContainer = screen.getByTestId(`accordion-header-${mockPageName1}`);
-    expect(headerContainer).toHaveClass('accordionHeader');
     expect(headerContainer).not.toHaveClass('accordionHeaderWarning');
   });
 });

--- a/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/PageAccordion.test.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/PageAccordion.test.tsx
@@ -148,19 +148,19 @@ describe('PageAccordion', () => {
   it('render warning class to header when isInvalid is true', async () => {
     await render({ props: { isInvalid: true } });
     const headerContainer = screen.getByTestId(`accordion-header-${mockPageName1}`);
-    expect(headerContainer).toHaveClass('accordionHeaderWarning');
+    expect(headerContainer).toHaveClass('detailsWarning');
   });
 
   it('render warning class to header when hasDuplicatedIds is true', async () => {
     await render({ props: { hasDuplicatedIds: true } });
     const headerContainer = screen.getByTestId(`accordion-header-${mockPageName1}`);
-    expect(headerContainer).toHaveClass('accordionHeaderWarning');
+    expect(headerContainer).toHaveClass('detailsWarning');
   });
 
   it('does not render warning class when neither isInvalid nor hasDuplicatedIds is true', async () => {
     await render({ props: { isInvalid: false, hasDuplicatedIds: false } });
     const headerContainer = screen.getByTestId(`accordion-header-${mockPageName1}`);
-    expect(headerContainer).not.toHaveClass('accordionHeaderWarning');
+    expect(headerContainer).not.toHaveClass('detailsWarning');
   });
 });
 

--- a/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/PageAccordion.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/PageAccordion.tsx
@@ -61,8 +61,6 @@ export const PageAccordion = ({
   const { mutate: deletePage, isPending } = useDeletePageMutation(org, app, layoutSet);
   const { mutate: changePageGroups } = useChangePageGroupOrder(org, app, layoutSet);
 
-  // The open state is driven entirely by isOpen, so the native toggle is prevented to stop
-  // Details from opening and closing the panel on its own before React updates.
   const handleSummaryClick = (event: MouseEvent<HTMLElement>): void => {
     event.preventDefault();
     onClick();
@@ -87,7 +85,7 @@ export const PageAccordion = ({
 
   return (
     <div className={classes.detailsWrapper}>
-      <StudioDetails open={isOpen} onToggle={onClick} className={classes.details}>
+      <StudioDetails open={isOpen} className={classes.details}>
         <StudioDetails.Summary
           data-testid={accordionHeaderId(pageId)}
           onClick={handleSummaryClick}

--- a/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/PageAccordion.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/PageAccordion.tsx
@@ -86,18 +86,18 @@ export const PageAccordion = ({
   };
 
   return (
-    <div className={classes.accordionItem}>
+    <div className={classes.detailsWrapper}>
       <StudioDetails open={isOpen} onToggle={onClick} className={classes.details}>
         <StudioDetails.Summary
           data-testid={accordionHeaderId(pageId)}
           onClick={handleSummaryClick}
-          className={isInvalid || hasDuplicatedIds ? classes.accordionHeaderWarning : undefined}
+          className={isInvalid || hasDuplicatedIds ? classes.detailsWarning : undefined}
         >
           {pageName || pageId}
         </StudioDetails.Summary>
         <StudioDetails.Content
           data-testid={pageAccordionContentId(pageId)}
-          className={classes.accordionContent}
+          className={classes.detailsContent}
         >
           {children}
         </StudioDetails.Content>

--- a/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/PageAccordion.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/PageAccordion.tsx
@@ -1,13 +1,12 @@
 import type { ReactNode } from 'react';
 import classes from './PageAccordion.module.css';
-import { Accordion } from '@digdir/designsystemet-react';
 import { NavigationMenu } from './NavigationMenu';
 import { accordionHeaderId, pageAccordionContentId } from '@studio/testing/testids';
 import { FilePdfIcon, TrashIcon } from '@studio/icons';
 import { useTranslation } from 'react-i18next';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useAppContext } from '../../../hooks';
-import { StudioButton } from '@studio/components';
+import { StudioButton, StudioDetails } from '@studio/components';
 import { useDeletePageMutation } from '../../../hooks/mutations/useDeletePageMutation';
 import { usePagesQuery } from 'app-shared/hooks/queries/usePagesQuery';
 import { useChangePageGroupOrder } from '../../../hooks/mutations/useChangePageGroupOrder';
@@ -15,7 +14,6 @@ import { getUpdatedGroupsExcludingPage } from '../../../utils/designViewUtils/de
 import { isPagesModelWithGroups } from 'app-shared/types/api/dto/PagesModel';
 import { useTextResourceValue } from '../../../components/TextResource/hooks/useTextResourceValue';
 
-import cn from 'classnames';
 import useUxEditorParams from '@altinn/ux-editor/hooks/useUxEditorParams';
 
 export type PageAccordionProps = {
@@ -81,36 +79,32 @@ export const PageAccordion = ({
   };
 
   return (
-    <Accordion.Item open={isOpen} className={classes.accordionItem}>
-      <div className={classes.accordionHeaderRow}>
-        <div
+    <div className={classes.accordionItem}>
+      <StudioDetails open={isOpen} onToggle={onClick} className={classes.details}>
+        <StudioDetails.Summary
           data-testid={accordionHeaderId(pageId)}
-          className={
-            isInvalid || hasDuplicatedIds ? classes.accordionHeaderWarning : classes.accordionHeader
-          }
+          className={isInvalid || hasDuplicatedIds ? classes.accordionHeaderWarning : undefined}
         >
-          <Accordion.Header level={3} onHeaderClick={onClick} className={classes.headerContent}>
-            {pageName || pageId}
-          </Accordion.Header>
-        </div>
-        <div className={cn(classes.navigationMenu, { [classes.accordionSelected]: isOpen })}>
-          {pageIsPdf && <FilePdfIcon className={classes.pdfIcon} />}
-          {showNavigationMenu && <NavigationMenu pageName={pageId} />}
-          <StudioButton
-            icon={<TrashIcon aria-hidden />}
-            onClick={handleConfirmDelete}
-            title={t('general.delete_item', { item: pageName || pageId })}
-            variant='tertiary'
-            disabled={isPending}
-          />
-        </div>
+          {pageName || pageId}
+        </StudioDetails.Summary>
+        <StudioDetails.Content
+          data-testid={pageAccordionContentId(pageId)}
+          className={classes.accordionContent}
+        >
+          {children}
+        </StudioDetails.Content>
+      </StudioDetails>
+      <div className={classes.navigationMenu}>
+        {pageIsPdf && <FilePdfIcon className={classes.pdfIcon} />}
+        {showNavigationMenu && <NavigationMenu pageName={pageId} />}
+        <StudioButton
+          icon={<TrashIcon aria-hidden />}
+          onClick={handleConfirmDelete}
+          title={t('general.delete_item', { item: pageName || pageId })}
+          variant='tertiary'
+          disabled={isPending}
+        />
       </div>
-      <Accordion.Content
-        data-testid={pageAccordionContentId(pageId)}
-        className={classes.accordionContent}
-      >
-        {children}
-      </Accordion.Content>
-    </Accordion.Item>
+    </div>
   );
 };

--- a/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/PageAccordion.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/PageAccordion.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { MouseEvent, ReactNode } from 'react';
 import classes from './PageAccordion.module.css';
 import { NavigationMenu } from './NavigationMenu';
 import { accordionHeaderId, pageAccordionContentId } from '@studio/testing/testids';
@@ -61,6 +61,13 @@ export const PageAccordion = ({
   const { mutate: deletePage, isPending } = useDeletePageMutation(org, app, layoutSet);
   const { mutate: changePageGroups } = useChangePageGroupOrder(org, app, layoutSet);
 
+  // The open state is driven entirely by isOpen, so the native toggle is prevented to stop
+  // Details from opening and closing the panel on its own before React updates.
+  const handleSummaryClick = (event: MouseEvent<HTMLElement>): void => {
+    event.preventDefault();
+    onClick();
+  };
+
   const isUsingGroups = isPagesModelWithGroups(pages);
   const handleConfirmDelete = () => {
     if (!confirm(t('ux_editor.page_delete_text'))) return;
@@ -83,6 +90,7 @@ export const PageAccordion = ({
       <StudioDetails open={isOpen} onToggle={onClick} className={classes.details}>
         <StudioDetails.Summary
           data-testid={accordionHeaderId(pageId)}
+          onClick={handleSummaryClick}
           className={isInvalid || hasDuplicatedIds ? classes.accordionHeaderWarning : undefined}
         >
           {pageName || pageId}

--- a/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/PageGroupAccordion.module.css
+++ b/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/PageGroupAccordion.module.css
@@ -35,7 +35,7 @@
   font-size: var(--ds-size-5);
 }
 
-.groupPageAccordionWrapper {
+.pageAccordionWrapper {
   margin: auto;
   width: 90%;
 }

--- a/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/PageGroupAccordion.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/PageGroupAccordion.tsx
@@ -29,7 +29,6 @@ import { useChangePageGroupOrder } from '../../hooks/mutations/useChangePageGrou
 import { useAppContext } from '../../hooks';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { pageGroupAccordionHeader } from '@studio/testing/testids';
-import { Accordion } from '@digdir/designsystemet-react';
 import cn from 'classnames';
 import { ItemType } from '../../../../ux-editor/src/components/Properties/ItemType';
 import { usePagesQuery } from 'app-shared/hooks/queries/usePagesQuery';
@@ -162,7 +161,7 @@ export const PageGroupAccordion = ({
           const layout = layouts?.[page.id];
           const isInvalidLayout = layout ? duplicatedIdsExistsInLayout(layout) : false;
           return (
-            <Accordion key={page.id} className={classes.groupPageAccordionWrapper}>
+            <div className={classes.pageAccordionWrapper} key={page.id}>
               <PageAccordion
                 pageId={page.id}
                 isOpen={page.id === selectedFormLayoutName}
@@ -179,7 +178,7 @@ export const PageGroupAccordion = ({
                   />
                 )}
               </PageAccordion>
-            </Accordion>
+            </div>
           );
         })}
         <StudioButton

--- a/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/PdfLayout/PdfLayoutAccordion.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/PdfLayout/PdfLayoutAccordion.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { PageAccordion } from '@altinn/ux-editor/containers/DesignView/PageAccordion';
 import { duplicatedIdsExistsInLayout } from '@altinn/ux-editor/utils/formLayoutUtils';
 import { FormLayout } from '@altinn/ux-editor/containers/DesignView/FormLayout';
-import { Accordion } from '@digdir/designsystemet-react';
 import { useFormLayouts } from '@altinn/ux-editor/hooks';
 import { mapFormLayoutsToFormLayoutPages } from '@altinn/ux-editor/utils/formLayoutsUtils';
 
@@ -24,23 +23,21 @@ export const PdfLayoutAccordion = ({
   if (!pdfLayoutData) return null;
 
   return (
-    <Accordion>
-      <PageAccordion
-        pageId={pdfLayoutData.page}
-        isOpen={pdfLayoutData.page === selectedFormLayoutName}
-        onClick={onAccordionClick}
-        isInvalid={duplicatedIdsExistsInLayout(pdfLayoutData.data)}
-        hasDuplicatedIds={hasDuplicatedIds}
-        showNavigationMenu={false}
-        pageIsPdf={true}
-      >
-        {pdfLayoutData.page === selectedFormLayoutName && (
-          <FormLayout
-            layout={pdfLayoutData.data}
-            isInvalid={duplicatedIdsExistsInLayout(pdfLayoutData.data)}
-          />
-        )}
-      </PageAccordion>
-    </Accordion>
+    <PageAccordion
+      pageId={pdfLayoutData.page}
+      isOpen={pdfLayoutData.page === selectedFormLayoutName}
+      onClick={onAccordionClick}
+      isInvalid={duplicatedIdsExistsInLayout(pdfLayoutData.data)}
+      hasDuplicatedIds={hasDuplicatedIds}
+      showNavigationMenu={false}
+      pageIsPdf={true}
+    >
+      {pdfLayoutData.page === selectedFormLayoutName && (
+        <FormLayout
+          layout={pdfLayoutData.data}
+          isInvalid={duplicatedIdsExistsInLayout(pdfLayoutData.data)}
+        />
+      )}
+    </PageAccordion>
   );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Migrated areas (each in `ux-editor`, `ux-editor-v4` and `ux-editor-v3`):

- **Properties panel** — `ComponentConfigPanel`, `PageConfigPanel`, v3 `Properties`
- **Design view page list** — `DesignView`, `PageAccordion`, `PageGroupAccordion`, `PdfLayoutAccordion`, v3 `ReceiptContent`
- **Component toolbar** — `DefaultToolbar`


Notable changes:
- `Details` has no group element, so the wrapping `<Accordion>` is dropped; items are self-contained. `color='subtle'`/`color='neutral'` had no v1 successor and are dropped.
- `PageAccordion` keeps its action row (navigation menu, delete) *outside* the `<details>`, positioned over the summary row with CSS grid — `<summary>` must be the first child and can't hold sibling buttons.
- `PageAccordion` stays controlled: the summary click is `preventDefault`ed so `open` is driven only by `isOpen`. Without this, `Details` resets the attribute right after `onToggle` and the panel visibly flickers shut.
- Heading levels are lost — `Accordion.Header level={3}` rendered a real heading; `Details.Summary` renders a bare `<summary>`. Affects `PageAccordion` and `DefaultToolbar`.
- Tests move from `getByRole('button')`/`aria-expanded` to `getByText` and the `open` attribute, since `<summary>` exposes no role. `--fds-*` tokens in touched CSS updated to `--ds-*`.


<img width="1997" height="1142" alt="image" src="https://github.com/user-attachments/assets/aa60a9c1-2433-4602-8a66-a8693752b3c7" />



<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated toolbars, property panels and design views with a consistent expandable-details experience.
  * Preserved existing expand/collapse behaviour, page navigation, PDF indicators, deletion controls and validation warnings.
* **Style**
  * Refined spacing, borders, warning states and grid layouts across editor panels.
  * Improved navigation alignment and PDF icon sizing.
* **Bug Fixes**
  * Improved handling of expandable sections and optional toggle interactions.
* **Tests**
  * Expanded coverage for open and closed states, warning conditions and PDF settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->