### PR TITLE
chore: Replace direct import of paragraph and heading with studio components

### DIFF
--- a/src/Designer/frontend/app-development/features/appPublish/components/DeploymentEnvironmentStatus.tsx
+++ b/src/Designer/frontend/app-development/features/appPublish/components/DeploymentEnvironmentStatus.tsx
@@ -1,12 +1,12 @@
 import React, { type JSX } from 'react';
 import classes from './DeploymentEnvironmentStatus.module.css';
-import { Alert, Heading, Link, Spinner } from '@digdir/designsystemet-react';
+import { Alert, Link, Spinner } from '@digdir/designsystemet-react';
 import { Trans, useTranslation } from 'react-i18next';
 import type { KubernetesDeployment } from 'app-shared/types/api/KubernetesDeployment';
 import { DateUtils } from '@studio/pure-functions';
 import { ExternalLinkIcon } from '@studio/icons';
 import { DeployMoreOptionsMenu } from './DeployMoreOptionsMenu/DeployMoreOptionsMenu';
-import { StudioParagraph } from '@studio/components';
+import { StudioHeading, StudioParagraph } from '@studio/components';
 
 export interface DeploymentEnvironmentStatusProps {
   lastPublishedDate?: string;
@@ -46,9 +46,9 @@ export const DeploymentEnvironmentStatus = ({
     const envTitle = isProduction ? t('general.production') : envName.toUpperCase();
     return (
       <Alert severity={severity} className={classes.alert}>
-        <Heading spacing level={2} size='xsmall'>
+        <StudioHeading spacing level={2} data-size='xs'>
           {envTitle}
-        </Heading>
+        </StudioHeading>
         {kubernetesDeployment?.version && (
           <DeployMoreOptionsMenu linkToEnv={urlToApp} environment={envName} />
         )}

--- a/src/Designer/frontend/app-development/features/appPublish/components/DeploymentEnvironmentStatus.tsx
+++ b/src/Designer/frontend/app-development/features/appPublish/components/DeploymentEnvironmentStatus.tsx
@@ -1,11 +1,12 @@
 import React, { type JSX } from 'react';
 import classes from './DeploymentEnvironmentStatus.module.css';
-import { Alert, Heading, Link, Paragraph, Spinner } from '@digdir/designsystemet-react';
+import { Alert, Heading, Link, Spinner } from '@digdir/designsystemet-react';
 import { Trans, useTranslation } from 'react-i18next';
 import type { KubernetesDeployment } from 'app-shared/types/api/KubernetesDeployment';
 import { DateUtils } from '@studio/pure-functions';
 import { ExternalLinkIcon } from '@studio/icons';
 import { DeployMoreOptionsMenu } from './DeployMoreOptionsMenu/DeployMoreOptionsMenu';
+import { StudioParagraph } from '@studio/components';
 
 export interface DeploymentEnvironmentStatusProps {
   lastPublishedDate?: string;
@@ -52,10 +53,10 @@ export const DeploymentEnvironmentStatus = ({
           <DeployMoreOptionsMenu linkToEnv={urlToApp} environment={envName} />
         )}
 
-        <Paragraph size='small' spacing={!!footer} className={classes.content}>
+        <StudioParagraph data-size='sm' spacing={!!footer} className={classes.content}>
           {content}
-        </Paragraph>
-        {footer && <Paragraph size='xsmall'>{footer}</Paragraph>}
+        </StudioParagraph>
+        {footer && <StudioParagraph data-size='xs'>{footer}</StudioParagraph>}
       </Alert>
     );
   };

--- a/src/Designer/frontend/app-development/features/dataModelling/DataModelling.tsx
+++ b/src/Designer/frontend/app-development/features/dataModelling/DataModelling.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
-import { StudioCenter, StudioError, StudioPageSpinner } from '@studio/components';
-import { ErrorMessage, Paragraph } from '@digdir/designsystemet-react';
+import { StudioCenter, StudioError, StudioPageSpinner, StudioParagraph } from '@studio/components';
+import { ErrorMessage } from '@digdir/designsystemet-react';
 import { SchemaEditorWithToolbar } from './SchemaEditorWithToolbar';
 import { useDataModelsJsonQuery, useDataModelsXsdQuery } from 'app-shared/hooks/queries';
 import { useParams } from 'react-router-dom';
@@ -25,8 +25,8 @@ export function DataModelling({ createPathOption = false }: DataModellingProps):
       return (
         <StudioCenter>
           <StudioError>
-            <Paragraph>{t('general.fetch_error_message')}</Paragraph>
-            <Paragraph>{t('general.error_message_with_colon')}</Paragraph>
+            <StudioParagraph>{t('general.fetch_error_message')}</StudioParagraph>
+            <StudioParagraph>{t('general.error_message_with_colon')}</StudioParagraph>
             {jsonError && <ErrorMessage>{jsonError.message}</ErrorMessage>}
             {xsdError && <ErrorMessage>{xsdError.message}</ErrorMessage>}
           </StudioError>

--- a/src/Designer/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/SchemaGenerationErrorsPanel.tsx
+++ b/src/Designer/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/SchemaGenerationErrorsPanel.tsx
@@ -1,8 +1,8 @@
 import classes from './SchemaGenerationErrorsPanel.module.css';
-import { ErrorMessage, Paragraph } from '@digdir/designsystemet-react';
+import { ErrorMessage } from '@digdir/designsystemet-react';
 import { Trans, useTranslation } from 'react-i18next';
 import { StudioCloseIcon } from '@studio/icons';
-import { StudioButton, StudioError } from '@studio/components';
+import { StudioButton, StudioError, StudioParagraph } from '@studio/components';
 
 export interface SchemaGenerationErrorsPanelProps {
   onCloseErrorsPanel: () => void;
@@ -28,7 +28,7 @@ export const SchemaGenerationErrorsPanel = ({
     <StudioError>
       <div className={classes.errorPanel}>
         <div>
-          <Paragraph>{t('api_errors.DM_01')}</Paragraph>
+          <StudioParagraph>{t('api_errors.DM_01')}</StudioParagraph>
           <ul>
             {schemaGenerationErrorMessages?.map((errorMessage, index) => {
               return (

--- a/src/Designer/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/SelectedSchemaEditor.tsx
+++ b/src/Designer/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/SelectedSchemaEditor.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSchemaQuery, usePrefillQuery } from '../../../hooks/queries';
 import { useSchemaMutation, usePrefillMutation } from '../../../hooks/mutations';
-import { StudioCenter, StudioError, StudioPageSpinner } from '@studio/components';
-import { ErrorMessage, Paragraph } from '@digdir/designsystemet-react';
+import { ErrorMessage } from '@digdir/designsystemet-react';
+import { StudioCenter, StudioError, StudioPageSpinner, StudioParagraph } from '@studio/components';
 import { SchemaEditorApp } from '@altinn/schema-editor/SchemaEditorApp';
 import { useTranslation } from 'react-i18next';
 import { AUTOSAVE_DEBOUNCE_INTERVAL_MILLISECONDS } from 'app-shared/constants';
@@ -34,8 +34,8 @@ export const SelectedSchemaEditor = ({ modelPath }: SelectedSchemaEditorProps) =
       return (
         <StudioCenter>
           <StudioError>
-            <Paragraph>{t('general.fetch_error_message')}</Paragraph>
-            <Paragraph>{t('general.error_message_with_colon')}</Paragraph>
+            <StudioParagraph>{t('general.fetch_error_message')}</StudioParagraph>
+            <StudioParagraph>{t('general.error_message_with_colon')}</StudioParagraph>
             <ErrorMessage>
               {error.response?.data?.customErrorMessages[0] ?? error.message}
             </ErrorMessage>

--- a/src/Designer/frontend/app-development/features/overview/components/Deployments/DeploymentContainer/DeploymentLogList.tsx
+++ b/src/Designer/frontend/app-development/features/overview/components/Deployments/DeploymentContainer/DeploymentLogList.tsx
@@ -1,7 +1,7 @@
 import classes from './DeploymentLogList.module.css';
 import { useTranslation } from 'react-i18next';
 import type { Environment } from 'app-shared/types/Environment';
-import { Heading } from '@digdir/designsystemet-react';
+import { StudioHeading } from '@studio/components';
 import { DateUtils } from '@studio/pure-functions';
 import { getDeployStatus, type PipelineDeployment } from 'app-shared/types/api/PipelineDeployment';
 import { PROD_ENV_TYPE } from 'app-shared/constants';
@@ -33,9 +33,9 @@ export const DeploymentLogList = ({
 
   return (
     <div className={classes.container}>
-      <Heading level={2} size='xxsmall' className={classes.heading}>
+      <StudioHeading level={2} data-size='2xs' className={classes.heading}>
         {t('overview.activity')}
-      </Heading>
+      </StudioHeading>
       <ul className={classes.logs}>
         {hasSucceededDeployments ? (
           succeededPipelineDeploymentList.map((pipelineDeployment: PipelineDeployment) => {

--- a/src/Designer/frontend/app-development/features/overview/components/Deployments/DeploymentContainer/DeploymentStatus.tsx
+++ b/src/Designer/frontend/app-development/features/overview/components/Deployments/DeploymentContainer/DeploymentStatus.tsx
@@ -8,6 +8,7 @@ import { publishPath } from 'app-shared/api/paths';
 import type { KubernetesDeployment } from 'app-shared/types/api/KubernetesDeployment';
 import { ExternalLinkIcon } from '@studio/icons';
 import type { PipelineDeployment } from 'app-shared/types/api/PipelineDeployment';
+import { StudioParagraph } from '@studio/components';
 
 export type DeploymentStatusProps = {
   kubernetesDeployment?: KubernetesDeployment;
@@ -53,10 +54,8 @@ export const DeploymentStatus = ({
         <Heading spacing level={2} size='xsmall'>
           {envTitle}
         </Heading>
-        <Paragraph spacing size='small'>
-          {content}
-        </Paragraph>
-        <Paragraph size='xsmall'>{footer}</Paragraph>
+        <StudioParagraph spacing>{content}</StudioParagraph>
+        <StudioParagraph data-size='xs'>{footer}</StudioParagraph>
       </Alert>
     );
   };

--- a/src/Designer/frontend/app-development/features/overview/components/Deployments/DeploymentContainer/DeploymentStatus.tsx
+++ b/src/Designer/frontend/app-development/features/overview/components/Deployments/DeploymentContainer/DeploymentStatus.tsx
@@ -2,13 +2,13 @@ import React, { type JSX } from 'react';
 import classes from './DeploymentStatus.module.css';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { Trans, useTranslation } from 'react-i18next';
-import { Alert, Heading, Paragraph, Spinner, Link } from '@digdir/designsystemet-react';
+import { Alert, Spinner, Link } from '@digdir/designsystemet-react';
 import { DateUtils } from '@studio/pure-functions';
 import { publishPath } from 'app-shared/api/paths';
 import type { KubernetesDeployment } from 'app-shared/types/api/KubernetesDeployment';
 import { ExternalLinkIcon } from '@studio/icons';
 import type { PipelineDeployment } from 'app-shared/types/api/PipelineDeployment';
-import { StudioParagraph } from '@studio/components';
+import { StudioParagraph, StudioHeading } from '@studio/components';
 
 export type DeploymentStatusProps = {
   kubernetesDeployment?: KubernetesDeployment;
@@ -51,9 +51,9 @@ export const DeploymentStatus = ({
     const envTitle = isProduction ? t('general.production') : envName.toUpperCase();
     return (
       <Alert severity={severity} className={classes.alert}>
-        <Heading spacing level={2} size='xsmall'>
+        <StudioHeading spacing level={2} data-size='xs'>
           {envTitle}
-        </Heading>
+        </StudioHeading>
         <StudioParagraph spacing>{content}</StudioParagraph>
         <StudioParagraph data-size='xs'>{footer}</StudioParagraph>
       </Alert>

--- a/src/Designer/frontend/app-development/features/overview/components/Deployments/NoEnvironmentsAlert/NoEnvironmentsAlert.tsx
+++ b/src/Designer/frontend/app-development/features/overview/components/Deployments/NoEnvironmentsAlert/NoEnvironmentsAlert.tsx
@@ -1,8 +1,8 @@
 import { Trans, useTranslation } from 'react-i18next';
 import cn from 'classnames';
 import type { AlertProps } from '@digdir/designsystemet-react';
-import { StudioParagraph } from '@studio/components';
-import { Alert, Heading } from '@digdir/designsystemet-react';
+import { StudioParagraph, StudioHeading } from '@studio/components';
+import { Alert } from '@digdir/designsystemet-react';
 import { EmailContactProvider } from 'app-shared/getInTouch/providers';
 import { GetInTouchWith } from 'app-shared/getInTouch';
 import { altinnDocsUrl } from 'app-shared/ext-urls';
@@ -13,9 +13,9 @@ export const NoEnvironmentsAlert = ({ ...rest }: NoEnvironmentsAlertProps) => {
   const contactByEmail = new GetInTouchWith(new EmailContactProvider());
   return (
     <Alert severity='warning' className={cn(rest.className)} {...rest}>
-      <Heading level={2} size='small' spacing>
+      <StudioHeading level={2} data-size='sm' spacing>
         {t('app_deployment.no_env_title')}
-      </Heading>
+      </StudioHeading>
       <StudioParagraph spacing>
         <Trans i18nKey='app_deployment.no_env_1'>
           <a href={contactByEmail.url('serviceOwner')} />

--- a/src/Designer/frontend/app-development/features/overview/components/Deployments/NoEnvironmentsAlert/NoEnvironmentsAlert.tsx
+++ b/src/Designer/frontend/app-development/features/overview/components/Deployments/NoEnvironmentsAlert/NoEnvironmentsAlert.tsx
@@ -1,7 +1,8 @@
 import { Trans, useTranslation } from 'react-i18next';
 import cn from 'classnames';
 import type { AlertProps } from '@digdir/designsystemet-react';
-import { Alert, Heading, Paragraph } from '@digdir/designsystemet-react';
+import { StudioParagraph } from '@studio/components';
+import { Alert, Heading } from '@digdir/designsystemet-react';
 import { EmailContactProvider } from 'app-shared/getInTouch/providers';
 import { GetInTouchWith } from 'app-shared/getInTouch';
 import { altinnDocsUrl } from 'app-shared/ext-urls';
@@ -15,12 +16,12 @@ export const NoEnvironmentsAlert = ({ ...rest }: NoEnvironmentsAlertProps) => {
       <Heading level={2} size='small' spacing>
         {t('app_deployment.no_env_title')}
       </Heading>
-      <Paragraph spacing>
+      <StudioParagraph spacing>
         <Trans i18nKey='app_deployment.no_env_1'>
           <a href={contactByEmail.url('serviceOwner')} />
         </Trans>
-      </Paragraph>
-      <Paragraph>
+      </StudioParagraph>
+      <StudioParagraph>
         <Trans i18nKey='app_deployment.no_env_2'>
           <a
             href={altinnDocsUrl({ relativeUrl: 'altinn-studio/v8/reference/testing/local/' })}
@@ -28,7 +29,7 @@ export const NoEnvironmentsAlert = ({ ...rest }: NoEnvironmentsAlertProps) => {
             rel='noopener noreferrer'
           />
         </Trans>
-      </Paragraph>
+      </StudioParagraph>
     </Alert>
   );
 };

--- a/src/Designer/frontend/app-development/features/overview/components/Deployments/RepoOwnedByPersonInfo/RepoOwnedByPersonInfo.tsx
+++ b/src/Designer/frontend/app-development/features/overview/components/Deployments/RepoOwnedByPersonInfo/RepoOwnedByPersonInfo.tsx
@@ -1,4 +1,5 @@
-import { Alert, Paragraph, Link } from '@digdir/designsystemet-react';
+import { Alert, Link } from '@digdir/designsystemet-react';
+import { StudioParagraph } from '@studio/components';
 import { Trans, useTranslation } from 'react-i18next';
 import classes from './RepoOwnedByPersonInfo.module.css';
 
@@ -9,14 +10,14 @@ export const RepoOwnedByPersonInfo = () => {
       <Alert>{t('app_deployment.private_app_owner')}</Alert>
       <div className={classes.infoContainer}>
         <div className={classes.textContainer}>
-          <Paragraph>{t('app_deployment.private_app_owner_info')}</Paragraph>
-          <Paragraph>
+          <StudioParagraph>{t('app_deployment.private_app_owner_info')}</StudioParagraph>
+          <StudioParagraph>
             <Trans
               i18nKey={'app_deployment.private_app_owner_help'}
               components={{ a: <Link href='/info/contact'> </Link> }}
             />
-          </Paragraph>
-          <Paragraph>{t('app_deployment.private_app_owner_options')}</Paragraph>
+          </StudioParagraph>
+          <StudioParagraph>{t('app_deployment.private_app_owner_options')}</StudioParagraph>
         </div>
       </div>
     </>

--- a/src/Designer/frontend/app-development/features/overview/components/Documentation/Documentation.tsx
+++ b/src/Designer/frontend/app-development/features/overview/components/Documentation/Documentation.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import classes from './Documentation.module.css';
-import { Heading, Link } from '@digdir/designsystemet-react';
+import { StudioHeading, StudioLink } from '@studio/components';
 import { ExternalLinkIcon } from '@studio/icons';
 import { useTranslation } from 'react-i18next';
 import { altinnDocsUrl } from 'app-shared/ext-urls';
@@ -9,16 +9,16 @@ export const Documentation = (): React.ReactElement => {
   const { t } = useTranslation();
   return (
     <div className={classes.documentation}>
-      <Heading level={2} size='xxsmall'>
+      <StudioHeading level={2} data-size='2xs'>
         {t('overview.documentation.title')}
-      </Heading>
-      <Link
+      </StudioHeading>
+      <StudioLink
         href={altinnDocsUrl({ relativeUrl: 'altinn-studio/getting-started/' })}
         className={classes.link}
       >
         <span>{t('overview.documentation.link')}</span>
         <ExternalLinkIcon className={classes.linkIcon} />
-      </Link>
+      </StudioLink>
     </div>
   );
 };

--- a/src/Designer/frontend/app-development/features/overview/components/Header.tsx
+++ b/src/Designer/frontend/app-development/features/overview/components/Header.tsx
@@ -1,10 +1,9 @@
 import { useEffect } from 'react';
 import { useAppMetadataQuery, useTextResourcesQuery } from 'app-shared/hooks/queries';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
-import { Heading } from '@digdir/designsystemet-react';
 import { toast } from 'react-toastify';
 import { useTranslation } from 'react-i18next';
-import { StudioSpinner } from '@studio/components';
+import { StudioSpinner, StudioHeading } from '@studio/components';
 import { textResourceByLanguageAndIdSelector } from 'app-shared/selectors/textResourceSelectors';
 import { DEFAULT_LANGUAGE } from 'app-shared/constants';
 import type { ITextResources } from 'app-shared/types/global';
@@ -44,9 +43,9 @@ export const Header = () => {
   }
 
   return (
-    <Heading level={1} size='xlarge'>
+    <StudioHeading level={1} data-size='xl'>
       {title || getAppName(textResources) || app}
-    </Heading>
+    </StudioHeading>
   );
 };
 

--- a/src/Designer/frontend/app-development/features/overview/components/News/News.tsx
+++ b/src/Designer/frontend/app-development/features/overview/components/News/News.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { Card, Heading, Link, Paragraph } from '@digdir/designsystemet-react';
+import { Card } from '@digdir/designsystemet-react';
 import { Trans, useTranslation } from 'react-i18next';
 import classes from './News.module.css';
 import { gitHubRoadMapUrl } from 'app-shared/ext-urls';
 import newsData from './NewsContent/news.nb.json';
 import { NEWS_EXPIRATION_TIME_IN_DAYS } from 'app-shared/constants';
-import { StudioParagraph } from '@studio/components';
+import { StudioParagraph, StudioHeading, StudioLink } from '@studio/components';
 
 export const News = () => {
   const { t } = useTranslation();
@@ -37,9 +37,9 @@ export const News = () => {
               showNews(date) && (
                 <Card className={classes.newsContent} key={title}>
                   <Card.Header>
-                    <Heading level={3} size='xxsmall'>
+                    <StudioHeading level={3} data-size='xs'>
                       {title}
-                    </Heading>
+                    </StudioHeading>
                   </Card.Header>
                   <Card.Content>
                     <StudioParagraph data-size='xs'>
@@ -64,15 +64,15 @@ export const News = () => {
         ) : (
           <Card color='subtle' className={classes.noNews}>
             <Card.Header>
-              <Heading level={3} size='xxsmall'>
+              <StudioHeading level={3} data-size='xs'>
                 {t('overview.no_news_title')}
-              </Heading>
+              </StudioHeading>
             </Card.Header>
             <Card.Content>
               <StudioParagraph data-size='md'>
-                <Link href={gitHubRoadMapUrl} rel='noopener noreferrer' target='_newTab'>
+                <StudioLink href={gitHubRoadMapUrl} rel='noopener noreferrer' target='_newTab'>
                   {t('overview.no_news_content')}
-                </Link>
+                </StudioLink>
               </StudioParagraph>
             </Card.Content>
           </Card>
@@ -90,9 +90,9 @@ const NewsTemplate = ({ children }: NewsTemplateProps) => {
   const { t } = useTranslation();
   return (
     <>
-      <Heading level={2} size='xxsmall' spacing>
+      <StudioHeading level={2} data-size='xs' spacing>
         {t('overview.news_title')}
-      </Heading>
+      </StudioHeading>
       <div className={classes.news}>{children}</div>
     </>
   );

--- a/src/Designer/frontend/app-development/features/overview/components/News/News.tsx
+++ b/src/Designer/frontend/app-development/features/overview/components/News/News.tsx
@@ -42,9 +42,9 @@ export const News = () => {
                     </Heading>
                   </Card.Header>
                   <Card.Content>
-                    <Paragraph size='xsmall'>
+                    <StudioParagraph data-size='xs'>
                       {t('overview.news_date', { date: formatDateToText(date) })}
-                    </Paragraph>
+                    </StudioParagraph>
                   </Card.Content>
                   <Card.Content>
                     <StudioParagraph data-size='md'>
@@ -69,11 +69,11 @@ export const News = () => {
               </Heading>
             </Card.Header>
             <Card.Content>
-              <Paragraph size='small'>
+              <StudioParagraph data-size='md'>
                 <Link href={gitHubRoadMapUrl} rel='noopener noreferrer' target='_newTab'>
                   {t('overview.no_news_content')}
                 </Link>
-              </Paragraph>
+              </StudioParagraph>
             </Card.Content>
           </Card>
         )}

--- a/src/Designer/frontend/app-development/layout/NotFoundPage/NotFoundPage.tsx
+++ b/src/Designer/frontend/app-development/layout/NotFoundPage/NotFoundPage.tsx
@@ -1,5 +1,5 @@
-import { StudioNotFoundPage } from '@studio/components';
-import { Paragraph, Link } from '@digdir/designsystemet-react';
+import { StudioNotFoundPage, StudioParagraph } from '@studio/components';
+import { Link } from '@digdir/designsystemet-react';
 import { useTranslation, Trans } from 'react-i18next';
 
 export const NotFoundPage = () => {
@@ -9,14 +9,14 @@ export const NotFoundPage = () => {
     <StudioNotFoundPage
       title={t('not_found_page.heading')}
       body={
-        <Paragraph size='small'>
+        <StudioParagraph data-size='sm'>
           <Trans
             i18nKey='not_found_page.text'
             components={{
               a: <Link href='/info/contact'> </Link>,
             }}
           ></Trans>
-        </Paragraph>
+        </StudioParagraph>
       }
       redirectHref='/'
       redirectLinkText={t('not_found_page.redirect_to_dashboard')}

--- a/src/Designer/frontend/dashboard/components/DataModelsRepoList/DataModelsRepoList.tsx
+++ b/src/Designer/frontend/dashboard/components/DataModelsRepoList/DataModelsRepoList.tsx
@@ -7,7 +7,7 @@ import type { User } from 'app-shared/types/Repository';
 import type { Organization } from 'app-shared/types/Organization';
 import { useSearchReposQuery } from 'dashboard/hooks/queries/useSearchReposQuery';
 import { useSelectedContext } from 'dashboard/hooks/useSelectedContext';
-import { Heading } from '@digdir/designsystemet-react';
+import { StudioHeading } from '@studio/components';
 import { useStarredReposQuery } from 'dashboard/hooks/queries';
 import { DATA_MODEL_REPO_IDENTIFIER } from '../../constants';
 import { TableSortStorageKey } from '../../types/TableSortStorageKey';
@@ -43,9 +43,9 @@ export const DataModelsReposList = ({ user, organizations }: DataModelsReposList
 
   return (
     <div>
-      <Heading level={2} size='small' spacing>
+      <StudioHeading level={2} data-size='md' spacing>
         {getReposLabel({ selectedContext, orgs: organizations, t, isDataModelsRepo: true })}
-      </Heading>
+      </StudioHeading>
       <RepoList
         repos={dataModelsIncludingStarredData}
         isLoading={hasPendingDataModels || hasPendingStarredRepos}

--- a/src/Designer/frontend/dashboard/components/FavoriteReposList/FavoriteReposList.tsx
+++ b/src/Designer/frontend/dashboard/components/FavoriteReposList/FavoriteReposList.tsx
@@ -1,7 +1,7 @@
 import { RepoList } from '../RepoList';
 import { useTranslation } from 'react-i18next';
 import { useStarredReposQuery } from '../../hooks/queries';
-import { Heading } from '@digdir/designsystemet-react';
+import { StudioHeading } from '@studio/components';
 import { TableSortStorageKey } from '../../types/TableSortStorageKey';
 
 export const FavoriteReposList = () => {
@@ -10,9 +10,9 @@ export const FavoriteReposList = () => {
 
   return (
     <div>
-      <Heading level={2} size='small' spacing>
+      <StudioHeading level={2} data-size='md' spacing>
         {t('dashboard.favourites')}
-      </Heading>
+      </StudioHeading>
       <RepoList
         repos={userStarredRepos}
         isLoading={isPendingStarredRepos}

--- a/src/Designer/frontend/dashboard/components/OrgRepoList/OrgReposList.tsx
+++ b/src/Designer/frontend/dashboard/components/OrgRepoList/OrgReposList.tsx
@@ -6,7 +6,7 @@ import type { User } from 'app-shared/types/Repository';
 import type { Organization } from 'app-shared/types/Organization';
 import { useReposSearch } from 'dashboard/hooks/useReposSearch';
 import { useSelectedContext } from 'dashboard/hooks/useSelectedContext';
-import { Heading } from '@digdir/designsystemet-react';
+import { StudioHeading } from '@studio/components';
 import { DATA_MODEL_REPO_IDENTIFIER, DATAGRID_DEFAULT_PAGE_SIZE } from 'dashboard/constants';
 import { useAugmentReposWithStarred } from 'dashboard/hooks/useAugmentReposWithStarred';
 import { useSearchReposQuery, useStarredReposQuery } from 'dashboard/hooks/queries';
@@ -52,9 +52,9 @@ export const OrgReposList = ({ user, organizations }: OrgReposListProps) => {
 
   return (
     <div>
-      <Heading level={2} size='small' spacing>
+      <StudioHeading level={2} data-size='md' spacing>
         {getReposLabel({ selectedContext, orgs: organizations, t })}
-      </Heading>
+      </StudioHeading>
       <RepoList
         repos={reposIncludingStarredData.filter(
           (repo) => !repo.name.endsWith(DATA_MODEL_REPO_IDENTIFIER),

--- a/src/Designer/frontend/dashboard/components/RepoList/RepoList.tsx
+++ b/src/Designer/frontend/dashboard/components/RepoList/RepoList.tsx
@@ -3,13 +3,16 @@ import type { RepoIncludingStarredData } from 'dashboard/utils/repoUtils/repoUti
 import { useTranslation } from 'react-i18next';
 import type { DATAGRID_PAGE_SIZE_TYPE } from '../../constants';
 import { DATAGRID_DEFAULT_PAGE_SIZE, DATAGRID_PAGE_SIZE_OPTIONS } from '../../constants';
-import { StudioTableLocalPagination, StudioTableRemotePagination } from '@studio/components';
+import {
+  StudioTableLocalPagination,
+  StudioTableRemotePagination,
+  StudioParagraph,
+} from '@studio/components';
 import type { Columns, PaginationTexts, RemotePaginationProps } from '@studio/components';
 import { ActionLinks } from './ActionLinks';
 import { FavoriteButton } from './FavoriteButton';
 import classes from './RepoList.module.css';
 import { RepoNameWithLink } from './RepoNameWithLink';
-import { Paragraph } from '@digdir/designsystemet-react';
 import { TableSortStorageKey } from '../../types/TableSortStorageKey';
 
 export type RepoListProps = {
@@ -98,7 +101,7 @@ export const RepoList = ({
   }));
 
   const emptyTableFallback = (
-    <Paragraph size={tableSize}>{t('dashboard.no_repos_result')}</Paragraph>
+    <StudioParagraph data-size='sm'>{t('dashboard.no_repos_result')}</StudioParagraph>
   );
 
   const paginationTexts: PaginationTexts = {
@@ -126,7 +129,7 @@ export const RepoList = ({
         <StudioTableRemotePagination
           columns={columns}
           rows={rows}
-          data-size={tableSize}
+          data-size='sm'
           isLoading={isLoading}
           loadingText={t('dashboard.loading')}
           emptyTableFallback={emptyTableFallback}
@@ -137,7 +140,7 @@ export const RepoList = ({
         <StudioTableLocalPagination
           columns={columns}
           rows={rows}
-          size={tableSize}
+          data-size='sm'
           isLoading={isLoading}
           loadingText={t('general.loading')}
           emptyTableFallback={emptyTableFallback}

--- a/src/Designer/frontend/dashboard/components/RepoList/RepoList.tsx
+++ b/src/Designer/frontend/dashboard/components/RepoList/RepoList.tsx
@@ -47,7 +47,6 @@ export const RepoList = ({
   sortColumn,
 }: RepoListProps): React.ReactElement => {
   const { t } = useTranslation();
-  const tableSize = 'small';
 
   const columns: Columns = [
     {

--- a/src/Designer/frontend/dashboard/components/RepoNameInput/RepoNameInput.tsx
+++ b/src/Designer/frontend/dashboard/components/RepoNameInput/RepoNameInput.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import classes from './RepoNameInput.module.css';
-import { Paragraph } from '@digdir/designsystemet-react';
 import { useTranslation } from 'react-i18next';
-import { StudioTextfield } from '@studio/components';
+import { StudioParagraph, StudioTextfield } from '@studio/components';
 
 type RepoNameInputProps = {
   repoName?: string;
@@ -24,12 +23,12 @@ export const RepoNameInput = ({ repoName, errorMessage, name, onChange }: RepoNa
         error={errorMessage}
         onChange={onChange}
       />
-      <Paragraph size='small' className={classes.textWrapper}>
+      <StudioParagraph className={classes.textWrapper}>
         {t('dashboard.service_saved_name_description')}{' '}
         <strong style={{ fontWeight: '500' }}>
           {t('dashboard.service_saved_name_description_cannot_be_changed')}
         </strong>
-      </Paragraph>
+      </StudioParagraph>
     </div>
   );
 };

--- a/src/Designer/frontend/dashboard/components/ResourcesRepoList/ResourcesRepoList.tsx
+++ b/src/Designer/frontend/dashboard/components/ResourcesRepoList/ResourcesRepoList.tsx
@@ -7,8 +7,8 @@ import { getResourceDashboardURL, getResourcePageURL } from 'resourceadm/utils/u
 import { getReposLabel } from 'dashboard/utils/repoUtils';
 import type { Organization } from 'app-shared/types/Organization';
 import { useTranslation } from 'react-i18next';
-import { StudioSpinner } from '@studio/components';
-import { Alert, Heading, Link } from '@digdir/designsystemet-react';
+import { StudioHeading, StudioSpinner } from '@studio/components';
+import { Alert, Link } from '@digdir/designsystemet-react';
 import { useSearchReposQuery } from 'dashboard/hooks/queries';
 import type { User } from 'app-shared/types/Repository';
 import { getUidFilter } from 'dashboard/utils/filterUtils';
@@ -55,14 +55,14 @@ export const ResourcesRepoList = ({
 
   return (
     <div>
-      <Heading level={2} size='small' spacing>
+      <StudioHeading level={2} data-size='md' spacing>
         {getReposLabel({
           selectedContext,
           orgs: organizations,
           t,
           isResourcesRepo: true,
         })}
-      </Heading>
+      </StudioHeading>
       <Link href={`${RESOURCEADM_BASENAME}${getResourceDashboardURL(selectedContext, repo)}`}>
         {t('dashboard.go_to_resources')}
       </Link>

--- a/src/Designer/frontend/dashboard/components/SafeErrorView/SafeErrorView.tsx
+++ b/src/Designer/frontend/dashboard/components/SafeErrorView/SafeErrorView.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Heading, Paragraph } from '@digdir/designsystemet-react';
-import { StudioButton, StudioError } from '@studio/components';
+import { Heading } from '@digdir/designsystemet-react';
+import { StudioButton, StudioError, StudioParagraph } from '@studio/components';
 import { useTranslation } from 'react-i18next';
 
 export type SafeErrorViewProps = {
@@ -28,7 +28,7 @@ export const SafeErrorView = ({
         <Heading level={3} size='small' spacing>
           {title}
         </Heading>
-        <Paragraph spacing>{message}</Paragraph>
+        <StudioParagraph spacing>{message}</StudioParagraph>
         <div>
           <StudioButton data-color='accent' onClick={handleReloadPage}>
             {t('general.reload')}

--- a/src/Designer/frontend/dashboard/components/SafeErrorView/SafeErrorView.tsx
+++ b/src/Designer/frontend/dashboard/components/SafeErrorView/SafeErrorView.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Heading } from '@digdir/designsystemet-react';
-import { StudioButton, StudioError, StudioParagraph } from '@studio/components';
+import { StudioButton, StudioError, StudioParagraph, StudioHeading } from '@studio/components';
 import { useTranslation } from 'react-i18next';
 
 export type SafeErrorViewProps = {
@@ -20,14 +19,14 @@ export const SafeErrorView = ({
   return (
     <>
       {heading && (
-        <Heading level={2} size='small' spacing>
+        <StudioHeading level={2} data-size='md' spacing>
           {heading}
-        </Heading>
+        </StudioHeading>
       )}
       <StudioError>
-        <Heading level={3} size='small' spacing>
+        <StudioHeading level={3} data-size='md' spacing>
           {title}
-        </Heading>
+        </StudioHeading>
         <StudioParagraph spacing>{message}</StudioParagraph>
         <div>
           <StudioButton data-color='accent' onClick={handleReloadPage}>

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioExpression/SimplifiedEditor/LogicalExpressionEditor/LogicalOperatorToggle/LogicalOperatorToggle.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioExpression/SimplifiedEditor/LogicalExpressionEditor/LogicalOperatorToggle/LogicalOperatorToggle.tsx
@@ -1,8 +1,9 @@
 import { LogicalTupleOperator } from '../../../enums/LogicalTupleOperator';
 import React from 'react';
 import { useStudioExpressionContext } from '../../../StudioExpressionContext';
-import { Paragraph, ToggleGroup } from '@digdir/designsystemet-react';
+import { ToggleGroup } from '@digdir/designsystemet-react';
 import classes from './LogicalOperatorToggle.module.css';
+import { StudioParagraph } from '../../../../StudioParagraph';
 
 export type LogicalOperatorToggleProps = {
   onChange: (operator: LogicalTupleOperator) => void;
@@ -17,7 +18,7 @@ export const LogicalOperatorToggle = ({
 
   return (
     <div className={classes.logicalOperatorToggle}>
-      <Paragraph>{texts.logicalOperator}</Paragraph>
+      <StudioParagraph>{texts.logicalOperator}</StudioParagraph>
       <ToggleGroup data-toggle-group={texts.logicalOperator} value={operator} onChange={onChange}>
         {Object.values(LogicalTupleOperator).map((o) => (
           <ToggleGroup.Item key={o} value={o}>

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioExpression/SimplifiedEditor/LogicalExpressionEditor/OperatorBetweenSubexpressions/OperatorBetweenSubexpressions.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioExpression/SimplifiedEditor/LogicalExpressionEditor/OperatorBetweenSubexpressions/OperatorBetweenSubexpressions.tsx
@@ -2,8 +2,8 @@ import type { SimpleLogicalExpression } from '../../../types/SimplifiedExpressio
 import React from 'react';
 import { useStudioExpressionContext } from '../../../StudioExpressionContext';
 import { LogicalTupleOperator } from '../../../enums/LogicalTupleOperator';
-import { Paragraph } from '@digdir/designsystemet-react';
 import classes from './OperatorBetweenSubexpressions.module.css';
+import { StudioParagraph } from '../../../../StudioParagraph';
 
 export type OperatorBetweenSubexpressionsProps = {
   logicalExpression: SimpleLogicalExpression;
@@ -21,5 +21,5 @@ export const OperatorBetweenSubexpressions = ({
         : texts.or
       : texts.andOr;
 
-  return <Paragraph className={classes.operator}>{text}</Paragraph>;
+  return <StudioParagraph className={classes.operator}>{text}</StudioParagraph>;
 };

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioExpression/SimplifiedEditor/LogicalExpressionEditor/SubExpression/RelationalOperatorSelector/RelationalOperatorSelector.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioExpression/SimplifiedEditor/LogicalExpressionEditor/SubExpression/RelationalOperatorSelector/RelationalOperatorSelector.tsx
@@ -1,10 +1,10 @@
 import type { RelationalOperator } from '../../../../types/RelationalOperator';
 import { NumberRelationOperator } from '../../../../enums/NumberRelationOperator';
 import { GeneralRelationOperator } from '../../../../enums/GeneralRelationOperator';
-import { Paragraph } from '@digdir/designsystemet-react';
 import React from 'react';
 import { useStudioExpressionContext } from '../../../../StudioExpressionContext';
 import { StudioSelect } from '../../../../../StudioSelect';
+import { StudioParagraph } from '../../../../../StudioParagraph';
 
 export type RelationalOperatorSelectorProps = {
   className?: string;
@@ -27,7 +27,7 @@ export const RelationalOperatorSelector = ({
   const { texts } = useStudioExpressionContext();
   const { relationalOperators } = texts;
 
-  if (!isInEditMode) return <Paragraph>{relationalOperators[operator]}</Paragraph>;
+  if (!isInEditMode) return <StudioParagraph>{relationalOperators[operator]}</StudioParagraph>;
 
   const handleChange: React.ChangeEventHandler<HTMLSelectElement> = (event) =>
     onChange(event.target.value as RelationalOperator);

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioExpression/SimplifiedEditor/LogicalExpressionEditor/SubExpression/SubExpressionValueSelector/SubExpressionValueReadonly/SubexpressionValueReadonly.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioExpression/SimplifiedEditor/LogicalExpressionEditor/SubExpression/SubExpressionValueSelector/SubExpressionValueReadonly/SubexpressionValueReadonly.tsx
@@ -1,11 +1,12 @@
 import type { SimpleSubexpressionValue } from '../../../../../types/SimpleSubexpressionValue';
 import type { ReactElement, ReactNode } from 'react';
-import { Paragraph, Tag } from '@digdir/designsystemet-react';
+import { Tag } from '@digdir/designsystemet-react';
 import { SimpleSubexpressionValueType } from '../../../../../enums/SimpleSubexpressionValueType';
 import classes from './SubexpressionValueReadonly.module.css';
 import { StudioCodeFragment } from '../../../../../../StudioCodeFragment';
 import { LinkIcon } from '@studio/icons';
 import { useStudioExpressionContext } from '../../../../../StudioExpressionContext';
+import { StudioParagraph } from '../../../../../../StudioParagraph';
 
 export type SubexpressionValueReadonlyProps<T extends SimpleSubexpressionValueType> = {
   value: SimpleSubexpressionValue<T>;
@@ -82,14 +83,14 @@ const PredefinedGatewayAction = ({
 };
 
 const CurrentGatewayAction = (): ReactElement => {
-  return <Paragraph>GatewayAction</Paragraph>;
+  return <StudioParagraph>GatewayAction</StudioParagraph>;
 };
 
 const Binding = ({ name, binding }: { name: string; binding: ReactNode }): ReactElement => {
   return (
     <div className={classes.binding}>
       <LinkIcon />
-      <Paragraph>{name}</Paragraph>
+      <StudioParagraph>{name}</StudioParagraph>
       {binding}
     </div>
   );

--- a/src/Designer/frontend/packages/policy-editor/src/PolicyEditor.tsx
+++ b/src/Designer/frontend/packages/policy-editor/src/PolicyEditor.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { Heading } from '@digdir/designsystemet-react';
 import type {
   PolicyAction,
   Policy,
@@ -22,6 +21,7 @@ import type { PolicyAccessPackageAreaGroup } from 'app-shared/types/PolicyAccess
 import { PolicyRulesEditor } from './components/PolicyRulesEditor';
 import { PolicyEditorTabs } from './components/PolicyEditorTabs';
 import { ConsentResourcePolicyRulesEditor } from './components/ConsentResourcePolicyRulesEditor';
+import { StudioHeading } from '@studio/components';
 
 export type PolicyEditorProps = {
   policy: Policy;
@@ -86,9 +86,9 @@ export const PolicyEditor = ({
           requiredAuthenticationLevelEndUser={policy.requiredAuthenticationLevelEndUser}
           onSave={handleSavePolicyAuthLevel}
         />
-        <Heading level={4} size='xxsmall' className={classes.heading}>
+        <StudioHeading level={4} data-size='xs' className={classes.heading}>
           {t('policy_editor.rules')}
-        </Heading>
+        </StudioHeading>
         <div className={classes.alertWrapper}>
           <PolicyEditorAlert />
         </div>

--- a/src/Designer/frontend/packages/policy-editor/src/components/AddPolicyRuleButton/AddPolicyRuleButton.tsx
+++ b/src/Designer/frontend/packages/policy-editor/src/components/AddPolicyRuleButton/AddPolicyRuleButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classes from './AddPolicyRuleButton.module.css';
 import { PlusIcon } from '@studio/icons';
-import { Paragraph } from '@digdir/designsystemet-react';
+import { StudioParagraph } from '@studio/components';
 import { usePolicyEditorContext } from '../../contexts/PolicyEditorContext';
 import type { PolicyRuleResource, PolicyRuleCard } from '../../types';
 import { emptyPolicyRule, createNewPolicyResource, getNewRuleId } from '../../utils';
@@ -38,7 +38,7 @@ export const AddPolicyRuleButton = ({ onClick }: AddPolicyRuleButtonProps): Reac
 
   return (
     <button className={classes.button} type='button' onClick={handleAddCardClick}>
-      <Paragraph size='small'>{t('policy_editor.card_button_text')}</Paragraph>
+      <StudioParagraph>{t('policy_editor.card_button_text')}</StudioParagraph>
       <PlusIcon className={classes.icon} />
     </button>
   );

--- a/src/Designer/frontend/packages/policy-editor/src/components/PolicyEditorAlert/PolicyEditorAlert.tsx
+++ b/src/Designer/frontend/packages/policy-editor/src/components/PolicyEditorAlert/PolicyEditorAlert.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import classes from './PolicyEditorAlert.module.css';
-import { Alert, Paragraph } from '@digdir/designsystemet-react';
+import { Alert } from '@digdir/designsystemet-react';
+import { StudioParagraph } from '@studio/components';
 import { usePolicyEditorContext } from '../../contexts/PolicyEditorContext';
 import { useTranslation } from 'react-i18next';
 
@@ -14,12 +15,12 @@ export const PolicyEditorAlert = (): React.ReactElement => {
 
   return (
     <Alert severity='info' className={classes.alert}>
-      <Paragraph size='small'>
+      <StudioParagraph>
         {t('policy_editor.alert', {
           usageType:
             usageType === 'app' ? t('policy_editor.alert_app') : t('policy_editor.alert_resource'),
         })}
-      </Paragraph>
+      </StudioParagraph>
     </Alert>
   );
 };

--- a/src/Designer/frontend/packages/policy-editor/src/components/SecurityLevelSelect/SecurityLevelSelect.module.css
+++ b/src/Designer/frontend/packages/policy-editor/src/components/SecurityLevelSelect/SecurityLevelSelect.module.css
@@ -5,10 +5,6 @@
   padding-bottom: var(--fds-spacing-1);
 }
 
-.paragraph {
-  margin-bottom: var(--fds-spacing-5);
-}
-
 .link {
   display: inline;
   font: var(--fds-typography-paragraph-small);

--- a/src/Designer/frontend/packages/policy-editor/src/components/SecurityLevelSelect/SecurityLevelSelect.tsx
+++ b/src/Designer/frontend/packages/policy-editor/src/components/SecurityLevelSelect/SecurityLevelSelect.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import classes from './SecurityLevelSelect.module.css';
-import { Heading, Label, Paragraph, Link } from '@digdir/designsystemet-react';
-import { StudioHelpText, StudioSelect } from '@studio/components';
+import { Heading, Label, Link } from '@digdir/designsystemet-react';
+import { StudioHelpText, StudioSelect, StudioParagraph } from '@studio/components';
 import { useTranslation } from 'react-i18next';
 import type { RequiredAuthLevel } from '../../types';
 
@@ -33,9 +33,7 @@ export const SecurityLevelSelect = ({
       <Heading level={4} size='xxsmall' spacing>
         {t('policy_editor.security_level_label')}
       </Heading>
-      <Paragraph className={classes.paragraph} size='small'>
-        {t('policy_editor.security_level_description')}
-      </Paragraph>
+      <StudioParagraph spacing>{t('policy_editor.security_level_description')}</StudioParagraph>
       <div>
         <div className={classes.labelAndHelpTextWrapper}>
           <Label size='small' htmlFor={SELECT_AUTH_LEVEL_ID}>

--- a/src/Designer/frontend/packages/policy-editor/src/components/SecurityLevelSelect/SecurityLevelSelect.tsx
+++ b/src/Designer/frontend/packages/policy-editor/src/components/SecurityLevelSelect/SecurityLevelSelect.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import classes from './SecurityLevelSelect.module.css';
-import { Heading, Label, Link } from '@digdir/designsystemet-react';
-import { StudioHelpText, StudioSelect, StudioParagraph } from '@studio/components';
+import { Label, Link } from '@digdir/designsystemet-react';
+import { StudioHelpText, StudioSelect, StudioParagraph, StudioHeading } from '@studio/components';
 import { useTranslation } from 'react-i18next';
 import type { RequiredAuthLevel } from '../../types';
 
@@ -30,9 +30,9 @@ export const SecurityLevelSelect = ({
 
   return (
     <div>
-      <Heading level={4} size='xxsmall' spacing>
+      <StudioHeading level={4} data-size='xs' spacing>
         {t('policy_editor.security_level_label')}
-      </Heading>
+      </StudioHeading>
       <StudioParagraph spacing>{t('policy_editor.security_level_description')}</StudioParagraph>
       <div>
         <div className={classes.labelAndHelpTextWrapper}>

--- a/src/Designer/frontend/packages/process-editor/src/components/Canvas/BPMNViewer/BPMNViewerErrorAlert/BPMNViewerErrorAlert.tsx
+++ b/src/Designer/frontend/packages/process-editor/src/components/Canvas/BPMNViewer/BPMNViewerErrorAlert/BPMNViewerErrorAlert.tsx
@@ -2,8 +2,8 @@ import type { ReactNode } from 'react';
 import classes from './BPMNViewerErrorAlert.module.css';
 import type { BpmnViewerError } from '../../../../types/BpmnViewerError';
 import { useTranslation } from 'react-i18next';
-import { Alert, Heading } from '@digdir/designsystemet-react';
-import { StudioParagraph } from '@studio/components';
+import { Alert } from '@digdir/designsystemet-react';
+import { StudioParagraph, StudioHeading } from '@studio/components';
 
 interface ErrorMessage {
   heading: string;
@@ -52,9 +52,9 @@ export const BPMNViewerErrorAlert = ({ bpmnViewerError }: BPMNViewerErrorAlertPr
   return (
     <div className={classes.alertContainer}>
       <Alert severity='warning'>
-        <Heading size='small' spacing>
+        <StudioHeading data-size='md' spacing>
           {errorToDisplay.heading}
-        </Heading>
+        </StudioHeading>
         <StudioParagraph>{errorToDisplay.body}</StudioParagraph>
       </Alert>
     </div>

--- a/src/Designer/frontend/packages/process-editor/src/components/Canvas/BPMNViewer/BPMNViewerErrorAlert/BPMNViewerErrorAlert.tsx
+++ b/src/Designer/frontend/packages/process-editor/src/components/Canvas/BPMNViewer/BPMNViewerErrorAlert/BPMNViewerErrorAlert.tsx
@@ -2,7 +2,8 @@ import type { ReactNode } from 'react';
 import classes from './BPMNViewerErrorAlert.module.css';
 import type { BpmnViewerError } from '../../../../types/BpmnViewerError';
 import { useTranslation } from 'react-i18next';
-import { Alert, Heading, Paragraph } from '@digdir/designsystemet-react';
+import { Alert, Heading } from '@digdir/designsystemet-react';
+import { StudioParagraph } from '@studio/components';
 
 interface ErrorMessage {
   heading: string;
@@ -54,7 +55,7 @@ export const BPMNViewerErrorAlert = ({ bpmnViewerError }: BPMNViewerErrorAlertPr
         <Heading size='small' spacing>
           {errorToDisplay.heading}
         </Heading>
-        <Paragraph>{errorToDisplay.body}</Paragraph>
+        <StudioParagraph>{errorToDisplay.body}</StudioParagraph>
       </Alert>
     </div>
   );

--- a/src/Designer/frontend/packages/process-editor/src/components/Canvas/VersionHelpText/VersionHelpText.tsx
+++ b/src/Designer/frontend/packages/process-editor/src/components/Canvas/VersionHelpText/VersionHelpText.tsx
@@ -1,6 +1,5 @@
 import classes from './VersionHelpText.module.css';
-import { Paragraph } from '@digdir/designsystemet-react';
-import { StudioHelpText } from '@studio/components';
+import { StudioHelpText, StudioParagraph } from '@studio/components';
 import { useTranslation } from 'react-i18next';
 import { useBpmnContext } from '../../../contexts/BpmnContext';
 
@@ -18,16 +17,16 @@ export const VersionHelpText = (): JSX.Element => {
 
   return (
     <div className={classes.helpTextWrapper}>
-      <Paragraph size='medium'>{t('process_editor.too_old_version_title')}</Paragraph>
+      <StudioParagraph>{t('process_editor.too_old_version_title')}</StudioParagraph>
       <StudioHelpText
         aria-label={t('process_editor.too_old_version_helptext_title')}
         placement='bottom'
       >
-        <Paragraph spacing size='small' className={classes.helpTextContent}>
+        <StudioParagraph spacing className={classes.helpTextContent}>
           {t('process_editor.too_old_version_helptext_content', {
             version: appVersion?.backendVersion,
           })}
-        </Paragraph>
+        </StudioParagraph>
         {/*
           Temporarily hidden until v8 becomes available.
           TODO: Add back the below text/links when v8 is available.

--- a/src/Designer/frontend/packages/process-editor/src/components/ConfigPanel/ConfigEndEvent/ConfigEndEvent.module.css
+++ b/src/Designer/frontend/packages/process-editor/src/components/ConfigPanel/ConfigEndEvent/ConfigEndEvent.module.css
@@ -10,10 +10,6 @@
   padding-inline: var(--custom-receipt-spacing);
 }
 
-.paragraph {
-  padding-bottom: var(--fds-spacing-1);
-}
-
 .detailsContent {
   margin: 0;
   padding: var(--fds-spacing-5);

--- a/src/Designer/frontend/packages/process-editor/src/components/ConfigPanel/ConfigEndEvent/ConfigEndEvent.tsx
+++ b/src/Designer/frontend/packages/process-editor/src/components/ConfigPanel/ConfigEndEvent/ConfigEndEvent.tsx
@@ -1,5 +1,10 @@
-import { StudioDetails, StudioSectionHeader, StudioLabelAsParagraph } from '@studio/components';
-import { Link, Paragraph } from '@digdir/designsystemet-react';
+import {
+  StudioDetails,
+  StudioSectionHeader,
+  StudioLabelAsParagraph,
+  StudioParagraph,
+} from '@studio/components';
+import { Link } from '@digdir/designsystemet-react';
 import { useTranslation } from 'react-i18next';
 import classes from './ConfigEndEvent.module.css';
 import { ConfigIcon } from '../ConfigContent/ConfigIcon';
@@ -29,9 +34,9 @@ export const ConfigEndEvent = () => {
               <StudioLabelAsParagraph>
                 {t('process_editor.configuration_panel_custom_receipt_default_receipt_heading')}
               </StudioLabelAsParagraph>
-              <Paragraph size='small' className={classes.paragraph}>
+              <StudioParagraph spacing>
                 {t('process_editor.configuration_panel_custom_receipt_default_receipt_info')}
-              </Paragraph>
+              </StudioParagraph>
               <Link
                 href={altinnDocsUrl({
                   relativeUrl:
@@ -48,9 +53,9 @@ export const ConfigEndEvent = () => {
                 <StudioLabelAsParagraph>
                   {t('process_editor.configuration_panel_custom_receipt_heading')}
                 </StudioLabelAsParagraph>
-                <Paragraph size='small'>
+                <StudioParagraph>
                   {t('process_editor.configuration_panel_custom_receipt_info')}
-                </Paragraph>
+                </StudioParagraph>
               </div>
               <CustomReceiptContent />
             </div>

--- a/src/Designer/frontend/packages/process-editor/src/components/ConfigPanel/ConfigPanel.tsx
+++ b/src/Designer/frontend/packages/process-editor/src/components/ConfigPanel/ConfigPanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Alert, Heading } from '@digdir/designsystemet-react';
+import { Alert } from '@digdir/designsystemet-react';
 import { useBpmnContext } from '../../contexts/BpmnContext';
 import { BpmnTypeEnum } from '../../enum/BpmnTypeEnum';
 import { ConfigContent } from './ConfigContent';
@@ -8,7 +8,7 @@ import { ConfigEndEvent } from './ConfigEndEvent';
 import { ConfigSurface } from '../ConfigSurface/ConfigSurface';
 import { ConfigSequenceFlow } from './ConfigSequenceFlow';
 import { ConfigServiceTask } from './ConfigServiceTask';
-import { StudioParagraph } from '@studio/components';
+import { StudioParagraph, StudioHeading } from '@studio/components';
 
 export const ConfigPanel = (): React.ReactElement => {
   return (
@@ -67,9 +67,9 @@ type BpmnAlertProps = {
 const BpmnAlert = ({ title, message }: BpmnAlertProps): React.ReactElement => {
   return (
     <Alert>
-      <Heading level={3} size='xxsmall' spacing>
+      <StudioHeading level={3} data-size='xs' spacing>
         {title}
-      </Heading>
+      </StudioHeading>
       <StudioParagraph data-size='md'>{message}</StudioParagraph>
     </Alert>
   );

--- a/src/Designer/frontend/packages/process-editor/src/components/ConfigPanel/ConfigPanel.tsx
+++ b/src/Designer/frontend/packages/process-editor/src/components/ConfigPanel/ConfigPanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Paragraph, Alert, Heading } from '@digdir/designsystemet-react';
+import { Alert, Heading } from '@digdir/designsystemet-react';
 import { useBpmnContext } from '../../contexts/BpmnContext';
 import { BpmnTypeEnum } from '../../enum/BpmnTypeEnum';
 import { ConfigContent } from './ConfigContent';
@@ -8,6 +8,7 @@ import { ConfigEndEvent } from './ConfigEndEvent';
 import { ConfigSurface } from '../ConfigSurface/ConfigSurface';
 import { ConfigSequenceFlow } from './ConfigSequenceFlow';
 import { ConfigServiceTask } from './ConfigServiceTask';
+import { StudioParagraph } from '@studio/components';
 
 export const ConfigPanel = (): React.ReactElement => {
   return (
@@ -69,7 +70,7 @@ const BpmnAlert = ({ title, message }: BpmnAlertProps): React.ReactElement => {
       <Heading level={3} size='xxsmall' spacing>
         {title}
       </Heading>
-      <Paragraph size='small'>{message}</Paragraph>
+      <StudioParagraph data-size='md'>{message}</StudioParagraph>
     </Alert>
   );
 };

--- a/src/Designer/frontend/packages/process-editor/src/components/ConfigPanel/ConfigSequenceFlow/ConfigSequenceFlow.tsx
+++ b/src/Designer/frontend/packages/process-editor/src/components/ConfigPanel/ConfigSequenceFlow/ConfigSequenceFlow.tsx
@@ -6,11 +6,11 @@ import {
   PredefinedGatewayAction,
   SimpleSubexpressionValueType,
   StudioExpression,
+  StudioParagraph,
 } from '@studio/components';
 import { StudioSectionHeader, StudioButton } from '@studio/components';
 import { PlusIcon } from '@studio/icons';
 import { useBpmnContext } from '../../../contexts/BpmnContext';
-import { Paragraph } from '@digdir/designsystemet-react';
 import { BpmnExpressionModeler } from '../../../utils/bpmnModeler/BpmnExpressionModeler';
 import { useExpressionTexts } from 'app-shared/hooks/useExpressionTexts';
 import { useTranslation } from 'react-i18next';
@@ -78,9 +78,9 @@ export const ConfigSequenceFlow = (): React.ReactElement => {
         }}
       />
       <div className={classes.container}>
-        <Paragraph spacing>
+        <StudioParagraph spacing>
           {t('process_editor.sequence_flow_configuration_panel_explanation')}
-        </Paragraph>
+        </StudioParagraph>
         {!expression ? (
           <StudioButton
             variant='secondary'

--- a/src/Designer/frontend/packages/process-editor/src/components/ConfigViewerPanel/ConfigViewerPanel.tsx
+++ b/src/Designer/frontend/packages/process-editor/src/components/ConfigViewerPanel/ConfigViewerPanel.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
-import { StudioSectionHeader, StudioDisplayTile, StudioParagraph } from '@studio/components';
+import {
+  StudioSectionHeader,
+  StudioDisplayTile,
+  StudioParagraph,
+  StudioHeading,
+} from '@studio/components';
 import { useBpmnContext } from '../../contexts/BpmnContext';
 import { ConfigIcon } from '../ConfigPanel/ConfigContent/ConfigIcon';
 import { getConfigTitleHelpTextKey, getConfigTitleKey } from '../../utils/configPanelUtils';
 import { useTranslation } from 'react-i18next';
-import { Alert, Heading } from '@digdir/designsystemet-react';
+import { Alert } from '@digdir/designsystemet-react';
 import { ConfigSurface } from '../ConfigSurface/ConfigSurface';
 import classes from './ConfigViewerPanel.module.css';
 
@@ -66,9 +71,9 @@ const ChooseElementToViewAlert = (): React.ReactElement => {
   const { t } = useTranslation();
   return (
     <Alert>
-      <Heading level={3} size='xxsmall' spacing>
+      <StudioHeading level={3} data-size='xs' spacing>
         {t('process_editor.configuration_view_panel_no_task')}
-      </Heading>
+      </StudioHeading>
       <StudioParagraph data-size='md'>
         {t('process_editor.configuration_view_panel_please_choose_task')}
       </StudioParagraph>

--- a/src/Designer/frontend/packages/process-editor/src/components/ConfigViewerPanel/ConfigViewerPanel.tsx
+++ b/src/Designer/frontend/packages/process-editor/src/components/ConfigViewerPanel/ConfigViewerPanel.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { StudioSectionHeader, StudioDisplayTile } from '@studio/components';
+import { StudioSectionHeader, StudioDisplayTile, StudioParagraph } from '@studio/components';
 import { useBpmnContext } from '../../contexts/BpmnContext';
 import { ConfigIcon } from '../ConfigPanel/ConfigContent/ConfigIcon';
 import { getConfigTitleHelpTextKey, getConfigTitleKey } from '../../utils/configPanelUtils';
 import { useTranslation } from 'react-i18next';
-import { Alert, Heading, Paragraph } from '@digdir/designsystemet-react';
+import { Alert, Heading } from '@digdir/designsystemet-react';
 import { ConfigSurface } from '../ConfigSurface/ConfigSurface';
 import classes from './ConfigViewerPanel.module.css';
 
@@ -69,9 +69,9 @@ const ChooseElementToViewAlert = (): React.ReactElement => {
       <Heading level={3} size='xxsmall' spacing>
         {t('process_editor.configuration_view_panel_no_task')}
       </Heading>
-      <Paragraph size='small'>
+      <StudioParagraph data-size='md'>
         {t('process_editor.configuration_view_panel_please_choose_task')}
-      </Paragraph>
+      </StudioParagraph>
     </Alert>
   );
 };

--- a/src/Designer/frontend/packages/schema-editor/src/components/NodePanel/HeadingRow/HeadingRow.tsx
+++ b/src/Designer/frontend/packages/schema-editor/src/components/NodePanel/HeadingRow/HeadingRow.tsx
@@ -1,5 +1,4 @@
 import classes from './HeadingRow.module.css';
-import { Heading } from '@digdir/designsystemet-react';
 import { NodeIcon } from '../../NodeIcon';
 import type { ReactNode } from 'react';
 import { useSchemaEditorAppContext } from '../../../hooks/useSchemaEditorAppContext';
@@ -12,7 +11,12 @@ import {
   SchemaModel,
 } from '@altinn/schema-model';
 import { useTranslation } from 'react-i18next';
-import { StudioDeleteButton, StudioButton, StudioDropdown } from '@studio/components';
+import {
+  StudioDeleteButton,
+  StudioButton,
+  StudioDropdown,
+  StudioHeading,
+} from '@studio/components';
 
 import {
   BooleanIcon,
@@ -45,7 +49,7 @@ export const HeadingRow = ({ schemaPointer }: HeadingRowProps) => {
 
   return (
     <div className={cn(classes.root, isSelected && classes.selected)}>
-      <Heading level={1} className={classes.heading}>
+      <StudioHeading level={1} className={classes.heading}>
         <StudioButton
           className={classes.headingButton}
           icon={<NodeIcon node={node} />}
@@ -54,7 +58,7 @@ export const HeadingRow = ({ schemaPointer }: HeadingRowProps) => {
         >
           {title}
         </StudioButton>
-      </Heading>
+      </StudioHeading>
       {isValidParent && <AddNodeMenu schemaPointer={schemaPointer} />}
       {!isDataModelRoot && <DeleteButton schemaPointer={schemaPointer} />}
     </div>

--- a/src/Designer/frontend/packages/shared/src/components/GiteaHeader/ThreeDotsMenu/ClonePopoverContent/ClonePopoverContent.module.css
+++ b/src/Designer/frontend/packages/shared/src/components/GiteaHeader/ThreeDotsMenu/ClonePopoverContent/ClonePopoverContent.module.css
@@ -3,11 +3,6 @@
   cursor: auto;
 }
 
-.link {
-  margin-bottom: var(--ds-size-2);
-  padding: 0%;
-}
-
 .button {
   justify-content: center;
   margin-top: var(--ds-size-4);

--- a/src/Designer/frontend/packages/shared/src/components/GiteaHeader/ThreeDotsMenu/ClonePopoverContent/ClonePopoverContent.tsx
+++ b/src/Designer/frontend/packages/shared/src/components/GiteaHeader/ThreeDotsMenu/ClonePopoverContent/ClonePopoverContent.tsx
@@ -1,11 +1,16 @@
 import { repositoryGitPath } from 'app-shared/api/paths';
 import { altinnDocsUrl } from 'app-shared/ext-urls';
 import classes from './ClonePopoverContent.module.css';
-import { Link, Paragraph } from '@digdir/designsystemet-react';
 import { useTranslation } from 'react-i18next';
 import { useDataModelsXsdQuery } from 'app-shared/hooks/queries';
 import { InformationSquareFillIcon } from '@studio/icons';
-import { StudioButton, StudioLabelAsParagraph, StudioTextfield } from '@studio/components';
+import {
+  StudioButton,
+  StudioLabelAsParagraph,
+  StudioTextfield,
+  StudioParagraph,
+  StudioLink,
+} from '@studio/components';
 import { PackagesRouter } from 'app-shared/navigation/PackagesRouter';
 import { useGiteaHeaderContext } from '../../context/GiteaHeaderContext';
 
@@ -24,33 +29,25 @@ export const ClonePopoverContent = () => {
       <StudioLabelAsParagraph data-size='sm'>
         {t('sync_header.favourite_tool')}
       </StudioLabelAsParagraph>
-      <Paragraph asChild size='small'>
-        <Link
-          className={classes.link}
-          href={altinnDocsUrl({ language: 'nb' })}
-          target='_blank'
-          rel='noopener noreferrer'
-        >
-          {t('sync_header.favourite_tool_link')}
-        </Link>
-      </Paragraph>
+
+      <StudioLink
+        href={altinnDocsUrl({ language: 'nb' })}
+        target='_blank'
+        rel='noopener noreferrer'
+      >
+        {t('sync_header.favourite_tool_link')}
+      </StudioLink>
+
       {dataModel.length === 0 && (
         <>
           <div className={classes.iconAndText}>
             <InformationSquareFillIcon className={classes.infoIcon} />
-            <Paragraph size='small'>{t('sync_header.data_model_missing')}</Paragraph>
+            <StudioParagraph>{t('sync_header.data_model_missing')}</StudioParagraph>
           </div>
-          <Paragraph size='small' spacing>
-            {t('sync_header.data_model_missing_helper')}
-          </Paragraph>
-          <Paragraph size='small' asChild>
-            <Link
-              className={classes.link}
-              href={packagesRouter.getPackageNavigationUrl('dataModel')}
-            >
-              {t('sync_header.data_model_missing_link')}
-            </Link>
-          </Paragraph>
+          <StudioParagraph spacing>{t('sync_header.data_model_missing_helper')}</StudioParagraph>
+          <StudioLink href={packagesRouter.getPackageNavigationUrl('dataModel')}>
+            {t('sync_header.data_model_missing_link')}
+          </StudioLink>
         </>
       )}
       <StudioTextfield readOnly value={gitUrl} label={t('sync_header.clone_https')} />

--- a/src/Designer/frontend/packages/shared/src/components/GiteaHeader/ThreeDotsMenu/LocalChangesModal/DeleteModal/DeleteModal.tsx
+++ b/src/Designer/frontend/packages/shared/src/components/GiteaHeader/ThreeDotsMenu/LocalChangesModal/DeleteModal/DeleteModal.tsx
@@ -7,11 +7,11 @@ import {
   StudioHeading,
   StudioSpinner,
   StudioTextfield,
+  StudioParagraph,
 } from '@studio/components';
 import { useForwardedRef } from '@studio/hooks';
 import { TrashIcon } from '@studio/icons';
 import { useResetRepositoryMutation } from 'app-shared/hooks/mutations/useResetRepositoryMutation';
-import { Paragraph } from '@digdir/designsystemet-react';
 
 export type DeleteModalProps = {
   org: string;
@@ -52,9 +52,7 @@ export const DeleteModal = forwardRef<HTMLDialogElement, DeleteModalProps>(
           </StudioHeading>
         </StudioDialog.Block>
         <StudioDialog.Block>
-          <Paragraph size='small' spacing>
-            {t('local_changes.modal_delete_modal_text')}
-          </Paragraph>
+          <StudioParagraph spacing>{t('local_changes.modal_delete_modal_text')}</StudioParagraph>
           <StudioTextfield
             label={t('local_changes.modal_delete_modal_textfield_label')}
             description={t('local_changes.modal_delete_modal_textfield_description', {

--- a/src/Designer/frontend/packages/shared/src/components/GiteaHeader/ThreeDotsMenu/LocalChangesModal/LocalChanges/LocalChanges.tsx
+++ b/src/Designer/frontend/packages/shared/src/components/GiteaHeader/ThreeDotsMenu/LocalChangesModal/LocalChanges/LocalChanges.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 import { useRef } from 'react';
 import classes from './LocalChanges.module.css';
 import { useTranslation } from 'react-i18next';
-import { Paragraph } from '@digdir/designsystemet-react';
+import { StudioParagraph } from '@studio/components';
 import { DownloadIcon, TrashIcon } from '@studio/icons';
 import { LocalChangesActionButton } from '../LocalChangesActionButton';
 import { DeleteModal } from '../DeleteModal';
@@ -20,7 +20,7 @@ export const LocalChanges = (): ReactNode => {
 
   return (
     <div className={classes.contentWrapper}>
-      <Paragraph size='small'>{t('local_changes.modal_info_text')}</Paragraph>
+      <StudioParagraph>{t('local_changes.modal_info_text')}</StudioParagraph>
       <LocalChangesActionButton
         label={t('local_changes.modal_download_your_files_label')}
         description={t('local_changes.modal_download_your_files_description')}

--- a/src/Designer/frontend/packages/shared/src/components/GiteaHeader/ThreeDotsMenu/LocalChangesModal/LocalChangesActionButton/LocalChangesActionButton.module.css
+++ b/src/Designer/frontend/packages/shared/src/components/GiteaHeader/ThreeDotsMenu/LocalChangesModal/LocalChangesActionButton/LocalChangesActionButton.module.css
@@ -1,7 +1,3 @@
-.paragraph {
-  margin-bottom: var(--fds-spacing-2);
-}
-
 .linkAndIconWrapper {
   display: flex;
   align-items: center;

--- a/src/Designer/frontend/packages/shared/src/components/GiteaHeader/ThreeDotsMenu/LocalChangesModal/LocalChangesActionButton/LocalChangesActionButton.tsx
+++ b/src/Designer/frontend/packages/shared/src/components/GiteaHeader/ThreeDotsMenu/LocalChangesModal/LocalChangesActionButton/LocalChangesActionButton.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import classes from './LocalChangesActionButton.module.css';
-import { Link, Paragraph } from '@digdir/designsystemet-react';
-import { StudioButton, StudioLabelAsParagraph } from '@studio/components';
+import { Link } from '@digdir/designsystemet-react';
+import { StudioButton, StudioLabelAsParagraph, StudioParagraph } from '@studio/components';
 
 interface LinkAction {
   /**
@@ -120,10 +120,8 @@ export const LocalChangesActionButton = ({
 
   return (
     <div>
-      <StudioLabelAsParagraph data-size='sm'>{label}</StudioLabelAsParagraph>
-      <Paragraph className={classes.paragraph} size='small'>
-        {description}
-      </Paragraph>
+      <StudioLabelAsParagraph>{label}</StudioLabelAsParagraph>
+      <StudioParagraph spacing>{description}</StudioParagraph>
       {displayLinkOrButton()}
     </div>
   );

--- a/src/Designer/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/components/Notification/Notification.module.css
+++ b/src/Designer/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/components/Notification/Notification.module.css
@@ -7,7 +7,3 @@
   border-radius: 100%;
   background-color: var(--fds-semantic-surface-danger-default);
 }
-
-.number {
-  color: var(--fds-semantic-text-neutral-on_inverted);
-}

--- a/src/Designer/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/components/Notification/Notification.tsx
+++ b/src/Designer/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/components/Notification/Notification.tsx
@@ -1,6 +1,5 @@
 import classes from './Notification.module.css';
-import { Paragraph } from '@digdir/designsystemet-react';
-
+import { StudioParagraph } from '@studio/components';
 export type NotificationProps = {
   numChanges?: number;
 };
@@ -8,9 +7,7 @@ export type NotificationProps = {
 export const Notification = ({ numChanges }: NotificationProps) => {
   return (
     <span className={classes.wrapper} aria-hidden aria-label={'sync_header.notification_label'}>
-      <Paragraph asChild size='xsmall' variant='short' className={classes.number}>
-        <span>{numChanges}</span>
-      </Paragraph>
+      <StudioParagraph>{numChanges}</StudioParagraph>
     </span>
   );
 };

--- a/src/Designer/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/components/ShareChangesPopover/CommitAndPushContent/CommitAndPushContent.module.css
+++ b/src/Designer/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/components/ShareChangesPopover/CommitAndPushContent/CommitAndPushContent.module.css
@@ -1,7 +1,3 @@
-.heading {
-  padding-bottom: var(--fds-spacing-3);
-}
-
 .commitAndPushButton {
   margin-top: var(--fds-spacing-3);
 }

--- a/src/Designer/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/components/ShareChangesPopover/CommitAndPushContent/CommitAndPushContent.tsx
+++ b/src/Designer/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/components/ShareChangesPopover/CommitAndPushContent/CommitAndPushContent.tsx
@@ -2,8 +2,7 @@ import React, { useState } from 'react';
 import classes from './CommitAndPushContent.module.css';
 import { useTranslation } from 'react-i18next';
 import { useVersionControlButtonsContext } from '../../../context';
-import { Heading } from '@digdir/designsystemet-react';
-import { StudioButton, StudioTextarea, StudioParagraph } from '@studio/components';
+import { StudioButton, StudioHeading, StudioParagraph, StudioTextarea } from '@studio/components';
 import type { RepoContentStatus } from 'app-shared/types/RepoStatus';
 import { FileChangesInfoModal } from './FileChangesInfoModal';
 
@@ -32,9 +31,9 @@ export const CommitAndPushContent = ({
 
   return (
     <>
-      <Heading size='xxsmall' className={classes.heading} level={3}>
+      <StudioHeading data-size='xs' spacing level={3}>
         {t('sync_header.describe_and_validate')}
-      </Heading>
+      </StudioHeading>
       <StudioParagraph spacing>
         {t('sync_header.describe_and_validate_sub_message')}
       </StudioParagraph>

--- a/src/Designer/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/components/ShareChangesPopover/CommitAndPushContent/CommitAndPushContent.tsx
+++ b/src/Designer/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/components/ShareChangesPopover/CommitAndPushContent/CommitAndPushContent.tsx
@@ -2,8 +2,8 @@ import React, { useState } from 'react';
 import classes from './CommitAndPushContent.module.css';
 import { useTranslation } from 'react-i18next';
 import { useVersionControlButtonsContext } from '../../../context';
-import { Heading, Paragraph } from '@digdir/designsystemet-react';
-import { StudioButton, StudioTextarea } from '@studio/components';
+import { Heading } from '@digdir/designsystemet-react';
+import { StudioButton, StudioTextarea, StudioParagraph } from '@studio/components';
 import type { RepoContentStatus } from 'app-shared/types/RepoStatus';
 import { FileChangesInfoModal } from './FileChangesInfoModal';
 
@@ -35,9 +35,9 @@ export const CommitAndPushContent = ({
       <Heading size='xxsmall' className={classes.heading} level={3}>
         {t('sync_header.describe_and_validate')}
       </Heading>
-      <Paragraph size='small' spacing>
+      <StudioParagraph spacing>
         {t('sync_header.describe_and_validate_sub_message')}
-      </Paragraph>
+      </StudioParagraph>
       <FileChangesInfoModal fileChanges={fileChanges} />
       <StudioTextarea
         label={t('sync_header.describe_changes_made')}

--- a/src/Designer/frontend/packages/text-editor/src/RightMenu.tsx
+++ b/src/Designer/frontend/packages/text-editor/src/RightMenu.tsx
@@ -3,7 +3,8 @@ import classes from './RightMenu.module.css';
 import type { LangCode } from './types';
 import { LangSelector } from './LangSelector';
 import { getLangName, langOptions } from './utils';
-import { Checkbox, Fieldset, Heading } from '@digdir/designsystemet-react';
+import { Checkbox, Fieldset } from '@digdir/designsystemet-react';
+import { StudioHeading } from '@studio/components';
 import { defaultLangCode } from './constants';
 import { useTranslation } from 'react-i18next';
 import { AltinnConfirmDialog } from 'app-shared/components';
@@ -44,9 +45,7 @@ export const RightMenu = ({
   return (
     <aside className={classes.rightMenuSidebar}>
       <div className={classes.rightMenuVerticalContent}>
-        <Heading level={2} size='small'>
-          {t('schema_editor.language')}
-        </Heading>
+        <StudioHeading level={2}>{t('schema_editor.language')}</StudioHeading>
         <div> {t('schema_editor.language_info_melding')}</div>
       </div>
       <div className={classes.rightMenuVerticalContent}>

--- a/src/Designer/frontend/packages/ux-editor-v3/src/components/Elements/Elements.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/components/Elements/Elements.tsx
@@ -1,7 +1,6 @@
 import { useSelector } from 'react-redux';
 import { ConfPageToolbar } from './ConfPageToolbar';
 import { DefaultToolbar } from './DefaultToolbar';
-import { Heading, Paragraph } from '@digdir/designsystemet-react';
 import { useText } from '../../hooks';
 import { selectedLayoutNameSelector } from '../../selectors/formLayoutSelectors';
 import { useFormLayoutSettingsQuery } from '../../hooks/queries/useFormLayoutSettingsQuery';
@@ -11,6 +10,7 @@ import { LayoutSetsContainer } from './LayoutSetsContainer';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import classes from './Elements.module.css';
 import { useAppContext } from '../../hooks/useAppContext';
+import { StudioHeading, StudioParagraph } from '@studio/components';
 
 export const Elements = () => {
   const { org, app } = useStudioEnvironmentParams();
@@ -28,13 +28,13 @@ export const Elements = () => {
   return (
     <div className={classes.root}>
       {layoutSetNames && <LayoutSetsContainer />}
-      <Heading size='xxsmall' className={classes.componentsHeader}>
+      <StudioHeading data-size='xs' className={classes.componentsHeader}>
         {t('left_menu.components')}
-      </Heading>
+      </StudioHeading>
       {hideComponents ? (
-        <Paragraph className={classes.noPageSelected} size='small'>
+        <StudioParagraph className={classes.noPageSelected} data-size='sm'>
           {t('left_menu.no_components_selected')}
-        </Paragraph>
+        </StudioParagraph>
       ) : receiptName === selectedLayout ? (
         <ConfPageToolbar />
       ) : (

--- a/src/Designer/frontend/packages/ux-editor-v3/src/components/Preview/Preview.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/components/Preview/Preview.tsx
@@ -8,8 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { useAppContext } from '../../hooks/useAppContext';
 import { useUpdate } from 'app-shared/hooks/useUpdate';
 import { previewPage } from 'app-shared/api/paths';
-import { Paragraph } from '@digdir/designsystemet-react';
-import { StudioButton, StudioCenter } from '@studio/components';
+import { StudioButton, StudioCenter, StudioParagraph } from '@studio/components';
 import type { SupportedView } from './ViewToggler/ViewToggler';
 import { ViewToggler } from './ViewToggler/ViewToggler';
 import { ArrowRightIcon } from '@studio/icons';
@@ -48,7 +47,7 @@ const NoSelectedPageMessage = () => {
   const { t } = useTranslation();
   return (
     <StudioCenter>
-      <Paragraph size='medium'>{t('ux_editor.no_components_selected')}</Paragraph>
+      <StudioParagraph data-size='md'>{t('ux_editor.no_components_selected')}</StudioParagraph>
     </StudioCenter>
   );
 };

--- a/src/Designer/frontend/packages/ux-editor-v3/src/components/TextResource.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/components/TextResource.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { Paragraph } from '@digdir/designsystemet-react';
 import { MagnifyingGlassIcon, PencilIcon, PlusIcon, TrashIcon, XMarkIcon } from '@studio/icons';
 import classes from './TextResource.module.css';
 import { useDispatch, useSelector } from 'react-redux';
@@ -20,7 +19,7 @@ import { FormField } from './FormField';
 import { AltinnConfirmDialog } from 'app-shared/components/AltinnConfirmDialog';
 import { useTranslation } from 'react-i18next';
 import { shouldDisplayFeature, FeatureFlag } from 'app-shared/utils/featureToggleUtils';
-import { StudioButton, StudioSelect } from '@studio/components';
+import { StudioButton, StudioParagraph, StudioSelect } from '@studio/components';
 
 export interface TextResourceProps {
   description?: string;
@@ -132,7 +131,7 @@ export const TextResource = ({
       )}
       <span className={classes.textResource}>
         {textResource?.value ? (
-          <Paragraph className={classes.paragraph}>{textResource.value}</Paragraph>
+          <StudioParagraph className={classes.paragraph}>{textResource.value}</StudioParagraph>
         ) : (
           <span className={classes.placeholder}>{placeholder}</span>
         )}

--- a/src/Designer/frontend/packages/ux-editor-v3/src/components/config/EditFormComponent.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/components/config/EditFormComponent.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import type { EditSettings, IGenericEditComponent } from './componentConfig';
 import { componentSpecificEditConfig, configComponents } from './componentConfig';
-
 import { ComponentSpecificContent } from './componentSpecificContent';
-import { Fieldset, Heading, Switch } from '@digdir/designsystemet-react';
+import { Fieldset, Switch } from '@digdir/designsystemet-react';
 import classes from './EditFormComponent.module.css';
 import type { FormComponent } from '../../types/FormComponent';
 import { selectedLayoutNameSelector } from '../../selectors/formLayoutSelectors';
 import { useComponentSchemaQuery } from '../../hooks/queries/useComponentSchemaQuery';
-import { StudioSpinner } from '@studio/components';
+import { StudioSpinner, StudioHeading } from '@studio/components';
 import { FormComponentConfig } from './FormComponentConfig';
 import { EditComponentId } from './editModal/EditComponentId';
 import { useLayoutSchemaQuery } from '../../hooks/queries/useLayoutSchemaQuery';
@@ -82,9 +81,9 @@ export const EditFormComponent = ({
       <Switch onChange={toggleShowBetaFunc} checked={showComponentConfigBeta} size='small'>
         {t('ux_editor.edit_component.show_beta_func')}
       </Switch>
-      <Heading level={2} size='xsmall'>
+      <StudioHeading level={2} data-size='sm'>
         {getComponentTitleByComponentType(component.type, t)} ({component.type})
-      </Heading>
+      </StudioHeading>
       {showComponentConfigBeta && isPending && (
         <StudioSpinner aria-hidden spinnerTitle={t('ux_editor.edit_component.loading_schema')} />
       )}

--- a/src/Designer/frontend/packages/ux-editor-v3/src/components/config/EditFormContainer.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/components/config/EditFormContainer.tsx
@@ -5,7 +5,7 @@ import { EditGroupDataModelBindings } from './group/EditGroupDataModelBindings';
 import { getTextResource } from '../../utils/language';
 import { idExists } from '../../utils/formLayoutUtils';
 import type { DataModelFieldElement } from 'app-shared/types/DataModelFieldElement';
-import { Alert, Switch, Checkbox, Paragraph } from '@digdir/designsystemet-react';
+import { Alert, Switch, Checkbox } from '@digdir/designsystemet-react';
 import classes from './EditFormContainer.module.css';
 import { TextResource } from '../TextResource';
 import { useDataModelMetadataQuery } from '../../hooks/queries/useDataModelMetadataQuery';
@@ -21,7 +21,7 @@ import type { FormContainer } from '../../types/FormContainer';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useAppContext } from '../../hooks/useAppContext';
 import { ComponentTypeV3 } from 'app-shared/types/ComponentTypeV3';
-import { StudioProperty, StudioTextfield } from '@studio/components';
+import { StudioParagraph, StudioProperty, StudioTextfield } from '@studio/components';
 
 export interface IEditFormContainerProps {
   editFormId: string;
@@ -242,7 +242,7 @@ export const EditFormContainer = ({
     </StudioProperty.Group>
   ) : (
     <Alert severity='info'>
-      <Paragraph size='small'>{t('ux_editor.container_not_editable_info')}</Paragraph>
+      <StudioParagraph data-size='sm'>{t('ux_editor.container_not_editable_info')}</StudioParagraph>
     </Alert>
   );
 };

--- a/src/Designer/frontend/packages/ux-editor-v3/src/components/config/FormComponentConfig.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/components/config/FormComponentConfig.tsx
@@ -1,6 +1,7 @@
 import { Fragment } from 'react';
 import { EditComponentId } from './editModal/EditComponentId';
-import { Alert, Heading, Paragraph } from '@digdir/designsystemet-react';
+import { Alert } from '@digdir/designsystemet-react';
+import { StudioHeading, StudioParagraph } from '@studio/components';
 import type { FormComponent } from '../../types/FormComponent';
 import { selectedLayoutNameSelector } from '../../selectors/formLayoutSelectors';
 import { EditDataModelBindings } from './editModal/EditDataModelBindings';
@@ -69,9 +70,9 @@ export const FormComponentConfig = ({
       )}
       {textResourceBindings?.properties && (
         <>
-          <Heading level={3} size='xxsmall'>
+          <StudioHeading level={3} data-size='xs'>
             {t('general.text')}
-          </Heading>
+          </StudioHeading>
           <EditTextResourceBindings
             component={component}
             handleComponentChange={handleComponentUpdate}
@@ -83,9 +84,9 @@ export const FormComponentConfig = ({
       )}
       {dataModelBindings?.properties && (
         <>
-          <Heading level={3} size='xxsmall'>
+          <StudioHeading level={3} data-size='xs'>
             {t('top_menu.data_model')}
-          </Heading>
+          </StudioHeading>
           {Object.keys(dataModelBindings?.properties).map((propertyKey: any) => {
             return (
               <EditDataModelBindings
@@ -105,9 +106,9 @@ export const FormComponentConfig = ({
       )}
       {grid && (
         <div>
-          <Heading level={3} size='xxsmall'>
+          <StudioHeading level={3} data-size='xs'>
             {t('ux_editor.component_properties.grid')}
-          </Heading>
+          </StudioHeading>
           <EditGrid
             key={component.id}
             component={component}
@@ -116,9 +117,9 @@ export const FormComponentConfig = ({
         </div>
       )}
       {!hideUnsupported && (
-        <Heading level={3} size='xxsmall'>
+        <StudioHeading level={3} data-size='xs'>
           {t('ux_editor.component_other_properties_title')}
-        </Heading>
+        </StudioHeading>
       )}
       {options && optionsId && (
         <EditOptions
@@ -232,11 +233,11 @@ export const FormComponentConfig = ({
         if (rest[propertyKey].type === 'object' && rest[propertyKey].properties) {
           return (
             <Fragment key={propertyKey}>
-              <Heading level={3} size='xxsmall'>
+              <StudioHeading level={3} data-size='xs'>
                 {getComponentPropertyLabel(propertyKey, t)}
-              </Heading>
+              </StudioHeading>
               {rest[propertyKey]?.description && (
-                <Paragraph size='small'>{rest[propertyKey].description}</Paragraph>
+                <StudioParagraph data-size='sm'>{rest[propertyKey].description}</StudioParagraph>
               )}
               <FormComponentConfig
                 key={propertyKey}

--- a/src/Designer/frontend/packages/ux-editor-v3/src/components/config/editModal/EditGrid/EditGridForGivenViewSize.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/components/config/editModal/EditGrid/EditGridForGivenViewSize.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 import { useText } from '../../../../hooks';
 import type { GridSize } from '@studio/components-legacy';
 import { StudioGridSelector } from '@studio/components-legacy';
-import { Paragraph, Switch } from '@digdir/designsystemet-react';
+import { Switch } from '@digdir/designsystemet-react';
 import { PadlockLockedFillIcon } from '@studio/icons';
 import classes from './EditGridForGivenViewSize.module.css';
 import { ObjectUtils } from '@studio/pure-functions';
 import type { GridSizes } from './types/GridSizes';
 import type { ViewSize } from './types/ViewSize';
 import { findEffectiveGridSize } from './utils';
+import { StudioParagraph } from '@studio/components';
 
 export interface EditGridForGivenViewSizeProps {
   handleUpdateGrid: (newGridValues: GridSizes) => void;
@@ -43,7 +44,7 @@ export const EditGridForGivenViewSize = ({
   return (
     <>
       <div className={classes.lockIcon}>
-        <Paragraph size='small'>{t('ux_editor.modal_properties_grid')}</Paragraph>
+        <StudioParagraph data-size='sm'>{t('ux_editor.modal_properties_grid')}</StudioParagraph>
         {!gridValues[viewSize] && <PadlockLockedFillIcon title='lockIcon' fontSize='1.5rem' />}
       </div>
       <StudioGridSelector

--- a/src/Designer/frontend/packages/ux-editor-v3/src/components/toolbar/InformationPanelComponent.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/components/toolbar/InformationPanelComponent.tsx
@@ -6,9 +6,8 @@ import {
   getComponentTitleByComponentType,
 } from '../../utils/language';
 import { useTranslation } from 'react-i18next';
-import { StudioPopover, StudioLabelAsParagraph } from '@studio/components';
+import { StudioLabelAsParagraph, StudioParagraph, StudioPopover } from '@studio/components';
 import { InformationIcon } from '@studio/icons';
-import { Paragraph } from '@digdir/designsystemet-react';
 
 export type InformationPanelProvidedProps = {
   isOpen: boolean;
@@ -34,9 +33,9 @@ export const InformationPanelComponent = ({
           </StudioLabelAsParagraph>
         </div>
         <div className={classNames(classes.informationPanelText)}>
-          <Paragraph size='small'>
+          <StudioParagraph data-size='sm'>
             {getComponentHelperTextByComponentType(selectedComponent, t)}
-          </Paragraph>
+          </StudioParagraph>
         </div>
       </StudioPopover>
     </StudioPopover.TriggerContext>

--- a/src/Designer/frontend/packages/ux-editor-v3/src/containers/DesignView/FormLayout.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/containers/DesignView/FormLayout.tsx
@@ -2,7 +2,8 @@ import type { IInternalLayout } from '../../types/global';
 import { FormTree } from './FormTree';
 import { hasMultiPageGroup } from '../../utils/formLayoutUtils';
 import { useTranslation } from 'react-i18next';
-import { Alert, Paragraph } from '@digdir/designsystemet-react';
+import { Alert } from '@digdir/designsystemet-react';
+import { StudioParagraph } from '@studio/components';
 
 export interface FormLayoutProps {
   layout: IInternalLayout;
@@ -19,7 +20,7 @@ const MultiPageWarning = () => {
   const { t } = useTranslation();
   return (
     <Alert severity='warning'>
-      <Paragraph size='small'>{t('ux_editor.multi_page_warning')}</Paragraph>
+      <StudioParagraph data-size='sm'>{t('ux_editor.multi_page_warning')}</StudioParagraph>
     </Alert>
   );
 };

--- a/src/Designer/frontend/packages/ux-editor-v4/src/components/Elements/Elements.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/components/Elements/Elements.tsx
@@ -6,12 +6,17 @@ import { DefaultToolbar } from './DefaultToolbar';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import classes from './Elements.module.css';
 
-import { StudioButton, StudioError, StudioHeading, StudioSpinner } from '@studio/components';
+import {
+  StudioButton,
+  StudioError,
+  StudioHeading,
+  StudioSpinner,
+  StudioParagraph,
+} from '@studio/components';
 import { SidebarLeftIcon } from '@studio/icons';
 import { useCustomReceiptLayoutSetName } from 'app-shared/hooks/useCustomReceiptLayoutSetName';
 import { useTranslation } from 'react-i18next';
 import { useProcessTaskTypeQuery } from '../../hooks/queries/useProcessTaskTypeQuery';
-import { Heading, Paragraph } from '@digdir/designsystemet-react';
 import { ElementsUtils } from './ElementsUtils';
 import type { ConfPageType } from './types/ConfigPageType';
 import useUxEditorParams from '@altinn/ux-editor-v4/hooks/useUxEditorParams';
@@ -55,12 +60,14 @@ export const Elements = ({ collapsed, onCollapseToggle }: ElementsProps): React.
       <div>
         <div className={classes.errorMessage}>
           <StudioError>
-            <Heading level={3} size='xsmall' spacing>
+            <StudioHeading level={3} spacing>
               {t('schema_editor.error_could_not_detect_taskType', {
                 layout: layoutSet,
               })}
-            </Heading>
-            <Paragraph>{t('schema_editor.error_could_not_detect_taskType_description')}</Paragraph>
+            </StudioHeading>
+            <StudioParagraph>
+              {t('schema_editor.error_could_not_detect_taskType_description')}
+            </StudioParagraph>
           </StudioError>
         </div>
       </div>
@@ -88,9 +95,9 @@ export const Elements = ({ collapsed, onCollapseToggle }: ElementsProps): React.
         <TogglePanelButton onClick={onCollapseToggle} isCollapsed={collapsed} />
       </div>
       {hideComponents ? (
-        <Paragraph className={classes.noPageSelected} size='small'>
+        <StudioParagraph className={classes.noPageSelected} data-size='sm'>
           {t('left_menu.no_components_selected')}
-        </Paragraph>
+        </StudioParagraph>
       ) : shouldShowConfPageToolbar ? (
         <ConfPageToolbar confPageType={configToolbarMode} />
       ) : (

--- a/src/Designer/frontend/packages/ux-editor-v4/src/components/Preview/Preview.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/components/Preview/Preview.tsx
@@ -5,10 +5,10 @@ import { useTranslation } from 'react-i18next';
 import { useAppContext, useGetLayoutSetByName } from '../../hooks';
 import { useChecksum } from '../../hooks/useChecksum.ts';
 import { previewPage } from 'app-shared/api/paths';
-import { Paragraph } from '@digdir/designsystemet-react';
 import {
-  StudioCenter,
   StudioAlert,
+  StudioCenter,
+  StudioParagraph,
   StudioSpinner,
   StudioValidationMessage,
 } from '@studio/components';
@@ -53,7 +53,7 @@ const NoSelectedPageMessage = () => {
   const { t } = useTranslation();
   return (
     <StudioCenter>
-      <Paragraph size='medium'>{t('ux_editor.no_components_selected')}</Paragraph>
+      <StudioParagraph data-size='md'>{t('ux_editor.no_components_selected')}</StudioParagraph>
     </StudioCenter>
   );
 };

--- a/src/Designer/frontend/packages/ux-editor-v4/src/components/Properties/PageConfigPanel/PageConfigWarning.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/components/Properties/PageConfigPanel/PageConfigWarning.tsx
@@ -1,10 +1,10 @@
-import { List, Link, Heading } from '@digdir/designsystemet-react';
+import { List, Link } from '@digdir/designsystemet-react';
 import { repositoryLayoutPath } from 'app-shared/api/paths';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { getDuplicatedIds } from '../../../utils/formLayoutUtils';
 import type { IInternalLayout } from '../../../types/global';
 import { useTranslation } from 'react-i18next';
-import { StudioSectionHeader } from '@studio/components';
+import { StudioHeading, StudioSectionHeader } from '@studio/components';
 import { SectionHeaderWarningIcon } from '@studio/icons';
 import classes from './PageConfigWarning.module.css';
 
@@ -31,9 +31,9 @@ export const PageConfigWarning = ({ layout, selectedFormLayoutName }: PageConfig
         className={classes.configWarningHeader}
       />
       <div className={classes.configWarningContent}>
-        <Heading level={3} size='xxsmall' spacing>
+        <StudioHeading level={3} data-size='xs' spacing>
           {t('ux_editor.config.warning_duplicates.solution_heading')}
-        </Heading>
+        </StudioHeading>
         <List.Root className={classes.configWarningList} size='small'>
           <List.Ordered>
             <List.Item>

--- a/src/Designer/frontend/packages/ux-editor-v4/src/components/Properties/PageConfigPanel/PdfConfig/ConvertPageToPdfWhenExistingModal/OverrideCurrentPdfByConversionChoices.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/components/Properties/PageConfigPanel/PdfConfig/ConvertPageToPdfWhenExistingModal/OverrideCurrentPdfByConversionChoices.tsx
@@ -1,5 +1,4 @@
-import { StudioButton } from '@studio/components';
-import { Paragraph } from '@digdir/designsystemet-react';
+import { StudioButton, StudioParagraph } from '@studio/components';
 import { useTranslation } from 'react-i18next';
 import classes from './OverrideCurrentPdfByConversionChoices.module.css';
 
@@ -16,7 +15,9 @@ export const OverrideCurrentPdfByConversionChoices = ({
 
   return (
     <div className={classes.modal}>
-      <Paragraph>{t('ux_editor.page_config_pdf_convert_info_when_custom_pdf_exists')}</Paragraph>
+      <StudioParagraph>
+        {t('ux_editor.page_config_pdf_convert_info_when_custom_pdf_exists')}
+      </StudioParagraph>
       <div className={classes.buttonContainer}>
         <StudioButton onClick={onConvertPageToPdfAndConvertCurrent}>
           {t('ux_editor.page_config_pdf_convert_existing_pdf')}

--- a/src/Designer/frontend/packages/ux-editor-v4/src/components/config/ExpressionContent/ExpressionContent.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/components/config/ExpressionContent/ExpressionContent.tsx
@@ -2,11 +2,10 @@ import type { ReactNode } from 'react';
 import { useMemo } from 'react';
 import { getComponentIds, getDataModelElementNames } from '../../../utils/expressionsUtils';
 import type { Expression, DataLookupOptions } from '@studio/components';
-import { DataLookupFuncName, StudioDeleteButton } from '@studio/components';
+import { DataLookupFuncName, StudioDeleteButton, StudioParagraph } from '@studio/components';
 import { useFormLayoutsQuery } from '../../../hooks/queries/useFormLayoutsQuery';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useDataModelMetadataQuery } from '../../../hooks/queries/useDataModelMetadataQuery';
-import { Paragraph } from '@digdir/designsystemet-react';
 import classes from './ExpressionContent.module.css';
 import { Expression as ExpressionWithTexts } from './Expression';
 import { useText } from '../../../hooks';
@@ -45,9 +44,9 @@ export const ExpressionContent = ({
   return (
     <fieldset className={classes.expressionContent}>
       <legend className={classes.legend}>
-        <Paragraph className={classes.legendContent} size='small'>
+        <StudioParagraph className={classes.legendContent} data-size='sm'>
           {heading}
-        </Paragraph>
+        </StudioParagraph>
       </legend>
       {expression && (
         <StudioDeleteButton

--- a/src/Designer/frontend/packages/ux-editor-v4/src/components/config/Expressions/Expressions.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/components/config/Expressions/Expressions.tsx
@@ -1,5 +1,4 @@
 import { useContext } from 'react';
-import { Paragraph } from '@digdir/designsystemet-react';
 import { ExpressionContent } from '../ExpressionContent';
 import classes from './Expressions.module.css';
 import { FormItemContext } from '../../../containers/FormItemContext';
@@ -15,7 +14,7 @@ import type { FormItemProperty } from '../../../types/FormItemProperty';
 import { ExpressionHeading } from './ExpressionHeading';
 import type { FormItem } from '../../../types/FormItem';
 import type { BooleanExpression } from '@studio/components';
-import { StudioCodeFragment } from '@studio/components';
+import { StudioCodeFragment, StudioParagraph } from '@studio/components';
 
 export const Expressions = () => {
   const { formItem, handleUpdate, debounceSave } = useContext(FormItemContext);
@@ -55,7 +54,7 @@ export const Expressions = () => {
 };
 
 const Placeholder = ({ componentName }: { componentName: string }) => (
-  <Paragraph size='small' className={classes.placeHolder}>
+  <StudioParagraph data-size='sm' className={classes.placeHolder}>
     <Trans
       i18nKey={'right_menu.expressions_property_on_component'}
       values={{ componentName }}
@@ -63,5 +62,5 @@ const Placeholder = ({ componentName }: { componentName: string }) => (
         bold: <StudioCodeFragment className={classes.wrapper} title={componentName} />,
       }}
     />
-  </Paragraph>
+  </StudioParagraph>
 );

--- a/src/Designer/frontend/packages/ux-editor-v4/src/components/config/editModal/EditGrid/EditGridForGivenViewSize.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/components/config/editModal/EditGrid/EditGridForGivenViewSize.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { useText } from '../../../../hooks';
 import type { GridSize } from '@studio/components-legacy';
-import { StudioGridSelector } from '@studio/components';
-import { Paragraph, Switch } from '@digdir/designsystemet-react';
+import { StudioGridSelector, StudioParagraph } from '@studio/components';
+import { Switch } from '@digdir/designsystemet-react';
 import { PadlockLockedFillIcon } from '@studio/icons';
 import classes from './EditGridForGivenViewSize.module.css';
 import { ObjectUtils } from '@studio/pure-functions';
@@ -43,7 +43,7 @@ export const EditGridForGivenViewSize = ({
   return (
     <>
       <div className={classes.lockIcon}>
-        <Paragraph size='small'>{t('ux_editor.modal_properties_grid')}</Paragraph>
+        <StudioParagraph data-size='sm'>{t('ux_editor.modal_properties_grid')}</StudioParagraph>
         {!gridValues[viewSize] && <PadlockLockedFillIcon title='lockIcon' />}
       </div>
       <StudioGridSelector

--- a/src/Designer/frontend/packages/ux-editor-v4/src/components/config/editModal/EditOptions/EditOptions.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/components/config/editModal/EditOptions/EditOptions.tsx
@@ -1,8 +1,8 @@
 import type { IGenericEditComponent } from '../../componentConfig';
 import type { SelectionComponentType } from '../../../../types/FormComponent';
 import { useOptionListIdsQuery } from '../../../../hooks/queries/useOptionListIdsQuery';
-import { ErrorMessage, Heading } from '@digdir/designsystemet-react';
-import { StudioSpinner } from '@studio/components';
+import { ErrorMessage } from '@digdir/designsystemet-react';
+import { StudioHeading, StudioSpinner } from '@studio/components';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useTranslation } from 'react-i18next';
 import { OptionTabs } from './OptionTabs';
@@ -22,9 +22,9 @@ export function EditOptions<T extends SelectionComponentType>({
 
   return (
     <div className={classes.root}>
-      <Heading level={4} size='xxsmall' spacing={true} className={classes.optionsHeading}>
+      <StudioHeading level={4} data-size='xs' spacing={true} className={classes.optionsHeading}>
         {t('ux_editor.options.section_heading')}
-      </Heading>
+      </StudioHeading>
       {isPending ? (
         <StudioSpinner aria-label={t('ux_editor.modal_properties_loading')} />
       ) : isError ? (

--- a/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/FormLayout.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/FormLayout.tsx
@@ -2,11 +2,12 @@ import type { IInternalLayout } from '../../types/global';
 import { FormTree } from './FormTree';
 import { hasMultiPageGroup } from '../../utils/formLayoutUtils';
 import { useTranslation } from 'react-i18next';
-import { Alert, Paragraph } from '@digdir/designsystemet-react';
+import { Alert } from '@digdir/designsystemet-react';
 import { FormLayoutWarning } from './FormLayoutWarning';
 import { BASE_CONTAINER_ID } from 'app-shared/constants';
 import { AddItem } from './AddItem';
 import { useFeatureFlag, FeatureFlag } from '@studio/feature-flags';
+import { StudioParagraph } from '@studio/components';
 
 export interface FormLayoutProps {
   layout: IInternalLayout;
@@ -39,7 +40,7 @@ const MultiPageWarning = () => {
   const { t } = useTranslation();
   return (
     <Alert severity='warning'>
-      <Paragraph size='small'>{t('ux_editor.multi_page_warning')}</Paragraph>
+      <StudioParagraph data-size='sm'>{t('ux_editor.multi_page_warning')}</StudioParagraph>
     </Alert>
   );
 };

--- a/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/FormLayoutWarning.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/FormLayoutWarning.tsx
@@ -1,8 +1,8 @@
 import type { IInternalLayout } from '../../types/global';
 import { getDuplicatedIds } from '../../utils/formLayoutUtils';
-import { Paragraph } from '@digdir/designsystemet-react';
 import { useTranslation } from 'react-i18next';
 import classes from './FormLayoutWarning.module.css';
+import { StudioParagraph } from '@studio/components';
 
 interface FormLayoutWarningProps {
   layout: IInternalLayout;
@@ -13,13 +13,13 @@ export const FormLayoutWarning = ({ layout }: FormLayoutWarningProps) => {
   const { t } = useTranslation();
   return (
     <div className={classes.warningWrapper}>
-      <Paragraph size='small'>
+      <StudioParagraph data-size='sm'>
         {t('ux_editor.formLayout.warning_duplicates')}
         <span className={classes.duplicatedId}> {duplicatedIds}</span>
-      </Paragraph>
-      <Paragraph size='small'>
+      </StudioParagraph>
+      <StudioParagraph data-size='sm'>
         {t('ux_editor.formLayout.warning_duplicates.cannot_publish')}
-      </Paragraph>
+      </StudioParagraph>
     </div>
   );
 };

--- a/src/Designer/frontend/packages/ux-editor/src/components/Elements/Elements.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/components/Elements/Elements.tsx
@@ -5,10 +5,9 @@ import { DefaultToolbar } from './DefaultToolbar';
 
 import classes from './Elements.module.css';
 
-import { StudioButton, StudioHeading } from '@studio/components';
+import { StudioButton, StudioHeading, StudioParagraph } from '@studio/components';
 import { SidebarLeftIcon } from '@studio/icons';
 import { useTranslation } from 'react-i18next';
-import { Paragraph } from '@digdir/designsystemet-react';
 
 export interface ElementsProps {
   collapsed: boolean;
@@ -36,9 +35,9 @@ export const Elements = ({ collapsed, onCollapseToggle }: ElementsProps): React.
         <TogglePanelButton onClick={onCollapseToggle} isCollapsed={collapsed} />
       </div>
       {hideComponents ? (
-        <Paragraph className={classes.noPageSelected} size='small'>
+        <StudioParagraph className={classes.noPageSelected}>
           {t('left_menu.no_components_selected')}
-        </Paragraph>
+        </StudioParagraph>
       ) : shouldShowConfPageToolbar ? (
         <ConfPageToolbar confPageType={configToolbarMode} />
       ) : (

--- a/src/Designer/frontend/packages/ux-editor/src/components/Preview/Preview.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/components/Preview/Preview.tsx
@@ -5,10 +5,10 @@ import { useTranslation } from 'react-i18next';
 import { useAppContext, useGetLayoutSetByName } from '../../hooks';
 import { useChecksum } from '../../hooks/useChecksum.ts';
 import { previewPage } from 'app-shared/api/paths';
-import { Paragraph } from '@digdir/designsystemet-react';
 import {
-  StudioCenter,
   StudioAlert,
+  StudioCenter,
+  StudioParagraph,
   StudioSpinner,
   StudioValidationMessage,
 } from '@studio/components';
@@ -53,7 +53,7 @@ const NoSelectedPageMessage = () => {
   const { t } = useTranslation();
   return (
     <StudioCenter>
-      <Paragraph size='medium'>{t('ux_editor.no_components_selected')}</Paragraph>
+      <StudioParagraph data-size='md'>{t('ux_editor.no_components_selected')}</StudioParagraph>
     </StudioCenter>
   );
 };

--- a/src/Designer/frontend/packages/ux-editor/src/components/Properties/PageConfigPanel/PageConfigWarning.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/components/Properties/PageConfigPanel/PageConfigWarning.tsx
@@ -1,10 +1,10 @@
-import { List, Link, Heading } from '@digdir/designsystemet-react';
+import { List, Link } from '@digdir/designsystemet-react';
 import { repositoryLayoutPath } from 'app-shared/api/paths';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { getDuplicatedIds } from '../../../utils/formLayoutUtils';
 import type { IInternalLayout } from '../../../types/global';
 import { useTranslation } from 'react-i18next';
-import { StudioSectionHeader } from '@studio/components';
+import { StudioHeading, StudioSectionHeader } from '@studio/components';
 import { SectionHeaderWarningIcon } from '@studio/icons';
 import classes from './PageConfigWarning.module.css';
 
@@ -31,9 +31,9 @@ export const PageConfigWarning = ({ layout, selectedFormLayoutName }: PageConfig
         className={classes.configWarningHeader}
       />
       <div className={classes.configWarningContent}>
-        <Heading level={3} size='xxsmall' spacing>
+        <StudioHeading level={3} data-size='xs' spacing>
           {t('ux_editor.config.warning_duplicates.solution_heading')}
-        </Heading>
+        </StudioHeading>
         <List.Root className={classes.configWarningList} size='small'>
           <List.Ordered>
             <List.Item>

--- a/src/Designer/frontend/packages/ux-editor/src/components/Properties/PageConfigPanel/PdfConfig/ConvertPageToPdfWhenExistingModal/OverrideCurrentPdfByConversionChoices.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/components/Properties/PageConfigPanel/PdfConfig/ConvertPageToPdfWhenExistingModal/OverrideCurrentPdfByConversionChoices.tsx
@@ -1,5 +1,4 @@
-import { StudioButton } from '@studio/components';
-import { Paragraph } from '@digdir/designsystemet-react';
+import { StudioButton, StudioParagraph } from '@studio/components';
 import { useTranslation } from 'react-i18next';
 import classes from './OverrideCurrentPdfByConversionChoices.module.css';
 
@@ -16,7 +15,9 @@ export const OverrideCurrentPdfByConversionChoices = ({
 
   return (
     <div className={classes.modal}>
-      <Paragraph>{t('ux_editor.page_config_pdf_convert_info_when_custom_pdf_exists')}</Paragraph>
+      <StudioParagraph>
+        {t('ux_editor.page_config_pdf_convert_info_when_custom_pdf_exists')}
+      </StudioParagraph>
       <div className={classes.buttonContainer}>
         <StudioButton onClick={onConvertPageToPdfAndConvertCurrent}>
           {t('ux_editor.page_config_pdf_convert_existing_pdf')}

--- a/src/Designer/frontend/packages/ux-editor/src/components/config/ExpressionContent/ExpressionContent.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/components/config/ExpressionContent/ExpressionContent.tsx
@@ -2,11 +2,10 @@ import type { ReactNode } from 'react';
 import { useMemo } from 'react';
 import { getComponentIds, getDataModelElementNames } from '../../../utils/expressionsUtils';
 import type { Expression, DataLookupOptions } from '@studio/components';
-import { DataLookupFuncName, StudioDeleteButton } from '@studio/components';
+import { DataLookupFuncName, StudioDeleteButton, StudioParagraph } from '@studio/components';
 import { useFormLayoutsQuery } from '../../../hooks/queries/useFormLayoutsQuery';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useDataModelMetadataQuery } from '../../../hooks/queries/useDataModelMetadataQuery';
-import { Paragraph } from '@digdir/designsystemet-react';
 import classes from './ExpressionContent.module.css';
 import { Expression as ExpressionWithTexts } from './Expression';
 import { useText } from '../../../hooks';
@@ -45,9 +44,9 @@ export const ExpressionContent = ({
   return (
     <fieldset className={classes.expressionContent}>
       <legend className={classes.legend}>
-        <Paragraph className={classes.legendContent} size='small'>
+        <StudioParagraph className={classes.legendContent} data-size='sm'>
           {heading}
-        </Paragraph>
+        </StudioParagraph>
       </legend>
       {expression && (
         <StudioDeleteButton

--- a/src/Designer/frontend/packages/ux-editor/src/components/config/Expressions/Expressions.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/components/config/Expressions/Expressions.tsx
@@ -1,5 +1,4 @@
 import { useContext } from 'react';
-import { Paragraph } from '@digdir/designsystemet-react';
 import { ExpressionContent } from '../ExpressionContent';
 import classes from './Expressions.module.css';
 import { FormItemContext } from '../../../containers/FormItemContext';
@@ -15,7 +14,7 @@ import type { FormItemProperty } from '../../../types/FormItemProperty';
 import { ExpressionHeading } from './ExpressionHeading';
 import type { FormItem } from '../../../types/FormItem';
 import type { BooleanExpression } from '@studio/components';
-import { StudioCodeFragment } from '@studio/components';
+import { StudioCodeFragment, StudioParagraph } from '@studio/components';
 
 export const Expressions = () => {
   const { formItem, handleUpdate, debounceSave } = useContext(FormItemContext);
@@ -55,7 +54,7 @@ export const Expressions = () => {
 };
 
 const Placeholder = ({ componentName }: { componentName: string }) => (
-  <Paragraph size='small' className={classes.placeHolder}>
+  <StudioParagraph data-size='sm' className={classes.placeHolder}>
     <Trans
       i18nKey={'right_menu.expressions_property_on_component'}
       values={{ componentName }}
@@ -63,5 +62,5 @@ const Placeholder = ({ componentName }: { componentName: string }) => (
         bold: <StudioCodeFragment className={classes.wrapper} title={componentName} />,
       }}
     />
-  </Paragraph>
+  </StudioParagraph>
 );

--- a/src/Designer/frontend/packages/ux-editor/src/components/config/editModal/EditGrid/EditGridForGivenViewSize.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/components/config/editModal/EditGrid/EditGridForGivenViewSize.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { useText } from '../../../../hooks';
 import type { GridSize } from '@studio/components-legacy';
-import { StudioGridSelector } from '@studio/components';
-import { Paragraph, Switch } from '@digdir/designsystemet-react';
+import { StudioGridSelector, StudioParagraph } from '@studio/components';
+import { Switch } from '@digdir/designsystemet-react';
 import { PadlockLockedFillIcon } from '@studio/icons';
 import classes from './EditGridForGivenViewSize.module.css';
 import { ObjectUtils } from '@studio/pure-functions';
@@ -43,7 +43,7 @@ export const EditGridForGivenViewSize = ({
   return (
     <>
       <div className={classes.lockIcon}>
-        <Paragraph size='small'>{t('ux_editor.modal_properties_grid')}</Paragraph>
+        <StudioParagraph data-size='sm'>{t('ux_editor.modal_properties_grid')}</StudioParagraph>
         {!gridValues[viewSize] && <PadlockLockedFillIcon title='lockIcon' />}
       </div>
       <StudioGridSelector

--- a/src/Designer/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/EditOptions.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/EditOptions.tsx
@@ -1,8 +1,8 @@
 import type { IGenericEditComponent } from '../../componentConfig';
 import type { SelectionComponentType } from '../../../../types/FormComponent';
 import { useOptionListIdsQuery } from '../../../../hooks/queries/useOptionListIdsQuery';
-import { ErrorMessage, Heading } from '@digdir/designsystemet-react';
-import { StudioSpinner } from '@studio/components';
+import { ErrorMessage } from '@digdir/designsystemet-react';
+import { StudioHeading, StudioSpinner } from '@studio/components';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useTranslation } from 'react-i18next';
 import { OptionTabs } from './OptionTabs';
@@ -22,9 +22,9 @@ export function EditOptions<T extends SelectionComponentType>({
 
   return (
     <div className={classes.root}>
-      <Heading level={4} size='xxsmall' spacing={true} className={classes.optionsHeading}>
+      <StudioHeading level={4} data-size='xs' spacing={true} className={classes.optionsHeading}>
         {t('ux_editor.options.section_heading')}
-      </Heading>
+      </StudioHeading>
       {isPending ? (
         <StudioSpinner aria-label={t('ux_editor.modal_properties_loading')} />
       ) : isError ? (

--- a/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/FormLayout.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/FormLayout.tsx
@@ -2,7 +2,8 @@ import type { IInternalLayout } from '../../types/global';
 import { FormTree } from './FormTree';
 import { hasMultiPageGroup } from '../../utils/formLayoutUtils';
 import { useTranslation } from 'react-i18next';
-import { Alert, Paragraph } from '@digdir/designsystemet-react';
+import { Alert } from '@digdir/designsystemet-react';
+import { StudioParagraph } from '@studio/components';
 import { FormLayoutWarning } from './FormLayoutWarning';
 import { BASE_CONTAINER_ID } from 'app-shared/constants';
 import { AddItem } from './AddItem';
@@ -39,7 +40,7 @@ const MultiPageWarning = () => {
   const { t } = useTranslation();
   return (
     <Alert severity='warning'>
-      <Paragraph size='small'>{t('ux_editor.multi_page_warning')}</Paragraph>
+      <StudioParagraph>{t('ux_editor.multi_page_warning')}</StudioParagraph>
     </Alert>
   );
 };

--- a/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/FormLayoutWarning.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/FormLayoutWarning.tsx
@@ -1,6 +1,6 @@
 import type { IInternalLayout } from '../../types/global';
 import { getDuplicatedIds } from '../../utils/formLayoutUtils';
-import { Paragraph } from '@digdir/designsystemet-react';
+import { StudioParagraph } from '@studio/components';
 import { useTranslation } from 'react-i18next';
 import classes from './FormLayoutWarning.module.css';
 
@@ -13,13 +13,13 @@ export const FormLayoutWarning = ({ layout }: FormLayoutWarningProps) => {
   const { t } = useTranslation();
   return (
     <div className={classes.warningWrapper}>
-      <Paragraph size='small'>
+      <StudioParagraph>
         {t('ux_editor.formLayout.warning_duplicates')}
         <span className={classes.duplicatedId}> {duplicatedIds}</span>
-      </Paragraph>
-      <Paragraph size='small'>
+      </StudioParagraph>
+      <StudioParagraph>
         {t('ux_editor.formLayout.warning_duplicates.cannot_publish')}
-      </Paragraph>
+      </StudioParagraph>
     </div>
   );
 };

--- a/src/Designer/frontend/studio-root/app/App.tsx
+++ b/src/Designer/frontend/studio-root/app/App.tsx
@@ -1,7 +1,6 @@
 import classes from './App.module.css';
 import { Route, Routes } from 'react-router-dom';
-import { StudioNotFoundPage } from '@studio/components';
-import { Paragraph, Link } from '@digdir/designsystemet-react';
+import { StudioNotFoundPage, StudioParagraph, StudioLink } from '@studio/components';
 import { useTranslation, Trans } from 'react-i18next';
 import './App.css';
 import { PageLayout } from '../pages/PageLayout';
@@ -33,14 +32,14 @@ const NotFoundPage = () => {
     <StudioNotFoundPage
       title={t('not_found_page.heading')}
       body={
-        <Paragraph size='small'>
+        <StudioParagraph>
           <Trans
             i18nKey='not_found_page.text'
             components={{
-              a: <Link href='/info/contact'> </Link>,
+              a: <StudioLink href='/info/contact'> </StudioLink>,
             }}
           ></Trans>
-        </Paragraph>
+        </StudioParagraph>
       }
       redirectHref='/'
       redirectLinkText={t('not_found_page.redirect_to_dashboard')}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Replace direct import from Designsystemet with our wrappers: `StudioHeading` and `StudioParagraph`


<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ x **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated headings, paragraphs and links across the application to use the latest shared presentation components.
  - Standardised text sizing and spacing for a more consistent visual experience.
  - Preserved existing content, translations, links, alerts and interaction behaviour.
  - Removed obsolete styling associated with replaced text components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->