### PR TITLE
fix(renovate): synchronize App Designsystemet updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -86,14 +86,16 @@
       "groupName": "Design system in Designer"
     },
     {
-      "matchFileNames": ["src/App/**"],
-      "matchPackageNames": ["/^@digdir\\/designsystemet-/"],
-      "groupName": "Design system in App"
-    },
-    {
       "matchFileNames": ["src/App/**", "app-libs/**"],
       "additionalBranchPrefix": "app/",
       "commitMessageSuffix": " (app)"
+    },
+    {
+      "description": "Keep App Designsystemet updates together and separate from other dependency updates",
+      "matchManagers": ["npm"],
+      "matchFileNames": ["src/App/frontend/**", "app-libs/**"],
+      "matchPackageNames": ["/^@digdir\\/designsystemet-/"],
+      "groupName": "Design system in App"
     },
     {
       "description": "Automerge non-major Altinn app template package updates",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Designsystemet dependencies in `app-libs` were not covered by the existing App-specific grouping rule. They therefore inherited the general non-major dependency group and could be updated alongside unrelated packages.

Extend the dedicated App Designsystemet group to both `src/App/frontend/**` and `app-libs/**`. The specific grouping rule now follows the broader App branch metadata rule, consistent with Renovate's rule-merging precedence. Updates to Designsystemet packages in the two workspaces will consequently be synchronized in a separate `Design system in App` PR.

## Verification

- `git diff --check main...HEAD`
- Parsed `renovate.json` as JSON with Node.js
- `renovate-config-validator --strict` using Renovate 44.19.0: configuration validated successfully

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update rules for improved package matching.
  * Clarified the scope and description of applicable update rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->