### PR TITLE
chore(deps): update Designer Roslyn packages to 5.6.0

### DIFF
--- a/src/Designer/backend/Directory.Packages.props
+++ b/src/Designer/backend/Directory.Packages.props
@@ -47,9 +47,9 @@
     <PackageVersion Include="DistributedLock.Postgres" Version="1.3.1" />
     <PackageVersion Include="System.Text.Json" Version="[10.0.10]" />
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.14.28" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="5.0.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="[5.0.0]" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="[5.0.0]" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="[5.6.0]" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="[5.6.0]" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="[12.29.1]" />
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="[4.11.0]" />
@@ -76,7 +76,7 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Basic.Reference.Assemblies" Version="1.8.10" />
     <PackageVersion Include="Fare" Version="2.2.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.8.0" />
     <PackageVersion Include="Testcontainers" Version="4.13.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.13.0" />


### PR DESCRIPTION
## Description

Updates the Designer Roslyn package family from 5.0.0 to 5.6.0:

- `Microsoft.CodeAnalysis.Common`
- `Microsoft.CodeAnalysis.CSharp`
- `Microsoft.CodeAnalysis.CSharp.Workspaces`
- `Microsoft.CodeAnalysis.Workspaces.MSBuild`

These versions must stay aligned because the Roslyn packages use exact-version dependencies internally. Designer directly uses `Common`; DataModeling uses `Common` and `CSharp` to validate generated C# by compiling it in memory. The Workspace packages are pulled into Designer through EF Core design tooling.

### Compatibility audit

- Inspected the official 5.0.0 and 5.6.0 NuGet package metadata and assets. Roslyn 5.6 provides native `net10.0` assets and updates its analyzer/runtime dependency baseline.
- Compared the public `net9.0` 5.0 assemblies with the `net10.0` 5.6 assemblies using Microsoft ApiCompat.
- `Microsoft.CodeAnalysis.CSharp` has no backward-breaking public API changes.
- `Microsoft.CodeAnalysis.Common` adds members to three public Roslyn interfaces (`IMethodSymbol`, `IPropertySymbol`, and `ICollectionExpressionOperation`). This is a source/binary risk only for consumers implementing those Roslyn interfaces themselves; Altinn Studio has no such implementations and only consumes the APIs.
- Restore resolves the complete Roslyn compiler/workspace family at 5.6.0, including EF Core's transitive design-time dependencies.
- No vulnerable packages were reported for the Designer solution.

Official 5.6 source build: https://github.com/dotnet/roslyn/commit/c0573ed0a7dc3e3b4d2e70da47f97cc51a35524f

## Verification

- [x] Related issues are connected (not applicable; split from Renovate PR #19759)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Existing relevant automated tests exercised; no new product behavior requires a new test

Commands/checks:

- `dotnet restore Designer.sln --disable-parallel`
- `dotnet build Designer.sln --no-restore -m:1 -v minimal` — 0 warnings, 0 errors
- `dotnet csharpier check .` — 1,448 files checked
- `dotnet list Designer.sln package --vulnerable --include-transitive` — no vulnerabilities
- Full sequential non-integration Designer partition — 1,272 passed, 3 skipped
- Full DataModeling suite — 478 passed
- Focused data-model controller/service tests — 48 passed, 1 skipped

Manual Designer/Localtest verification:

- Built and started the complete Designer Docker Compose stack from this branch, including Release publish and EF migration script generation.
- Logged in through Fake Ansattporten and loaded the dashboard.
- Created a temporary app and data model through the Designer UI.
- Generated the model: the API returned HTTP 204 and produced `.schema.json`, `.xsd`, and `.cs` files using Roslyn 5.6.
- Reloaded the persisted model, opened the UI editor, and opened app preview.
- The clean end-to-end run had no console errors, page errors, Designer failures, or HTTP 5xx responses.
- Deleted the temporary app and stopped the local stack after verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the centrally managed Microsoft.CodeAnalysis packages to version 5.6.0.
  * No user-facing features or behaviour changes are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->