### PR TITLE
refactor: move texts into new useAssistantTexts hook

### DIFF
--- a/src/Designer/frontend/app-development/features/aiAssistant/AiAssistant.tsx
+++ b/src/Designer/frontend/app-development/features/aiAssistant/AiAssistant.tsx
@@ -1,8 +1,7 @@
 import type { ReactElement } from 'react';
-import type { AssistantTexts } from '@studio/assistant';
 import { Assistant } from '@studio/assistant';
-import { Trans, useTranslation } from 'react-i18next';
-import { useAssistant, useAssistantPermissions } from './hooks';
+import { useTranslation } from 'react-i18next';
+import { useAssistant, useAssistantPermissions, useAssistantTexts } from './hooks';
 import { Preview } from './components/Preview';
 import { FileBrowser } from './components/FileBrowser';
 import classes from './AiAssistant.module.css';
@@ -17,6 +16,7 @@ function AiAssistant(): ReactElement {
   const { data: currentUser } = useUserQuery();
   const userHasAccessToAssistant = useAssistantPermissions();
   const { mutate: sendChatFeedback } = useChatFeedbackMutation(org, app);
+  const texts = useAssistantTexts();
 
   const {
     connectionStatus,
@@ -32,71 +32,6 @@ function AiAssistant(): ReactElement {
     selectThread,
     deleteThread,
   } = useAssistant();
-
-  // TODO: extract into new useAssistantTexts hook
-  const texts: AssistantTexts = {
-    heading: t('top_menu.ai_assistant'),
-    preview: t('ai_assistant.preview'),
-    fileBrowser: t('ai_assistant.file_browser'),
-    hideThreads: t('ai_assistant.hide_threads'),
-    showThreads: t('ai_assistant.show_threads'),
-    newThread: t('ai_assistant.new_thread'),
-    previousThreads: t('ai_assistant.threads'),
-    aboutAssistantDialog: {
-      heading: t('ai_assistant.about_assistant_heading'),
-      intro: t('ai_assistant.about_assistant_intro'),
-      howToHeading: t('ai_assistant.about_assistant_how_to_heading'),
-      description: (
-        <Trans
-          i18nKey='ai_assistant.about_assistant_description'
-          components={{ strong: <strong /> }}
-        />
-      ),
-      branchInfo: (
-        <Trans
-          i18nKey='ai_assistant.about_assistant_branch_info'
-          components={{ strong: <strong /> }}
-        />
-      ),
-      branchDocsLink: t('ai_assistant.about_assistant_branch_docs_link'),
-      disclaimer: t('ai_assistant.about_assistant_disclaimer'),
-      privacyHeading: t('ai_assistant.about_assistant_privacy_heading'),
-      privacyDataHandling: t('ai_assistant.about_assistant_privacy_data_handling'),
-    },
-    emptyThread: {
-      welcome: t('ai_assistant.empty_thread_welcome'),
-      instruction: t('ai_assistant.empty_thread_instruction'),
-    },
-    textarea: {
-      placeholder: t('ai_assistant.textarea_placeholder'),
-      wait: 'Vent litt ...',
-      waitingForConnection: 'Venter på forbindelse med assistenten ...',
-    },
-    addAttachment: t('ai_assistant.add_attachment'),
-    allowAppChangesSwitch: t('ai_assistant.allow_app_changes'),
-    send: t('ai_assistant.send'),
-    cancel: 'Avbryt',
-    assistantFirstMessage: t('ai_assistant.assistant_first_message'),
-    feedback: {
-      thumbsUp: t('ai_assistant.feedback_thumbs_up'),
-      thumbsDown: t('ai_assistant.feedback_thumbs_down'),
-      heading: t('ai_assistant.feedback_heading'),
-      detailsLabel: t('ai_assistant.feedback_details_label'),
-      detailsOptionalTag: t('general.optional'),
-      submit: t('ai_assistant.feedback_submit'),
-      cancel: t('general.cancel'),
-    },
-    criticalFileAlert: {
-      heading: t('ai_assistant.critical_file_alert_heading'),
-      description: t('ai_assistant.critical_file_alert_description'),
-    },
-    permissionPrompt: {
-      heading: t('ai_assistant.permission_prompt_heading'),
-      allow: t('ai_assistant.permission_prompt_allow'),
-      deny: t('ai_assistant.permission_prompt_deny'),
-    },
-    sourcesLabel: t('ai_assistant.sources_label'),
-  };
 
   if (!userHasAccessToAssistant) {
     return (

--- a/src/Designer/frontend/app-development/features/aiAssistant/hooks/index.ts
+++ b/src/Designer/frontend/app-development/features/aiAssistant/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from './useAssistantPermissions/useAssistantPermissions';
+export * from './useAssistantTexts/useAssistantTexts';
 export * from './useAssistant/useAssistant';
 export * from './useAssistantThreads/useAssistantThreads';
 export * from './useAssistantWorkflow/useAssistantWorkflow';

--- a/src/Designer/frontend/app-development/features/aiAssistant/hooks/useAssistantTexts/useAssistantTexts.test.tsx
+++ b/src/Designer/frontend/app-development/features/aiAssistant/hooks/useAssistantTexts/useAssistantTexts.test.tsx
@@ -1,0 +1,13 @@
+import { renderHook } from '@testing-library/react';
+import { useAssistantTexts } from './useAssistantTexts';
+import { textMock } from '@studio/testing/mocks/i18nMock';
+
+describe('useAssistantTexts', () => {
+  it('maps translation keys into the assistant texts structure', () => {
+    const { result } = renderHook(() => useAssistantTexts());
+
+    expect(result.current.heading).toBe(textMock('top_menu.ai_assistant'));
+    expect(result.current.textarea.placeholder).toBe(textMock('ai_assistant.textarea_placeholder'));
+    expect(result.current.feedback.submit).toBe(textMock('ai_assistant.feedback_submit'));
+  });
+});

--- a/src/Designer/frontend/app-development/features/aiAssistant/hooks/useAssistantTexts/useAssistantTexts.tsx
+++ b/src/Designer/frontend/app-development/features/aiAssistant/hooks/useAssistantTexts/useAssistantTexts.tsx
@@ -1,0 +1,68 @@
+import { Trans, useTranslation } from 'react-i18next';
+import type { AssistantTexts } from '@studio/assistant';
+
+export const useAssistantTexts = (): AssistantTexts => {
+  const { t } = useTranslation();
+
+  return {
+    heading: t('top_menu.ai_assistant'),
+    preview: t('ai_assistant.preview'),
+    fileBrowser: t('ai_assistant.file_browser'),
+    hideThreads: t('ai_assistant.hide_threads'),
+    showThreads: t('ai_assistant.show_threads'),
+    newThread: t('ai_assistant.new_thread'),
+    previousThreads: t('ai_assistant.threads'),
+    aboutAssistantDialog: {
+      heading: t('ai_assistant.about_assistant_heading'),
+      intro: t('ai_assistant.about_assistant_intro'),
+      howToHeading: t('ai_assistant.about_assistant_how_to_heading'),
+      description: (
+        <Trans
+          i18nKey='ai_assistant.about_assistant_description'
+          components={{ strong: <strong /> }}
+        />
+      ),
+      branchInfo: (
+        <Trans
+          i18nKey='ai_assistant.about_assistant_branch_info'
+          components={{ strong: <strong /> }}
+        />
+      ),
+      branchDocsLink: t('ai_assistant.about_assistant_branch_docs_link'),
+      disclaimer: t('ai_assistant.about_assistant_disclaimer'),
+      privacyHeading: t('ai_assistant.about_assistant_privacy_heading'),
+      privacyDataHandling: t('ai_assistant.about_assistant_privacy_data_handling'),
+    },
+    emptyThread: {
+      welcome: t('ai_assistant.empty_thread_welcome'),
+      instruction: t('ai_assistant.empty_thread_instruction'),
+    },
+    textarea: {
+      placeholder: t('ai_assistant.textarea_placeholder'),
+    },
+    addAttachment: t('ai_assistant.add_attachment'),
+    allowAppChangesSwitch: t('ai_assistant.allow_app_changes'),
+    send: t('ai_assistant.send'),
+    cancel: t('general.cancel'),
+    assistantFirstMessage: t('ai_assistant.assistant_first_message'),
+    feedback: {
+      thumbsUp: t('ai_assistant.feedback_thumbs_up'),
+      thumbsDown: t('ai_assistant.feedback_thumbs_down'),
+      heading: t('ai_assistant.feedback_heading'),
+      detailsLabel: t('ai_assistant.feedback_details_label'),
+      detailsOptionalTag: t('general.optional'),
+      submit: t('ai_assistant.feedback_submit'),
+      cancel: t('general.cancel'),
+    },
+    criticalFileAlert: {
+      heading: t('ai_assistant.critical_file_alert_heading'),
+      description: t('ai_assistant.critical_file_alert_description'),
+    },
+    permissionPrompt: {
+      heading: t('ai_assistant.permission_prompt_heading'),
+      allow: t('ai_assistant.permission_prompt_allow'),
+      deny: t('ai_assistant.permission_prompt_deny'),
+    },
+    sourcesLabel: t('ai_assistant.sources_label'),
+  };
+};

--- a/src/Designer/frontend/libs/studio-assistant/src/mocks/mockTexts.ts
+++ b/src/Designer/frontend/libs/studio-assistant/src/mocks/mockTexts.ts
@@ -27,8 +27,6 @@ const emptyThreadTexts: EmptyThreadTexts = {
 
 const textAreaTexts: TextAreaTexts = {
   placeholder: 'placeholder',
-  wait: 'wait',
-  waitingForConnection: 'waitingForConnection',
 };
 
 export const messageFeedbackTexts: MessageFeedbackTexts = {

--- a/src/Designer/frontend/libs/studio-assistant/src/types/AssistantTexts.ts
+++ b/src/Designer/frontend/libs/studio-assistant/src/types/AssistantTexts.ts
@@ -62,6 +62,4 @@ export type EmptyThreadTexts = {
 
 export type TextAreaTexts = {
   placeholder: string;
-  wait: string;
-  waitingForConnection: string;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Moves all assistant texts into a new hook `useAssistantTexts`. Makes the data flow in the `AiAssistant` component easier to read. Also removes two unused texts.

## Verification

- [x] Related issues are connected (N/A, but TODO reference in code has been removed)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of translated text throughout the AI Assistant experience.
  * Updated assistant messaging to use the correct available text fields.

* **Tests**
  * Added coverage for translated headings, input placeholders and feedback submission text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->