### PR TITLE
chore: group Dependabot security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,11 +7,26 @@ updates:
     directories:
       - '/'
       - '/src/lhci-server'
+      - '/src/Runtime/localtest'
+      - '/src/Runtime/pdf3'
+      - '/src/test/K6'
     schedule:
       interval: weekly
     open-pull-requests-limit: 0
     groups:
       npm-security-updates:
+        applies-to: security-updates
+        patterns:
+          - '*'
+
+  - package-ecosystem: nuget
+    directories:
+      - '**/*'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    groups:
+      nuget-security-updates:
         applies-to: security-updates
         patterns:
           - '*'
@@ -24,6 +39,17 @@ updates:
     open-pull-requests-limit: 0
     groups:
       go-security-updates:
+        applies-to: security-updates
+        patterns:
+          - '*'
+
+  - package-ecosystem: pip
+    directory: '/src/tools/altinn-fleet-stats/backend'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    groups:
+      pip-security-updates:
         applies-to: security-updates
         patterns:
           - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+version: 2
+
+# Renovate owns routine dependency updates. These entries only customize
+# Dependabot security updates and explicitly disable version-update PRs.
+updates:
+  - package-ecosystem: npm
+    directories:
+      - '/'
+      - '/src/lhci-server'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    groups:
+      npm-security-updates:
+        applies-to: security-updates
+        patterns:
+          - '*'
+
+  - package-ecosystem: gomod
+    directories:
+      - '**/*'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    groups:
+      go-security-updates:
+        applies-to: security-updates
+        patterns:
+          - '*'
+
+  - package-ecosystem: uv
+    directories:
+      - '/src/AI/agents'
+      - '/src/AI/mcp'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    groups:
+      uv-security-updates:
+        applies-to: security-updates
+        patterns:
+          - '*'


### PR DESCRIPTION
## Description

Add a Dependabot configuration that groups security updates by ecosystem:

- npm for every standalone lockfile, including the root workspace
- all NuGet projects
- all Go modules
- the pip-managed fleet stats tool
- uv projects under `src/AI`

Routine Dependabot version-update PRs are disabled with `open-pull-requests-limit: 0`, so Renovate remains the only routine dependency updater. The grouping rules apply only to security updates.

Docker images remain Renovate-managed because they are not represented in Dependabot's security-alert dependency graph. GitHub Actions also remain Renovate-managed: all external actions are SHA-pinned, and GitHub only generates Dependabot alerts for actions referenced by semantic versions.

## Verification

- [x] Related issues are connected (not applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done: verified all relevant manifest and lockfile locations are covered
- [x] Configuration passes YAML lint, Prettier, and GitHub's Dependabot schema validation
