### PR TITLE
feat: add support for NuGet versioning in project checks and tests

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -9,6 +9,9 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+### Fixed
+- Relax rules for validating Altinn.App.Api and Altinn.App.Core nuget versions to allow missing Core reference and range versions `8.*`, `[8.11.3]` and `[8.0,9.0)`
+
 ## [0.1.0-preview.21] - 2026-08-11
 
 ### Added

--- a/src/cli/Directory.Packages.props
+++ b/src/cli/Directory.Packages.props
@@ -21,6 +21,7 @@
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.4.0" />
     <PackageVersion Include="Microsoft.NET.StringTools" Version="18.4.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageVersion Include="NuGet.Versioning" Version="6.14.3" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/src/cli/studioctl-server-tests/Upgrade/v8Tov9/ProjectChecksTests.cs
+++ b/src/cli/studioctl-server-tests/Upgrade/v8Tov9/ProjectChecksTests.cs
@@ -89,6 +89,9 @@ public sealed class ProjectChecksTests : IDisposable
     [InlineData("7.5.0")]
     [InlineData("9.0.0")]
     [InlineData("[7.0,8.0)")]
+    [InlineData("[8.0,9.0]")]
+    [InlineData("[8.0,10.0)")]
+    [InlineData("[8.0,)")]
     public void SupportedSourceVersion_Rejects_WhenApiIsOutsideThe8xRange(string apiVersion)
     {
         var path = CreateTempProject(apiVersion);

--- a/src/cli/studioctl-server-tests/Upgrade/v8Tov9/ProjectChecksTests.cs
+++ b/src/cli/studioctl-server-tests/Upgrade/v8Tov9/ProjectChecksTests.cs
@@ -1,0 +1,116 @@
+using Altinn.Studio.Cli.Upgrade.v8Tov9.ProjectChecks;
+
+namespace Studioctl.Tests.Upgrade.v8Tov9;
+
+public sealed class ProjectChecksTests : IDisposable
+{
+    private readonly List<string> _tempFiles = [];
+
+    public void Dispose()
+    {
+        foreach (var path in _tempFiles)
+        {
+            File.Delete(path);
+        }
+    }
+
+    private string CreateTempProject(string apiVersion, string? coreVersion = null)
+    {
+        var coreReference = coreVersion is null
+            ? ""
+            : $"""<PackageReference Include="Altinn.App.Core" Version="{coreVersion}" />""";
+        var xml = $"""
+            <Project Sdk="Microsoft.NET.Sdk.Web">
+              <ItemGroup>
+                <PackageReference Include="Altinn.App.Api" Version="{apiVersion}" />
+                {coreReference}
+              </ItemGroup>
+            </Project>
+            """;
+        return CreateTempFile(xml);
+    }
+
+    private string CreateTempFile(string xml)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.csproj");
+        File.WriteAllText(path, xml);
+        _tempFiles.Add(path);
+        return path;
+    }
+
+    [Theory]
+    [InlineData("[8.11.3]")]
+    [InlineData("[8.0,9.0)")]
+    [InlineData("8.*")]
+    [InlineData("8.11.3")]
+    public void SupportedSourceVersion_AcceptsVariousNuGetVersionSyntaxes_WhenBothPackagesDeclared(string apiVersion)
+    {
+        var path = CreateTempProject(apiVersion, coreVersion: apiVersion);
+        var checks = new ProjectChecks(path);
+
+        Assert.True(checks.SupportedSourceVersion());
+    }
+
+    [Fact]
+    public void SupportedSourceVersion_AcceptsApiOnly_WhenCoreIsNotExplicitlyDeclared()
+    {
+        var path = CreateTempProject("[8.11.3]");
+        var checks = new ProjectChecks(path);
+
+        Assert.True(checks.SupportedSourceVersion());
+    }
+
+    [Fact]
+    public void SupportedSourceVersion_StillValidatesCore_WhenExplicitlyDeclaredAndOutOfRange()
+    {
+        var path = CreateTempProject("8.11.3", coreVersion: "7.5.0");
+        var checks = new ProjectChecks(path);
+
+        Assert.False(checks.SupportedSourceVersion());
+    }
+
+    [Fact]
+    public void SupportedSourceVersion_Rejects_WhenApiIsMissing()
+    {
+        var xml = """
+            <Project Sdk="Microsoft.NET.Sdk.Web">
+              <ItemGroup>
+                <PackageReference Include="Altinn.App.Core" Version="8.11.3" />
+              </ItemGroup>
+            </Project>
+            """;
+        var path = CreateTempFile(xml);
+        var checks = new ProjectChecks(path);
+
+        Assert.False(checks.SupportedSourceVersion());
+    }
+
+    [Theory]
+    [InlineData("7.5.0")]
+    [InlineData("9.0.0")]
+    [InlineData("[7.0,8.0)")]
+    public void SupportedSourceVersion_Rejects_WhenApiIsOutsideThe8xRange(string apiVersion)
+    {
+        var path = CreateTempProject(apiVersion);
+        var checks = new ProjectChecks(path);
+
+        Assert.False(checks.SupportedSourceVersion());
+    }
+
+    [Fact]
+    public void SupportedSourceVersion_Accepts_WhenUsingProjectReferencesInsteadOfPackageReferences()
+    {
+        var xml = """
+            <Project Sdk="Microsoft.NET.Sdk.Web">
+              <ItemGroup>
+                <ProjectReference Include="../../../src/Altinn.App.Api/Altinn.App.Api.csproj" />
+                <ProjectReference Include="../../../src/Altinn.App.Core/Altinn.App.Core.csproj" />
+              </ItemGroup>
+            </Project>
+            """;
+        var path = CreateTempFile(xml);
+        var checks = new ProjectChecks(path);
+
+        Assert.True(checks.SupportedSourceVersion());
+    }
+}

--- a/src/cli/studioctl-server-tests/Upgrade/v8Tov9/ProjectFileRewriterTests.cs
+++ b/src/cli/studioctl-server-tests/Upgrade/v8Tov9/ProjectFileRewriterTests.cs
@@ -1,0 +1,113 @@
+using System.Xml.Linq;
+using Altinn.Studio.Cli.Upgrade.ProjectFile;
+
+namespace Studioctl.Tests.Upgrade.v8Tov9;
+
+/// <summary>
+/// Covers the actual csproj output of <see cref="ProjectFileRewriter.Upgrade"/> for the project
+/// shapes that <c>ProjectChecks</c> now accepts as 8.x (NuGet range/bracket syntax, and an app
+/// that only declares Altinn.App.Api explicitly).
+/// </summary>
+public sealed class ProjectFileRewriterTests : IDisposable
+{
+    private readonly TempAppFolder _app = new();
+
+    public void Dispose() => _app.Dispose();
+
+    private static string? VersionOf(XDocument doc, string packageId) =>
+        doc.Descendants("PackageReference")
+            .SingleOrDefault(e => e.Attribute("Include")?.Value == packageId)
+            ?.Attribute("Version")
+            ?.Value;
+
+    [Theory]
+    [InlineData("[8.11.3]")]
+    [InlineData("[8.0,9.0)")]
+    [InlineData("8.*")]
+    public async Task Upgrade_NormalizesNuGetRangeSyntax_ToPlainTargetVersion(string sourceVersion)
+    {
+        var csproj = _app.Write(
+            "App.csproj",
+            $"""
+            <Project Sdk="Microsoft.NET.Sdk.Web">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Altinn.App.Api" Version="{sourceVersion}" />
+                <PackageReference Include="Altinn.App.Core" Version="{sourceVersion}" />
+              </ItemGroup>
+            </Project>
+            """
+        );
+
+        await new ProjectFileRewriter(csproj, targetVersion: "9.0.5", targetFramework: "net10.0").Upgrade();
+
+        var doc = XDocument.Load(csproj);
+        // The range/bracket syntax must be fully replaced, not merely widened or left in place -
+        // a leftover "[9.0.5]" or "[8.0,9.0)" would still restore, but would silently re-trigger
+        // the same "not a supported source version" gate on the *next* upgrade attempt.
+        Assert.Equal("9.0.5", VersionOf(doc, "Altinn.App.Api"));
+        Assert.Equal("9.0.5", VersionOf(doc, "Altinn.App.Core"));
+    }
+
+    [Fact]
+    public async Task Upgrade_LeavesAltinnAppCoreUndeclared_WhenOnlyApiWasPresent()
+    {
+        var csproj = _app.Write(
+            "App.csproj",
+            """
+            <Project Sdk="Microsoft.NET.Sdk.Web">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Altinn.App.Api" Version="[8.11.3]" />
+              </ItemGroup>
+            </Project>
+            """
+        );
+
+        await new ProjectFileRewriter(csproj, targetVersion: "9.0.5", targetFramework: "net10.0").Upgrade();
+
+        var doc = XDocument.Load(csproj);
+        Assert.Equal("9.0.5", VersionOf(doc, "Altinn.App.Api"));
+        // ProjectChecks accepts this shape without an explicit Altinn.App.Core reference, since
+        // Api pulls in a compatible Core transitively - but the rewriter has no logic to add one.
+        // The app is left depending on Api's v9 Core floor implicitly; document that explicitly
+        // here so a future change to either side doesn't silently drift out of sync.
+        Assert.Null(VersionOf(doc, "Altinn.App.Core"));
+        Assert.DoesNotContain(
+            doc.Descendants("PackageReference"),
+            e => e.Attribute("Include")?.Value == "Altinn.App.Core"
+        );
+    }
+
+    [Fact]
+    public async Task Upgrade_AlwaysBumpsExplicitCoreReference_RegardlessOfSourceVersion()
+    {
+        // ProjectChecks would already reject this project (Core explicitly 7.x fails the gate),
+        // but the rewriter itself has no such gate - it must not be asked to run against project
+        // shapes ProjectChecks rejects. This pins today's (unconditional) rewrite behavior.
+        var csproj = _app.Write(
+            "App.csproj",
+            """
+            <Project Sdk="Microsoft.NET.Sdk.Web">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Altinn.App.Api" Version="8.11.3" />
+                <PackageReference Include="Altinn.App.Core" Version="7.5.0" />
+              </ItemGroup>
+            </Project>
+            """
+        );
+
+        await new ProjectFileRewriter(csproj, targetVersion: "9.0.5", targetFramework: "net10.0").Upgrade();
+
+        var doc = XDocument.Load(csproj);
+        Assert.Equal("9.0.5", VersionOf(doc, "Altinn.App.Api"));
+        Assert.Equal("9.0.5", VersionOf(doc, "Altinn.App.Core"));
+    }
+}

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/ProjectChecks/ProjectChecks.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/ProjectChecks/ProjectChecks.cs
@@ -8,6 +8,8 @@ namespace Altinn.Studio.Cli.Upgrade.v8Tov9.ProjectChecks;
 /// </summary>
 internal sealed class ProjectChecks
 {
+    private static readonly NuGetVersion _nineZero = new(9, 0, 0);
+
     private readonly XDocument _doc;
 
     /// <summary>
@@ -128,8 +130,32 @@ internal sealed class ProjectChecks
             return false;
         }
 
-        // Covers exact versions ("8.11.3"), bracket/range syntax ("[8.11.3]", "[8.0,9.0)")
-        // and floating versions ("8.*") — all resolve to a floor version we can check.
-        return range.MinVersion?.Major == 8;
+        if (range.MinVersion?.Major != 8)
+        {
+            return false;
+        }
+
+        // A floating version ("8.*") is bounded to its major version by definition.
+        if (range.IsFloating)
+        {
+            return true;
+        }
+
+        // A bare version ("8.11.3", no "[...]"/"(...)" syntax) is a pinned floor, not an
+        // open-ended range - NuGet resolves it to that specific version.
+        var isExplicitRange = version.StartsWith('[') || version.StartsWith('(');
+        if (!isExplicitRange)
+        {
+            return true;
+        }
+
+        // Explicit bracket/range syntax must not admit any version >= 9.0.0
+        // (e.g. "[8.0,9.0]", "[8.0,10.0)" and "[8.0,)" are all rejected).
+        if (range.MaxVersion is null)
+        {
+            return false;
+        }
+
+        return range.MaxVersion < _nineZero || (range.MaxVersion == _nineZero && !range.IsMaxInclusive);
     }
 }

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/ProjectChecks/ProjectChecks.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/ProjectChecks/ProjectChecks.cs
@@ -1,4 +1,5 @@
 using System.Xml.Linq;
+using NuGet.Versioning;
 
 namespace Altinn.Studio.Cli.Upgrade.v8Tov9.ProjectChecks;
 
@@ -20,11 +21,13 @@ internal sealed class ProjectChecks
     }
 
     /// <summary>
-    /// Verifies that the project is using supported versions of Altinn.App.Api and Altinn.App.Core
-    /// for the 'v8Tov9' upgrade. Accepts versions &gt;= 8.0.0 and &lt; 9.0.0.
+    /// Verifies that the project is using a supported version of Altinn.App.Api (and, if explicitly
+    /// declared, Altinn.App.Core) for the 'v8Tov9' upgrade. Accepts versions &gt;= 8.0.0 and &lt; 9.0.0,
+    /// including NuGet range/bracket syntax (e.g. "[8.11.3]", "[8.0,9.0)", "8.*").
     /// Also allows projects using ProjectReference instead of PackageReference (e.g., local development).
     /// </summary>
-    /// <returns>True if both packages are present and in the supported version range, or if using project references</returns>
+    /// <returns>True if Altinn.App.Api is present and in the supported version range (and Altinn.App.Core,
+    /// if present, is too), or if using project references</returns>
     public bool SupportedSourceVersion()
     {
         // Check if using project references instead of package references
@@ -33,17 +36,9 @@ internal sealed class ProjectChecks
             return true;
         }
 
-        var altinnAppCoreElements = GetAltinnAppCoreElement();
+        // Altinn.App.Api is required; it pulls in a compatible Altinn.App.Core transitively.
         var altinnAppApiElements = GetAltinnAppApiElement();
-
-        // Both packages must be present
-        if (altinnAppCoreElements is null || altinnAppApiElements is null)
-        {
-            return false;
-        }
-
-        // If no elements found for either package, fail
-        if (altinnAppCoreElements.Count == 0 || altinnAppApiElements.Count == 0)
+        if (altinnAppApiElements is null || altinnAppApiElements.Count == 0)
         {
             return false;
         }
@@ -58,7 +53,14 @@ internal sealed class ProjectChecks
             return false;
         }
 
-        // Check all Altinn.App.Core versions
+        // Altinn.App.Core is only validated if explicitly declared; otherwise it's obtained
+        // transitively via Altinn.App.Api and there's nothing explicit to check.
+        var altinnAppCoreElements = GetAltinnAppCoreElement();
+        if (altinnAppCoreElements is null || altinnAppCoreElements.Count == 0)
+        {
+            return true;
+        }
+
         return altinnAppCoreElements
             .Select(coreElement => coreElement.Attribute("Version")?.Value)
             .All(altinnAppCoreVersion => SupportedSourceVersion(altinnAppCoreVersion));
@@ -121,18 +123,13 @@ internal sealed class ProjectChecks
             return false;
         }
 
-        var versionParts = version.Split('.');
-        if (versionParts.Length < 3)
+        if (!VersionRange.TryParse(version, out var range))
         {
             return false;
         }
 
-        if (!int.TryParse(versionParts[0], out int major))
-        {
-            return false;
-        }
-
-        // Must be version 8.x.x (>= 8.0.0 and < 9.0.0)
-        return major == 8;
+        // Covers exact versions ("8.11.3"), bracket/range syntax ("[8.11.3]", "[8.0,9.0)")
+        // and floating versions ("8.*") — all resolve to a floor version we can check.
+        return range.MinVersion?.Major == 8;
     }
 }

--- a/src/cli/studioctl-server/studioctl-server.csproj
+++ b/src/cli/studioctl-server/studioctl-server.csproj
@@ -32,5 +32,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" />
     <PackageReference Include="Microsoft.NET.StringTools" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="NuGet.Versioning" />
   </ItemGroup>
 </Project>

--- a/src/cli/studioctl.slnx
+++ b/src/cli/studioctl.slnx
@@ -1,3 +1,6 @@
 <Solution>
   <Project Path="studioctl-server/studioctl-server.csproj" />
+  <Folder Name="/studioctl-server-tests/">
+    <Project Path="studioctl-server-tests/Studioctl.Tests.csproj" />
+  </Folder>
 </Solution>


### PR DESCRIPTION
Use the microsoft owned NuGet.Versioning to parse the version references.

* Fixes https://github.com/Altinn/altinn-studio/issues/19918

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved upgrade checks for NuGet version declarations, supporting exact, range, bracketed and floating-version formats.
  * Projects using API-only or project-reference configurations are now handled correctly.
  * Explicit Core package references are validated and upgraded consistently.
  * Projects must include a compatible API version, while Core references remain optional where appropriate.

* **Tests**
  * Added comprehensive coverage for supported project configurations, version validation and project file upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->