### PR TITLE
ci(designer): increase Playwright job timeout

### DIFF
--- a/.github/workflows/designer-frontend-run-playwright-on-pr.yaml
+++ b/.github/workflows/designer-frontend-run-playwright-on-pr.yaml
@@ -29,7 +29,7 @@ jobs:
   playwright-tests:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Playwright
-    timeout-minutes: 25
+    timeout-minutes: 35
     runs-on: self-hosted-single
 
     steps:


### PR DESCRIPTION
## Description

Increases the Designer Playwright PR job timeout from 25 to 35 minutes.

The failed run on #19917 spent about 14 minutes checking out and preparing Designer before Playwright started. Repeated 30-second test retries then exhausted the remaining 25-minute job budget and GitHub cancelled the job before diagnostic artifacts could be uploaded. A 35-minute ceiling leaves enough room for cold setup, retries, and artifact collection while retaining a bounded job timeout.

This PR contains only the workflow timeout adjustment.

Follow-up to #19917.

## Verification

- [x] Related work is connected (#19917)
- [x] Workflow validates cleanly
- [x] Prior successful and timed-out job durations inspected manually
- [x] Automated test not applicable to a timeout-only workflow change

Commands and observations:

- `actionlint -ignore SC2129 .github/workflows/designer-frontend-run-playwright-on-pr.yaml`: passed
- `git diff --check`: passed
- Timed-out run: setup took approximately 14 minutes, leaving approximately 9 minutes for 69 Playwright tests with one worker and retries
- Previous successful run completed in approximately 21 minutes; 35 minutes provides retry headroom without making the job unbounded


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the automated Playwright test workflow timeout from 25 to 35 minutes, allowing longer-running checks to complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->