### PR TITLE
chore(deps): update Swashbuckle and OpenAPI packages

### DIFF
--- a/src/App/backend/Directory.Packages.props
+++ b/src/App/backend/Directory.Packages.props
@@ -37,7 +37,7 @@
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.8.0" />
     <PackageVersion Include="Microsoft.FeatureManagement.AspNetCore" Version="4.4.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-    <PackageVersion Include="Microsoft.OpenApi" Version="2.7.4" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.11.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="NetEscapades.EnumGenerators" Version="1.0.0-beta21" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
@@ -51,7 +51,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
     <PackageVersion Include="PolySharp" Version="1.15.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.7" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <PackageVersion Include="System.Formats.Asn1" Version="10.0.8" />
     <PackageVersion Include="Verify.AspNetCore" Version="4.0.0" />
     <PackageVersion Include="Verify.Moq" Version="2.2.0" />

--- a/src/App/backend/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveCustomOpenApiSpec.verified.json
+++ b/src/App/backend/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveCustomOpenApiSpec.verified.json
@@ -50,9 +50,7 @@
           "description": "Instance document, formData and attachments\n\nAny mime type that is not ``\"application/json\"`` or ``\"multipart/form-data\"`` with an instance document\nwill require the ``instanceOwnerPartyId`` parameter. Otherwise you must use the simplified instance document to specify instance owner.\nEither using ``instanceOwner.partyId`` or ``instanceOwner.personNumber`` or ``instanceOwner.organisationNumber`` (or ``instanceOwner.username`` see [app-lib-dotnet/#652](https://github.com/Altinn/app-lib-dotnet/issues/652)).",
           "content": {
             "empty": {
-              "schema": {
-                "nullable": true
-              }
+              "schema": {}
             },
             "application/json": {
               "schema": {

--- a/src/App/backend/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveJsonSwagger.verified.json
+++ b/src/App/backend/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveJsonSwagger.verified.json
@@ -8713,9 +8713,7 @@
           },
           "changedFields": {
             "type": "object",
-            "additionalProperties": {
-              "nullable": true
-            },
+            "additionalProperties": {},
             "nullable": true
           }
         },
@@ -8993,19 +8991,13 @@
         ],
         "type": "object",
         "properties": {
-          "schema": {
-            "nullable": true
-          },
-          "initialData": {
-            "nullable": true
-          },
+          "schema": {},
+          "initialData": {},
           "dataElementId": {
             "type": "string",
             "nullable": true
           },
-          "expressionValidationConfig": {
-            "nullable": true
-          },
+          "expressionValidationConfig": {},
           "initialValidationIssues": {
             "type": "array",
             "items": {
@@ -9101,8 +9093,7 @@
             "nullable": true
           },
           "newDataModel": {
-            "description": "The current data model after the patch operation.",
-            "nullable": true
+            "description": "The current data model after the patch operation."
           },
           "instance": {
             "$ref": "#/components/schemas/Instance"
@@ -9518,9 +9509,7 @@
         ],
         "type": "object",
         "properties": {
-          "layouts": {
-            "nullable": true
-          },
+          "layouts": {},
           "dataModels": {
             "type": "object",
             "additionalProperties": {

--- a/src/Runtime/gateway/Directory.Packages.props
+++ b/src/Runtime/gateway/Directory.Packages.props
@@ -17,7 +17,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.7" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.2.3" />
     <PackageVersion Include="KubernetesClient.Aot" Version="18.0.13" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.8.0" />

--- a/src/Runtime/kubernetes-wrapper/Directory.Packages.props
+++ b/src/Runtime/kubernetes-wrapper/Directory.Packages.props
@@ -11,7 +11,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.7" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
 
     <!-- Static analysis, formatting -->
     <PackageVersion Include="CSharpier.MsBuild" Version="1.3.0" />

--- a/src/Runtime/workflow-engine-app/Directory.Packages.props
+++ b/src/Runtime/workflow-engine-app/Directory.Packages.props
@@ -16,7 +16,7 @@
     <PackageVersion Include="CSharpier.MsBuild" Version="1.3.0" />
     <PackageVersion Include="Nullable.Extended.Analyzer" Version="1.15.6581" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.31.0.145097" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.7" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.2.3" />
     <PackageVersion Include="System.Net.Http.Json" Version="10.0.10" />
     <PackageVersion Include="OpenTelemetry" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />

--- a/src/Runtime/workflow-engine/Directory.Packages.props
+++ b/src/Runtime/workflow-engine/Directory.Packages.props
@@ -20,7 +20,7 @@
     <PackageVersion Include="CSharpier.MsBuild" Version="1.3.0" />
     <PackageVersion Include="Nullable.Extended.Analyzer" Version="1.15.6581" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.31.0.145097" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.7" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.2.3" />
     <PackageVersion Include="System.Net.Http.Json" Version="10.0.10" />
     <PackageVersion Include="OpenTelemetry" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />


### PR DESCRIPTION
## Description

Extracts the Swashbuckle/OpenAPI dependency topic from #19759 and updates every current repository declaration.

@martinothamar — the dependency and behavior audit below is included to make the merge risk and required validation explicit.

### Version audit (2026-08-11)

- Swashbuckle.AspNetCore and Swashbuckle.AspNetCore.SwaggerUI: 10.1.7 → 10.2.3 (latest stable). Applied across App backend, gateway, Kubernetes wrapper, workflow engine, and workflow engine app.
- Microsoft.OpenApi: 2.7.4 → 2.11.0 (latest stable in the compatible 2.x line). Version 3.9.0 is the newest major, but adopting it is a separate source/API migration; Swashbuckle 10.2.3 itself is built against 2.7.5.
- Microsoft.AspNetCore.OpenApi declarations are already on the latest servicing versions for their target frameworks (9.0.18/10.0.10), so they are unchanged.

### Upstream change audit

- Swashbuckle 10.2 adds endpoint-routing helpers, HEAD support, updated Swagger UI/ReDoc assets, and fixes for unmatched routes, required+nullable schemas, dictionary min/max-property mapping, and empty examples. 10.2.1 also consumes the Microsoft.OpenApi security fix. Releases: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/compare/v10.1.7...v10.2.3
- OpenAPI.NET 2.7.5–2.11 improves circular/external reference handling and parser allocations, adds schema keyword/reference support, and changes nullability serialization for OpenAPI 3.0/2.0. Releases: https://github.com/microsoft/OpenAPI.NET/compare/v2.7.4...v2.11.0
- The OpenAPI snapshots changed only where an unconstrained schema previously emitted nullable: true. In OpenAPI 3.0 that flag has no effect without a type in the same schema, so the resulting empty schema remains nullable and semantically equivalent.

### Risk and recommended test level

**Risk: medium.** Runtime request handling is unaffected, but generated OpenAPI documents and hosted documentation assets change. The main review surface is schema nullability/required metadata and consumers that compare or generate clients from these documents.

Recommended before/after deployment:

- keep the OpenAPI snapshot review as the primary regression gate;
- smoke-test each hosted Swagger UI endpoint;
- regenerate any downstream clients that consume these documents and inspect diffs if such a pipeline exists.

## Verification

- [x] Related issue/PR connected: #19759
- [x] All five affected .NET solutions build with 0 warnings and 0 errors.
- [x] App OpenAPI snapshot tests: 2/2 passed; intentional snapshots reviewed and updated.
- [x] Kubernetes wrapper OpenAPI snapshot: 1/1 passed.
- [x] Gateway unit tests excluding Kubernetes: 19/19 passed.
- [x] Manual browser testing: Swagger UI loaded both the general 70-path document and the metadata-generated custom document; the definition selector, custom 15-path/51-schema rendering, direct endpoints, and browser console were verified, with screenshots posted in the review thread.

An additional WorkflowEngine.App run completed all 76 test assertions, but its collection fixture reported a cleanup failure after the tests; CI remains the authoritative integrated result.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Improvements**
  * Updated OpenAPI documentation to more accurately describe object-valued fields and request bodies.
  * Corrected nullability information for data, layout, validation, and patch response properties.
  * Improved representation of unrestricted object schemas in generated API specifications.

* **Maintenance**
  * Updated API documentation tooling to improve compatibility and consistency across runtime components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

