### PR TITLE
chore(designer): remove unused backend dependencies

### DIFF
--- a/src/Designer/backend/Directory.Packages.props
+++ b/src/Designer/backend/Directory.Packages.props
@@ -18,10 +18,7 @@
     <PackageVersion Include="JsonSchema.Net" Version="7.4.0" />
     <PackageVersion Include="JsonPatch.Net" Version="3.3.0" />
     <PackageVersion Include="JetBrains.Annotations" Version="2026.2.0" />
-    <PackageVersion Include="CompilerAttributes" Version="1.1.2" />
     <PackageVersion Include="CSharpier.MsBuild" Version="1.3.0" />
-    <PackageVersion Include="ini-parser-netstandard" Version="2.5.3" />
-    <PackageVersion Include="JWTCookieAuthentication" Version="4.0.4" />
     <PackageVersion Include="LibGit2Sharp" Version="0.32.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
@@ -35,19 +32,15 @@
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection.AzureKeyVault" Version="3.1.24" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Azure.KeyVault" Version="3.0.5" />
-    <PackageVersion Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
     <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.10" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.10" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
-    <PackageVersion Include="Microsoft.DiaSymReader.Native" Version="1.7.0" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.10" />
     <PackageVersion Include="Microsoft.FeatureManagement.AspNetCore" Version="4.4.0" />
-    <PackageVersion Include="Scrutor" Version="5.1.2" />
     <PackageVersion Include="Polly" Version="8.6.6" />
     <PackageVersion Include="MediatR" Version="12.5.0" />
     <PackageVersion Include="DotNetEnv" Version="3.1.1" />
@@ -92,7 +85,6 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.10" />
     <PackageVersion Include="WireMock.Net.Minimal" Version="2.14.0" />
     <PackageVersion Include="DistributedLock.FileSystem" Version="1.0.3" />
-    <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.7.3" />
     <PackageVersion Include="SSH.NET" Version="2026.0.0" />
     <PackageVersion Include="Verify.Xunit" Version="31.12.5" />
   </ItemGroup>

--- a/src/Designer/backend/src/Designer/Designer.csproj
+++ b/src/Designer/backend/src/Designer/Designer.csproj
@@ -24,13 +24,9 @@
     <PackageReference Include="Altinn.Platform.Storage.Interface" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Storage.Blobs" />
-    <PackageReference Include="Azure.Security.KeyVault.Secrets" />
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" />
-    <PackageReference Include="CompilerAttributes" />
     <PackageReference Include="DistributedLock.Postgres" />
     <PackageReference Include="DotNetEnv" />
-    <PackageReference Include="ini-parser-netstandard" />
-    <PackageReference Include="JWTCookieAuthentication" />
     <PackageReference Include="JetBrains.Annotations" />
     <PackageReference Include="LibGit2Sharp" />
     <PackageReference Include="MediatR" />
@@ -49,9 +45,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" />
-    <PackageReference Include="Microsoft.Azure.KeyVault" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -60,9 +53,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" />
     <PackageReference Include="HtmlAgilityPack" />
-    <PackageReference Include="Microsoft.DiaSymReader.Native" />
     <PackageReference Include="NJsonSchema" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     <PackageReference Include="NuGet.Versioning" />
@@ -71,7 +62,6 @@
     <PackageReference Include="Quartz.Extensions.DependencyInjection" />
     <PackageReference Include="Quartz.Extensions.Hosting" />
     <PackageReference Include="Quartz.Serialization.SystemTextJson" />
-    <PackageReference Include="Scrutor" />
     <PackageReference Include="YamlDotNet" />
   </ItemGroup>
 

--- a/src/Designer/backend/tests/DataModeling.Tests/DataModeling.Tests.csproj
+++ b/src/Designer/backend/tests/DataModeling.Tests/DataModeling.Tests.csproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit" />

--- a/src/Designer/backend/tests/Designer.Tests/Designer.Tests.csproj
+++ b/src/Designer/backend/tests/Designer.Tests/Designer.Tests.csproj
@@ -11,14 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Altinn.ApiClients.Maskinporten" />
-    <PackageReference Include="Basic.Reference.Assemblies" />
     <PackageReference Include="DistributedLock.FileSystem" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Fare" />
     <PackageReference Include="Moq" />
     <PackageReference Include="Polly" />
     <PackageReference Include="Testcontainers" />
@@ -26,14 +23,12 @@
     <PackageReference Include="WireMock.Net.Minimal" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" />
     <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyModel" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" />
-    <PackageReference Include="System.Linq.Dynamic.Core" />
     <PackageReference Include="Verify.Xunit" />
   </ItemGroup>
 


### PR DESCRIPTION
## Description

Remove unused and redundant NuGet references from the Designer backend and test projects.

The removed app dependencies are either no longer used after earlier feature removals, build-time remnants, or redundant direct references already supplied transitively. Redundant test-only references are removed as well. `JetBrains.Annotations` is intentionally excluded because it is handled separately in #19941.

## Verification

- [x] Related issues are connected (if applicable) — follow-up to #19941
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required) — inspected source and compiled assembly references, and verified resolved dependency graphs after removal
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out) — dependency-only cleanup; existing tests cover behavior

Commands run:

```text
dotnet build Designer.sln --no-incremental
Build succeeded. 0 Warning(s), 0 Error(s).

dotnet test tests/DataModeling.Tests/DataModeling.Tests.csproj --no-build
Passed: 478, Failed: 0, Skipped: 0.

DOTNET_USE_POLLING_FILE_WATCHER=1 dotnet test tests/Designer.Tests/Designer.Tests.csproj --no-build --filter '<previously failing and representative startup tests>'
Passed: 8, Failed: 0, Skipped: 0.
```

A full Designer test run was also attempted. The initial run exhausted the host's 1,024 inotify-instance limit; the affected tests passed when rerun with polling file watchers. The polling full-suite rerun progressed without failures but was interrupted before its final summary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined internal package configuration by removing unused dependencies from the application and test projects.
  * Retained required packages for Azure Secrets, database locking, environment configuration, HTML processing, testing, hosting, containers and coverage.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->