### PR TITLE
chore(deps): update CLI parsing packages

### DIFF
--- a/src/cli/Directory.Packages.props
+++ b/src/cli/Directory.Packages.props
@@ -4,9 +4,8 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Acornima" Version="1.6.2" />
-    <PackageVersion Include="AngleSharp" Version="1.4.0" />
-    <PackageVersion Include="Jint" Version="4.6.4" />
+    <PackageVersion Include="Acornima" Version="1.7.0" />
+    <PackageVersion Include="AngleSharp" Version="1.7.1" />
     <PackageVersion Include="LibGit2Sharp" Version="0.32.0" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.11.2" />
     <PackageVersion Include="Microsoft.Build" Version="18.4.0" />


### PR DESCRIPTION
## Description

Extracts the CLI parsing dependency topic from #19759 and updates the packages used by studioctl's app-upgrade source transformations.

@martinothamar — the audit below focuses on migration-output risk, since these libraries parse user application JavaScript and Razor/HTML rather than ordinary CLI arguments.

### Version audit (2026-08-11)

- Acornima: 1.6.2 → 1.7.0 (latest stable)
- AngleSharp: 1.4.0 → 1.7.1 (latest stable)
- Removed the stale central Jint 4.6.4 pin. Repository and resolved-package audits found no PackageReference, source usage, or transitive resolution for Jint, so updating it to 4.15.3 would not change any built artifact.

### Upstream change audit

- Acornima 1.7 reports parser performance/allocation improvements and fixes AST/token behavior for regular expressions, parenthesized patterns, exponentiation/await, serialization, and JSX. The ParenthesizedExpression preservation change is the most relevant behavioral surface for RuleHandler migrations. Release: https://github.com/adams85/acornima/releases/tag/v1.7.0
- AngleSharp 1.5 fixes GHSA-pgww-w46g-26qg, which affects the currently pinned 1.4.0. Releases through 1.7.1 also change tokenizer performance, bounded streaming, URL canonicalization, DOM iteration/range behavior, selectors, and document parsing. Releases: https://github.com/AngleSharp/AngleSharp/releases/tag/1.5.0 and https://github.com/AngleSharp/AngleSharp/releases/tag/v1.7.1
- Repository usage is limited to the v8→v9 upgrade path: Acornima parses and rewrites RuleHandler/index JavaScript, while AngleSharp parses and categorizes Index.cshtml content.

### Risk and recommended test level

**Risk: medium.** There is no long-running service/runtime impact, but parser and AST behavior can change generated app-upgrade output. A subtle migration rewrite is more likely than a CLI startup regression.

Recommended validation:

- keep the full studioctl server suite as the primary regression gate;
- run v8→v9 upgrades on representative apps containing parenthesized expressions, regex literals, custom RuleHandler logic, and modified Index.cshtml markup;
- inspect generated diffs and build the upgraded apps.

## Verification

- [x] Related issue/PR connected: #19759
- [x] studioctl.slnx builds with 0 warnings and 0 errors.
- [x] make test: all Go package tests passed; .NET studioctl server tests 216/216 passed.
- [x] dotnet csharpier check: 185 files checked successfully.
- [x] Resolved-package audit confirms only Acornima 1.7.0 and AngleSharp 1.7.1; Jint is absent.
- [x] Manual end-to-end app upgrade: upgraded the real `ttd/testprefix` app from Altinn.App 8.10.2 to v9, reviewed the staged migration diff, built the net10 app successfully, started it with Localtest, and verified HTTP 200 from `/health` plus the expected application metadata.

