### PR TITLE
fix(deps): update fast-uri to 3.1.5

### DIFF
--- a/src/lhci-server/yarn.lock
+++ b/src/lhci-server/yarn.lock
@@ -1116,9 +1116,9 @@ __metadata:
   linkType: hard
 
 "fast-uri@npm:^3.0.1":
-  version: 3.1.2
-  resolution: "fast-uri@npm:3.1.2"
-  checksum: 10/1dff04865b2a38d3e0659deadfbf72efdf83a776bfbf9667e4aa9e5a3ec31bc341cda9622136b32b7652a857c8ba11896794186e8f876f8b2b72731fce8622f6
+  version: 3.1.5
+  resolution: "fast-uri@npm:3.1.5"
+  checksum: 10/784bef687ca3ecfb4587a05104a4d41101796f0fec72be47a9abed743b10109e69a24d1ad0854ee7d2705912dc2ca9d93e03d35b65df0a3da0339e05b5d83b5c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11506,9 +11506,9 @@ __metadata:
   linkType: hard
 
 "fast-uri@npm:^3.0.1":
-  version: 3.1.0
-  resolution: "fast-uri@npm:3.1.0"
-  checksum: 10/818b2c96dc913bcf8511d844c3d2420e2c70b325c0653633f51821e4e29013c2015387944435cd0ef5322c36c9beecc31e44f71b257aeb8e0b333c1d62bb17c2
+  version: 3.1.5
+  resolution: "fast-uri@npm:3.1.5"
+  checksum: 10/784bef687ca3ecfb4587a05104a4d41101796f0fec72be47a9abed743b10109e69a24d1ad0854ee7d2705912dc2ca9d93e03d35b65df0a3da0339e05b5d83b5c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Updates the transitive `fast-uri` resolution to 3.1.5 in both the root and LHCI Server Yarn lockfiles.

The existing `ajv` dependency range already permits this version. This remediates eight HIGH Dependabot alerts covering URI path traversal and host-confusion vulnerabilities without changing package manifests or introducing a major-version upgrade.

## Verification

- [ ] Related issues are connected (not applicable; Dependabot security alerts are not linkable as public issues)
- [ ] **Your** code builds clean without any errors or warnings (not run; lockfile-only change)
- [x] Manual testing done: sequential `yarn install --immutable --mode=skip-build` completed for the root workspace and `src/lhci-server`
- [ ] Relevant automated test added (not applicable; transitive lockfile update)

Additional checks:

- `git diff --check`
- Confirmed both lockfiles resolve `fast-uri@npm:^3.0.1` to `3.1.5`
- Confirmed GitHub Advisory Database currently reports no advisories affecting `fast-uri@3.1.5`
