### PR TITLE
fix(deps): update @nevware21/ts-utils to 0.15.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3724,14 +3724,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nevware21/ts-utils@npm:>= 0.10.4 < 2.x, @nevware21/ts-utils@npm:>= 0.11.3 < 2.x, @nevware21/ts-utils@npm:>= 0.11.6 < 2.x, @nevware21/ts-utils@npm:>= 0.11.8 < 2.x, @nevware21/ts-utils@npm:>= 0.9.4 < 2.x":
-  version: 0.12.5
-  resolution: "@nevware21/ts-utils@npm:0.12.5"
-  checksum: 10/666b19acfc6f7ee661db17110f9c058905b664e430c5e6b52d51df39e771fe9502642a185a97bc9c7f8cf60ce691b6c4006355b6e84a5697ff6f1ea7fe063913
-  languageName: node
-  linkType: hard
-
-"@nevware21/ts-utils@npm:>= 0.12.2 < 2.x, @nevware21/ts-utils@npm:>= 0.14.0 < 2.x":
+"@nevware21/ts-utils@npm:>= 0.10.4 < 2.x, @nevware21/ts-utils@npm:>= 0.11.3 < 2.x, @nevware21/ts-utils@npm:>= 0.11.6 < 2.x, @nevware21/ts-utils@npm:>= 0.11.8 < 2.x, @nevware21/ts-utils@npm:>= 0.12.2 < 2.x, @nevware21/ts-utils@npm:>= 0.14.0 < 2.x, @nevware21/ts-utils@npm:>= 0.9.4 < 2.x":
   version: 0.15.0
   resolution: "@nevware21/ts-utils@npm:0.15.0"
   checksum: 10/ff8484a0c6d10aca1e7a4bcd497608cb2da3659ac6c110a1d70829c472b6ff6e2d24ae91b457328a7dbf3e62751ae8c8a6e9878c3d5ea62864a6e9a3eb413265


### PR DESCRIPTION
## Description

Consolidates the vulnerable transitive `@nevware21/ts-utils@0.12.5` lockfile resolution onto the already-present `0.15.0` resolution. All requesting dependency ranges permit `0.15.0`.

This addresses [Dependabot alert #1062](https://github.com/Altinn/altinn-studio/security/dependabot/1062) for prototype pollution in `objDeepCopy` and `objCopyProps`. The dependency is used by Application Insights in the deployed Designer frontend.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required): `yarn install --immutable --mode=skip-build`
- [ ] Relevant automated test added (not applicable for a transitive lockfile-only update)

The immutable install completed successfully. Existing peer-dependency warnings remain unchanged. Compile and build coverage is delegated to CI; no local test suites were run.
