### PR TITLE
chore(deps): update OpenTelemetry dependencies

### DIFF
--- a/src/App/backend/Directory.Packages.props
+++ b/src/App/backend/Directory.Packages.props
@@ -42,14 +42,14 @@
     <PackageVersion Include="NetEscapades.EnumGenerators" Version="1.0.0-beta21" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Nullable.Extended.Analyzer" Version="1.15.6581" />
-    <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
     <PackageVersion Include="PolySharp" Version="1.15.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.7" />
     <PackageVersion Include="System.Formats.Asn1" Version="10.0.8" />

--- a/src/Designer/backend/Directory.Packages.props
+++ b/src/Designer/backend/Directory.Packages.props
@@ -20,13 +20,13 @@
     <PackageVersion Include="ini-parser-netstandard" Version="2.5.3" />
     <PackageVersion Include="JWTCookieAuthentication" Version="4.0.4" />
     <PackageVersion Include="LibGit2Sharp" Version="0.32.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.15.0-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Quartz" Version="1.15.0-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.15.0-beta.1" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection.AzureKeyVault" Version="3.1.24" />

--- a/src/Runtime/gateway/Directory.Packages.props
+++ b/src/Runtime/gateway/Directory.Packages.props
@@ -12,11 +12,11 @@
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.19.2" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.7" />
     <PackageVersion Include="KubernetesClient.Aot" Version="18.0.13" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />

--- a/src/Runtime/kubernetes-wrapper/Directory.Packages.props
+++ b/src/Runtime/kubernetes-wrapper/Directory.Packages.props
@@ -6,11 +6,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="KubernetesClient" Version="18.0.13" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.7" />
 
     <!-- Static analysis, formatting -->

--- a/src/Runtime/workflow-engine-app/Directory.Packages.props
+++ b/src/Runtime/workflow-engine-app/Directory.Packages.props
@@ -18,12 +18,12 @@
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.21.0.135717" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.7" />
     <PackageVersion Include="System.Net.Http.Json" Version="10.0.10" />
-    <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.15.0-beta.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Runtime/workflow-engine/Directory.Packages.props
+++ b/src/Runtime/workflow-engine/Directory.Packages.props
@@ -22,12 +22,12 @@
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.21.0.135717" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.7" />
     <PackageVersion Include="System.Net.Http.Json" Version="10.0.10" />
-    <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.15.0-beta.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Description

Split the OpenTelemetry updates out of #19759 and apply them consistently across the repository.

- Upgrade the stable OpenTelemetry packages to 1.17.0 in App backend, Designer backend, gateway, Kubernetes wrapper, workflow engine, and workflow-engine app.
- Keep the existing prerelease-only instrumentation packages on their current beta versions.

## Upstream changelog summary

This update includes OpenTelemetry .NET [1.16.0](https://github.com/open-telemetry/opentelemetry-dotnet/blob/core-1.17.0/RELEASENOTES.md#1160) and [1.17.0](https://github.com/open-telemetry/opentelemetry-dotnet/blob/core-1.17.0/RELEASENOTES.md#1170):

- **Declared breaking change:** explicit histogram boundaries are limited to 10 million values. Altinn's only affected configuration has 16 boundaries, so no change is required.
- **OTLP reliability:** fixes data loss on HTTP export timeouts and persistent-storage retries, corrects timeout logging and log-exporter option handling, and improves log/metric export performance and memory use.
- **Metrics:** fixes a storage leak when meters/instruments are repeatedly recreated, runs observable callbacks once per collection rather than once per reader, and adds tag exclusion support.
- **Propagation:** improves W3C `tracestate` validation and normalization, adds the W3C randomness flag, deduplicates `tracestate` keys, and corrects baggage encoding behavior.
- **Resources and deployment:** adds Resource schema URLs, reports them through console/OTLP exporters, and marks the core libraries as trim/AOT compatible.

Instrumentation changes from the [.NET contrib changelogs](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/Instrumentation.AspNetCore-1.17.0/src):

- ASP.NET Core avoids duplicate tag work on .NET 10, prevents enrich callbacks from running more than once, and updates gRPC semantic conventions/fixes missing gRPC attributes with non-default propagators.
- HTTP instrumentation prevents enrich callbacks from running more than once and adds instrumentation scope version/schema URL to traces and metrics.
- The Runtime instrumentation release contains core-version alignment and package-signing changes only.

## Verification

- [x] Related dependency PR is connected (#19759)
- [x] Affected solutions build successfully
- [ ] Manual testing done (not applicable: dependency-only update)
- [ ] Relevant automated test added (not applicable: dependency-only update)

Built successfully:

- `dotnet build solutions/All.slnx -v minimal` (`src/App/backend`)
- `dotnet build Designer.sln -v minimal`
- `dotnet build Altinn.Studio.Gateway.slnx -v minimal`
- `dotnet build Altinn.Studio.KubernetesWrapper.slnx -v minimal`
- `dotnet build WorkflowEngine.slnx -v minimal`
- `dotnet build WorkflowEngine.App.slnx -v minimal`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenTelemetry components across application, gateway, Kubernetes, and workflow services to version 1.17.0.
  * Standardised core, hosting, exporter, ASP.NET Core, HTTP, and runtime instrumentation versions.
  * Retained selected Entity Framework Core and Quartz instrumentation versions where required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
