### PR TITLE
fix(designer): correct static file cache policy

### DIFF
--- a/src/Designer/backend/src/Designer/Hosting/StaticFileCachePolicy.cs
+++ b/src/Designer/backend/src/Designer/Hosting/StaticFileCachePolicy.cs
@@ -1,0 +1,28 @@
+using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
+
+namespace Altinn.Studio.Designer.Hosting;
+
+internal static class StaticFileCachePolicy
+{
+    private static readonly TimeSpan DefaultMaxAge = TimeSpan.FromHours(1);
+    private static readonly TimeSpan ImmutableAssetMaxAge = TimeSpan.FromDays(365);
+
+    internal static CacheControlHeaderValue Create(PathString requestPath, string fileName)
+    {
+        if (fileName.EndsWith(".html", StringComparison.OrdinalIgnoreCase))
+        {
+            return new CacheControlHeaderValue { NoCache = true };
+        }
+
+        if (requestPath.Value?.Contains("/assets/", StringComparison.Ordinal) is true)
+        {
+            CacheControlHeaderValue cacheControl = new() { Public = true, MaxAge = ImmutableAssetMaxAge };
+            cacheControl.Extensions.Add(new NameValueHeaderValue("immutable"));
+            return cacheControl;
+        }
+
+        return new CacheControlHeaderValue { Public = true, MaxAge = DefaultMaxAge };
+    }
+}

--- a/src/Designer/backend/src/Designer/Hosting/StaticFileCachePolicy.cs
+++ b/src/Designer/backend/src/Designer/Hosting/StaticFileCachePolicy.cs
@@ -1,5 +1,4 @@
 using System;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Net.Http.Headers;
 
 namespace Altinn.Studio.Designer.Hosting;
@@ -7,20 +6,12 @@ namespace Altinn.Studio.Designer.Hosting;
 internal static class StaticFileCachePolicy
 {
     private static readonly TimeSpan DefaultMaxAge = TimeSpan.FromHours(1);
-    private static readonly TimeSpan ImmutableAssetMaxAge = TimeSpan.FromDays(365);
 
-    internal static CacheControlHeaderValue Create(PathString requestPath, string fileName)
+    internal static CacheControlHeaderValue Create(string fileName)
     {
         if (fileName.EndsWith(".html", StringComparison.OrdinalIgnoreCase))
         {
             return new CacheControlHeaderValue { NoCache = true };
-        }
-
-        if (requestPath.Value?.Contains("/assets/", StringComparison.Ordinal) is true)
-        {
-            CacheControlHeaderValue cacheControl = new() { Public = true, MaxAge = ImmutableAssetMaxAge };
-            cacheControl.Extensions.Add(new NameValueHeaderValue("immutable"));
-            return cacheControl;
         }
 
         return new CacheControlHeaderValue { Public = true, MaxAge = DefaultMaxAge };

--- a/src/Designer/backend/src/Designer/Program.cs
+++ b/src/Designer/backend/src/Designer/Program.cs
@@ -40,7 +40,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.FeatureManagement;
-using Microsoft.Net.Http.Headers;
 
 ILogger logger;
 
@@ -272,7 +271,7 @@ void Configure(IConfiguration configuration)
             OnPrepareResponse = context =>
             {
                 ResponseHeaders headers = context.Context.Response.GetTypedHeaders();
-                headers.CacheControl = new CacheControlHeaderValue { Public = true, MaxAge = TimeSpan.FromMinutes(60) };
+                headers.CacheControl = StaticFileCachePolicy.Create(context.Context.Request.Path, context.File.Name);
             },
         }
     );

--- a/src/Designer/backend/src/Designer/Program.cs
+++ b/src/Designer/backend/src/Designer/Program.cs
@@ -271,7 +271,7 @@ void Configure(IConfiguration configuration)
             OnPrepareResponse = context =>
             {
                 ResponseHeaders headers = context.Context.Response.GetTypedHeaders();
-                headers.CacheControl = StaticFileCachePolicy.Create(context.Context.Request.Path, context.File.Name);
+                headers.CacheControl = StaticFileCachePolicy.Create(context.File.Name);
             },
         }
     );

--- a/src/Designer/backend/tests/Designer.Tests/Hosting/StaticFileCachePolicyTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Hosting/StaticFileCachePolicyTests.cs
@@ -1,0 +1,49 @@
+using System;
+using Altinn.Studio.Designer.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
+using Xunit;
+
+namespace Designer.Tests.Hosting;
+
+public class StaticFileCachePolicyTests
+{
+    [Fact]
+    public void CreateForHtmlFileRequiresRevalidation()
+    {
+        CacheControlHeaderValue result = StaticFileCachePolicy.Create(
+            new PathString("/editor/index.html"),
+            "index.html"
+        );
+
+        Assert.True(result.NoCache);
+        Assert.False(result.Public);
+        Assert.Null(result.MaxAge);
+    }
+
+    [Fact]
+    public void CreateForHashedAssetCachesImmutably()
+    {
+        CacheControlHeaderValue result = StaticFileCachePolicy.Create(
+            new PathString("/editor/assets/Overview-CUBLCBy3.js"),
+            "Overview-CUBLCBy3.js"
+        );
+
+        Assert.True(result.Public);
+        Assert.Equal(TimeSpan.FromDays(365), result.MaxAge);
+        Assert.Contains(result.Extensions, extension => extension.Name.Equals("immutable", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void CreateForOtherStaticFilePreservesDefaultCacheDuration()
+    {
+        CacheControlHeaderValue result = StaticFileCachePolicy.Create(
+            new PathString("/img/Altinn-studio-3.svg"),
+            "Altinn-studio-3.svg"
+        );
+
+        Assert.True(result.Public);
+        Assert.Equal(TimeSpan.FromHours(1), result.MaxAge);
+        Assert.Empty(result.Extensions);
+    }
+}

--- a/src/Designer/backend/tests/Designer.Tests/Hosting/StaticFileCachePolicyTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Hosting/StaticFileCachePolicyTests.cs
@@ -1,6 +1,5 @@
 using System;
 using Altinn.Studio.Designer.Hosting;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Net.Http.Headers;
 using Xunit;
 
@@ -11,10 +10,7 @@ public class StaticFileCachePolicyTests
     [Fact]
     public void CreateForHtmlFileRequiresRevalidation()
     {
-        CacheControlHeaderValue result = StaticFileCachePolicy.Create(
-            new PathString("/editor/index.html"),
-            "index.html"
-        );
+        CacheControlHeaderValue result = StaticFileCachePolicy.Create("index.html");
 
         Assert.True(result.NoCache);
         Assert.False(result.Public);
@@ -22,25 +18,9 @@ public class StaticFileCachePolicyTests
     }
 
     [Fact]
-    public void CreateForHashedAssetCachesImmutably()
+    public void CreateForJavaScriptAssetPreservesDefaultCacheDuration()
     {
-        CacheControlHeaderValue result = StaticFileCachePolicy.Create(
-            new PathString("/editor/assets/Overview-CUBLCBy3.js"),
-            "Overview-CUBLCBy3.js"
-        );
-
-        Assert.True(result.Public);
-        Assert.Equal(TimeSpan.FromDays(365), result.MaxAge);
-        Assert.Contains(result.Extensions, extension => extension.Name.Equals("immutable", StringComparison.Ordinal));
-    }
-
-    [Fact]
-    public void CreateForOtherStaticFilePreservesDefaultCacheDuration()
-    {
-        CacheControlHeaderValue result = StaticFileCachePolicy.Create(
-            new PathString("/img/Altinn-studio-3.svg"),
-            "Altinn-studio-3.svg"
-        );
+        CacheControlHeaderValue result = StaticFileCachePolicy.Create("Overview-CUBLCBy3.js");
 
         Assert.True(result.Public);
         Assert.Equal(TimeSpan.FromHours(1), result.MaxAge);


### PR DESCRIPTION
## Description

Fixes the stale Designer frontend cache behavior observed after deployment, where a cached SPA entry document could reference a Vite chunk that no longer existed and return 404 until a hard refresh.

The static-file policy now:

- requires HTML responses to revalidate with `Cache-Control: no-cache`
- preserves the existing one-hour public cache for all other static files, including JavaScript assets

The policy is kept in a focused helper with coverage for both cases. This intentionally avoids coupling the backend cache policy to Vite's filename conventions.

Follow-up to #19917.

## Verification

- [x] Related work is connected (#19917)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added

Commands and observations:

- `dotnet build Designer.sln --no-restore -v minimal`: succeeded with 0 warnings and 0 errors
- `dotnet test tests/Designer.Tests/Designer.Tests.csproj --filter FullyQualifiedName~StaticFileCachePolicyTests --no-build --no-restore -v minimal`: 2/2 tests passed
- Ran Designer locally and requested real static files:
  - `/designer/openapi.html`: `200 OK`, `Cache-Control: no-cache`
  - `/img/Altinn-studio-3.svg`: `200 OK`, `Cache-Control: public, max-age=3600`
- Confirmed the local Designer process shut down cleanly after testing
