### PR TITLE
chore: align shared .NET project tooling

### DIFF
--- a/src/Runtime/common/dotnet/Altinn.Studio.Runtime.Common/.config/dotnet-tools.json
+++ b/src/Runtime/common/dotnet/Altinn.Studio.Runtime.Common/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "csharpier": {
+      "version": "1.3.0",
+      "commands": [
+        "csharpier"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/src/Runtime/common/dotnet/Altinn.Studio.Runtime.Common/.csharpierignore
+++ b/src/Runtime/common/dotnet/Altinn.Studio.Runtime.Common/.csharpierignore
@@ -1,0 +1,7 @@
+bin/
+obj/
+.git/
+*.xml
+*.csproj
+*.props
+*.targets

--- a/src/Runtime/common/dotnet/Altinn.Studio.Runtime.Common/.csharpierrc.yaml
+++ b/src/Runtime/common/dotnet/Altinn.Studio.Runtime.Common/.csharpierrc.yaml
@@ -1,0 +1,4 @@
+printWidth: 120
+useTabs: false
+tabWidth: 4
+endOfLine: auto

--- a/src/Runtime/common/dotnet/Altinn.Studio.Runtime.Common/.editorconfig
+++ b/src/Runtime/common/dotnet/Altinn.Studio.Runtime.Common/.editorconfig
@@ -109,28 +109,22 @@ csharp_style_namespace_declarations = file_scoped:error
 
 #### Diagnostics ####
 
-# S2325: Methods and properties that don't access instance data should be static
-dotnet_diagnostic.S2325.severity = none
-# CA1034: Nested types should not be visible
-dotnet_diagnostic.CA1034.severity = none
-# CA2007: Do not directly await a Task without ConfigureAwait
-dotnet_diagnostic.CA2007.severity = none
-# CA1062: Validate arguments of public methods
-dotnet_diagnostic.CA1062.severity = none
-# S3251: Supply an implementation for this partial method
-dotnet_diagnostic.S3251.severity = none
-# S3267: Loops should be simplified with "LINQ" expressions
-dotnet_diagnostic.S3267.severity = none
-# CA1031: Do not catch general exception types
-dotnet_diagnostic.CA1031.severity = none
-# CA1848: Existing hosting logs use the ILogger extension API
-dotnet_diagnostic.CA1848.severity = none
-# CA1873: Existing signal logging evaluates an enum value
-dotnet_diagnostic.CA1873.severity = none
-# CA1812: ASP.NET Core DI and ActivatorUtilities instantiate internal implementation types
-dotnet_diagnostic.CA1812.severity = none
-# CA1724: Hosting and Ports are established public API names; renaming them would be breaking
-dotnet_diagnostic.CA1724.severity = none
+# Runtime common exposes cross-language configuration and wire-protocol contracts. These rules would
+# require breaking their serialized shapes or public APIs rather than improving their implementations.
+# CA1002: Configuration binding and JSON contracts intentionally expose List<T>
+dotnet_diagnostic.CA1002.severity = none
+# CA1008: HostBridge frame kind zero is intentionally invalid on the wire
+dotnet_diagnostic.CA1008.severity = none
+# CA1028: HostBridge frame kinds are encoded as a single byte
+dotnet_diagnostic.CA1028.severity = none
+# CA1056: The bound-topology URL is a cross-language serialized string field
+dotnet_diagnostic.CA1056.severity = none
+# CA1308: DNS host names are intentionally canonicalized to lowercase
+dotnet_diagnostic.CA1308.severity = none
+# CA1819: HostBridge header values and body payloads are serialized array contracts
+dotnet_diagnostic.CA1819.severity = none
+# CA2227: Configuration binding and JSON contracts require settable collection properties
+dotnet_diagnostic.CA2227.severity = none
 
 [*.{yml,yaml,json}]
 indent_size = 2

--- a/src/Runtime/common/dotnet/Altinn.Studio.Runtime.Common/Altinn.Studio.Runtime.Common.csproj
+++ b/src/Runtime/common/dotnet/Altinn.Studio.Runtime.Common/Altinn.Studio.Runtime.Common.csproj
@@ -5,10 +5,18 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <AnalysisMode>Recommended</AnalysisMode>
+    <AnalysisMode>All</AnalysisMode>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <Features>strict</Features>
+    <NuGetAudit>true</NuGetAudit>
+    <NuGetAuditMode>all</NuGetAuditMode>
   </PropertyGroup>
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include=".config\dotnet-tools.json" />
   </ItemGroup>
 </Project>

--- a/src/Runtime/common/dotnet/Altinn.Studio.Runtime.Common/Altinn.Studio.Runtime.Common.csproj
+++ b/src/Runtime/common/dotnet/Altinn.Studio.Runtime.Common/Altinn.Studio.Runtime.Common.csproj
@@ -15,8 +15,4 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Content Include=".config\dotnet-tools.json" />
-  </ItemGroup>
 </Project>

--- a/src/Runtime/common/dotnet/Altinn.Studio.Runtime.Common/EnvTopology/BoundTopologyConfigurationExtensions.cs
+++ b/src/Runtime/common/dotnet/Altinn.Studio.Runtime.Common/EnvTopology/BoundTopologyConfigurationExtensions.cs
@@ -1,5 +1,6 @@
 #nullable enable
 
+using System;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -14,6 +15,8 @@ public static class BoundTopologyConfigurationExtensions
         bool optionalBoundConfig = false
     )
     {
+        ArgumentNullException.ThrowIfNull(configuration);
+
         services.Configure<BoundTopologyOptions>(configuration.GetSection(BoundTopologyOptions.SectionName));
         services.AddSingleton(sp => sp.GetRequiredService<IOptions<BoundTopologyOptions>>().Value);
         services.Configure<BoundTopologyConfig>(
@@ -22,7 +25,10 @@ public static class BoundTopologyConfigurationExtensions
         );
         services.Configure<BoundTopologyConfig>(
             BoundTopologyOptions.BoundName,
-            BoundTopologyConfiguration(configuration[BoundTopologyOptions.ConfigPathConfigurationKey], optionalBoundConfig)
+            BoundTopologyConfiguration(
+                configuration[BoundTopologyOptions.ConfigPathConfigurationKey],
+                optionalBoundConfig
+            )
         );
         services.AddSingleton<BoundTopologyIndexAccessor>();
         return services;

--- a/src/Runtime/common/dotnet/Altinn.Studio.Runtime.Common/EnvTopology/BoundTopologyIndex.cs
+++ b/src/Runtime/common/dotnet/Altinn.Studio.Runtime.Common/EnvTopology/BoundTopologyIndex.cs
@@ -29,7 +29,7 @@ public sealed class BoundTopologyIndex
         _appsById = apps.RoutesById;
     }
 
-    public IReadOnlyList<BoundTopologyAppRoute> GetApps() => _apps;
+    public IReadOnlyList<BoundTopologyAppRoute> Apps => _apps;
 
     public IReadOnlyList<BoundTopologyComponentRoute> GetComponentRoutes(string component)
     {
@@ -109,7 +109,9 @@ public sealed class BoundTopologyIndex
             routesById.TryAdd(appId, new BoundTopologyAppRoute(route.Route, httpDestinationUri, appId));
         }
 
-        var appRoutes = routesById.Values.OrderBy(static route => route.AppId, StringComparer.OrdinalIgnoreCase).ToArray();
+        var appRoutes = routesById
+            .Values.OrderBy(static route => route.AppId, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
         return (appRoutes, routesById);
     }
 
@@ -136,15 +138,18 @@ public sealed class BoundTopologyIndex
 
     private static Dictionary<string, RouteGroup[]> BuildRouteGroups(IEnumerable<CompiledRoute> routes)
     {
-        return routes.GroupBy(static route => route.Host, StringComparer.OrdinalIgnoreCase)
+        return routes
+            .GroupBy(static route => route.Host, StringComparer.OrdinalIgnoreCase)
             .ToDictionary(
                 static hostGroup => hostGroup.Key,
-                static hostGroup => hostGroup.GroupBy(static route => route.GroupKey, StringComparer.Ordinal)
-                    .Select(static routeGroup => new RouteGroup([.. routeGroup]))
-                    .OrderBy(static group => group.IsHostOnly)
-                    .ThenByDescending(static group => group.PathPrefixLength)
-                    .ThenBy(static group => group.GroupKey, StringComparer.Ordinal)
-                    .ToArray(),
+                static hostGroup =>
+                    hostGroup
+                        .GroupBy(static route => route.GroupKey, StringComparer.Ordinal)
+                        .Select(static routeGroup => new RouteGroup([.. routeGroup]))
+                        .OrderBy(static group => group.IsHostOnly)
+                        .ThenByDescending(static group => group.PathPrefixLength)
+                        .ThenBy(static group => group.GroupKey, StringComparer.Ordinal)
+                        .ToArray(),
                 StringComparer.OrdinalIgnoreCase
             );
     }
@@ -251,12 +256,8 @@ public sealed class BoundTopologyIndex
         public BoundTopologyRequestMatch Match() => new(Route, HttpDestinationUri);
     }
 
-    private sealed class HostRoute(
-        BoundTopologyRoute route,
-        string host,
-        string groupKey,
-        Uri? httpDestinationUri
-    ) : CompiledRoute(route, host, groupKey, httpDestinationUri)
+    private sealed class HostRoute(BoundTopologyRoute route, string host, string groupKey, Uri? httpDestinationUri)
+        : CompiledRoute(route, host, groupKey, httpDestinationUri)
     {
         public override bool IsHostOnly => true;
 

--- a/src/Runtime/common/dotnet/Altinn.Studio.Runtime.Common/EnvTopology/BoundTopologyIndexAccessor.cs
+++ b/src/Runtime/common/dotnet/Altinn.Studio.Runtime.Common/EnvTopology/BoundTopologyIndexAccessor.cs
@@ -22,6 +22,9 @@ public sealed class BoundTopologyIndexAccessor
         BoundTopologyOptions options
     )
     {
+        ArgumentNullException.ThrowIfNull(boundTopologyConfig);
+        ArgumentNullException.ThrowIfNull(options);
+
         _boundConfigPath = options.ConfigPath;
         _current = new BoundTopologyIndex(boundTopologyConfig.Get(BoundTopologyOptions.BoundName));
         _currentFileStamp = TryGetFileStamp(_boundConfigPath, out var fileStamp) ? fileStamp : null;

--- a/src/Runtime/common/dotnet/Altinn.Studio.Runtime.Common/HostBridge/HostBridgeHttpHeaders.cs
+++ b/src/Runtime/common/dotnet/Altinn.Studio.Runtime.Common/HostBridge/HostBridgeHttpHeaders.cs
@@ -33,10 +33,7 @@ public static class HostBridgeHttpHeaders
         HeaderNames.AltSvc,
     }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 
-    private static readonly FrozenSet<string> ContentHeaders = new HashSet<string>(
-        11,
-        StringComparer.OrdinalIgnoreCase
-    )
+    private static readonly FrozenSet<string> ContentHeaders = new HashSet<string>(11, StringComparer.OrdinalIgnoreCase)
     {
         HeaderNames.Allow,
         HeaderNames.ContentDisposition,
@@ -53,6 +50,8 @@ public static class HostBridgeHttpHeaders
 
     public static bool ShouldSkipRequestHeader(string headerName)
     {
+        ArgumentNullException.ThrowIfNull(headerName);
+
         if (HeadersToExclude.Contains(headerName))
             return true;
 
@@ -63,6 +62,5 @@ public static class HostBridgeHttpHeaders
 
     public static bool IsContentHeader(string headerName) => ContentHeaders.Contains(headerName);
 
-    public static bool IsBodylessStatusCode(int statusCode) =>
-        statusCode is >= 100 and < 200 or 204 or 205;
+    public static bool IsBodylessStatusCode(int statusCode) => statusCode is >= 100 and < 200 or 204 or 205;
 }

--- a/src/Runtime/common/dotnet/Altinn.Studio.Runtime.Common/HostBridge/HostBridgeProtocol.cs
+++ b/src/Runtime/common/dotnet/Altinn.Studio.Runtime.Common/HostBridge/HostBridgeProtocol.cs
@@ -33,11 +33,7 @@ public sealed record RequestStartFrame(
     int TargetPort
 );
 
-public sealed record ResponseStartFrame(
-    long RequestId,
-    int StatusCode,
-    Dictionary<string, string[]> Headers
-);
+public sealed record ResponseStartFrame(long RequestId, int StatusCode, Dictionary<string, string[]> Headers);
 
 public sealed record HeadersFrame(long RequestId, Dictionary<string, string[]> Headers);
 
@@ -130,11 +126,14 @@ public static class HostBridgeProtocol
         CancellationToken cancellationToken
     )
     {
+        ArgumentNullException.ThrowIfNull(socket);
+        ArgumentNullException.ThrowIfNull(messageBuffer);
+
         messageBuffer.Clear();
 
         while (true)
         {
-            var result = await socket.ReceiveAsync(receiveBuffer, cancellationToken);
+            var result = await socket.ReceiveAsync(receiveBuffer, cancellationToken).ConfigureAwait(false);
             if (result.MessageType == WebSocketMessageType.Close)
                 return false;
 
@@ -152,12 +151,10 @@ public static class HostBridgeProtocol
         }
     }
 
-    public static Task SendFrame(
-        WebSocket socket,
-        byte[] payload,
-        CancellationToken cancellationToken
-    )
+    public static Task SendFrame(WebSocket socket, byte[] payload, CancellationToken cancellationToken)
     {
+        ArgumentNullException.ThrowIfNull(socket);
+
         return socket.SendAsync(payload, WebSocketMessageType.Binary, true, cancellationToken);
     }
 

--- a/src/Runtime/common/dotnet/Altinn.Studio.Runtime.Common/global.json
+++ b/src/Runtime/common/dotnet/Altinn.Studio.Runtime.Common/global.json
@@ -1,0 +1,7 @@
+{
+    "sdk": {
+        "version": "10.0.302",
+        "rollForward": "latestFeature",
+        "allowPrerelease": false
+    }
+}

--- a/src/Runtime/localtest/src/Services/LocalApp/Implementation/LocalAppHttp.cs
+++ b/src/Runtime/localtest/src/Services/LocalApp/Implementation/LocalAppHttp.cs
@@ -276,7 +276,7 @@ namespace LocalTest.Services.LocalApp.Implementation
 
         private IReadOnlyList<BoundTopologyAppRoute> GetBoundAppRoutes()
         {
-            return _boundTopologyIndex.Current.GetApps();
+            return _boundTopologyIndex.Current.Apps;
         }
 
         private BoundTopologyAppRoute? ResolveAppRoute(string? appId)

--- a/src/common/dotnet/Altinn.Studio.Common/Altinn.Studio.Common.csproj
+++ b/src/common/dotnet/Altinn.Studio.Common/Altinn.Studio.Common.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <AnalysisMode>Recommended</AnalysisMode>
+    <AnalysisMode>All</AnalysisMode>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <Features>strict</Features>
     <NuGetAudit>true</NuGetAudit>

--- a/src/common/dotnet/Altinn.Studio.Common/Altinn.Studio.Common.csproj
+++ b/src/common/dotnet/Altinn.Studio.Common/Altinn.Studio.Common.csproj
@@ -15,8 +15,4 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Content Include=".config\dotnet-tools.json" />
-  </ItemGroup>
 </Project>

--- a/src/common/dotnet/Altinn.Studio.Common/src/Hosting.cs
+++ b/src/common/dotnet/Altinn.Studio.Common/src/Hosting.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net;
 using System.Runtime.InteropServices;
@@ -18,11 +17,6 @@ using Microsoft.Extensions.Logging;
 
 namespace Altinn.Studio.Common;
 
-[SuppressMessage(
-    "Naming",
-    "CA1724:Type names should not match namespaces",
-    Justification = "Hosting is the established public API for common host configuration."
-)]
 public static class Hosting
 {
     private static readonly string[] _localEnvironments = ["local", "development"];
@@ -145,11 +139,6 @@ public static class Hosting
         }
     }
 
-    [SuppressMessage(
-        "Performance",
-        "CA1812:Avoid uninstantiated internal classes",
-        Justification = "The exception handler is registered and instantiated by ASP.NET Core dependency injection."
-    )]
     private sealed class BadRequestExceptionHandler : IExceptionHandler
     {
         public async ValueTask<bool> TryHandleAsync(
@@ -183,11 +172,6 @@ public static class Hosting
     /// <remarks>
     /// Based on guidance from https://github.com/dotnet/dotnet-docker/blob/2a6f35b9361d1aacb664b0ce09e529698b622d2b/samples/kubernetes/graceful-shutdown/graceful-shutdown.md
     /// </remarks>
-    [SuppressMessage(
-        "Performance",
-        "CA1812:Avoid uninstantiated internal classes",
-        Justification = "The host lifetime is instantiated through ActivatorUtilities in the service registration."
-    )]
     private sealed class AppHostLifetime(
         ILogger<AppHostLifetime> logger,
         IHostEnvironment environment,

--- a/src/common/dotnet/Altinn.Studio.Common/src/Hosting.cs
+++ b/src/common/dotnet/Altinn.Studio.Common/src/Hosting.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net;
 using System.Runtime.InteropServices;
@@ -17,6 +18,11 @@ using Microsoft.Extensions.Logging;
 
 namespace Altinn.Studio.Common;
 
+[SuppressMessage(
+    "Naming",
+    "CA1724:Type names should not match namespaces",
+    Justification = "Hosting is the established public API for common host configuration."
+)]
 public static class Hosting
 {
     private static readonly string[] _localEnvironments = ["local", "development"];
@@ -139,6 +145,11 @@ public static class Hosting
         }
     }
 
+    [SuppressMessage(
+        "Performance",
+        "CA1812:Avoid uninstantiated internal classes",
+        Justification = "The exception handler is registered and instantiated by ASP.NET Core dependency injection."
+    )]
     private sealed class BadRequestExceptionHandler : IExceptionHandler
     {
         public async ValueTask<bool> TryHandleAsync(
@@ -172,6 +183,11 @@ public static class Hosting
     /// <remarks>
     /// Based on guidance from https://github.com/dotnet/dotnet-docker/blob/2a6f35b9361d1aacb664b0ce09e529698b622d2b/samples/kubernetes/graceful-shutdown/graceful-shutdown.md
     /// </remarks>
+    [SuppressMessage(
+        "Performance",
+        "CA1812:Avoid uninstantiated internal classes",
+        Justification = "The host lifetime is instantiated through ActivatorUtilities in the service registration."
+    )]
     private sealed class AppHostLifetime(
         ILogger<AppHostLifetime> logger,
         IHostEnvironment environment,

--- a/src/common/dotnet/Altinn.Studio.Common/src/Ports.cs
+++ b/src/common/dotnet/Altinn.Studio.Common/src/Ports.cs
@@ -1,16 +1,10 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 
 namespace Altinn.Studio.Common;
 
-[SuppressMessage(
-    "Naming",
-    "CA1724:Type names should not match namespaces",
-    Justification = "Ports is the established public API for common endpoint port configuration."
-)]
 public static class Ports
 {
     private static int? _publicPort;

--- a/src/common/dotnet/Altinn.Studio.Common/src/Ports.cs
+++ b/src/common/dotnet/Altinn.Studio.Common/src/Ports.cs
@@ -1,10 +1,16 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 
 namespace Altinn.Studio.Common;
 
+[SuppressMessage(
+    "Naming",
+    "CA1724:Type names should not match namespaces",
+    Justification = "Ports is the established public API for common endpoint port configuration."
+)]
 public static class Ports
 {
     private static int? _publicPort;


### PR DESCRIPTION
## Description

Follow-up to #19840 and its review discussion.

Aligns `Altinn.Studio.Common` and `Altinn.Studio.Runtime.Common` on the same shared-project baseline:

- .NET 10 with all .NET analyzers, warnings as errors, strict compiler features, code-style enforcement, and full NuGet auditing
- pinned .NET SDK and local CSharpier tool/configuration
- matching naming, formatting, and code-style policy

Analyzer exceptions remain project-specific. For `Altinn.Studio.Common`, CA1812 and CA1724 are configured in `.editorconfig` instead of source attributes. [Microsoft documents CA1812 suppression for DI/reflection-created types](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1812); CA1724 is a naming/usability warning, and renaming the established `Hosting` and `Ports` public APIs would be breaking.

Enabling the full analyzer set in Runtime Common also surfaced existing code. Actionable findings were fixed (argument validation, async configuration, and an `Apps` property); only rules that conflict with its cross-language configuration or HostBridge wire contracts are documented in its `.editorconfig`.

## Verification

- [x] Related issues are connected (follow-up to #19840)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (project/tooling change; existing consumers provide build coverage)

Commands run:

```text
# Altinn.Studio.Common
dotnet tool restore
dotnet csharpier check .
dotnet build Altinn.Studio.Common.csproj
# 3 files checked; build succeeded, 0 warnings, 0 errors

# Altinn.Studio.Runtime.Common
dotnet tool restore
dotnet csharpier check .
dotnet build Altinn.Studio.Runtime.Common.csproj
# 8 files checked; build succeeded, 0 warnings, 0 errors

dotnet build src/Runtime/localtest/src/LocalTest.csproj
dotnet build src/cli/studioctl-server/studioctl-server.csproj
# Both direct-source consumers succeeded, 0 warnings, 0 errors

dotnet build src/Runtime/gateway/Altinn.Studio.Gateway.slnx
dotnet build src/Runtime/workflow-engine/WorkflowEngine.slnx --no-restore
dotnet build src/Runtime/workflow-engine-app/WorkflowEngine.App.slnx
# All Altinn.Studio.Common consumers succeeded
```

The three consumer solutions still report pre-existing NuGet audit warnings for their dependencies; this change introduces no analyzer or compiler warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved runtime validation for invalid or missing configuration, network, and messaging inputs.
  * Simplified access to application routing information.

* **Chores**
  * Standardised .NET SDK, formatting, editor, and code analysis settings.
  * Enabled stricter build checks and package security auditing.
  * Added consistent C# formatting and repository configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->