### PR TITLE
feat(workflow-engine-app): propagate HTTP status code in AppCommand error results

### DIFF
--- a/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/Commands/AppCommand/AppCommand.cs
+++ b/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/Commands/AppCommand/AppCommand.cs
@@ -186,12 +186,14 @@ internal sealed class AppCommand : Command<AppCommandData, AppWorkflowContext>
         if (statusCode is >= 400 and < 500 and not 408 and not 418 and not 429)
         {
             return ExecutionResult.CriticalError(
-                $"AppCommand failed with client error {response.StatusCode}: {errorBody}"
+                $"AppCommand failed with client error {response.StatusCode}: {errorBody}",
+                httpStatusCode: statusCode
             );
         }
 
         return ExecutionResult.RetryableError(
-            $"AppCommand execution failed with status code {response.StatusCode}: {errorBody}"
+            $"AppCommand execution failed with status code {response.StatusCode}: {errorBody}",
+            httpStatusCode: statusCode
         );
     }
 

--- a/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/Commands/AppCommand/AppCommandExecutionTests.cs
+++ b/src/Runtime/workflow-engine-app/tests/WorkflowEngine.App.Tests/Commands/AppCommand/AppCommandExecutionTests.cs
@@ -203,6 +203,7 @@ public class AppCommandExecutionTests
 
         Assert.Equal(ExecutionStatus.RetryableError, result.Status);
         Assert.Contains("InternalServerError", result.Message, StringComparison.Ordinal);
+        Assert.Equal(500, result.HttpStatusCode);
     }
 
     [Theory]
@@ -225,6 +226,7 @@ public class AppCommandExecutionTests
         var result = await command.Execute(context, TestContext.Current.CancellationToken);
 
         Assert.Equal(ExecutionStatus.RetryableError, result.Status);
+        Assert.Equal((int)statusCode, result.HttpStatusCode);
     }
 
     [Theory]
@@ -250,6 +252,7 @@ public class AppCommandExecutionTests
 
         Assert.Equal(ExecutionStatus.CriticalError, result.Status);
         Assert.Contains("client error", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal((int)statusCode, result.HttpStatusCode);
     }
 
     // --- StateOut handling ---
@@ -317,6 +320,9 @@ public class AppCommandExecutionTests
 
         Assert.Equal(ExecutionStatus.CriticalError, result.Status);
         Assert.Contains("invalid response body", result.Message, StringComparison.OrdinalIgnoreCase);
+        // Only failure-classifying HTTP branches carry a status code; this is a 2xx response with a
+        // bad body, so the error is not an HTTP transport failure and the code stays null.
+        Assert.Null(result.HttpStatusCode);
     }
 
     // --- StateIn / payload completeness ---


### PR DESCRIPTION
## Description

`AppCommand` now passes the callback response's status code into `ExecutionResult.CriticalError`/`RetryableError`, giving app-callback error history parity with `WebhookCommand`: every persisted `ErrorEntry` carries a machine-readable `HttpStatusCode` instead of embedding it only in the message text.

- Both HTTP error-classification branches (4xx → critical, 5xx/408/418/429 → retryable) pass `httpStatusCode`; message strings are unchanged.
- Non-HTTP paths are untouched and keep a null status code, including the invalid-JSON-on-2xx branch (now pinned by a test): only failure-classifying HTTP responses carry a code.
- No wire-contract change (snapshot unchanged).

Second prerequisite of the failure-storm throttling design (#18481), whose detection refinements group failures by status code; stacked on #19957 (and the ADR in #19954).

## Verification

- Full workflow-engine-app suite: 76 passed, 0 failed, 0 skipped (incl. Testcontainers/WireMock integration).
- Extended tests assert the code on both classifications across the status matrix, and null on the invalid-JSON branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Failed AppCommand callbacks now include the relevant HTTP status code in execution errors.
  - Retryable, non-retryable and server-error responses are reported more accurately.
  - Invalid JSON in otherwise successful responses no longer reports an incorrect HTTP status code.

- **Tests**
  - Added coverage for HTTP status codes across callback success and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->