### PR TITLE
chore(deps): update test dependencies

### DIFF
--- a/src/AI/augmenter-agent/test/Altinn.Augmenter.Agent.Tests/Altinn.Augmenter.Agent.Tests.csproj
+++ b/src/AI/augmenter-agent/test/Altinn.Augmenter.Agent.Tests/Altinn.Augmenter.Agent.Tests.csproj
@@ -11,12 +11,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1*" />
     <PackageReference Include="xunit" Version="2.*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.*" />
     <PackageReference Include="FluentAssertions" Version="7.*" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.*" />
-    <PackageReference Include="WireMock.Net" Version="1.*" />
+    <PackageReference Include="WireMock.Net" Version="1.2*" />
     <PackageReference Include="coverlet.collector" Version="6.*" />
   </ItemGroup>
 

--- a/src/App/backend/Directory.Packages.props
+++ b/src/App/backend/Directory.Packages.props
@@ -34,9 +34,9 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.14.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.5.0" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.5.0" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.8.0" />
     <PackageVersion Include="Microsoft.FeatureManagement.AspNetCore" Version="4.4.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="Microsoft.OpenApi" Version="2.7.4" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="NetEscapades.EnumGenerators" Version="1.0.0-beta21" />

--- a/src/App/codelists/Directory.Packages.props
+++ b/src/App/codelists/Directory.Packages.props
@@ -4,7 +4,7 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="RichardSzalay.MockHttp" Version="7.0.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/src/App/fileanalyzers/Directory.Packages.props
+++ b/src/App/fileanalyzers/Directory.Packages.props
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="CSharpier.MsBuild" Version="1.1.2" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Mime-Detective" Version="25.8.1" />

--- a/src/Designer/backend/Directory.Packages.props
+++ b/src/Designer/backend/Directory.Packages.props
@@ -84,8 +84,8 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc" Version="2.3.11" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.10.0" />
-    <PackageVersion Include="Testcontainers" Version="4.11.0" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.11.0" />
+    <PackageVersion Include="Testcontainers" Version="4.13.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.13.0" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.18" />
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="9.0.18" />
     <PackageVersion Include="WireMock.Net" Version="1.25.0" />

--- a/src/Runtime/gateway/Directory.Packages.props
+++ b/src/Runtime/gateway/Directory.Packages.props
@@ -20,8 +20,8 @@
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.7" />
     <PackageVersion Include="KubernetesClient.Aot" Version="18.0.13" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.4.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.8.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="CSharpier.MsBuild" Version="1.2.6" />

--- a/src/Runtime/kubernetes-wrapper/Directory.Packages.props
+++ b/src/Runtime/kubernetes-wrapper/Directory.Packages.props
@@ -20,7 +20,7 @@
 
     <!-- Testing -->
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.18" />
-    <PackageVersion Include="TUnit" Version="1.20.0" />
-    <PackageVersion Include="Verify.TUnit" Version="31.13.5" />
+    <PackageVersion Include="TUnit" Version="1.63.0" />
+    <PackageVersion Include="Verify.TUnit" Version="31.28.0" />
   </ItemGroup>
 </Project>

--- a/src/Runtime/workflow-engine-app/Directory.Packages.props
+++ b/src/Runtime/workflow-engine-app/Directory.Packages.props
@@ -27,7 +27,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.15.0-beta.1" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="coverlet.collector" Version="8.0.1" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
@@ -35,8 +35,8 @@
     <PackageVersion Include="xunit.v3.extensibility.core" Version="3.2.2" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.11.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.13.0" />
     <PackageVersion Include="WireMock.Net" Version="1.25.0" />
-    <PackageVersion Include="Verify.XunitV3" Version="31.13.5" />
+    <PackageVersion Include="Verify.XunitV3" Version="31.28.0" />
   </ItemGroup>
 </Project>

--- a/src/Runtime/workflow-engine/Directory.Packages.props
+++ b/src/Runtime/workflow-engine/Directory.Packages.props
@@ -31,16 +31,16 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.15.0-beta.1" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="coverlet.collector" Version="8.0.1"/>
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.v3.assert" Version="3.2.2" />
     <PackageVersion Include="xunit.v3.extensibility.core" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.4.0" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.8.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.11.0" />
-    <PackageVersion Include="Verify.XunitV3" Version="31.13.5" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.13.0" />
+    <PackageVersion Include="Verify.XunitV3" Version="31.28.0" />
     <PackageVersion Include="WireMock.Net" Version="1.25.0" />
   </ItemGroup>
 </Project>

--- a/src/cli/Directory.Packages.props
+++ b/src/cli/Directory.Packages.props
@@ -21,7 +21,7 @@
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="18.4.0" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.4.0" />
     <PackageVersion Include="Microsoft.NET.StringTools" Version="18.4.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>


### PR DESCRIPTION
## Description

Split the test-only dependency updates out of #19759 and apply them consistently across the repository.

This updates Microsoft.NET.Test.Sdk, Microsoft.Extensions.TimeProvider.Testing, Testcontainers, TUnit, Verify, and the floating test dependencies in the augmenter agent. Existing xUnit package versions that were already current are unchanged.

## Verification

- [x] Related dependency PR is connected (#19759)
- [x] All affected test projects build successfully
- [ ] Manual testing done (not applicable: test-only dependencies)
- [ ] Relevant automated test added (not applicable: test-only dependencies)

Affected solutions/projects build successfully, including App backend, Designer backend, gateway, Kubernetes wrapper, workflow engine, workflow-engine app, studioctl server tests, Codelists, FileAnalyzers, and the augmenter-agent tests.

Passing test runs:

- Altinn.Codelists.Tests: 41 passed, 3 skipped
- Altinn.FileAnalyzers.Tests: 5 passed
- Altinn.Studio.KubernetesWrapper.Tests: 1 passed
- Studioctl.Tests: 136 passed
- WorkflowEngine.Models.Tests: 63 passed
- WorkflowEngine.Resilience.Tests: 51 passed

Full environment-dependent suites were also attempted locally. Their remaining failures require external runtime services or Docker Hub access (missing kubeconfig/local gateway services and PostgreSQL image-pull EOFs); compilation and package restore succeeded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal tooling used for automated testing and validation.
  * Refreshed test infrastructure to improve compatibility with current development environments.
  * Standardised testing components across application, runtime, designer, command-line, and AI-related areas.

* **Tests**
  * Improved consistency and reliability of test execution across the solution.
  * Updated test support tooling, including time-based testing, container-based testing, and result verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->