### PR TITLE
chore(deps): update Quartz packages to 3.19.1

### DIFF
--- a/.github/workflows/designer-backend-check-quartz-update.yml
+++ b/.github/workflows/designer-backend-check-quartz-update.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      tables-file: src/Designer/backend/src/Designer/Migrations/SqlScripts/QuartzTables/tables_postgres.sql
+      tables-file: src/Designer/backend/src/Designer/Migrations/SqlScripts/QuartzTables/tables_postgres_3.19.1.sql
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/src/Designer/backend/Directory.Packages.props
+++ b/src/Designer/backend/Directory.Packages.props
@@ -61,10 +61,10 @@
     <PackageVersion Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     <PackageVersion Include="YamlDotNet" Version="18.1.0" />
     <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
-    <PackageVersion Include="Quartz" Version="3.16.1" />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection" Version="3.16.1" />
-    <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.16.1" />
-    <PackageVersion Include="Quartz.Serialization.SystemTextJson" Version="3.16.1" />
+    <PackageVersion Include="Quartz" Version="3.19.1" />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection" Version="3.19.1" />
+    <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.19.1" />
+    <PackageVersion Include="Quartz.Serialization.SystemTextJson" Version="3.19.1" />
   </ItemGroup>
   <ItemGroup Label="Packages used for testing">
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />

--- a/src/Designer/backend/src/Designer/Migrations/20260814060655_UpgradeQuartzTo3191.Designer.cs
+++ b/src/Designer/backend/src/Designer/Migrations/20260814060655_UpgradeQuartzTo3191.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Altinn.Studio.Designer.Repository.ORMImplementation.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Altinn.Studio.Designer.Migrations
 {
     [DbContext(typeof(DesignerdbContext))]
-    partial class DesignerdbContextModelSnapshot : ModelSnapshot
+    [Migration("20260814060655_UpgradeQuartzTo3191")]
+    partial class UpgradeQuartzTo3191
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Designer/backend/src/Designer/Migrations/20260814060655_UpgradeQuartzTo3191.cs
+++ b/src/Designer/backend/src/Designer/Migrations/20260814060655_UpgradeQuartzTo3191.cs
@@ -1,0 +1,23 @@
+﻿using Altinn.Studio.Designer.Migrations.SqlScripts;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Altinn.Studio.Designer.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpgradeQuartzTo3191 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(SqlScriptsReadHelper.ReadSqlScript("QuartzTables/upgrade_3.16.1_to_3.19.1.sql"));
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(SqlScriptsReadHelper.ReadSqlScript("QuartzTables/downgrade_3.19.1_to_3.16.1.sql"));
+        }
+    }
+}

--- a/src/Designer/backend/src/Designer/Migrations/SqlScripts/QuartzTables/downgrade_3.19.1_to_3.16.1.sql
+++ b/src/Designer/backend/src/Designer/Migrations/SqlScripts/QuartzTables/downgrade_3.19.1_to_3.16.1.sql
@@ -1,0 +1,8 @@
+ALTER TABLE qrtz_fired_triggers
+    DROP COLUMN execution_group;
+
+ALTER TABLE qrtz_triggers
+    DROP COLUMN preferred_node_auto,
+    DROP COLUMN preferred_node,
+    DROP COLUMN execution_group,
+    DROP COLUMN misfire_orig_fire_time;

--- a/src/Designer/backend/src/Designer/Migrations/SqlScripts/QuartzTables/tables_postgres_3.19.1.sql
+++ b/src/Designer/backend/src/Designer/Migrations/SqlScripts/QuartzTables/tables_postgres_3.19.1.sql
@@ -1,0 +1,191 @@
+-- This script is for PostgreSQL
+
+-- This initializes the database to pristine for Quartz, by first removing any existing Quartz tables
+-- and then recreating them from scratch.
+-- Should you only require it to create the tables, set DropDb to 0.
+
+DO $$
+  DECLARE DropDb INT := 1; -- Set this to 0 to skip DROP statements, 1 to include them
+BEGIN
+  IF DropDb = 1 THEN
+    SET client_min_messages = WARNING;
+    DROP TABLE IF EXISTS qrtz_fired_triggers;
+    DROP TABLE IF EXISTS qrtz_paused_trigger_grps;
+    DROP TABLE IF EXISTS qrtz_scheduler_state;
+    DROP TABLE IF EXISTS qrtz_locks;
+    DROP TABLE IF EXISTS qrtz_simprop_triggers;
+    DROP TABLE IF EXISTS qrtz_simple_triggers;
+    DROP TABLE IF EXISTS qrtz_cron_triggers;
+    DROP TABLE IF EXISTS qrtz_blob_triggers;
+    DROP TABLE IF EXISTS qrtz_triggers;
+    DROP TABLE IF EXISTS qrtz_job_details;
+    DROP TABLE IF EXISTS qrtz_calendars;
+    SET client_min_messages = NOTICE;
+  END IF;
+END $$;
+
+CREATE TABLE qrtz_job_details
+  (
+    sched_name TEXT NOT NULL,
+    job_name TEXT NOT NULL,
+    job_group TEXT NOT NULL,
+    description TEXT NULL,
+    job_class_name TEXT NOT NULL,
+    is_durable BOOL NOT NULL,
+    is_nonconcurrent BOOL NOT NULL,
+    is_update_data BOOL NOT NULL,
+    requests_recovery BOOL NOT NULL,
+    job_data BYTEA NULL,
+    PRIMARY KEY (sched_name, job_name, job_group)
+);
+
+CREATE TABLE qrtz_triggers
+  (
+    sched_name TEXT NOT NULL,
+    trigger_name TEXT NOT NULL,
+    trigger_group TEXT NOT NULL,
+    job_name TEXT NOT NULL,
+    job_group TEXT NOT NULL,
+    description TEXT NULL,
+    next_fire_time BIGINT NULL,
+    prev_fire_time BIGINT NULL,
+    priority INTEGER NULL,
+    trigger_state TEXT NOT NULL,
+    trigger_type TEXT NOT NULL,
+    start_time BIGINT NOT NULL,
+    end_time BIGINT NULL,
+    calendar_name TEXT NULL,
+    misfire_instr SMALLINT NULL,
+    misfire_orig_fire_time BIGINT NULL,
+    execution_group VARCHAR(200) NULL,
+    preferred_node VARCHAR(200) NULL,
+    preferred_node_auto BOOL NOT NULL DEFAULT FALSE,
+    job_data BYTEA NULL,
+    PRIMARY KEY (sched_name, trigger_name, trigger_group),
+    FOREIGN KEY (sched_name, job_name, job_group)
+      REFERENCES qrtz_job_details (sched_name, job_name, job_group)
+);
+
+CREATE TABLE qrtz_simple_triggers
+  (
+    sched_name TEXT NOT NULL,
+    trigger_name TEXT NOT NULL,
+    trigger_group TEXT NOT NULL,
+    repeat_count BIGINT NOT NULL,
+    repeat_interval BIGINT NOT NULL,
+    times_triggered BIGINT NOT NULL,
+    PRIMARY KEY (sched_name, trigger_name, trigger_group),
+    FOREIGN KEY (sched_name, trigger_name, trigger_group)
+      REFERENCES qrtz_triggers (sched_name, trigger_name, trigger_group)
+      ON DELETE CASCADE
+);
+
+CREATE TABLE qrtz_simprop_triggers
+  (
+    sched_name TEXT NOT NULL,
+    trigger_name TEXT NOT NULL,
+    trigger_group TEXT NOT NULL,
+    str_prop_1 TEXT NULL,
+    str_prop_2 TEXT NULL,
+    str_prop_3 TEXT NULL,
+    int_prop_1 INTEGER NULL,
+    int_prop_2 INTEGER NULL,
+    long_prop_1 BIGINT NULL,
+    long_prop_2 BIGINT NULL,
+    dec_prop_1 NUMERIC NULL,
+    dec_prop_2 NUMERIC NULL,
+    bool_prop_1 BOOL NULL,
+    bool_prop_2 BOOL NULL,
+    time_zone_id TEXT NULL,
+    PRIMARY KEY (sched_name, trigger_name, trigger_group),
+    FOREIGN KEY (sched_name, trigger_name, trigger_group)
+      REFERENCES qrtz_triggers (sched_name, trigger_name, trigger_group)
+      ON DELETE CASCADE
+);
+
+CREATE TABLE qrtz_cron_triggers
+  (
+    sched_name TEXT NOT NULL,
+    trigger_name TEXT NOT NULL,
+    trigger_group TEXT NOT NULL,
+    cron_expression TEXT NOT NULL,
+    time_zone_id TEXT,
+    PRIMARY KEY (sched_name, trigger_name, trigger_group),
+    FOREIGN KEY (sched_name, trigger_name, trigger_group)
+      REFERENCES qrtz_triggers (sched_name, trigger_name, trigger_group)
+      ON DELETE CASCADE
+);
+
+CREATE TABLE qrtz_blob_triggers
+  (
+    sched_name TEXT NOT NULL,
+    trigger_name TEXT NOT NULL,
+    trigger_group TEXT NOT NULL,
+    blob_data BYTEA NULL,
+    PRIMARY KEY (sched_name, trigger_name, trigger_group),
+    FOREIGN KEY (sched_name, trigger_name, trigger_group)
+      REFERENCES qrtz_triggers (sched_name, trigger_name, trigger_group)
+      ON DELETE CASCADE
+);
+
+CREATE TABLE qrtz_calendars
+  (
+    sched_name TEXT NOT NULL,
+    calendar_name TEXT NOT NULL,
+    calendar BYTEA NOT NULL,
+    PRIMARY KEY (sched_name, calendar_name)
+);
+
+CREATE TABLE qrtz_paused_trigger_grps
+  (
+    sched_name TEXT NOT NULL,
+    trigger_group TEXT NOT NULL,
+    PRIMARY KEY (sched_name, trigger_group)
+);
+
+CREATE TABLE qrtz_fired_triggers
+  (
+    sched_name TEXT NOT NULL,
+    entry_id TEXT NOT NULL,
+    trigger_name TEXT NOT NULL,
+    trigger_group TEXT NOT NULL,
+    instance_name TEXT NOT NULL,
+    fired_time BIGINT NOT NULL,
+    sched_time BIGINT NOT NULL,
+    priority INTEGER NOT NULL,
+    state TEXT NOT NULL,
+    job_name TEXT NULL,
+    job_group TEXT NULL,
+    is_nonconcurrent BOOL NOT NULL,
+    requests_recovery BOOL NULL,
+    execution_group VARCHAR(200) NULL,
+    PRIMARY KEY (sched_name, entry_id)
+);
+
+CREATE TABLE qrtz_scheduler_state
+  (
+    sched_name TEXT NOT NULL,
+    instance_name TEXT NOT NULL,
+    last_checkin_time BIGINT NOT NULL,
+    checkin_interval BIGINT NOT NULL,
+    PRIMARY KEY (sched_name, instance_name)
+);
+
+CREATE TABLE qrtz_locks
+  (
+    sched_name TEXT NOT NULL,
+    lock_name TEXT NOT NULL,
+    PRIMARY KEY (sched_name, lock_name)
+);
+
+CREATE INDEX idx_qrtz_j_req_recovery ON qrtz_job_details (requests_recovery);
+CREATE INDEX idx_qrtz_t_next_fire_time ON qrtz_triggers (next_fire_time);
+CREATE INDEX idx_qrtz_t_state ON qrtz_triggers (trigger_state);
+CREATE INDEX idx_qrtz_t_nft_st ON qrtz_triggers (next_fire_time, trigger_state);
+CREATE INDEX idx_qrtz_ft_trig_name ON qrtz_fired_triggers (trigger_name);
+CREATE INDEX idx_qrtz_ft_trig_group ON qrtz_fired_triggers (trigger_group);
+CREATE INDEX idx_qrtz_ft_trig_nm_gp ON qrtz_fired_triggers (sched_name, trigger_name, trigger_group);
+CREATE INDEX idx_qrtz_ft_trig_inst_name ON qrtz_fired_triggers (instance_name);
+CREATE INDEX idx_qrtz_ft_job_name ON qrtz_fired_triggers (job_name);
+CREATE INDEX idx_qrtz_ft_job_group ON qrtz_fired_triggers (job_group);
+CREATE INDEX idx_qrtz_ft_job_req_recovery ON qrtz_fired_triggers (requests_recovery);

--- a/src/Designer/backend/src/Designer/Migrations/SqlScripts/QuartzTables/upgrade_3.16.1_to_3.19.1.sql
+++ b/src/Designer/backend/src/Designer/Migrations/SqlScripts/QuartzTables/upgrade_3.16.1_to_3.19.1.sql
@@ -1,0 +1,8 @@
+ALTER TABLE qrtz_triggers
+    ADD COLUMN misfire_orig_fire_time BIGINT NULL,
+    ADD COLUMN execution_group VARCHAR(200) NULL,
+    ADD COLUMN preferred_node VARCHAR(200) NULL,
+    ADD COLUMN preferred_node_auto BOOL NOT NULL DEFAULT FALSE;
+
+ALTER TABLE qrtz_fired_triggers
+    ADD COLUMN execution_group VARCHAR(200) NULL;


### PR DESCRIPTION
## Description

Splits the Quartz dependency family out of #19759 and updates these packages together from 3.16.1 to the current 3.x release, 3.19.1:

- Quartz
- Quartz.Extensions.DependencyInjection
- Quartz.Extensions.Hosting
- Quartz.Serialization.SystemTextJson

Quartz added five PostgreSQL columns across 3.17-3.19 for original misfire timestamps, execution groups, and preferred-node affinity. This PR therefore also:

- adds an EF migration with explicit upgrade and rollback SQL,
- keeps the historical 3.16.1 pristine-schema script unchanged,
- adds a versioned pristine 3.19.1 schema reference, and
- points the Quartz compatibility workflow at that new reference.

## SQL provenance

Quartz does not provide an incremental PostgreSQL upgrade script for these releases; the upstream repository only contains the complete schema. The SQL in this PR was derived as follows:

1. Downloaded the official PostgreSQL schemas from Quartz tags [v3.16.1](https://github.com/quartznet/quartznet/blob/v3.16.1/database/tables/tables_postgres.sql) and [v3.19.1](https://github.com/quartznet/quartznet/blob/v3.19.1/database/tables/tables_postgres.sql).
2. Diffed the table definitions to identify the exact schema delta: four columns on `qrtz_triggers` and one on `qrtz_fired_triggers`.
3. Encoded that delta as the minimal additive `ALTER TABLE ... ADD COLUMN` upgrade and the exact inverse `DROP COLUMN` downgrade. EF is only the delivery wrapper; Quartz tables are not modeled by `DesignerdbContext`, so EF cannot infer this migration.
4. Kept the historical 3.16.1 schema input unchanged and retained the official 3.19.1 full schema as a versioned reference for the compatibility workflow.

The derived SQL was checked on PostgreSQL 16 in both directions: applying the upgrade to the 3.16.1 schema produced the same Quartz columns, types, nullability, and defaults as a pristine 3.19.1 database; applying the downgrade restored the 3.16.1 schema. A separate live EF test seeded persisted job/trigger rows before upgrading and confirmed that the data survived. The versioned pristine file also passes the workflow comparison against the tagged upstream file (`diff -b`); its only byte-level difference is a conventional final newline.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we will help out)

Verified with:

- `dotnet restore Designer.sln --locked-mode`
- `dotnet build Designer.sln --no-restore` (0 warnings, 0 errors)
- `dotnet csharpier check .`
- The same eight sequential non-integration test partitions used by CI, serialized with `-m:1` (Designer: 1,270 passed / 3 skipped; DataModeling: 478 passed)
- Focused scheduling tests (23 passed)
- `dotnet ef migrations script --project src/Designer --no-build`
- `dotnet list src/Designer/Designer.csproj package --vulnerable --include-transitive` (no vulnerable packages)
- PostgreSQL 16 schema verification: 3.16.1 plus the upgrade migration matches a pristine 3.19.1 schema; rollback matches the original 3.16.1 schema

The initial one-process `dotnet test Designer.sln` attempt exhausted this development machine. Retrying with the repository’s CI partitioning completed the full non-integration suite without failures. No new test was added for this dependency and migration update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the scheduling infrastructure to Quartz 3.19.1.
  - Added support for enhanced trigger metadata, including execution groups, preferred nodes and misfire timing.
  - Added updated database setup scripts, indexes and table definitions for PostgreSQL.

- **Bug Fixes**
  - Improved upgrade and downgrade handling for Quartz scheduling data.
  - Ensured database validation uses the correct versioned schema.

- **Maintenance**
  - Updated database migration support to align with the latest platform tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->