### PR TITLE
chore(deps): update studioctl MSBuild packages to 18.9.6

### DIFF
--- a/src/cli/Directory.Packages.props
+++ b/src/cli/Directory.Packages.props
@@ -8,7 +8,7 @@
     <PackageVersion Include="AngleSharp" Version="1.7.1" />
     <PackageVersion Include="LibGit2Sharp" Version="0.32.0" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.11.2" />
-    <PackageVersion Include="Microsoft.Build" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.Build" Version="18.8.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.14.0" />
     <PackageVersion Include="MinVer" Version="6.1.0" />
@@ -16,10 +16,10 @@
     <PackageVersion Include="CSharpier.MsBuild" Version="1.3.0" />
     <PackageVersion Include="Nullable.Extended.Analyzer" Version="1.15.6581" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.31.0.145097" />
-    <PackageVersion Include="Microsoft.Build.Framework" Version="18.4.0" />
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="18.4.0" />
-    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.4.0" />
-    <PackageVersion Include="Microsoft.NET.StringTools" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.Build.Framework" Version="18.8.2" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="18.8.2" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.8.2" />
+    <PackageVersion Include="Microsoft.NET.StringTools" Version="18.8.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="NuGet.Versioning" Version="6.14.3" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />

--- a/src/cli/Directory.Packages.props
+++ b/src/cli/Directory.Packages.props
@@ -8,7 +8,7 @@
     <PackageVersion Include="AngleSharp" Version="1.7.1" />
     <PackageVersion Include="LibGit2Sharp" Version="0.32.0" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.11.2" />
-    <PackageVersion Include="Microsoft.Build" Version="18.8.2" />
+    <PackageVersion Include="Microsoft.Build" Version="18.9.6" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.14.0" />
     <PackageVersion Include="MinVer" Version="6.1.0" />
@@ -16,10 +16,10 @@
     <PackageVersion Include="CSharpier.MsBuild" Version="1.3.0" />
     <PackageVersion Include="Nullable.Extended.Analyzer" Version="1.15.6581" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.31.0.145097" />
-    <PackageVersion Include="Microsoft.Build.Framework" Version="18.8.2" />
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="18.8.2" />
-    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.8.2" />
-    <PackageVersion Include="Microsoft.NET.StringTools" Version="18.8.2" />
+    <PackageVersion Include="Microsoft.Build.Framework" Version="18.9.6" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="18.9.6" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.9.6" />
+    <PackageVersion Include="Microsoft.NET.StringTools" Version="18.9.6" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="NuGet.Versioning" Version="6.14.3" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />


### PR DESCRIPTION
## Description

Splits the studioctl MSBuild dependency family out of #19759 and updates these packages together from 18.4.0 to the current NuGet release, 18.9.6:

- Microsoft.Build
- Microsoft.Build.Framework
- Microsoft.Build.Tasks.Core
- Microsoft.Build.Utilities.Core
- Microsoft.NET.StringTools

They provide the compile-time MSBuild APIs used by the v7-to-v8 backend upgrader. Runtime Microsoft.Build assemblies remain excluded and are selected through Microsoft.Build.Locator. No studioctl behavior or code changes are included.

This focused, compatibility-tested update intentionally accepts 18.9.6 before the shared Renovate configuration’s three-day release-age window expires. It also advances System.Security.Cryptography.Xml from the vulnerable 10.0.1 dependency to patched 10.0.10.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we will help out)

Verified with:

- `dotnet list studioctl-server-tests/Studioctl.Tests.csproj package --vulnerable --include-transitive` (no vulnerable packages)
- `make build`
- `make fmt`
- `make lint` (0 issues)
- `make test` (Go race suite passed; .NET: 255 passed)
- Published backend-v8 upgrade path against SDK 8.0.423 and 9.0.316
- `go run . workflow --component studioctl --base-branch main --dry-run --skip-branch-check` (all 15 release artifacts built)

No new test was added for this dependency-only update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Microsoft Build and .NET StringTools tooling to version 18.9.6 for improved build reliability and compatibility.
  * No user-facing functionality or public API changes were introduced.
  * Existing projects and workflows continue to operate as before, with the update applied transparently during development and build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->