### PR TITLE
chore(deps): update Azure client packages

### DIFF
--- a/src/App/backend/Directory.Packages.props
+++ b/src/App/backend/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="Altinn.Common.PEP" Version="4.2.2" />
     <PackageVersion Include="Altinn.Platform.Models" Version="1.6.1" />
     <PackageVersion Include="Altinn.Platform.Storage.Interface" Version="4.7.0" />
-    <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.0" />
+    <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.7.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />

--- a/src/Designer/backend/Directory.Packages.props
+++ b/src/Designer/backend/Directory.Packages.props
@@ -51,15 +51,15 @@
     <PackageVersion Include="DotNetEnv" Version="3.1.1" />
     <PackageVersion Include="NuGet.Versioning" Version="6.14.3" />
     <PackageVersion Include="DistributedLock.Postgres" Version="1.3.1" />
-    <PackageVersion Include="System.Text.Json" Version="[9.0.18]" />
+    <PackageVersion Include="System.Text.Json" Version="[10.0.10]" />
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.14.28" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="[4.14.0]" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="[4.14.0]" />
-    <PackageVersion Include="Azure.Identity" Version="1.17.2" />
-    <PackageVersion Include="Azure.Storage.Blobs" Version="[12.27.0]" />
-    <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="[4.8.0]" />
-    <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.21.0" />
+    <PackageVersion Include="Azure.Storage.Blobs" Version="[12.29.1]" />
+    <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="[4.11.0]" />
+    <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
     <PackageVersion Include="System.Formats.Asn1" Version="9.0.18" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="[9.0.18]" />
     <PackageVersion Include="System.Net.Http" Version="[4.3.4]" />


### PR DESCRIPTION
## Description

Extracts the Azure client dependency topic from #19759 and updates the active Azure SDK package set to the latest stable versions.

@martinothamar — this PR includes the required direct dependency needed to make the Azure update resolvable, plus an audit of the resulting runtime behavior changes.

### Version audit (2026-08-11)

- Azure.Identity: 1.17.2 → 1.21.0
- Azure.Storage.Blobs: 12.27.0 → 12.29.1
- Azure.Security.KeyVault.Secrets: 4.8.0 → 4.11.0
- Azure.Extensions.AspNetCore.Configuration.Secrets: Designer 1.4.0 → 1.5.1; App backend 1.5.0 → 1.5.1
- System.Text.Json: Designer 9.0.18 → 10.0.10. This is an explicit enabling dependency: the updated Azure SDK resolves Azure.Core 1.55.0, which requires System.Text.Json 10.x. Without this change NuGet rejects the graph as a package downgrade.
- Other Azure.Identity declarations in App backend, gateway, and workflow engine were already at 1.21.0.

### Upstream change audit

- Azure.Identity 1.20 changes the return types of AddAzureClient/AddKeyedAzureClient/WithAzureCredential registration APIs. Repository usage was audited and none of those APIs are called, so the source-breaking surface is not exercised. 1.21 moves shared identity types into Azure.Core through type forwarding. Changelog: https://github.com/Azure/azure-sdk-for-net/blob/Azure.Identity_1.21.0/sdk/identity/Azure.Identity/CHANGELOG.md
- Azure.Storage.Blobs 12.28 changes default transfer concurrency from a fixed value to a CPU-based value, so throughput and resource use can change when no StorageTransferOptions are supplied. 12.29 adds malformed-query length validation/memory hardening; 12.29.1 fixes SAS-builder field handling and empty-content checksums. Changelog: https://github.com/Azure/azure-sdk-for-net/blob/Azure.Storage.Blobs_12.29.1/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
- Azure.Security.KeyVault.Secrets updates its default service API version and adds configuration/DI support; later fixes align identity type registration with Azure.Core. Changelog: https://github.com/Azure/azure-sdk-for-net/blob/Azure.Security.KeyVault.Secrets_4.11.0/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
- Azure.Extensions.AspNetCore.Configuration.Secrets adds configuration helpers and fixes cancellation/disposal behavior; 1.5.1 aligns with identity types moved to Azure.Core. Changelog: https://github.com/Azure/azure-sdk-for-net/blob/Azure.Extensions.AspNetCore.Configuration.Secrets_1.5.1/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/CHANGELOG.md
- System.Text.Json 10 introduces a behavioral check that rejects serializer contracts whose properties conflict with reserved metadata names. Audit: https://learn.microsoft.com/dotnet/core/compatibility/serialization/10/property-name-validation

### Risk and recommended test level

**Risk: medium-high.** Authentication registration APIs used by this repository are source-compatible, but Blob transfer defaults can affect CPU/memory/network behavior and System.Text.Json 10 applies across Designer serialization. Key Vault also moves to a newer default service API version.

Recommended before/after deployment:

- smoke-test Designer startup with managed identity/default credentials and App startup with client-secret Key Vault configuration;
- exercise shared-content Blob upload, listing, and download against a real Azure storage account, watching memory/CPU and throttling;
- run the full Designer test suite in CI and smoke-test representative JSON-heavy Designer APIs because System.Text.Json is a broad enabling change.

## Verification

- [x] Related issue/PR connected: #19759
- [x] Designer.sln builds with 0 warnings and 0 errors.
- [x] After rebase, App backend solutions/All.slnx builds with 0 errors; restore reports 62 NuGet audit warnings for pre-existing Microsoft.Build, System.Security.Cryptography.Xml, and Scriban.Signed versions on main.
- [x] AzureSharedContentClientTests: 28/28 passed.
- [x] App Key Vault-focused tests: 4/4 passed.
- [x] DataModeling.Tests from the broader Designer solution run: 469/469 passed.
- [ ] Manual Azure integration testing: not performed; environment-backed smoke tests are recommended above.

The full Designer.Tests run was attempted, but this host exhausted its configured 1,024 inotify-instance limit and unrelated WebApplicationFactory tests began failing in FileSystemWatcher startup. The focused Azure tests completed successfully before and independently of that host-resource failure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Azure Identity, Azure Storage Blobs, Azure Key Vault Secrets, Azure ASP.NET Core Configuration Secrets, and System.Text.Json components to newer versions.
  * Applied routine package maintenance across the application and designer experiences to support improved compatibility, reliability, and security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
