### PR TITLE
fix(deps): update tar to 7.5.22

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -19171,15 +19171,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.5.2":
-  version: 7.5.2
-  resolution: "tar@npm:7.5.2"
+  version: 7.5.22
+  resolution: "tar@npm:7.5.22"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10/dbad9c9a07863cd1bdf8801d563b3280aa7dd0f4a6cead779ff7516d148dc80b4c04639ba732d47f91f04002f57e8c3c6573a717d649daecaac74ce71daa7ad3
+  checksum: 10/129606384b3c895f422aaca48bf316357be6dc7aa35c1066c3f06c28acfff0be5b356e1b0a0be7c53a7a8945534ac06cec6d8e296d170d8a09c8bff67b29300e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Updates the transitive `tar` resolution from 7.5.2 to 7.5.22 within `node-gyp`'s existing `^7.5.2` range.

This remediates the open `tar` Dependabot alerts, including the critical decompression denial-of-service advisory GHSA-23hp-3jrh-7fpw and the newer GHSA-r292-9mhp-454m advisory affecting versions through 7.5.20.

## Verification

- `yarn install --immutable`
- `yarn build` in `src/Designer/frontend`
- `yarn build` in `src/App/frontend`
- `yarn test:ci` in `app-libs` (80 test files, 645 tests)
- Full frontend suites left to CI due to local memory constraints

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
