### PR TITLE
chore: add default textresourcebindings for navigationbuttons

### DIFF
--- a/app-libs/language/src/texts/en.ts
+++ b/app-libs/language/src/texts/en.ts
@@ -144,6 +144,7 @@ export function en() {
     'navigation.back_to_main_form': 'Back to {0}',
     'navigation.main_form': '{0}',
     'navigation.back': 'Back',
+    'navigation.previous': 'Previous',
     'navigation.next': 'Next',
     'navigation.page_complete': 'Page completed',
     'navigation.page_error': 'Error on page',

--- a/app-libs/language/src/texts/en.ts
+++ b/app-libs/language/src/texts/en.ts
@@ -144,6 +144,7 @@ export function en() {
     'navigation.back_to_main_form': 'Back to {0}',
     'navigation.main_form': '{0}',
     'navigation.back': 'Back',
+    'navigation.next': 'Next',
     'navigation.page_complete': 'Page completed',
     'navigation.page_error': 'Error on page',
     'navigation.page_group_complete': 'Page group completed',

--- a/app-libs/language/src/texts/nb.ts
+++ b/app-libs/language/src/texts/nb.ts
@@ -145,6 +145,7 @@ export function nb() {
     'navigation.back_to_main_form': 'Tilbake til {0}',
     'navigation.main_form': '{0}',
     'navigation.back': 'Tilbake',
+    'navigation.previous': 'Forrige',
     'navigation.next': 'Neste',
     'navigation.page_error': 'Feil på side',
     'navigation.page_complete': 'Side fullført',

--- a/app-libs/language/src/texts/nb.ts
+++ b/app-libs/language/src/texts/nb.ts
@@ -145,6 +145,7 @@ export function nb() {
     'navigation.back_to_main_form': 'Tilbake til {0}',
     'navigation.main_form': '{0}',
     'navigation.back': 'Tilbake',
+    'navigation.next': 'Neste',
     'navigation.page_error': 'Feil på side',
     'navigation.page_complete': 'Side fullført',
     'navigation.page_group_error': 'Feil i sidegruppe',

--- a/app-libs/language/src/texts/nn.ts
+++ b/app-libs/language/src/texts/nn.ts
@@ -145,6 +145,7 @@ export function nn() {
     'navigation.back_to_main_form': 'Tilbake til {0}',
     'navigation.main_form': '{0}',
     'navigation.back': 'Tilbake',
+    'navigation.previous': 'Tilbake',
     'navigation.next': 'Neste',
     'navigation.page_error': 'Feil på side',
     'navigation.page_complete': 'Side fullført',

--- a/app-libs/language/src/texts/nn.ts
+++ b/app-libs/language/src/texts/nn.ts
@@ -145,6 +145,7 @@ export function nn() {
     'navigation.back_to_main_form': 'Tilbake til {0}',
     'navigation.main_form': '{0}',
     'navigation.back': 'Tilbake',
+    'navigation.next': 'Neste',
     'navigation.page_error': 'Feil på side',
     'navigation.page_complete': 'Side fullført',
     'navigation.page_group_error': 'Feil i sidegruppe',

--- a/src/App/frontend/src/components/form/Form.test.tsx
+++ b/src/App/frontend/src/components/form/Form.test.tsx
@@ -221,7 +221,7 @@ describe('Form', () => {
 
     expect(screen.queryByTestId('ErrorReport')).not.toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole('button', { name: /next/i }));
+    await userEvent.click(screen.getByRole('button', { name: /Neste/i }));
 
     const errorReport = await screen.findByTestId('ErrorReport');
     expect(errorReport).toBeInTheDocument();

--- a/src/App/frontend/src/layout/NavigationButtons/NavigationButtonsComponent.test.tsx
+++ b/src/App/frontend/src/layout/NavigationButtons/NavigationButtonsComponent.test.tsx
@@ -116,13 +116,13 @@ describe('NavigationButtons', () => {
   test('renders default NavigationButtons component', async () => {
     await render({ component: navButton1, currentPageId: 'layout2' });
 
-    expect(await screen.findByText('back')).toBeInTheDocument();
+    expect(await screen.findByText('Forrige')).toBeInTheDocument();
   });
 
   test('does not render back button when explicitly disabled', async () => {
     await render({ component: navButtonWithoutBackButton, currentPageId: 'layout2' });
 
-    expect(screen.queryByText('back')).not.toBeInTheDocument();
+    expect(screen.queryByText('Forrige')).not.toBeInTheDocument();
   });
 
   test('renders NavigationButtons component without back button if there is no previous page', async () => {

--- a/src/App/frontend/src/layout/NavigationButtons/NavigationButtonsComponent.test.tsx
+++ b/src/App/frontend/src/layout/NavigationButtons/NavigationButtonsComponent.test.tsx
@@ -130,14 +130,14 @@ describe('NavigationButtons', () => {
       component: navButton2,
     });
 
-    expect(screen.getByText('next')).toBeInTheDocument();
-    expect(screen.queryByText('back')).toBeNull();
+    expect(screen.getByText('Neste')).toBeInTheDocument();
+    expect(screen.queryByText('Forrige')).toBeNull();
   });
 
   test('renders NavigationButtons component with back button if there is a previous page', async () => {
     await render({ component: navButton2, currentPageId: 'layout2' });
 
-    expect(screen.getByText('back')).toBeInTheDocument();
+    expect(screen.getByText('Forrige')).toBeInTheDocument();
   });
 
   test('uses page validation when button has no validation config', async () => {
@@ -148,11 +148,11 @@ describe('NavigationButtons', () => {
       inputRequired: true,
     });
 
-    await userEvent.click(screen.getByText('next'));
+    await userEvent.click(screen.getByText('Neste'));
 
-    await waitFor(() => expect(screen.getByText('next').closest('button')).not.toBeDisabled());
+    await waitFor(() => expect(screen.getByText('Neste').closest('button')).not.toBeDisabled());
 
-    expect(screen.getByText('next')).toBeInTheDocument();
+    expect(screen.getByText('Neste')).toBeInTheDocument();
   });
 
   test('page validation overrides button validation', async () => {
@@ -163,11 +163,11 @@ describe('NavigationButtons', () => {
       inputRequired: true,
     });
 
-    await userEvent.click(screen.getByText('next'));
+    await userEvent.click(screen.getByText('Neste'));
 
-    await waitFor(() => expect(screen.getByText('next').closest('button')).not.toBeDisabled());
+    await waitFor(() => expect(screen.getByText('Neste').closest('button')).not.toBeDisabled());
 
-    expect(screen.getByText('next')).toBeInTheDocument();
+    expect(screen.getByText('Neste')).toBeInTheDocument();
   });
 
   test('button validation is used when page has no validation config', async () => {
@@ -177,10 +177,10 @@ describe('NavigationButtons', () => {
       inputRequired: true,
     });
 
-    await userEvent.click(screen.getByText('next'));
+    await userEvent.click(screen.getByText('Neste'));
 
-    await waitForElementToBeRemoved(() => screen.queryByText('next'));
+    await waitForElementToBeRemoved(() => screen.queryByText('Neste'));
 
-    expect(screen.queryByText('next')).not.toBeInTheDocument();
+    expect(screen.queryByText('Neste')).not.toBeInTheDocument();
   });
 });

--- a/src/App/frontend/src/layout/NavigationButtons/NavigationButtonsComponent.tsx
+++ b/src/App/frontend/src/layout/NavigationButtons/NavigationButtonsComponent.tsx
@@ -97,8 +97,8 @@ function NavigationButtonsComponentInner({
   const currentProcessKey = useCurrentProcessKey<NavigatePageProcessKey>('navigate-page');
   const isAnyProcessing = useIsAnyProcessing();
 
-  const nextTextKey = textResourceBindings?.next || 'next';
-  const backTextKey = textResourceBindings?.back || 'back';
+  const nextTextKey = textResourceBindings?.next || 'navigation.next';
+  const backTextKey = textResourceBindings?.back || 'navigation.back';
 
   const backToPageTextKey = textResourceBindings?.backToPage || 'form_filler.back_to_page';
 

--- a/src/App/frontend/src/layout/NavigationButtons/NavigationButtonsComponent.tsx
+++ b/src/App/frontend/src/layout/NavigationButtons/NavigationButtonsComponent.tsx
@@ -98,7 +98,7 @@ function NavigationButtonsComponentInner({
   const isAnyProcessing = useIsAnyProcessing();
 
   const nextTextKey = textResourceBindings?.next || 'navigation.next';
-  const backTextKey = textResourceBindings?.back || 'navigation.back';
+  const backTextKey = textResourceBindings?.back || 'navigation.previous';
 
   const backToPageTextKey = textResourceBindings?.backToPage || 'form_filler.back_to_page';
 

--- a/src/App/frontend/test/e2e/integration/anonymous-stateless-app/auto-save-behavior.ts
+++ b/src/App/frontend/test/e2e/integration/anonymous-stateless-app/auto-save-behavior.ts
@@ -33,7 +33,7 @@ describe('Auto save behavior', () => {
     cy.wait('@putFormData').then(() => {
       expect(postFormDataCounter).to.be.eq(2);
     });
-    cy.findByRole('button', { name: 'next' }).click();
+    cy.findByRole('button', { name: 'Neste' }).click();
     cy.findByText('Welcome to page 2');
   });
   it('onChangePage: Should not save form when interacting with form element(input), but should save on navigating between pages', () => {
@@ -64,7 +64,7 @@ describe('Auto save behavior', () => {
     cy.findByRole('radiogroup', { name: 'Velg kjønn' }).within(() => {
       cy.findByRole('radio', { name: 'mann' }).check();
     });
-    cy.findByRole('button', { name: 'next' }).click();
+    cy.findByRole('button', { name: 'Neste' }).click();
     cy.findByText('Welcome to page 2');
     cy.wait('@putFormData').then(() => {
       expect(postFormDataCounter).to.be.eq(1);

--- a/src/App/frontend/test/e2e/integration/anonymous-stateless-app/validation.ts
+++ b/src/App/frontend/test/e2e/integration/anonymous-stateless-app/validation.ts
@@ -8,7 +8,7 @@ describe('Validation in anonymous stateless app', () => {
     cy.startAppInstance(appFrontend.apps.anonymousStateless, { cyUser: null, tenorUser: null });
     cy.get(appFrontend.stateless.name).should('exist').and('be.visible');
     cy.get(appFrontend.stateless.name).invoke('val').should('be.empty');
-    cy.get(appFrontend.navButtons).contains('button', 'next').click();
+    cy.get(appFrontend.navButtons).contains('button', 'Neste').click();
 
     const nameError = appFrontend.fieldValidation(appFrontend.stateless.name);
 
@@ -25,7 +25,7 @@ describe('Validation in anonymous stateless app', () => {
     cy.get(nameError).should('not.exist');
     cy.get(appFrontend.errorReport).should('not.exist');
 
-    cy.get(appFrontend.navButtons).contains('button', 'next').click();
+    cy.get(appFrontend.navButtons).contains('button', 'Neste').click();
     cy.get(appFrontend.navButtons).should('not.exist');
   });
 });

--- a/src/App/frontend/test/e2e/integration/component-library/address.ts
+++ b/src/App/frontend/test/e2e/integration/component-library/address.ts
@@ -50,7 +50,7 @@ describe('Address component', () => {
     cy.findByText('Du må fylle ut postnr').should('not.exist');
     cy.findByText('Du må fylle ut bolignummer').should('not.exist');
 
-    cy.findByRole('button', { name: /next/i }).click();
+    cy.findByRole('button', { name: /neste/i }).click();
 
     cy.findAllByText('Du må fylle ut gateadresse').first().should('exist');
     cy.findAllByText('Du må fylle ut C/O eller annen tilleggsadresse').first().should('exist');

--- a/src/App/frontend/test/e2e/integration/component-library/image-upload.ts
+++ b/src/App/frontend/test/e2e/integration/component-library/image-upload.ts
@@ -88,7 +88,7 @@ describe('ImageUpload component', () => {
     });
 
     cy.get('[data-componentId="ImageUploadPage-ImageUpload"]').should('be.visible');
-    cy.findByRole('button', { name: /next/i }).click();
+    cy.findByRole('button', { name: /neste/i }).click();
     cy.findAllByText('Du må laste opp et bilde').first().should('be.visible');
 
     uploadImageAndVerify(fileName1);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds the textresources 'navigation.previous' and 'navigation.next' and uses them as default values for the navigationbuttons when text textResourceBindings are not set for the component.
Also updates any tests referring to the old default values.

The new values are based on suggestions from the Designsystem: https://designsystemet.no/no/best-practices/content-work/terms#dette-er-begrepene-vi-har-laget-anbefalinger-for

<!--- Describe your changes in detail -->

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
