### PR TITLE
fix(app): dispose HttpResponseMessage in Altinn.App.Core HTTP clients

### DIFF
--- a/src/App/backend/CHANGELOG.md
+++ b/src/App/backend/CHANGELOG.md
@@ -11,7 +11,7 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ### Fixed
 
-- The app's HTTP clients now release each response as soon as they are done with it, rather than leaving it for the garbage collector. This was never severe — the responses are read in full, so connections went back to the pool either way — but it removes needless cleanup work from a running app. Two of these clients hand you a stream instead: `IDataClient.GetBinaryData`/`GetBinaryDataStream` and `IPdfGeneratorClient.GeneratePdf`. Those streams hold the response open, so dispose them when you are done reading — the interfaces now say so. Nothing changes for code that already disposed them, and code that never did keeps working exactly as before.
+- Dispose the streams you get from `IDataClient.GetBinaryData`, `IDataClient.GetBinaryDataStream` and `IPdfGeneratorClient.GeneratePdf` once you have finished reading them — each one holds an HTTP response open until it is disposed, and disposing the stream releases it. The interfaces now say so. Code that already disposed these streams is unaffected, and code that does not is no worse off than before. The app's other HTTP clients now release their responses promptly too, which needs nothing from you.
 
 ## [9.0.0-preview.4] - 2026-08-11
 

--- a/src/App/backend/CHANGELOG.md
+++ b/src/App/backend/CHANGELOG.md
@@ -9,6 +9,10 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+### Fixed
+
+- The app's HTTP clients now release each response as soon as they are done with it, rather than leaving it for the garbage collector. This was never severe — the responses are read in full, so connections went back to the pool either way — but it removes needless cleanup work from a running app. Two of these clients hand you a stream instead: `IDataClient.GetBinaryData`/`GetBinaryDataStream` and `IPdfGeneratorClient.GeneratePdf`. Those streams hold the response open, so dispose them when you are done reading — the interfaces now say so. Nothing changes for code that already disposed them, and code that never did keeps working exactly as before.
+
 ## [9.0.0-preview.4] - 2026-08-11
 
 ### Added

--- a/src/App/backend/src/Altinn.App.Api/Controllers/DataController.cs
+++ b/src/App/backend/src/Altinn.App.Api/Controllers/DataController.cs
@@ -866,7 +866,14 @@ public class DataController : ControllerBase
             CancellationToken.None
         );
 
-        if (dataStream is not null)
+        if (dataStream is null)
+        {
+            return NotFound();
+        }
+
+        // The stream owns the HTTP response behind it. File(...) hands it to the result pipeline,
+        // which disposes it — until then this scope owns it, including if the read-status update throws.
+        try
         {
             string? userOrgClaim = User.GetOrg();
             if (userOrgClaim is null || !org.Equals(userOrgClaim, StringComparison.OrdinalIgnoreCase))
@@ -879,11 +886,14 @@ public class DataController : ControllerBase
                     CancellationToken.None
                 );
             }
-
-            return File(dataStream, dataElement.ContentType, dataElement.Filename);
+        }
+        catch
+        {
+            await dataStream.DisposeAsync();
+            throw;
         }
 
-        return NotFound();
+        return File(dataStream, dataElement.ContentType, dataElement.Filename);
     }
 
     private async Task<DataType?> GetDataType(DataElement element)

--- a/src/App/backend/src/Altinn.App.Core/Features/Payment/Processors/Nets/NetsClient.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Payment/Processors/Nets/NetsClient.cs
@@ -50,14 +50,14 @@ internal class NetsClient : INetsClient
     /// <inheritdoc/>
     public async Task<HttpApiResult<NetsPaymentFull>> RetrievePayment(string paymentId)
     {
-        HttpResponseMessage response = await _httpClient.GetAsync($"/v1/payments/{paymentId}");
+        using HttpResponseMessage response = await _httpClient.GetAsync($"/v1/payments/{paymentId}");
         return await HttpApiResult<NetsPaymentFull>.FromHttpResponse(response);
     }
 
     /// <inheritdoc/>
     public async Task<bool> TerminatePayment(string paymentId)
     {
-        HttpResponseMessage response = await _httpClient.PutAsync($"v1/payments/{paymentId}/terminate", null);
+        using HttpResponseMessage response = await _httpClient.PutAsync($"v1/payments/{paymentId}/terminate", null);
         return response.IsSuccessStatusCode;
     }
 }

--- a/src/App/backend/src/Altinn.App.Core/Features/Payment/Processors/Nets/NetsClient.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Payment/Processors/Nets/NetsClient.cs
@@ -43,7 +43,7 @@ internal class NetsClient : INetsClient
     /// </summary>
     public async Task<HttpApiResult<NetsCreatePaymentSuccess>> CreatePayment(NetsCreatePayment payment)
     {
-        HttpResponseMessage? response = await _httpClient.PostAsJsonAsync("/v1/payments", payment);
+        using HttpResponseMessage response = await _httpClient.PostAsJsonAsync("/v1/payments", payment);
         return await HttpApiResult<NetsCreatePaymentSuccess>.FromHttpResponse(response);
     }
 

--- a/src/App/backend/src/Altinn.App.Core/Features/Payment/Services/PaymentService.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Payment/Services/PaymentService.cs
@@ -363,7 +363,7 @@ internal class PaymentService : IPaymentService
             System.Text.Encoding.UTF8,
             "application/json"
         );
-        var response = await client.PutAsync($"instances/{instance.Id}/process/next", content);
+        using var response = await client.PutAsync($"instances/{instance.Id}/process/next", content);
         if (!response.IsSuccessStatusCode)
         {
             _logger.LogError(

--- a/src/App/backend/src/Altinn.App.Core/Features/Signing/Services/SigningReceiptService.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Signing/Services/SigningReceiptService.cs
@@ -195,35 +195,45 @@ internal sealed class SigningReceiptService(
         List<CorrespondenceAttachment> attachments = [];
         IEnumerable<DataElement> signedElements = context.Instance.Data.Where(IsSignedDataElement);
 
+        // Acquired but not yet owned by an attachment in the list; the catch below is responsible for it.
+        Stream? currentStream = null;
         try
         {
             foreach (DataElement element in signedElements)
             {
                 string filename = GetDataElementFilename(element, appMetadata);
 
+                currentStream = await dataClient.GetBinaryDataStream(
+                    instanceIdentifier.InstanceOwnerPartyId,
+                    instanceIdentifier.InstanceGuid,
+                    Guid.Parse(element.Id),
+                    authenticationMethod: null,
+                    timeout: TimeSpan.FromHours(1),
+                    cancellationToken
+                );
+
                 attachments.Add(
                     CorrespondenceAttachmentBuilder
                         .Create()
                         .WithFilename(filename)
                         .WithSendersReference(element.Id)
-                        .WithData(
-                            await dataClient.GetBinaryDataStream(
-                                instanceIdentifier.InstanceOwnerPartyId,
-                                instanceIdentifier.InstanceGuid,
-                                Guid.Parse(element.Id),
-                                authenticationMethod: null,
-                                timeout: TimeSpan.FromHours(1),
-                                cancellationToken
-                            )
-                        )
+                        .WithData(currentStream)
                         .Build()
                 );
+
+                currentStream = null;
             }
         }
         catch
         {
             // Each stream acquired so far holds an open, unbuffered HTTP response. Nothing downstream
-            // will receive them now, so this scope must release them before propagating.
+            // will receive them now, so this scope must release them before propagating: the one still
+            // in flight (acquired, but attachment construction failed) plus every attachment already built.
+            if (currentStream is not null)
+            {
+                await currentStream.DisposeAsync();
+            }
+
             foreach (CorrespondenceAttachment attachment in attachments)
             {
                 await attachment.Data.DisposeAsync();

--- a/src/App/backend/src/Altinn.App.Core/Features/Signing/Services/SigningReceiptService.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Signing/Services/SigningReceiptService.cs
@@ -195,27 +195,41 @@ internal sealed class SigningReceiptService(
         List<CorrespondenceAttachment> attachments = [];
         IEnumerable<DataElement> signedElements = context.Instance.Data.Where(IsSignedDataElement);
 
-        foreach (DataElement element in signedElements)
+        try
         {
-            string filename = GetDataElementFilename(element, appMetadata);
+            foreach (DataElement element in signedElements)
+            {
+                string filename = GetDataElementFilename(element, appMetadata);
 
-            attachments.Add(
-                CorrespondenceAttachmentBuilder
-                    .Create()
-                    .WithFilename(filename)
-                    .WithSendersReference(element.Id)
-                    .WithData(
-                        await dataClient.GetBinaryDataStream(
-                            instanceIdentifier.InstanceOwnerPartyId,
-                            instanceIdentifier.InstanceGuid,
-                            Guid.Parse(element.Id),
-                            authenticationMethod: null,
-                            timeout: TimeSpan.FromHours(1),
-                            cancellationToken
+                attachments.Add(
+                    CorrespondenceAttachmentBuilder
+                        .Create()
+                        .WithFilename(filename)
+                        .WithSendersReference(element.Id)
+                        .WithData(
+                            await dataClient.GetBinaryDataStream(
+                                instanceIdentifier.InstanceOwnerPartyId,
+                                instanceIdentifier.InstanceGuid,
+                                Guid.Parse(element.Id),
+                                authenticationMethod: null,
+                                timeout: TimeSpan.FromHours(1),
+                                cancellationToken
+                            )
                         )
-                    )
-                    .Build()
-            );
+                        .Build()
+                );
+            }
+        }
+        catch
+        {
+            // Each stream acquired so far holds an open, unbuffered HTTP response. Nothing downstream
+            // will receive them now, so this scope must release them before propagating.
+            foreach (CorrespondenceAttachment attachment in attachments)
+            {
+                await attachment.Data.DisposeAsync();
+            }
+
+            throw;
         }
 
         return attachments;

--- a/src/App/backend/src/Altinn.App.Core/Helpers/ResponseWrapperStream.cs
+++ b/src/App/backend/src/Altinn.App.Core/Helpers/ResponseWrapperStream.cs
@@ -8,12 +8,7 @@ internal sealed class ResponseWrapperStream : Stream
     private readonly HttpResponseMessage _response;
     private readonly Stream _innerStream;
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ResponseWrapperStream"/> class.
-    /// </summary>
-    /// <param name="response">The HTTP response message to be disposed when the stream is disposed.</param>
-    /// <param name="innerStream">The inner stream to wrap and delegate operations to.</param>
-    public ResponseWrapperStream(HttpResponseMessage response, Stream innerStream)
+    private ResponseWrapperStream(HttpResponseMessage response, Stream innerStream)
     {
         ArgumentNullException.ThrowIfNull(response);
         ArgumentNullException.ThrowIfNull(innerStream);
@@ -24,7 +19,8 @@ internal sealed class ResponseWrapperStream : Stream
 
     /// <summary>
     /// Reads <paramref name="response"/>'s content as a stream and wraps the pair, handing ownership of
-    /// the response to the stream returned: disposing that stream disposes the response.
+    /// the response to the stream returned: disposing that stream disposes the response. This is the only
+    /// way to create a <see cref="ResponseWrapperStream"/>, so the ownership transfer cannot be skipped.
     /// </summary>
     /// <remarks>
     /// For a method that returns a stream taken from a response, this is the alternative to a
@@ -36,10 +32,7 @@ internal sealed class ResponseWrapperStream : Stream
     /// <param name="response">The response to take over. Owned by the returned stream once this succeeds.</param>
     /// <param name="cancellationToken">Cancels reading the content stream.</param>
     /// <returns>A stream over the response content that disposes the response when disposed.</returns>
-    public static async Task<Stream> TakeOwnershipOf(
-        HttpResponseMessage response,
-        CancellationToken cancellationToken = default
-    )
+    public static async Task<Stream> Create(HttpResponseMessage response, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(response);
 

--- a/src/App/backend/src/Altinn.App.Core/Helpers/ResponseWrapperStream.cs
+++ b/src/App/backend/src/Altinn.App.Core/Helpers/ResponseWrapperStream.cs
@@ -156,7 +156,10 @@ internal sealed class ResponseWrapperStream : Stream
 
     // CopyTo/CopyToAsync are delegated rather than left to the base implementation, which would read
     // through this wrapper in chunks. A buffered response hands out a MemoryStream, whose own copy is a
-    // single block copy, and these streams are copied wholesale on the file-download and PDF paths.
+    // single block copy, and the PDF and signing paths copy these streams wholesale (PdfService,
+    // SigningProcessTask and PaymentProcessTask all call CopyToAsync on the stream they are handed).
+    // Note that MVC's FileStreamResult does not come through here — it runs its own pooled-buffer loop
+    // over ReadAsync(Memory<byte>), which is delegated above.
 
     /// <summary>
     /// Reads the bytes from the current stream and writes them to another stream.

--- a/src/App/backend/src/Altinn.App.Core/Helpers/ResponseWrapperStream.cs
+++ b/src/App/backend/src/Altinn.App.Core/Helpers/ResponseWrapperStream.cs
@@ -23,6 +23,39 @@ internal sealed class ResponseWrapperStream : Stream
     }
 
     /// <summary>
+    /// Reads <paramref name="response"/>'s content as a stream and wraps the pair, handing ownership of
+    /// the response to the stream returned: disposing that stream disposes the response.
+    /// </summary>
+    /// <remarks>
+    /// For a method that returns a stream taken from a response, this is the alternative to a
+    /// <c>using</c> on the response — which would dispose the content the returned stream reads from,
+    /// and fail in the caller rather than here. Ownership transfer is atomic: if the content stream
+    /// cannot be read, the response is disposed before the exception propagates, so a call that throws
+    /// leaks nothing and leaves the caller nothing to clean up.
+    /// </remarks>
+    /// <param name="response">The response to take over. Owned by the returned stream once this succeeds.</param>
+    /// <param name="cancellationToken">Cancels reading the content stream.</param>
+    /// <returns>A stream over the response content that disposes the response when disposed.</returns>
+    public static async Task<Stream> TakeOwnershipOf(
+        HttpResponseMessage response,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(response);
+
+        try
+        {
+            Stream stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+            return new ResponseWrapperStream(response, stream);
+        }
+        catch
+        {
+            response.Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>
     /// Releases the unmanaged resources used by the <see cref="ResponseWrapperStream"/> and optionally releases the managed resources.
     /// </summary>
     /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
@@ -113,6 +146,34 @@ internal sealed class ResponseWrapperStream : Stream
     /// <returns>A task that represents the asynchronous read operation. The value contains the total number of bytes read into the buffer.</returns>
     public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) =>
         _innerStream.ReadAsync(buffer, cancellationToken);
+
+    /// <summary>
+    /// Reads a sequence of bytes from the current stream and advances the position within the stream by the number of bytes read.
+    /// </summary>
+    /// <param name="buffer">The region of memory to write the data into.</param>
+    /// <returns>The total number of bytes read into the buffer.</returns>
+    public override int Read(Span<byte> buffer) => _innerStream.Read(buffer);
+
+    // CopyTo/CopyToAsync are delegated rather than left to the base implementation, which would read
+    // through this wrapper in chunks. A buffered response hands out a MemoryStream, whose own copy is a
+    // single block copy, and these streams are copied wholesale on the file-download and PDF paths.
+
+    /// <summary>
+    /// Reads the bytes from the current stream and writes them to another stream.
+    /// </summary>
+    /// <param name="destination">The stream to which the contents of the current stream will be copied.</param>
+    /// <param name="bufferSize">The size of the buffer, in bytes.</param>
+    public override void CopyTo(Stream destination, int bufferSize) => _innerStream.CopyTo(destination, bufferSize);
+
+    /// <summary>
+    /// Asynchronously reads the bytes from the current stream and writes them to another stream.
+    /// </summary>
+    /// <param name="destination">The stream to which the contents of the current stream will be copied.</param>
+    /// <param name="bufferSize">The size of the buffer, in bytes.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous copy operation.</returns>
+    public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken) =>
+        _innerStream.CopyToAsync(destination, bufferSize, cancellationToken);
 
     /// <summary>
     /// Sets the position within the current stream.

--- a/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Authentication/AuthenticationClient.cs
+++ b/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Authentication/AuthenticationClient.cs
@@ -45,7 +45,7 @@ public class AuthenticationClient : IAuthenticationClient
     {
         string endpointUrl = $"refresh";
         string token = _authenticationContext.Current.Token; // TODO: check if authenticated?
-        HttpResponseMessage response = await _client.GetAsync(token, endpointUrl);
+        using HttpResponseMessage response = await _client.GetAsync(token, endpointUrl);
 
         if (response.StatusCode == System.Net.HttpStatusCode.OK)
         {

--- a/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Authorization/AuthorizationClient.cs
+++ b/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Authorization/AuthorizationClient.cs
@@ -69,7 +69,7 @@ public class AuthorizationClient : IAuthorizationClient
             .GetAccessToken(authenticationMethod ?? _defaultAuthenticationMethod);
         try
         {
-            HttpResponseMessage response = await _client.GetAsync(token, apiUrl);
+            using HttpResponseMessage response = await _client.GetAsync(token, apiUrl);
 
             if (response.StatusCode == System.Net.HttpStatusCode.OK)
             {
@@ -98,7 +98,7 @@ public class AuthorizationClient : IAuthorizationClient
         JwtToken token = await GetAuthTokenResolver()
             .GetAccessToken(authenticationMethod ?? _defaultAuthenticationMethod);
 
-        HttpResponseMessage response = await _client.GetAsync(token, apiUrl);
+        using HttpResponseMessage response = await _client.GetAsync(token, apiUrl);
 
         if (response.StatusCode == System.Net.HttpStatusCode.OK)
         {

--- a/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Events/EventsClient.cs
+++ b/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Events/EventsClient.cs
@@ -94,7 +94,7 @@ public class EventsClient : IEventsClient
 
         string serializedCloudEvent = JsonSerializer.Serialize(cloudEvent);
 
-        HttpResponseMessage response = await _client.PostAsync(
+        using HttpResponseMessage response = await _client.PostAsync(
             token,
             "app",
             new StringContent(serializedCloudEvent, Encoding.UTF8, "application/json"),

--- a/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Pdf/PdfGeneratorClient.cs
+++ b/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Pdf/PdfGeneratorClient.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Features;
+using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Internal.Auth;
 using Altinn.App.Core.Internal.Pdf;
 using Altinn.App.Core.Models.Pdf;
@@ -147,19 +148,30 @@ internal sealed class PdfGeneratorClient : IPdfGeneratorClient
 
         string requestContent = JsonSerializer.Serialize(generatorRequest, _jsonSerializerOptions);
         using StringContent stringContent = new(requestContent, Encoding.UTF8, "application/json");
-        var httpResponseMessage = await _httpClient.PostAsync(_platformSettings.ApiPdf2Endpoint, stringContent, ct);
+        HttpResponseMessage httpResponseMessage = await _httpClient.PostAsync(
+            _platformSettings.ApiPdf2Endpoint,
+            stringContent,
+            ct
+        );
 
         if (!httpResponseMessage.IsSuccessStatusCode)
         {
-            var content = await httpResponseMessage.Content.ReadAsStringAsync(ct);
-            var ex = new PdfGenerationException("Pdf generation failed");
-            ex.Data.Add("responseContent", content);
-            ex.Data.Add("responseStatusCode", httpResponseMessage.StatusCode.ToString());
-            ex.Data.Add("responseReasonPhrase", httpResponseMessage.ReasonPhrase);
+            // Nothing takes the response over on the failure path, so this scope owns it. The diagnostic
+            // content is copied onto the exception, which outlives the response.
+            using (httpResponseMessage)
+            {
+                var content = await httpResponseMessage.Content.ReadAsStringAsync(ct);
+                var ex = new PdfGenerationException("Pdf generation failed");
+                ex.Data.Add("responseContent", content);
+                ex.Data.Add("responseStatusCode", httpResponseMessage.StatusCode.ToString());
+                ex.Data.Add("responseReasonPhrase", httpResponseMessage.ReasonPhrase);
 
-            throw ex;
+                throw ex;
+            }
         }
 
-        return await httpResponseMessage.Content.ReadAsStreamAsync(ct);
+        // Ownership of the response moves to the returned stream — a `using` here would dispose the
+        // content the caller is about to read.
+        return await ResponseWrapperStream.TakeOwnershipOf(httpResponseMessage, ct);
     }
 }

--- a/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Pdf/PdfGeneratorClient.cs
+++ b/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Pdf/PdfGeneratorClient.cs
@@ -172,6 +172,6 @@ internal sealed class PdfGeneratorClient : IPdfGeneratorClient
 
         // Ownership of the response moves to the returned stream — a `using` here would dispose the
         // content the caller is about to read.
-        return await ResponseWrapperStream.TakeOwnershipOf(httpResponseMessage, ct);
+        return await ResponseWrapperStream.Create(httpResponseMessage, ct);
     }
 }

--- a/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Profile/ProfileClient.cs
+++ b/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Profile/ProfileClient.cs
@@ -91,7 +91,7 @@ public class ProfileClient : IProfileClient
             .GetAccessToken(authenticationMethod ?? _defaultAuthenticationMethod);
 
         ApplicationMetadata applicationMetadata = await _appMetadata.GetApplicationMetadata();
-        HttpResponseMessage response = await _client.GetAsync(
+        using HttpResponseMessage response = await _client.GetAsync(
             token,
             endpointUrl,
             _accessTokenGenerator.GenerateAccessToken(applicationMetadata.Org, applicationMetadata.AppIdentifier.App)
@@ -129,7 +129,7 @@ public class ProfileClient : IProfileClient
 
         ApplicationMetadata applicationMetadata = await _appMetadata.GetApplicationMetadata();
         StringContent content = new(JsonSerializer.Serialize(ssn), Encoding.UTF8, "application/json");
-        HttpResponseMessage response = await _client.PostAsync(
+        using HttpResponseMessage response = await _client.PostAsync(
             token,
             endpointUrl,
             content,

--- a/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Register/AltinnPartyClient.cs
+++ b/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Register/AltinnPartyClient.cs
@@ -112,7 +112,7 @@ public class AltinnPartyClient : IAltinnPartyClient
 
         using StringContent content = new(JsonSerializerPermissive.Serialize(partyLookup));
         content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
-        HttpResponseMessage response = await _client.PostAsync(
+        using HttpResponseMessage response = await _client.PostAsync(
             token,
             endpointUrl,
             content,

--- a/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Register/PersonClient.cs
+++ b/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Register/PersonClient.cs
@@ -69,7 +69,7 @@ public class PersonClient : IPersonClient
         request.Headers.Add("X-Ai-NationalIdentityNumber", nationalIdentityNumber);
         request.Headers.Add("X-Ai-LastName", ConvertToBase64(lastName));
 
-        var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseContentRead, ct);
+        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseContentRead, ct);
 
         return await ReadResponse(response, ct);
     }

--- a/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Register/RegisterERClient.cs
+++ b/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Register/RegisterERClient.cs
@@ -65,7 +65,7 @@ public class RegisterERClient : IOrganizationClient
         );
 
         ApplicationMetadata application = await _appMetadata.GetApplicationMetadata();
-        HttpResponseMessage response = await _client.GetAsync(
+        using HttpResponseMessage response = await _client.GetAsync(
             token,
             endpointUrl,
             _accessTokenGenerator.GenerateAccessToken(application.Org, application.AppIdentifier.App)

--- a/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Storage/ApplicationClient.cs
+++ b/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Storage/ApplicationClient.cs
@@ -46,7 +46,7 @@ public class ApplicationClient : IApplicationClient
         Application? application = null;
         string getApplicationMetadataUrl = $"applications/{appId}";
 
-        HttpResponseMessage response = await _client.GetAsync(getApplicationMetadataUrl);
+        using HttpResponseMessage response = await _client.GetAsync(getApplicationMetadataUrl);
         if (response.StatusCode == HttpStatusCode.OK)
         {
             string applicationData = await response.Content.ReadAsStringAsync();

--- a/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Storage/DataClient.cs
+++ b/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Storage/DataClient.cs
@@ -165,7 +165,7 @@ public sealed class DataClient : IDataClient
         StreamContent streamContent = new(new MemoryAsStream(serializedBytes));
         streamContent.Headers.ContentType = MediaTypeHeaderValue.Parse(contentType);
 
-        HttpResponseMessage response = await _client.PutAsync(
+        using HttpResponseMessage response = await _client.PutAsync(
             token,
             apiUrl,
             streamContent,
@@ -322,7 +322,7 @@ public sealed class DataClient : IDataClient
             );
         }
 
-        HttpResponseMessage response = await _client.GetAsync(token, apiUrl, cancellationToken: cts.Token);
+        using HttpResponseMessage response = await _client.GetAsync(token, apiUrl, cancellationToken: cts.Token);
         if (response.IsSuccessStatusCode)
         {
             var bytes = await response.Content.ReadAsByteArrayAsync(cts.Token);
@@ -391,7 +391,7 @@ public sealed class DataClient : IDataClient
             cancellationToken: cts.Token
         );
 
-        HttpResponseMessage response = await _client.GetAsync(token, apiUrl, cancellationToken: cts.Token);
+        using HttpResponseMessage response = await _client.GetAsync(token, apiUrl, cancellationToken: cts.Token);
 
         if (response.IsSuccessStatusCode)
         {
@@ -422,7 +422,7 @@ public sealed class DataClient : IDataClient
         DataElementList dataList;
         List<AttachmentList> attachmentList = [];
 
-        HttpResponseMessage response = await _client.GetAsync(token, apiUrl, cancellationToken: cts.Token);
+        using HttpResponseMessage response = await _client.GetAsync(token, apiUrl, cancellationToken: cts.Token);
         if (response.StatusCode == HttpStatusCode.OK)
         {
             string instanceData = await response.Content.ReadAsStringAsync(cts.Token);
@@ -495,7 +495,7 @@ public sealed class DataClient : IDataClient
             cancellationToken: cts.Token
         );
 
-        HttpResponseMessage response = await _client.DeleteAsync(
+        using HttpResponseMessage response = await _client.DeleteAsync(
             token,
             apiUrl,
             lockToken: _instanceLocker.CurrentLockToken,
@@ -538,7 +538,7 @@ public sealed class DataClient : IDataClient
         );
 
         StreamContent content = request.CreateContentStream();
-        HttpResponseMessage response = await _client.PostAsync(
+        using HttpResponseMessage response = await _client.PostAsync(
             token,
             apiUrl,
             content,
@@ -597,7 +597,7 @@ public sealed class DataClient : IDataClient
             };
         }
 
-        HttpResponseMessage response = await _client.PostAsync(
+        using HttpResponseMessage response = await _client.PostAsync(
             token,
             apiUrl,
             content,
@@ -648,7 +648,7 @@ public sealed class DataClient : IDataClient
 
         StreamContent content = request.CreateContentStream();
 
-        HttpResponseMessage response = await _client.PutAsync(
+        using HttpResponseMessage response = await _client.PutAsync(
             token,
             apiUrl,
             content,
@@ -703,7 +703,7 @@ public sealed class DataClient : IDataClient
             };
         }
 
-        HttpResponseMessage response = await _client.PutAsync(
+        using HttpResponseMessage response = await _client.PutAsync(
             token,
             apiUrl,
             content,
@@ -740,7 +740,7 @@ public sealed class DataClient : IDataClient
         );
 
         StringContent jsonString = new(JsonConvert.SerializeObject(dataElement), Encoding.UTF8, "application/json");
-        HttpResponseMessage response = await _client.PutAsync(
+        using HttpResponseMessage response = await _client.PutAsync(
             token,
             apiUrl,
             jsonString,
@@ -784,7 +784,7 @@ public sealed class DataClient : IDataClient
             instanceIdentifier,
             apiUrl
         );
-        HttpResponseMessage response = await _client.PutAsync(
+        using HttpResponseMessage response = await _client.PutAsync(
             token,
             apiUrl,
             content: null,
@@ -832,7 +832,7 @@ public sealed class DataClient : IDataClient
             instanceIdentifier,
             apiUrl
         );
-        HttpResponseMessage response = await _client.DeleteAsync(
+        using HttpResponseMessage response = await _client.DeleteAsync(
             token,
             apiUrl,
             lockToken: _instanceLocker.CurrentLockToken,

--- a/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Storage/DataClient.cs
+++ b/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Storage/DataClient.cs
@@ -239,16 +239,22 @@ public sealed class DataClient : IDataClient
 
         if (response.IsSuccessStatusCode)
         {
-            return await response.Content.ReadAsStreamAsync(cts.Token);
+            // Ownership of the response moves to the returned stream — a `using` here would dispose the
+            // content the caller is about to read.
+            return await ResponseWrapperStream.TakeOwnershipOf(response, cts.Token);
         }
 
-        if (response.StatusCode == HttpStatusCode.NotFound)
+        // Nothing takes the response over on the remaining paths, so this scope owns it.
+        using (response)
         {
-            // ! TODO: Remove null return in v9 and throw exception instead
-            return null!;
-        }
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                // ! TODO: Remove null return in v9 and throw exception instead
+                return null!;
+            }
 
-        throw await PlatformHttpException.Create(response, cts.Token);
+            throw await PlatformHttpException.Create(response, cts.Token);
+        }
     }
 
     /// <inheritdoc />
@@ -275,19 +281,16 @@ public sealed class DataClient : IDataClient
 
         if (response.IsSuccessStatusCode)
         {
-            try
-            {
-                Stream stream = await response.Content.ReadAsStreamAsync(cts.Token);
-                return new ResponseWrapperStream(response, stream);
-            }
-            catch (Exception)
-            {
-                response.Dispose();
-                throw;
-            }
+            // Ownership of the response moves to the returned stream — a `using` here would dispose the
+            // content the caller is about to read.
+            return await ResponseWrapperStream.TakeOwnershipOf(response, cts.Token);
         }
 
-        throw await PlatformHttpException.Create(response, cts.Token);
+        // Nothing takes the response over on the failure path, so this scope owns it.
+        using (response)
+        {
+            throw await PlatformHttpException.Create(response, cts.Token);
+        }
     }
 
     /// <inheritdoc />

--- a/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Storage/DataClient.cs
+++ b/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Storage/DataClient.cs
@@ -241,7 +241,7 @@ public sealed class DataClient : IDataClient
         {
             // Ownership of the response moves to the returned stream — a `using` here would dispose the
             // content the caller is about to read.
-            return await ResponseWrapperStream.TakeOwnershipOf(response, cts.Token);
+            return await ResponseWrapperStream.Create(response, cts.Token);
         }
 
         // Nothing takes the response over on the remaining paths, so this scope owns it.
@@ -283,7 +283,7 @@ public sealed class DataClient : IDataClient
         {
             // Ownership of the response moves to the returned stream — a `using` here would dispose the
             // content the caller is about to read.
-            return await ResponseWrapperStream.TakeOwnershipOf(response, cts.Token);
+            return await ResponseWrapperStream.Create(response, cts.Token);
         }
 
         // Nothing takes the response over on the failure path, so this scope owns it.

--- a/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Storage/InstanceClient.cs
+++ b/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Storage/InstanceClient.cs
@@ -141,7 +141,7 @@ internal sealed class InstanceClient : IInstanceClient
     {
         string token = await _tokenResolver.GetAccessToken(authenticationMethod ?? _defaultAuthenticationMethod, ct);
         using var activity = _telemetry?.StartQueryInstancesActivity();
-        HttpResponseMessage response = await _client.GetAsync(token, url, cancellationToken: ct);
+        using HttpResponseMessage response = await _client.GetAsync(token, url, cancellationToken: ct);
 
         if (response.StatusCode == HttpStatusCode.OK)
         {
@@ -174,7 +174,7 @@ internal sealed class InstanceClient : IInstanceClient
         _logger.LogInformation($"update process state: {processStateString}");
 
         StringContent httpContent = new(processStateString, Encoding.UTF8, "application/json");
-        HttpResponseMessage response = await _client.PutAsync(
+        using HttpResponseMessage response = await _client.PutAsync(
             token,
             apiUrl,
             httpContent,
@@ -218,7 +218,7 @@ internal sealed class InstanceClient : IInstanceClient
         _logger.LogInformation($"update process state: {updateString}");
 
         StringContent httpContent = new(updateString, Encoding.UTF8, "application/json");
-        HttpResponseMessage response = await _client.PutAsync(
+        using HttpResponseMessage response = await _client.PutAsync(
             token,
             apiUrl,
             httpContent,
@@ -254,7 +254,7 @@ internal sealed class InstanceClient : IInstanceClient
         string token = await _tokenResolver.GetAccessToken(authenticationMethod ?? _defaultAuthenticationMethod, ct);
 
         StringContent content = new(JsonConvert.SerializeObject(instanceTemplate), Encoding.UTF8, "application/json");
-        HttpResponseMessage response = await _client.PostAsync(
+        using HttpResponseMessage response = await _client.PostAsync(
             token,
             apiUrl,
             content,
@@ -287,7 +287,7 @@ internal sealed class InstanceClient : IInstanceClient
         string apiUrl = $"instances/{instanceOwnerPartyId}/{instanceGuid}/complete";
         string token = await _tokenResolver.GetAccessToken(authenticationMethod ?? _defaultAuthenticationMethod, ct);
 
-        HttpResponseMessage response = await _client.PostAsync(
+        using HttpResponseMessage response = await _client.PostAsync(
             token,
             apiUrl,
             new StringContent(string.Empty),
@@ -318,7 +318,7 @@ internal sealed class InstanceClient : IInstanceClient
         string apiUrl = $"instances/{instanceOwnerPartyId}/{instanceGuid}/readstatus?status={readStatus}";
         string token = await _tokenResolver.GetAccessToken(authenticationMethod ?? _defaultAuthenticationMethod, ct);
 
-        HttpResponseMessage response = await _client.PutAsync(
+        using HttpResponseMessage response = await _client.PutAsync(
             token,
             apiUrl,
             new StringContent(string.Empty),
@@ -353,7 +353,7 @@ internal sealed class InstanceClient : IInstanceClient
         string apiUrl = $"instances/{instanceOwnerPartyId}/{instanceGuid}/substatus";
         string token = await _tokenResolver.GetAccessToken(authenticationMethod ?? _defaultAuthenticationMethod, ct);
 
-        HttpResponseMessage response = await _client.PutAsync(
+        using HttpResponseMessage response = await _client.PutAsync(
             token,
             apiUrl,
             new StringContent(JsonConvert.SerializeObject(substatus), Encoding.UTF8, "application/json"),
@@ -383,7 +383,7 @@ internal sealed class InstanceClient : IInstanceClient
         string apiUrl = $"instances/{instanceOwnerPartyId}/{instanceGuid}/presentationtexts";
         string token = await _tokenResolver.GetAccessToken(authenticationMethod ?? _defaultAuthenticationMethod, ct);
 
-        HttpResponseMessage response = await _client.PutAsync(
+        using HttpResponseMessage response = await _client.PutAsync(
             token,
             apiUrl,
             new StringContent(JsonConvert.SerializeObject(presentationTexts), Encoding.UTF8, "application/json"),
@@ -413,7 +413,7 @@ internal sealed class InstanceClient : IInstanceClient
         string apiUrl = $"instances/{instanceOwnerPartyId}/{instanceGuid}/datavalues";
         string token = await _tokenResolver.GetAccessToken(authenticationMethod ?? _defaultAuthenticationMethod, ct);
 
-        HttpResponseMessage response = await _client.PutAsync(
+        using HttpResponseMessage response = await _client.PutAsync(
             token,
             apiUrl,
             new StringContent(JsonConvert.SerializeObject(dataValues), Encoding.UTF8, "application/json"),
@@ -442,7 +442,7 @@ internal sealed class InstanceClient : IInstanceClient
         using var activity = _telemetry?.StartDeleteInstanceActivity(instanceGuid, instanceOwnerPartyId);
         string apiUrl = $"instances/{instanceOwnerPartyId}/{instanceGuid}?hard={hard}";
         string token = await _tokenResolver.GetAccessToken(authenticationMethod ?? _defaultAuthenticationMethod, ct);
-        HttpResponseMessage response = await _client.DeleteAsync(
+        using HttpResponseMessage response = await _client.DeleteAsync(
             token,
             apiUrl,
             lockToken: _instanceLocker.CurrentLockToken,

--- a/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Storage/InstanceEventClient.cs
+++ b/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Storage/InstanceEventClient.cs
@@ -82,7 +82,7 @@ public class InstanceEventClient : IInstanceEventClient
             apiUrl += $"{paramSeparator}from={from}&to={to}";
         }
 
-        HttpResponseMessage response = await _client.GetAsync(token, apiUrl);
+        using HttpResponseMessage response = await _client.GetAsync(token, apiUrl);
 
         if (response.IsSuccessStatusCode)
         {
@@ -112,7 +112,7 @@ public class InstanceEventClient : IInstanceEventClient
             authenticationMethod ?? _defaultAuthenticationMethod
         );
 
-        HttpResponseMessage response = await _client.PostAsync(
+        using HttpResponseMessage response = await _client.PostAsync(
             token,
             apiUrl,
             new StringContent(instanceEvent.ToString(), Encoding.UTF8, "application/json"),

--- a/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Storage/ProcessClient.cs
+++ b/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Storage/ProcessClient.cs
@@ -87,7 +87,7 @@ public class ProcessClient : IProcessClient
             authenticationMethod ?? _defaultAuthenticationMethod
         );
 
-        HttpResponseMessage response = await _client.GetAsync(token, apiUrl);
+        using HttpResponseMessage response = await _client.GetAsync(token, apiUrl);
 
         if (response.IsSuccessStatusCode)
         {

--- a/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Storage/SignClient.cs
+++ b/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Storage/SignClient.cs
@@ -54,7 +54,7 @@ public class SignClient : ISignClient
         JwtToken token = await _authenticationTokenResolver.GetAccessToken(
             authenticationMethod ?? _defaultAuthenticationMethod
         );
-        HttpResponseMessage response = await _client.PostAsync(
+        using HttpResponseMessage response = await _client.PostAsync(
             token,
             apiUrl,
             BuildSignRequest(signatureContext),

--- a/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Storage/TextClient.cs
+++ b/src/App/backend/src/Altinn.App.Core/Infrastructure/Clients/Storage/TextClient.cs
@@ -73,7 +73,7 @@ public class TextClient : IText
                 _settings.RuntimeCookieName
             );
 
-            HttpResponseMessage response = await _client.GetAsync(token, url);
+            using HttpResponseMessage response = await _client.GetAsync(token, url);
             if (response.StatusCode == System.Net.HttpStatusCode.OK)
             {
                 textResource = await JsonSerializerPermissive.DeserializeAsync<TextResource>(response.Content);

--- a/src/App/backend/src/Altinn.App.Core/Internal/Auth/AuthenticationTokenResolver.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/Auth/AuthenticationTokenResolver.cs
@@ -103,7 +103,6 @@ internal class AuthenticationTokenResolver : IAuthenticationTokenResolver
             throw await PlatformHttpException.Create(response, cancellationToken);
 
         string token = await response.Content.ReadAsStringAsync(cancellationToken);
-        response.Dispose(); // Disposing manually because PlatformHttpException pathway requires the response to be retained
 
         return JwtToken.Parse(token);
     }

--- a/src/App/backend/src/Altinn.App.Core/Internal/Auth/AuthenticationTokenResolver.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/Auth/AuthenticationTokenResolver.cs
@@ -97,7 +97,7 @@ internal class AuthenticationTokenResolver : IAuthenticationTokenResolver
             $"{_localtestBaseUrl}/Home/GetTestOrgToken?org={appMetadata.Org}&orgNumber=991825827&authenticationLevel=3&scopes={Uri.EscapeDataString(formattedScopes)}";
 
         using var client = _httpClientFactory.CreateClient();
-        var response = await client.GetAsync(url, cancellationToken);
+        using var response = await client.GetAsync(url, cancellationToken);
 
         if (!response.IsSuccessStatusCode)
             throw await PlatformHttpException.Create(response, cancellationToken);

--- a/src/App/backend/src/Altinn.App.Core/Internal/Data/IDataClient.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/Data/IDataClient.cs
@@ -320,8 +320,13 @@ public interface IDataClient
     /// <param name="authenticationMethod">An optional specification of the authentication method to use for requests</param>
     /// <param name="cancellationToken">An optional cancellation token</param>
     /// <returns>
-    /// A stream over the data, or <c>null</c> if the data element does not exist. The caller owns the
-    /// stream and should dispose it: it holds the underlying HTTP response, which is released with it.
+    /// A stream over the data. The caller owns the stream and should dispose it: it holds the underlying
+    /// HTTP response, which is released with it.
+    /// <para>
+    /// Despite the non-nullable signature this returns <c>null</c> when the data element does not exist,
+    /// so callers null-check it. That is long-standing behaviour due to be replaced by an exception in the
+    /// next major version, not something to depend on.
+    /// </para>
     /// </returns>
     Task<Stream> GetBinaryData(
         int instanceOwnerPartyId,
@@ -338,8 +343,13 @@ public interface IDataClient
     /// <param name="instanceGuid">The instance id</param>
     /// <param name="dataId">the data id</param>
     /// <returns>
-    /// A stream over the data, or <c>null</c> if the data element does not exist. The caller owns the
-    /// stream and should dispose it: it holds the underlying HTTP response, which is released with it.
+    /// A stream over the data. The caller owns the stream and should dispose it: it holds the underlying
+    /// HTTP response, which is released with it.
+    /// <para>
+    /// Despite the non-nullable signature this returns <c>null</c> when the data element does not exist,
+    /// so callers null-check it. That is long-standing behaviour due to be replaced by an exception in the
+    /// next major version, not something to depend on.
+    /// </para>
     /// </returns>
     Task<Stream> GetBinaryData(int instanceOwnerPartyId, Guid instanceGuid, Guid dataId) =>
         GetBinaryData(instanceOwnerPartyId, instanceGuid, dataId, null, default);

--- a/src/App/backend/src/Altinn.App.Core/Internal/Data/IDataClient.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/Data/IDataClient.cs
@@ -319,6 +319,10 @@ public interface IDataClient
     /// <param name="dataId">the data id</param>
     /// <param name="authenticationMethod">An optional specification of the authentication method to use for requests</param>
     /// <param name="cancellationToken">An optional cancellation token</param>
+    /// <returns>
+    /// A stream over the data, or <c>null</c> if the data element does not exist. The caller owns the
+    /// stream and should dispose it: it holds the underlying HTTP response, which is released with it.
+    /// </returns>
     Task<Stream> GetBinaryData(
         int instanceOwnerPartyId,
         Guid instanceGuid,
@@ -333,6 +337,10 @@ public interface IDataClient
     /// <param name="instanceOwnerPartyId">The instance owner id</param>
     /// <param name="instanceGuid">The instance id</param>
     /// <param name="dataId">the data id</param>
+    /// <returns>
+    /// A stream over the data, or <c>null</c> if the data element does not exist. The caller owns the
+    /// stream and should dispose it: it holds the underlying HTTP response, which is released with it.
+    /// </returns>
     Task<Stream> GetBinaryData(int instanceOwnerPartyId, Guid instanceGuid, Guid dataId) =>
         GetBinaryData(instanceOwnerPartyId, instanceGuid, dataId, null, default);
 
@@ -346,6 +354,10 @@ public interface IDataClient
     /// <param name="authenticationMethod">An optional specification of the authentication method to use for requests</param>
     /// <param name="timeout">Optional timeout for the operation. Defaults to 100 seconds if not specified.</param>
     /// <param name="cancellationToken">An optional cancellation token</param>
+    /// <returns>
+    /// An unbuffered stream over the data. The caller owns the stream and must dispose it: it holds the
+    /// underlying HTTP response — and with it a connection — open until it is disposed.
+    /// </returns>
     /// <exception cref="Altinn.App.Core.Helpers.PlatformHttpException">Thrown when the data element is not found or other HTTP errors occur</exception>
     Task<Stream> GetBinaryDataStream(
         int instanceOwnerPartyId,
@@ -363,6 +375,10 @@ public interface IDataClient
     /// <param name="instanceOwnerPartyId">The instance owner id</param>
     /// <param name="instanceGuid">The instance id</param>
     /// <param name="dataId">the data id</param>
+    /// <returns>
+    /// An unbuffered stream over the data. The caller owns the stream and must dispose it: it holds the
+    /// underlying HTTP response — and with it a connection — open until it is disposed.
+    /// </returns>
     /// <exception cref="Altinn.App.Core.Helpers.PlatformHttpException">Thrown when the data element is not found or other HTTP errors occur</exception>
     Task<Stream> GetBinaryDataStream(int instanceOwnerPartyId, Guid instanceGuid, Guid dataId) =>
         GetBinaryDataStream(instanceOwnerPartyId, instanceGuid, dataId, null, null, default);

--- a/src/App/backend/src/Altinn.App.Core/Internal/Pdf/IPdfGeneratorClient.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/Pdf/IPdfGeneratorClient.cs
@@ -10,19 +10,28 @@ public interface IPdfGeneratorClient
     /// <summary>
     /// Generates a PDF.
     /// </summary>
-    /// <returns>A stream with the binary content of the generated PDF</returns>
+    /// <returns>
+    /// A stream with the binary content of the generated PDF. The caller owns the stream and should
+    /// dispose it: it holds the underlying HTTP response, which is released with it.
+    /// </returns>
     Task<Stream> GeneratePdf(Uri uri, CancellationToken ct);
 
     /// <summary>
     /// Generates a PDF.
     /// </summary>
-    /// <returns>A stream with the binary content of the generated PDF with a footer</returns>
+    /// <returns>
+    /// A stream with the binary content of the generated PDF with a footer. The caller owns the stream
+    /// and should dispose it: it holds the underlying HTTP response, which is released with it.
+    /// </returns>
     Task<Stream> GeneratePdf(Uri uri, string? footerContent, CancellationToken ct);
 
     /// <summary>
     /// Generates a PDF.
     /// </summary>
-    /// <returns>A stream with the binary content of the generated PDF with a footer</returns>
+    /// <returns>
+    /// A stream with the binary content of the generated PDF with a footer. The caller owns the stream
+    /// and should dispose it: it holds the underlying HTTP response, which is released with it.
+    /// </returns>
     Task<Stream> GeneratePdf(
         Uri uri,
         string? footerContent,

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Http/WorkflowEngineClient.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/Http/WorkflowEngineClient.cs
@@ -49,7 +49,7 @@ internal sealed class WorkflowEngineClient : IWorkflowEngineClient
             httpRequest.Headers.Add(CollectionKeyHeader, collectionKey);
         }
 
-        HttpResponseMessage response = await _httpClient.SendAsync(httpRequest, ct);
+        using HttpResponseMessage response = await _httpClient.SendAsync(httpRequest, ct);
         if (!response.IsSuccessStatusCode)
         {
             string body = await response.Content.ReadAsStringAsync(ct);
@@ -142,7 +142,7 @@ internal sealed class WorkflowEngineClient : IWorkflowEngineClient
         var url = $"{GetWorkflowEngineEndpoint()}/{Uri.EscapeDataString(ns)}/workflows/{workflowId}/cancel";
         using var httpRequest = new HttpRequestMessage(HttpMethod.Post, url);
 
-        HttpResponseMessage response = await _httpClient.SendAsync(httpRequest, ct);
+        using HttpResponseMessage response = await _httpClient.SendAsync(httpRequest, ct);
         response.EnsureSuccessStatusCode();
 
         return await response.Content.ReadFromJsonAsync<CancelWorkflowResponse>(ct)
@@ -165,7 +165,7 @@ internal sealed class WorkflowEngineClient : IWorkflowEngineClient
 
         using var httpRequest = new HttpRequestMessage(HttpMethod.Post, url);
 
-        HttpResponseMessage response = await _httpClient.SendAsync(httpRequest, ct);
+        using HttpResponseMessage response = await _httpClient.SendAsync(httpRequest, ct);
         response.EnsureSuccessStatusCode();
 
         return await response.Content.ReadFromJsonAsync<ResumeWorkflowResponse>(ct)
@@ -180,7 +180,7 @@ internal sealed class WorkflowEngineClient : IWorkflowEngineClient
         var url = $"{GetWorkflowEngineEndpoint()}/{Uri.EscapeDataString(ns)}/workflows/{workflowId}/abandon";
         using var httpRequest = new HttpRequestMessage(HttpMethod.Post, url);
 
-        HttpResponseMessage response = await _httpClient.SendAsync(httpRequest, ct);
+        using HttpResponseMessage response = await _httpClient.SendAsync(httpRequest, ct);
         if (response.StatusCode == HttpStatusCode.Conflict)
         {
             // Compare-and-set lost: the workflow is not in an abandonable state (e.g. a concurrent

--- a/src/App/backend/test/Altinn.App.Api.Tests/Controllers/DataControllerTests.cs
+++ b/src/App/backend/test/Altinn.App.Api.Tests/Controllers/DataControllerTests.cs
@@ -246,7 +246,7 @@ public class DataControllerTests : ApiTestBase, IClassFixture<WebApplicationFact
         string token = TestAuthentication.GetUserToken(1337, instanceOwnerPartyId);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
 
-        HttpResponseMessage response = await client.GetAsync(
+        using HttpResponseMessage response = await client.GetAsync(
             $"/{org}/{app}/instances/{instanceOwnerPartyId}/{instanceGuid}/data/{dataGuid}"
         );
 

--- a/src/App/backend/test/Altinn.App.Api.Tests/Controllers/DataControllerTests.cs
+++ b/src/App/backend/test/Altinn.App.Api.Tests/Controllers/DataControllerTests.cs
@@ -4,11 +4,15 @@ using Altinn.App.Api.Tests.Data;
 using Altinn.App.Core.Constants;
 using Altinn.App.Core.Features.FileAnalysis;
 using Altinn.App.Core.Features.Validation;
+using Altinn.App.Core.Helpers;
+using Altinn.App.Core.Internal.Data;
+using Altinn.App.Core.Internal.Instances;
 using Altinn.App.Core.Models.Validation;
 using Altinn.Platform.Storage.Interface.Models;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
+using Moq;
 using Xunit.Abstractions;
 
 namespace Altinn.App.Api.Tests.Controllers;
@@ -176,6 +180,82 @@ public class DataControllerTests : ApiTestBase, IClassFixture<WebApplicationFact
         TestData.DeleteInstanceAndData(org, app, 1337, guid);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetBinaryData_DisposesTheStream_WhenTheReadStatusUpdateFails()
+    {
+        // The stream IDataClient.GetBinaryData returns owns the HTTP response behind it. The controller
+        // updates the instance's read status between obtaining the stream and handing it to the result
+        // pipeline — when that update throws, the controller must dispose the stream itself.
+        string org = "tdd";
+        string app = "contributer-restriction";
+        int instanceOwnerPartyId = 500600; // user 1337 has roles for this party in the authorization test data
+        Guid instanceGuid = new("0fc98a23-fe31-4ef5-8fb9-dd3f479354ce");
+        Guid dataGuid = new("cd9204e7-9b83-41b4-b2f2-9b196b4fafcc");
+
+        Instance instance = new()
+        {
+            Id = $"{instanceOwnerPartyId}/{instanceGuid}",
+            AppId = $"{org}/{app}",
+            Org = org,
+            InstanceOwner = new InstanceOwner { PartyId = instanceOwnerPartyId.ToString() },
+            Process = new ProcessState { CurrentTask = new ProcessElementInfo { ElementId = "Task_1" } },
+            Data =
+            [
+                new DataElement
+                {
+                    Id = dataGuid.ToString(),
+                    DataType = "specificFileType",
+                    ContentType = "application/pdf",
+                    Filename = "test.pdf",
+                },
+            ],
+        };
+
+        MemoryStream dataStream = new([1, 2, 3]);
+        Mock<IDataClient> dataClient = new();
+        dataClient
+            .Setup(d =>
+                d.GetBinaryData(instanceOwnerPartyId, instanceGuid, dataGuid, null, It.IsAny<CancellationToken>())
+            )
+            .ReturnsAsync(dataStream);
+
+        Mock<IInstanceClient> instanceClient = new();
+        instanceClient
+            .Setup(i =>
+                i.GetInstance(app, org, instanceOwnerPartyId, instanceGuid, null, It.IsAny<CancellationToken>())
+            )
+            .ReturnsAsync(instance);
+        instanceClient
+            .Setup(i =>
+                i.UpdateReadStatus(instanceOwnerPartyId, instanceGuid, "read", null, It.IsAny<CancellationToken>())
+            )
+            .ThrowsAsync(new PlatformHttpException(HttpStatusCode.ServiceUnavailable, "storage exploded"));
+
+        OverrideServicesForThisTest = (services) =>
+        {
+            services.AddTransient(_ => dataClient.Object);
+            services.AddTransient(_ => instanceClient.Object);
+        };
+
+        HttpClient client = GetRootedClient(org, app);
+        // A user token (no org claim) so the controller takes the read-status update path. The
+        // authorization mock enriches its decision request through IInstanceClient — the mock above —
+        // so no instance needs to exist on disk.
+        string token = TestAuthentication.GetUserToken(1337, instanceOwnerPartyId);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
+
+        HttpResponseMessage response = await client.GetAsync(
+            $"/{org}/{app}/instances/{instanceOwnerPartyId}/{instanceGuid}/data/{dataGuid}"
+        );
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        Assert.False(dataStream.CanRead, "the stream was not disposed when the read-status update failed");
+        instanceClient.Verify(
+            i => i.UpdateReadStatus(instanceOwnerPartyId, instanceGuid, "read", null, It.IsAny<CancellationToken>()),
+            Times.Once
+        );
     }
 
     private static async Task<ByteArrayContent> CreateBinaryContent(

--- a/src/App/backend/test/Altinn.App.Core.Tests/Features/Signing/SigningReceiptServiceTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Features/Signing/SigningReceiptServiceTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using Altinn.App.Core.Exceptions;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.Correspondence;
+using Altinn.App.Core.Features.Correspondence.Exceptions;
 using Altinn.App.Core.Features.Correspondence.Models;
 using Altinn.App.Core.Features.Signing.Models;
 using Altinn.App.Core.Features.Signing.Services;
@@ -519,6 +520,88 @@ public class SigningReceiptServiceTests(ITestOutputHelper output)
 
         // Assert — a disposed MemoryStream reports CanRead false.
         Assert.False(firstStream.CanRead, "the stream acquired before the failure was not disposed");
+    }
+
+    [Fact]
+    public async Task GetCorrespondenceAttachments_DisposesAllStreams_WhenAttachmentConstructionFails()
+    {
+        // Arrange
+        InstanceIdentifier instanceIdentifier = new(123456, Guid.NewGuid());
+
+        DataElement firstElement = new()
+        {
+            Id = "11111111-1111-1111-1111-111111111111",
+            Filename = "first.pdf",
+            ContentType = "application/pdf",
+            DataType = "someType",
+        };
+
+        // No filename and an empty data type produce an empty attachment filename, which the
+        // builder rejects in Build() — after this element's stream has already been acquired.
+        DataElement elementWithoutFilename = new()
+        {
+            Id = "22222222-2222-2222-2222-222222222222",
+            Filename = null,
+            ContentType = null,
+            DataType = "",
+        };
+
+        Instance instance = new() { Data = [firstElement, elementWithoutFilename] };
+
+        Mock<IInstanceDataMutator> instanceDataMutatorMock = new();
+        instanceDataMutatorMock.Setup(x => x.Instance).Returns(instance);
+        UserActionContext context = new(instanceDataMutatorMock.Object, 123456);
+        IEnumerable<DataElementSignature> dataElementSignatures =
+        [
+            new DataElementSignature(firstElement.Id),
+            new DataElementSignature(elementWithoutFilename.Id),
+        ];
+
+        ApplicationMetadata appMetadata = new("org/app") { DataTypes = [] };
+
+        var firstStream = new MemoryStream([1, 2, 3]);
+        var secondStream = new MemoryStream([4, 5, 6]);
+        var dataClientMock = new Mock<IDataClient>();
+        dataClientMock
+            .Setup(x =>
+                x.GetBinaryDataStream(
+                    It.IsAny<int>(),
+                    It.IsAny<Guid>(),
+                    It.Is<Guid>(id => id == Guid.Parse(firstElement.Id)),
+                    It.IsAny<StorageAuthenticationMethod?>(),
+                    It.IsAny<TimeSpan?>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(firstStream);
+        dataClientMock
+            .Setup(x =>
+                x.GetBinaryDataStream(
+                    It.IsAny<int>(),
+                    It.IsAny<Guid>(),
+                    It.Is<Guid>(id => id == Guid.Parse(elementWithoutFilename.Id)),
+                    It.IsAny<StorageAuthenticationMethod?>(),
+                    It.IsAny<TimeSpan?>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(secondStream);
+
+        // Act
+        await Assert.ThrowsAsync<CorrespondenceArgumentException>(async () =>
+            await SigningReceiptService.GetCorrespondenceAttachments(
+                instanceIdentifier,
+                dataElementSignatures,
+                appMetadata,
+                context,
+                dataClientMock.Object,
+                CancellationToken.None
+            )
+        );
+
+        // Assert — both the attachment already built and the stream whose attachment failed to build.
+        Assert.False(firstStream.CanRead, "the first stream (already wrapped in an attachment) was not disposed");
+        Assert.False(secondStream.CanRead, "the stream acquired for the failing attachment was not disposed");
     }
 
     [Fact]

--- a/src/App/backend/test/Altinn.App.Core.Tests/Features/Signing/SigningReceiptServiceTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Features/Signing/SigningReceiptServiceTests.cs
@@ -1,9 +1,11 @@
+using System.Net;
 using Altinn.App.Core.Exceptions;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.Correspondence;
 using Altinn.App.Core.Features.Correspondence.Models;
 using Altinn.App.Core.Features.Signing.Models;
 using Altinn.App.Core.Features.Signing.Services;
+using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Internal.AltinnCdn;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.Data;
@@ -437,6 +439,86 @@ public class SigningReceiptServiceTests(ITestOutputHelper output)
         using var ms = new MemoryStream();
         await attachment.Data.CopyToAsync(ms);
         Assert.Equal(new byte[] { 1, 2, 3 }, ms.ToArray());
+    }
+
+    [Fact]
+    public async Task GetCorrespondenceAttachments_DisposesAcquiredStreams_WhenALaterDownloadFails()
+    {
+        // Arrange
+        InstanceIdentifier instanceIdentifier = new(123456, Guid.NewGuid());
+
+        DataElement firstElement = new()
+        {
+            Id = "11111111-1111-1111-1111-111111111111",
+            Filename = "first.pdf",
+            ContentType = "application/pdf",
+            DataType = "someType",
+        };
+
+        DataElement secondElement = new()
+        {
+            Id = "22222222-2222-2222-2222-222222222222",
+            Filename = "second.pdf",
+            ContentType = "application/pdf",
+            DataType = "someType",
+        };
+
+        Instance instance = new() { Data = [firstElement, secondElement] };
+
+        Mock<IInstanceDataMutator> instanceDataMutatorMock = new();
+        instanceDataMutatorMock.Setup(x => x.Instance).Returns(instance);
+        UserActionContext context = new(instanceDataMutatorMock.Object, 123456);
+        IEnumerable<DataElementSignature> dataElementSignatures =
+        [
+            new DataElementSignature(firstElement.Id),
+            new DataElementSignature(secondElement.Id),
+        ];
+
+        ApplicationMetadata appMetadata = new("org/app");
+
+        // The first element's stream downloads fine; the second download fails. The stream already
+        // acquired holds an open HTTP response, so the failure path must dispose it.
+        var firstStream = new MemoryStream([1, 2, 3]);
+        var dataClientMock = new Mock<IDataClient>();
+        dataClientMock
+            .Setup(x =>
+                x.GetBinaryDataStream(
+                    It.IsAny<int>(),
+                    It.IsAny<Guid>(),
+                    It.Is<Guid>(id => id == Guid.Parse(firstElement.Id)),
+                    It.IsAny<StorageAuthenticationMethod?>(),
+                    It.IsAny<TimeSpan?>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(firstStream);
+        dataClientMock
+            .Setup(x =>
+                x.GetBinaryDataStream(
+                    It.IsAny<int>(),
+                    It.IsAny<Guid>(),
+                    It.Is<Guid>(id => id == Guid.Parse(secondElement.Id)),
+                    It.IsAny<StorageAuthenticationMethod?>(),
+                    It.IsAny<TimeSpan?>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ThrowsAsync(new PlatformHttpException(HttpStatusCode.InternalServerError, "storage exploded"));
+
+        // Act
+        await Assert.ThrowsAsync<PlatformHttpException>(async () =>
+            await SigningReceiptService.GetCorrespondenceAttachments(
+                instanceIdentifier,
+                dataElementSignatures,
+                appMetadata,
+                context,
+                dataClientMock.Object,
+                CancellationToken.None
+            )
+        );
+
+        // Assert — a disposed MemoryStream reports CanRead false.
+        Assert.False(firstStream.CanRead, "the stream acquired before the failure was not disposed");
     }
 
     [Fact]

--- a/src/App/backend/test/Altinn.App.Core.Tests/Helpers/ResponseWrapperStreamTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Helpers/ResponseWrapperStreamTests.cs
@@ -8,11 +8,11 @@ namespace Altinn.App.Core.Tests.Helpers;
 public class ResponseWrapperStreamTests
 {
     [Fact]
-    public async Task TakeOwnershipOf_returns_a_readable_stream_over_the_response_content()
+    public async Task Create_returns_a_readable_stream_over_the_response_content()
     {
         var (response, _) = DisposeTrackingContent.Response("hello worlds");
 
-        using Stream stream = await ResponseWrapperStream.TakeOwnershipOf(response);
+        using Stream stream = await ResponseWrapperStream.Create(response);
 
         using StreamReader reader = new(stream);
         var content = await reader.ReadToEndAsync();
@@ -20,11 +20,11 @@ public class ResponseWrapperStreamTests
     }
 
     [Fact]
-    public async Task TakeOwnershipOf_does_not_dispose_the_response_while_the_stream_is_alive()
+    public async Task Create_does_not_dispose_the_response_while_the_stream_is_alive()
     {
         var (response, content) = DisposeTrackingContent.Response("hello worlds");
 
-        Stream stream = await ResponseWrapperStream.TakeOwnershipOf(response);
+        Stream stream = await ResponseWrapperStream.Create(response);
 
         Assert.False(content.IsDisposed, "the returned stream is still the caller's to read");
         await stream.DisposeAsync();
@@ -35,7 +35,7 @@ public class ResponseWrapperStreamTests
     {
         var (response, content) = DisposeTrackingContent.Response("hello worlds");
 
-        Stream stream = await ResponseWrapperStream.TakeOwnershipOf(response);
+        Stream stream = await ResponseWrapperStream.Create(response);
         stream.Dispose();
 
         Assert.True(content.IsDisposed);
@@ -46,7 +46,7 @@ public class ResponseWrapperStreamTests
     {
         var (response, content) = DisposeTrackingContent.Response("hello worlds");
 
-        Stream stream = await ResponseWrapperStream.TakeOwnershipOf(response);
+        Stream stream = await ResponseWrapperStream.Create(response);
         await stream.DisposeAsync();
 
         Assert.True(
@@ -57,14 +57,14 @@ public class ResponseWrapperStreamTests
     }
 
     [Fact]
-    public async Task TakeOwnershipOf_disposes_the_response_when_the_content_stream_cannot_be_read()
+    public async Task Create_disposes_the_response_when_the_content_stream_cannot_be_read()
     {
         ThrowingContent content = new();
         using HttpResponseMessage response = new() { Content = content };
 
         // HttpContent wraps a content-read failure, so the caller sees HttpRequestException over the IOException.
         var thrown = await Assert.ThrowsAsync<HttpRequestException>(async () =>
-            await ResponseWrapperStream.TakeOwnershipOf(response)
+            await ResponseWrapperStream.Create(response)
         );
         var inner = Assert.IsType<IOException>(thrown.InnerException);
         Assert.Equal("cannot read this content", inner.Message);
@@ -76,9 +76,9 @@ public class ResponseWrapperStreamTests
     }
 
     [Fact]
-    public async Task TakeOwnershipOf_rejects_a_null_response()
+    public async Task Create_rejects_a_null_response()
     {
-        await Assert.ThrowsAsync<ArgumentNullException>(async () => await ResponseWrapperStream.TakeOwnershipOf(null!));
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await ResponseWrapperStream.Create(null!));
     }
 
     [Fact]
@@ -86,7 +86,7 @@ public class ResponseWrapperStreamTests
     {
         var (response, _) = DisposeTrackingContent.Response("hello worlds");
 
-        using Stream stream = await ResponseWrapperStream.TakeOwnershipOf(response);
+        using Stream stream = await ResponseWrapperStream.Create(response);
 
         // A buffered response hands out a seekable stream, and ASP.NET reads CanSeek/Length off the stream
         // returned from these clients to set Content-Length on a file result.
@@ -106,13 +106,15 @@ public class ResponseWrapperStreamTests
     // implementation — a buffered response hands out a MemoryStream, whose copy is a single block copy.
     // Stream's base implementations would produce identical bytes by looping over Read, so only asserting
     // on the bytes cannot tell the two apart. These assert on the delegation itself, which is the point.
+    // Create is the only way to construct the wrapper, so the RecordingStream is planted behind it as the
+    // response's content stream.
 
     [Fact]
-    public void CopyTo_is_delegated_to_the_content_stream()
+    public async Task CopyTo_is_delegated_to_the_content_stream()
     {
-        using HttpResponseMessage response = new();
         RecordingStream inner = new("hello worlds");
-        using ResponseWrapperStream stream = new(response, inner);
+        using HttpResponseMessage response = new() { Content = new StreamHandoutContent(inner) };
+        using Stream stream = await ResponseWrapperStream.Create(response);
 
         using MemoryStream destination = new();
         stream.CopyTo(destination);
@@ -124,9 +126,9 @@ public class ResponseWrapperStreamTests
     [Fact]
     public async Task CopyToAsync_is_delegated_to_the_content_stream()
     {
-        using HttpResponseMessage response = new();
         RecordingStream inner = new("hello worlds");
-        using ResponseWrapperStream stream = new(response, inner);
+        using HttpResponseMessage response = new() { Content = new StreamHandoutContent(inner) };
+        using Stream stream = await ResponseWrapperStream.Create(response);
 
         using MemoryStream destination = new();
         await stream.CopyToAsync(destination);
@@ -136,18 +138,18 @@ public class ResponseWrapperStreamTests
     }
 
     [Fact]
-    public void Read_span_is_delegated_to_the_content_stream()
+    public async Task Read_span_is_delegated_to_the_content_stream()
     {
-        using HttpResponseMessage response = new();
         RecordingStream inner = new("hello worlds");
-        using ResponseWrapperStream stream = new(response, inner);
+        using HttpResponseMessage response = new() { Content = new StreamHandoutContent(inner) };
+        using Stream stream = await ResponseWrapperStream.Create(response);
 
-        Span<byte> buffer = new byte[5];
-        var read = stream.Read(buffer);
+        var buffer = new byte[5];
+        var read = stream.Read(buffer.AsSpan());
 
         Assert.Equal(5, read);
         Assert.Equal(1, inner.ReadSpanCalls);
-        Assert.Equal("hello"u8.ToArray(), buffer.ToArray());
+        Assert.Equal("hello"u8.ToArray(), buffer);
     }
 
     /// <summary>
@@ -176,6 +178,25 @@ public class ResponseWrapperStreamTests
         {
             ReadSpanCalls++;
             return base.Read(buffer);
+        }
+    }
+
+    /// <summary>
+    /// Content that hands out a caller-supplied stream as its content stream, so a test can plant a
+    /// <see cref="RecordingStream"/> behind <see cref="ResponseWrapperStream.Create"/> — the only way
+    /// to construct the wrapper.
+    /// </summary>
+    private sealed class StreamHandoutContent(Stream stream) : HttpContent
+    {
+        protected override Task<Stream> CreateContentReadStreamAsync() => Task.FromResult(stream);
+
+        protected override Task SerializeToStreamAsync(Stream target, TransportContext? context) =>
+            stream.CopyToAsync(target);
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = 0;
+            return false;
         }
     }
 

--- a/src/App/backend/test/Altinn.App.Core.Tests/Helpers/ResponseWrapperStreamTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Helpers/ResponseWrapperStreamTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Text;
 using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Tests.TestUtils;
 using FluentAssertions;
@@ -101,6 +102,83 @@ public class ResponseWrapperStreamTests
 
         stream.Seek(0, SeekOrigin.Begin);
         stream.Position.Should().Be(0);
+    }
+
+    // The bulk-transfer members are overridden so a copy goes straight to the content stream's own
+    // implementation — a buffered response hands out a MemoryStream, whose copy is a single block copy.
+    // Stream's base implementations would produce identical bytes by looping over Read, so only asserting
+    // on the bytes cannot tell the two apart. These assert on the delegation itself, which is the point.
+
+    [Fact]
+    public void CopyTo_is_delegated_to_the_content_stream()
+    {
+        using HttpResponseMessage response = new();
+        RecordingStream inner = new("hello worlds");
+        using ResponseWrapperStream stream = new(response, inner);
+
+        using MemoryStream destination = new();
+        stream.CopyTo(destination);
+
+        inner.CopyToCalls.Should().Be(1, "the override must hand the copy to the content stream");
+        destination.ToArray().Should().Equal("hello worlds"u8.ToArray());
+    }
+
+    [Fact]
+    public async Task CopyToAsync_is_delegated_to_the_content_stream()
+    {
+        using HttpResponseMessage response = new();
+        RecordingStream inner = new("hello worlds");
+        using ResponseWrapperStream stream = new(response, inner);
+
+        using MemoryStream destination = new();
+        await stream.CopyToAsync(destination);
+
+        inner.CopyToAsyncCalls.Should().Be(1, "the override must hand the copy to the content stream");
+        destination.ToArray().Should().Equal("hello worlds"u8.ToArray());
+    }
+
+    [Fact]
+    public void Read_span_is_delegated_to_the_content_stream()
+    {
+        using HttpResponseMessage response = new();
+        RecordingStream inner = new("hello worlds");
+        using ResponseWrapperStream stream = new(response, inner);
+
+        Span<byte> buffer = new byte[5];
+        var read = stream.Read(buffer);
+
+        read.Should().Be(5);
+        inner.ReadSpanCalls.Should().Be(1, "the override must avoid the base implementation's array rental");
+        buffer.ToArray().Should().Equal("hello"u8.ToArray());
+    }
+
+    /// <summary>
+    /// A stream that records which bulk-transfer members were invoked on it, so a test can tell delegation
+    /// from the base <see cref="Stream"/> implementations looping over <c>Read</c>.
+    /// </summary>
+    private sealed class RecordingStream(string payload) : MemoryStream(Encoding.UTF8.GetBytes(payload))
+    {
+        public int CopyToCalls { get; private set; }
+        public int CopyToAsyncCalls { get; private set; }
+        public int ReadSpanCalls { get; private set; }
+
+        public override void CopyTo(Stream destination, int bufferSize)
+        {
+            CopyToCalls++;
+            base.CopyTo(destination, bufferSize);
+        }
+
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            CopyToAsyncCalls++;
+            return base.CopyToAsync(destination, bufferSize, cancellationToken);
+        }
+
+        public override int Read(Span<byte> buffer)
+        {
+            ReadSpanCalls++;
+            return base.Read(buffer);
+        }
     }
 
     private sealed class ThrowingContent : HttpContent

--- a/src/App/backend/test/Altinn.App.Core.Tests/Helpers/ResponseWrapperStreamTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Helpers/ResponseWrapperStreamTests.cs
@@ -2,7 +2,6 @@ using System.Net;
 using System.Text;
 using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Tests.TestUtils;
-using FluentAssertions;
 
 namespace Altinn.App.Core.Tests.Helpers;
 
@@ -17,7 +16,7 @@ public class ResponseWrapperStreamTests
 
         using StreamReader reader = new(stream);
         var content = await reader.ReadToEndAsync();
-        content.Should().Be("hello worlds");
+        Assert.Equal("hello worlds", content);
     }
 
     [Fact]
@@ -27,7 +26,7 @@ public class ResponseWrapperStreamTests
 
         Stream stream = await ResponseWrapperStream.TakeOwnershipOf(response);
 
-        content.IsDisposed.Should().BeFalse("the returned stream is still the caller's to read");
+        Assert.False(content.IsDisposed, "the returned stream is still the caller's to read");
         await stream.DisposeAsync();
     }
 
@@ -39,7 +38,7 @@ public class ResponseWrapperStreamTests
         Stream stream = await ResponseWrapperStream.TakeOwnershipOf(response);
         stream.Dispose();
 
-        content.IsDisposed.Should().BeTrue();
+        Assert.True(content.IsDisposed);
     }
 
     [Fact]
@@ -50,12 +49,11 @@ public class ResponseWrapperStreamTests
         Stream stream = await ResponseWrapperStream.TakeOwnershipOf(response);
         await stream.DisposeAsync();
 
-        content
-            .IsDisposed.Should()
-            .BeTrue(
-                $"{nameof(ResponseWrapperStream)} has no DisposeAsync override, so it relies on Stream's "
-                    + "default implementation routing through Dispose()"
-            );
+        Assert.True(
+            content.IsDisposed,
+            $"{nameof(ResponseWrapperStream)} has no DisposeAsync override, so it relies on Stream's "
+                + "default implementation routing through Dispose()"
+        );
     }
 
     [Fact]
@@ -68,13 +66,13 @@ public class ResponseWrapperStreamTests
         var thrown = await Assert.ThrowsAsync<HttpRequestException>(async () =>
             await ResponseWrapperStream.TakeOwnershipOf(response)
         );
-        thrown.InnerException.Should().BeOfType<IOException>().Which.Message.Should().Be("cannot read this content");
+        var inner = Assert.IsType<IOException>(thrown.InnerException);
+        Assert.Equal("cannot read this content", inner.Message);
 
-        content
-            .IsDisposed.Should()
-            .BeTrue(
-                "ownership transfer is atomic — a failed call must not leave the response for the caller to clean up"
-            );
+        Assert.True(
+            content.IsDisposed,
+            "ownership transfer is atomic — a failed call must not leave the response for the caller to clean up"
+        );
     }
 
     [Fact]
@@ -92,16 +90,16 @@ public class ResponseWrapperStreamTests
 
         // A buffered response hands out a seekable stream, and ASP.NET reads CanSeek/Length off the stream
         // returned from these clients to set Content-Length on a file result.
-        stream.CanRead.Should().BeTrue();
-        stream.CanSeek.Should().BeTrue();
-        stream.Length.Should().Be("hello worlds".Length);
+        Assert.True(stream.CanRead);
+        Assert.True(stream.CanSeek);
+        Assert.Equal("hello worlds".Length, stream.Length);
 
         using MemoryStream destination = new();
         await stream.CopyToAsync(destination);
-        destination.ToArray().Should().Equal("hello worlds"u8.ToArray());
+        Assert.Equal("hello worlds"u8.ToArray(), destination.ToArray());
 
         stream.Seek(0, SeekOrigin.Begin);
-        stream.Position.Should().Be(0);
+        Assert.Equal(0, stream.Position);
     }
 
     // The bulk-transfer members are overridden so a copy goes straight to the content stream's own
@@ -119,8 +117,8 @@ public class ResponseWrapperStreamTests
         using MemoryStream destination = new();
         stream.CopyTo(destination);
 
-        inner.CopyToCalls.Should().Be(1, "the override must hand the copy to the content stream");
-        destination.ToArray().Should().Equal("hello worlds"u8.ToArray());
+        Assert.Equal(1, inner.CopyToCalls);
+        Assert.Equal("hello worlds"u8.ToArray(), destination.ToArray());
     }
 
     [Fact]
@@ -133,8 +131,8 @@ public class ResponseWrapperStreamTests
         using MemoryStream destination = new();
         await stream.CopyToAsync(destination);
 
-        inner.CopyToAsyncCalls.Should().Be(1, "the override must hand the copy to the content stream");
-        destination.ToArray().Should().Equal("hello worlds"u8.ToArray());
+        Assert.Equal(1, inner.CopyToAsyncCalls);
+        Assert.Equal("hello worlds"u8.ToArray(), destination.ToArray());
     }
 
     [Fact]
@@ -147,9 +145,9 @@ public class ResponseWrapperStreamTests
         Span<byte> buffer = new byte[5];
         var read = stream.Read(buffer);
 
-        read.Should().Be(5);
-        inner.ReadSpanCalls.Should().Be(1, "the override must avoid the base implementation's array rental");
-        buffer.ToArray().Should().Equal("hello"u8.ToArray());
+        Assert.Equal(5, read);
+        Assert.Equal(1, inner.ReadSpanCalls);
+        Assert.Equal("hello"u8.ToArray(), buffer.ToArray());
     }
 
     /// <summary>

--- a/src/App/backend/test/Altinn.App.Core.Tests/Helpers/ResponseWrapperStreamTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Helpers/ResponseWrapperStreamTests.cs
@@ -1,0 +1,125 @@
+using System.Net;
+using Altinn.App.Core.Helpers;
+using Altinn.App.Core.Tests.TestUtils;
+using FluentAssertions;
+
+namespace Altinn.App.Core.Tests.Helpers;
+
+public class ResponseWrapperStreamTests
+{
+    [Fact]
+    public async Task TakeOwnershipOf_returns_a_readable_stream_over_the_response_content()
+    {
+        var (response, _) = DisposeTrackingContent.Response("hello worlds");
+
+        using Stream stream = await ResponseWrapperStream.TakeOwnershipOf(response);
+
+        using StreamReader reader = new(stream);
+        var content = await reader.ReadToEndAsync();
+        content.Should().Be("hello worlds");
+    }
+
+    [Fact]
+    public async Task TakeOwnershipOf_does_not_dispose_the_response_while_the_stream_is_alive()
+    {
+        var (response, content) = DisposeTrackingContent.Response("hello worlds");
+
+        Stream stream = await ResponseWrapperStream.TakeOwnershipOf(response);
+
+        content.IsDisposed.Should().BeFalse("the returned stream is still the caller's to read");
+        await stream.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Disposing_the_returned_stream_disposes_the_response()
+    {
+        var (response, content) = DisposeTrackingContent.Response("hello worlds");
+
+        Stream stream = await ResponseWrapperStream.TakeOwnershipOf(response);
+        stream.Dispose();
+
+        content.IsDisposed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Disposing_the_returned_stream_asynchronously_disposes_the_response()
+    {
+        var (response, content) = DisposeTrackingContent.Response("hello worlds");
+
+        Stream stream = await ResponseWrapperStream.TakeOwnershipOf(response);
+        await stream.DisposeAsync();
+
+        content
+            .IsDisposed.Should()
+            .BeTrue(
+                $"{nameof(ResponseWrapperStream)} has no DisposeAsync override, so it relies on Stream's "
+                    + "default implementation routing through Dispose()"
+            );
+    }
+
+    [Fact]
+    public async Task TakeOwnershipOf_disposes_the_response_when_the_content_stream_cannot_be_read()
+    {
+        ThrowingContent content = new();
+        using HttpResponseMessage response = new() { Content = content };
+
+        // HttpContent wraps a content-read failure, so the caller sees HttpRequestException over the IOException.
+        var thrown = await Assert.ThrowsAsync<HttpRequestException>(async () =>
+            await ResponseWrapperStream.TakeOwnershipOf(response)
+        );
+        thrown.InnerException.Should().BeOfType<IOException>().Which.Message.Should().Be("cannot read this content");
+
+        content
+            .IsDisposed.Should()
+            .BeTrue(
+                "ownership transfer is atomic — a failed call must not leave the response for the caller to clean up"
+            );
+    }
+
+    [Fact]
+    public async Task TakeOwnershipOf_rejects_a_null_response()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await ResponseWrapperStream.TakeOwnershipOf(null!));
+    }
+
+    [Fact]
+    public async Task Stream_capabilities_are_delegated_to_the_content_stream()
+    {
+        var (response, _) = DisposeTrackingContent.Response("hello worlds");
+
+        using Stream stream = await ResponseWrapperStream.TakeOwnershipOf(response);
+
+        // A buffered response hands out a seekable stream, and ASP.NET reads CanSeek/Length off the stream
+        // returned from these clients to set Content-Length on a file result.
+        stream.CanRead.Should().BeTrue();
+        stream.CanSeek.Should().BeTrue();
+        stream.Length.Should().Be("hello worlds".Length);
+
+        using MemoryStream destination = new();
+        await stream.CopyToAsync(destination);
+        destination.ToArray().Should().Equal("hello worlds"u8.ToArray());
+
+        stream.Seek(0, SeekOrigin.Begin);
+        stream.Position.Should().Be(0);
+    }
+
+    private sealed class ThrowingContent : HttpContent
+    {
+        public bool IsDisposed { get; private set; }
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
+            throw new IOException("cannot read this content");
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = 0;
+            return false;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            IsDisposed = true;
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/App/backend/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/DataClientTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/DataClientTests.cs
@@ -19,6 +19,7 @@ using Altinn.App.Core.Internal.Data;
 using Altinn.App.Core.Internal.InstanceLocking;
 using Altinn.App.Core.Models;
 using Altinn.App.Core.Tests.Infrastructure.Clients.Storage.TestData;
+using Altinn.App.Core.Tests.TestUtils;
 using Altinn.App.PlatformServices.Tests.Data;
 using Altinn.App.PlatformServices.Tests.Mocks;
 using Altinn.Platform.Storage.Interface.Models;
@@ -481,6 +482,198 @@ public class DataClientTests
         invocations.Should().Be(1);
         actual.Should().NotBeNull();
         actual.Response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+    }
+
+    // The stream GetBinaryData returns owns the HTTP response behind it. These tests pin both halves of
+    // that contract: the response survives until the caller disposes the stream, and it is not leaked on
+    // any path that returns no stream at all.
+
+    [Fact]
+    public async Task GetBinaryData_stream_is_readable_after_the_client_call_has_returned()
+    {
+        var instanceIdentifier = new InstanceIdentifier("501337/d3f3250d-705c-4683-a215-e05ebcbe6071");
+        var dataGuid = new Guid("67a5ef12-6e38-41f8-8b42-f91249ebcec0");
+        DisposeTrackingContent? content = null;
+
+        await using var fixture = Fixture.Create(
+            async (request, ct) =>
+            {
+                await Task.CompletedTask;
+                var (response, trackedContent) = DisposeTrackingContent.Response("hello worlds");
+                content = trackedContent;
+                return response;
+            }
+        );
+
+        // Deliberately not read inside a scope that still holds the response: this is the case a `using` on
+        // the response inside GetBinaryData would break, and it would break here rather than there.
+        using Stream stream = await fixture.DataClient.GetBinaryData(
+            instanceIdentifier.InstanceOwnerPartyId,
+            instanceIdentifier.InstanceGuid,
+            dataGuid
+        );
+
+        content.Should().NotBeNull();
+        content!.IsDisposed.Should().BeFalse("the caller has not disposed the stream yet");
+
+        using StreamReader reader = new(stream);
+        var read = await reader.ReadToEndAsync();
+        read.Should().Be("hello worlds");
+    }
+
+    [Fact]
+    public async Task GetBinaryData_disposing_the_returned_stream_disposes_the_response()
+    {
+        var instanceIdentifier = new InstanceIdentifier("501337/d3f3250d-705c-4683-a215-e05ebcbe6071");
+        var dataGuid = new Guid("67a5ef12-6e38-41f8-8b42-f91249ebcec0");
+        DisposeTrackingContent? content = null;
+
+        await using var fixture = Fixture.Create(
+            async (request, ct) =>
+            {
+                await Task.CompletedTask;
+                var (response, trackedContent) = DisposeTrackingContent.Response("hello worlds");
+                content = trackedContent;
+                return response;
+            }
+        );
+
+        Stream stream = await fixture.DataClient.GetBinaryData(
+            instanceIdentifier.InstanceOwnerPartyId,
+            instanceIdentifier.InstanceGuid,
+            dataGuid
+        );
+        await stream.DisposeAsync();
+
+        content.Should().NotBeNull();
+        content!.IsDisposed.Should().BeTrue("the returned stream owns the response");
+    }
+
+    [Fact]
+    public async Task GetBinaryData_disposes_the_response_when_storage_returns_notfound()
+    {
+        var instanceIdentifier = new InstanceIdentifier("501337/d3f3250d-705c-4683-a215-e05ebcbe6071");
+        var dataGuid = new Guid("67a5ef12-6e38-41f8-8b42-f91249ebcec0");
+        DisposeTrackingContent? content = null;
+
+        await using var fixture = Fixture.Create(
+            async (request, ct) =>
+            {
+                await Task.CompletedTask;
+                var (response, trackedContent) = DisposeTrackingContent.Response(statusCode: HttpStatusCode.NotFound);
+                content = trackedContent;
+                return response;
+            }
+        );
+
+        var stream = await fixture.DataClient.GetBinaryData(
+            instanceIdentifier.InstanceOwnerPartyId,
+            instanceIdentifier.InstanceGuid,
+            dataGuid
+        );
+
+        stream.Should().BeNull();
+        content.Should().NotBeNull();
+        content!.IsDisposed.Should().BeTrue("no stream is returned, so nothing else can release the response");
+    }
+
+    [Fact]
+    public async Task GetBinaryData_disposes_the_response_when_storage_returns_an_error()
+    {
+        var instanceIdentifier = new InstanceIdentifier("501337/d3f3250d-705c-4683-a215-e05ebcbe6071");
+        var dataGuid = new Guid("67a5ef12-6e38-41f8-8b42-f91249ebcec0");
+        DisposeTrackingContent? content = null;
+
+        await using var fixture = Fixture.Create(
+            async (request, ct) =>
+            {
+                await Task.CompletedTask;
+                var (response, trackedContent) = DisposeTrackingContent.Response(
+                    "storage exploded",
+                    HttpStatusCode.InternalServerError
+                );
+                content = trackedContent;
+                return response;
+            }
+        );
+
+        var actual = await Assert.ThrowsAsync<PlatformHttpException>(async () =>
+            await fixture.DataClient.GetBinaryData(
+                instanceIdentifier.InstanceOwnerPartyId,
+                instanceIdentifier.InstanceGuid,
+                dataGuid
+            )
+        );
+
+        content.Should().NotBeNull();
+        content!.IsDisposed.Should().BeTrue("no stream is returned, so nothing else can release the response");
+
+        // The exception is built from a snapshot, so disposing the response does not empty it.
+        actual.Response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+        actual.Response.Content.Should().Contain("storage exploded");
+    }
+
+    [Fact]
+    public async Task GetBinaryDataStream_disposes_the_response_when_storage_returns_an_error()
+    {
+        var instanceIdentifier = new InstanceIdentifier("501337/d3f3250d-705c-4683-a215-e05ebcbe6071");
+        var dataGuid = new Guid("67a5ef12-6e38-41f8-8b42-f91249ebcec0");
+        DisposeTrackingContent? content = null;
+
+        await using var fixture = Fixture.Create(
+            async (request, ct) =>
+            {
+                await Task.CompletedTask;
+                var (response, trackedContent) = DisposeTrackingContent.Response(
+                    "storage exploded",
+                    HttpStatusCode.InternalServerError
+                );
+                content = trackedContent;
+                return response;
+            }
+        );
+
+        var actual = await Assert.ThrowsAsync<PlatformHttpException>(async () =>
+            await fixture.DataClient.GetBinaryDataStream(
+                instanceIdentifier.InstanceOwnerPartyId,
+                instanceIdentifier.InstanceGuid,
+                dataGuid
+            )
+        );
+
+        content.Should().NotBeNull();
+        content!.IsDisposed.Should().BeTrue("no stream is returned, so nothing else can release the response");
+        actual.Response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+    }
+
+    [Fact]
+    public async Task GetBinaryDataStream_disposing_the_returned_stream_disposes_the_response()
+    {
+        var instanceIdentifier = new InstanceIdentifier("501337/d3f3250d-705c-4683-a215-e05ebcbe6071");
+        var dataGuid = new Guid("67a5ef12-6e38-41f8-8b42-f91249ebcec0");
+        DisposeTrackingContent? content = null;
+
+        await using var fixture = Fixture.Create(
+            async (request, ct) =>
+            {
+                await Task.CompletedTask;
+                var (response, trackedContent) = DisposeTrackingContent.Response("hello worlds");
+                content = trackedContent;
+                return response;
+            }
+        );
+
+        Stream stream = await fixture.DataClient.GetBinaryDataStream(
+            instanceIdentifier.InstanceOwnerPartyId,
+            instanceIdentifier.InstanceGuid,
+            dataGuid
+        );
+
+        content.Should().NotBeNull();
+        content!.IsDisposed.Should().BeFalse("the caller has not disposed the stream yet");
+
+        await stream.DisposeAsync();
+        content!.IsDisposed.Should().BeTrue("the returned stream owns the response");
     }
 
     [Theory]

--- a/src/App/backend/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/DataClientTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/DataClientTests.cs
@@ -513,12 +513,12 @@ public class DataClientTests
             dataGuid
         );
 
-        content.Should().NotBeNull();
-        content!.IsDisposed.Should().BeFalse("the caller has not disposed the stream yet");
+        Assert.NotNull(content);
+        Assert.False(content.IsDisposed, "the caller has not disposed the stream yet");
 
         using StreamReader reader = new(stream);
         var read = await reader.ReadToEndAsync();
-        read.Should().Be("hello worlds");
+        Assert.Equal("hello worlds", read);
     }
 
     [Fact]
@@ -545,8 +545,8 @@ public class DataClientTests
         );
         await stream.DisposeAsync();
 
-        content.Should().NotBeNull();
-        content!.IsDisposed.Should().BeTrue("the returned stream owns the response");
+        Assert.NotNull(content);
+        Assert.True(content.IsDisposed, "the returned stream owns the response");
     }
 
     [Fact]
@@ -572,9 +572,9 @@ public class DataClientTests
             dataGuid
         );
 
-        stream.Should().BeNull();
-        content.Should().NotBeNull();
-        content!.IsDisposed.Should().BeTrue("no stream is returned, so nothing else can release the response");
+        Assert.Null(stream);
+        Assert.NotNull(content);
+        Assert.True(content.IsDisposed, "no stream is returned, so nothing else can release the response");
     }
 
     [Fact]
@@ -605,12 +605,12 @@ public class DataClientTests
             )
         );
 
-        content.Should().NotBeNull();
-        content!.IsDisposed.Should().BeTrue("no stream is returned, so nothing else can release the response");
+        Assert.NotNull(content);
+        Assert.True(content.IsDisposed, "no stream is returned, so nothing else can release the response");
 
         // The exception is built from a snapshot, so disposing the response does not empty it.
-        actual.Response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
-        actual.Response.Content.Should().Contain("storage exploded");
+        Assert.Equal(HttpStatusCode.InternalServerError, actual.Response.StatusCode);
+        Assert.Contains("storage exploded", actual.Response.Content);
     }
 
     [Fact]
@@ -641,9 +641,9 @@ public class DataClientTests
             )
         );
 
-        content.Should().NotBeNull();
-        content!.IsDisposed.Should().BeTrue("no stream is returned, so nothing else can release the response");
-        actual.Response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+        Assert.NotNull(content);
+        Assert.True(content.IsDisposed, "no stream is returned, so nothing else can release the response");
+        Assert.Equal(HttpStatusCode.InternalServerError, actual.Response.StatusCode);
     }
 
     [Fact]
@@ -669,11 +669,11 @@ public class DataClientTests
             dataGuid
         );
 
-        content.Should().NotBeNull();
-        content!.IsDisposed.Should().BeFalse("the caller has not disposed the stream yet");
+        Assert.NotNull(content);
+        Assert.False(content.IsDisposed, "the caller has not disposed the stream yet");
 
         await stream.DisposeAsync();
-        content!.IsDisposed.Should().BeTrue("the returned stream owns the response");
+        Assert.True(content.IsDisposed, "the returned stream owns the response");
     }
 
     [Theory]

--- a/src/App/backend/test/Altinn.App.Core.Tests/Internal/Pdf/PdfServiceTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Internal/Pdf/PdfServiceTests.cs
@@ -135,6 +135,98 @@ public class PdfServiceTests
         await func.Should().ThrowAsync<PdfGenerationException>();
     }
 
+    // The stream GeneratePdf returns owns the HTTP response behind it. These two tests pin both halves of
+    // that contract: the response survives until the caller disposes the stream, and it is not leaked when
+    // generation fails and no stream is returned at all.
+
+    [Fact]
+    public async Task GeneratePdf_stream_is_readable_after_the_call_returned_and_owns_the_response()
+    {
+        DisposeTrackingContent? content = null;
+        DelegatingHandlerStub delegatingHandler = new(
+            async (HttpRequestMessage request, CancellationToken token) =>
+            {
+                await Task.CompletedTask;
+                var (response, trackedContent) = DisposeTrackingContent.Response("a pdf, honest");
+                content = trackedContent;
+                return response;
+            }
+        );
+
+        var httpClient = new HttpClient(delegatingHandler);
+        var logger = new Mock<ILogger<PdfGeneratorClient>>();
+        var authenticationTokenResolver = CreateAuthenticationTokenResolver(TestAuthentication.GetUserToken());
+        var pdfGeneratorClient = new PdfGeneratorClient(
+            logger.Object,
+            httpClient,
+            _pdfGeneratorSettingsOptions,
+            _platformSettingsOptions,
+            authenticationTokenResolver.Object
+        );
+
+        // Deliberately read after GeneratePdf has returned: this is the case a `using` on the response
+        // inside GeneratePdf would break, and it would break here rather than there.
+        Stream pdf = await pdfGeneratorClient.GeneratePdf(
+            new Uri(@"https://org.apps.hostName/appId/instance/instanceId"),
+            CancellationToken.None
+        );
+
+        content.Should().NotBeNull();
+        content!.IsDisposed.Should().BeFalse("the caller has not disposed the stream yet");
+
+        using (StreamReader reader = new(pdf, leaveOpen: true))
+        {
+            var read = await reader.ReadToEndAsync();
+            read.Should().Be("a pdf, honest");
+        }
+
+        await pdf.DisposeAsync();
+        content!.IsDisposed.Should().BeTrue("the returned stream owns the response");
+    }
+
+    [Fact]
+    public async Task GeneratePdf_disposes_the_response_when_generation_fails()
+    {
+        DisposeTrackingContent? content = null;
+        DelegatingHandlerStub delegatingHandler = new(
+            async (HttpRequestMessage request, CancellationToken token) =>
+            {
+                await Task.CompletedTask;
+                var (response, trackedContent) = DisposeTrackingContent.Response(
+                    "pdf generator exploded",
+                    HttpStatusCode.RequestTimeout
+                );
+                content = trackedContent;
+                return response;
+            }
+        );
+
+        var httpClient = new HttpClient(delegatingHandler);
+        var logger = new Mock<ILogger<PdfGeneratorClient>>();
+        var authenticationTokenResolver = CreateAuthenticationTokenResolver(TestAuthentication.GetUserToken());
+        var pdfGeneratorClient = new PdfGeneratorClient(
+            logger.Object,
+            httpClient,
+            _pdfGeneratorSettingsOptions,
+            _platformSettingsOptions,
+            authenticationTokenResolver.Object
+        );
+
+        var thrown = await Assert.ThrowsAsync<PdfGenerationException>(async () =>
+            await pdfGeneratorClient.GeneratePdf(
+                new Uri(@"https://org.apps.hostName/appId/instance/instanceId"),
+                CancellationToken.None
+            )
+        );
+
+        content.Should().NotBeNull();
+        content!.IsDisposed.Should().BeTrue("no stream is returned, so nothing else can release the response");
+
+        // The diagnostic content is copied onto the exception, so disposing the response does not empty it.
+        thrown.Data["responseContent"].Should().Be("pdf generator exploded");
+        thrown.Data["responseStatusCode"].Should().Be(nameof(HttpStatusCode.RequestTimeout));
+    }
+
     [Fact]
     public async Task GeneratePdf_WithServiceOwnerAuthentication_UsesServiceOwnerToken()
     {

--- a/src/App/backend/test/Altinn.App.Core.Tests/Internal/Pdf/PdfServiceTests.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Internal/Pdf/PdfServiceTests.cs
@@ -171,17 +171,17 @@ public class PdfServiceTests
             CancellationToken.None
         );
 
-        content.Should().NotBeNull();
-        content!.IsDisposed.Should().BeFalse("the caller has not disposed the stream yet");
+        Assert.NotNull(content);
+        Assert.False(content.IsDisposed, "the caller has not disposed the stream yet");
 
         using (StreamReader reader = new(pdf, leaveOpen: true))
         {
             var read = await reader.ReadToEndAsync();
-            read.Should().Be("a pdf, honest");
+            Assert.Equal("a pdf, honest", read);
         }
 
         await pdf.DisposeAsync();
-        content!.IsDisposed.Should().BeTrue("the returned stream owns the response");
+        Assert.True(content.IsDisposed, "the returned stream owns the response");
     }
 
     [Fact]
@@ -219,12 +219,12 @@ public class PdfServiceTests
             )
         );
 
-        content.Should().NotBeNull();
-        content!.IsDisposed.Should().BeTrue("no stream is returned, so nothing else can release the response");
+        Assert.NotNull(content);
+        Assert.True(content.IsDisposed, "no stream is returned, so nothing else can release the response");
 
         // The diagnostic content is copied onto the exception, so disposing the response does not empty it.
-        thrown.Data["responseContent"].Should().Be("pdf generator exploded");
-        thrown.Data["responseStatusCode"].Should().Be(nameof(HttpStatusCode.RequestTimeout));
+        Assert.Equal("pdf generator exploded", thrown.Data["responseContent"]);
+        Assert.Equal(nameof(HttpStatusCode.RequestTimeout), thrown.Data["responseStatusCode"]);
     }
 
     [Fact]

--- a/src/App/backend/test/Altinn.App.Core.Tests/TestUtils/DisposeTrackingContent.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/TestUtils/DisposeTrackingContent.cs
@@ -1,0 +1,53 @@
+using System.Net;
+using System.Text;
+
+namespace Altinn.App.Core.Tests.TestUtils;
+
+/// <summary>
+/// Response content that records whether it was disposed, so a test can observe that the
+/// <see cref="HttpResponseMessage"/> carrying it was disposed — disposing a response disposes its content.
+/// </summary>
+/// <remarks>
+/// This is the probe for HTTP-response ownership: whether a client disposed a response is otherwise
+/// invisible from the outside. The content is a real, readable body, so a response built with it behaves
+/// like any other for the code under test.
+/// </remarks>
+internal sealed class DisposeTrackingContent : HttpContent
+{
+    private readonly byte[] _payload;
+
+    /// <summary>
+    /// Whether this content — and therefore the response holding it — has been disposed.
+    /// </summary>
+    public bool IsDisposed { get; private set; }
+
+    public DisposeTrackingContent(string payload = "") => _payload = Encoding.UTF8.GetBytes(payload);
+
+    /// <summary>
+    /// Builds a response carrying a <see cref="DisposeTrackingContent"/>, handing back both so the caller
+    /// can pass the response to the code under test and then assert on the content's disposal.
+    /// </summary>
+    public static (HttpResponseMessage Response, DisposeTrackingContent Content) Response(
+        string payload = "",
+        HttpStatusCode statusCode = HttpStatusCode.OK
+    )
+    {
+        DisposeTrackingContent content = new(payload);
+        return (new HttpResponseMessage(statusCode) { Content = content }, content);
+    }
+
+    protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
+        stream.WriteAsync(_payload, 0, _payload.Length);
+
+    protected override bool TryComputeLength(out long length)
+    {
+        length = _payload.Length;
+        return true;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        IsDisposed = true;
+        base.Dispose(disposing);
+    }
+}


### PR DESCRIPTION
Fixes #19857

`HttpResponseMessage` locals across `Altinn.App.Core`'s HTTP clients were never disposed, so each response and its content lingered until finalization. Low severity — nearly all of these use the default `HttpCompletionOption.ResponseContentRead`, so the body is buffered and the connection returns to the pool once read — but it is not what we tell app developers to do, and this repo's own guidance says to dispose `IDisposable` instances.

## What changed

**The mechanical sweep (46 sites, 18 files).** Each gained a `using` and nothing else. This is safe at every site because `PlatformHttpException.Create` snapshots the response rather than borrowing it (#19810), so `throw await PlatformHttpException.Create(response, ct)` inside a `using` still yields a fully readable exception after disposal.

**The three methods that return a `Stream` taken from the response.** These worked *because* the response was never disposed: disposing an `HttpResponseMessage` disposes its content, which invalidates the stream `ReadAsStreamAsync` handed out — so a plain `using` here would surface as an `ObjectDisposedException` in the *caller*, not as a leak here.

`DataClient.GetBinaryDataStream` already solved this with `ResponseWrapperStream`, which owns the response and disposes it with the stream. That is now generalized into `ResponseWrapperStream.TakeOwnershipOf(response, ct)` — it reads the content stream and wraps the pair in one step — and used from all three sites:

- `DataClient.GetBinaryData`
- `DataClient.GetBinaryDataStream`
- `PdfGeneratorClient.GeneratePdf`

The name is doing real work. The review comment behind this issue was that *passing an `IDisposable` to a method does not transfer ownership*; a method named `TakeOwnershipOf` opts explicitly into the opposite, which a bare `using` cannot express and a plain argument does not imply. Transfer is atomic: if the content stream cannot be read, the response is disposed before the exception propagates, so a failed call leaks nothing.

**The paths where no stream is returned leaked the response outright**, and are also fixed: `GetBinaryData`'s 404, and the error paths of all three methods.

**`ResponseWrapperStream` gained `CopyTo`/`CopyToAsync`/`Read(Span<byte>)` overrides.** Without them the base `Stream` implementations read through the wrapper in chunks, losing the single block copy a buffered `MemoryStream` does. `PdfService`, `SigningProcessTask` and `PaymentProcessTask` all call `CopyToAsync` directly on the stream they are handed.

**Ownership is now documented** on `IDataClient.GetBinaryData`/`GetBinaryDataStream` and `IPdfGeneratorClient.GeneratePdf`, none of which said anything about who disposes the returned stream — even though `GetBinaryDataStream` has always returned an owning one.

## Acceptance criteria

- [x] Every undisposed `HttpResponseMessage` local in `Altinn.App.Core` is disposed, except where ownership legitimately escapes.
- [x] The three stream-returning methods hand response ownership to the returned stream; no path leaks, including the failure and 404 paths.
- [x] No public API change — `PublicApiTests` snapshots untouched (signatures are unchanged; `ResponseWrapperStream` is `internal`).
- [x] Full non-integration suite green (4001 passed, 0 failed across 6 projects); CSharpier clean.
- [x] Non-goal: no refactoring of the clients themselves, and no change to `HttpClientExtension`'s ownership semantics.

## How it was verified

**Mutation testing.** Every new test was proven load-bearing — each mutation below was caught by exactly the intended test(s) and nothing else:

| Mutation | Caught by |
| --- | --- |
| Naive `using` on `GetBinaryData` | new readable-after-return test **+ 4 pre-existing tests** |
| Naive `using` on `PdfGeneratorClient` | new test **+ pre-existing `ValidRequest_ShouldReturnPdf`** |
| Drop `GetBinaryData`'s 404/error dispose | the 2 corresponding new tests |
| Drop `GetBinaryDataStream`'s error dispose | 1 new test |
| Drop the PDF failure-path dispose | 1 new test |
| Make `TakeOwnershipOf` non-atomic | 1 new test |
| Wrapper never disposes the response | 5 tests |
| Remove each bulk-transfer override individually | the 3 corresponding new tests |

**Correction to the issue's premise:** the issue expected that no existing test read a returned stream after the producing method returned. In fact `GetBinaryData_returns_stream_of_binary_data` (4 theory cases) and `PdfServiceTests.ValidRequest_ShouldReturnPdf` both already did, and both fail under the naive `using`. So the trap the issue warned about was already covered; the genuinely uncovered guarantees were the *new* ones — that disposing the returned stream disposes the response, and that the no-stream paths do not leak. Those are what the new tests pin.

**`FileStreamResult` interaction**, verified against the decompiled `FileStreamResultExecutor` in the shared framework the app runs on (not documentation): it disposes the stream it is given (twice, harmlessly — `HttpResponseMessage.Dispose` is idempotent), reads `Length` for `Content-Length` before the body copy, and never reads after dispose. It uses its own pooled-buffer loop over `ReadAsync(Memory<byte>)` rather than `Stream.CopyToAsync`, so the download path exercises the pre-existing `ReadAsync` delegation.

**New test double:** `DisposeTrackingContent` records `HttpContent.Dispose`, which is how these tests observe that a response was disposed. Confirmed sound — `HttpClient`'s buffering loads into the *same* `HttpContent` instance rather than replacing it, so the probe cannot report a false pass.

## What I deliberately did not do

- **`Extensions/HttpClientExtension.cs`'s `return await httpClient.SendAsync(...)` sites are not swept.** These are factories that hand ownership to their callers — the very sites the sweep depends on returning an undisposed response.
- **The four notification clients and `AccessManagementClient` are untouched** — they already dispose correctly in a `finally` / `using (x = await ...)`.
- **`GetBinaryData` still returns `null!` on 404** rather than throwing. That is a pre-existing `// TODO: Remove null return in v9` contract that callers null-check and a test pins; changing it belongs with that TODO, not here.
- **No end-to-end assertion was added through `FileStreamResult`.** The Api tests register `DataClientMock` globally, so they never push a real `ResponseWrapperStream` through MVC. The integration suite does — `BasicAppTests` downloads both binary data and a PDF from a real running app, and its snapshots assert `Content-Length`, which derives from `CanSeek`/`Length` on the wrapper. I did not run the integration suite locally (this worktree's path length trips the macOS socket limit that breaks `studioctl` dev-run, and a failed run auto-accepts error HTML into snapshots), so **CI's integration job is the arbiter for that path.**

## Note for reviewers

The sweep was regex-driven, and regexes missed sites twice: the issue's own pattern missed 4 (it only matched `HttpResponseMessage response = await`), and mine missed `NetsClient.CreatePayment` because it declared `HttpResponseMessage?` with a nullable annotation — caught in review and fixed in f8ce005ab1. The final set was established by scanning for *all* locals of the type including nullable, then classifying each by hand. Enabling `CA2000` would make this class of bug an analyzer error rather than a periodic sweep; see the issue for why that is not a free win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP response cleanup across service operations.
  * Ensured downloaded data and generated PDF streams remain readable while releasing resources correctly.
  * Prevented resource leaks when binary data, PDF generation or attachment retrieval fails.
  * Preserved diagnostic details when requests fail.

* **Documentation**
  * Clarified stream ownership and disposal requirements for binary data and generated PDFs.

* **Tests**
  * Added coverage for stream readability, ownership transfer, disposal and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->