### PR TITLE
chore: make .NET container builds common-aware

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,6 +15,7 @@
 !src/App/template/v8/src
 !src/App/template/v9/src
 !src/common/ts
+!src/common/dotnet/Altinn.Studio.Common
 
 # Test-apps are built in its own container, so they need to be included
 !src/App/backend

--- a/.github/workflows/deploy-designer.yaml
+++ b/.github/workflows/deploy-designer.yaml
@@ -10,8 +10,13 @@ on:
       - 'src/Designer/backend/**'
       - 'src/Designer/frontend/**'
       - 'src/Designer/Dockerfile'
+      - 'src/common/dotnet/**'
+      - 'src/common/ts/**'
       - 'src/App/template/**'
       - 'package.json'
+      - 'yarn.lock'
+      - '.yarnrc.yml'
+      - '.yarn/**'
       - 'charts/altinn-designer/**'
       - 'charts/altinn-designer-config/**'
 
@@ -73,7 +78,7 @@ jobs:
       tags: ${{ needs.determine-tag.outputs.tag }},latest
       registry-name: altinntjenestercontainerregistry.azurecr.io
       repository-name: altinn-designer-db-migrations
-      context: src/Designer/backend
+      context: src
       dockerfile: src/Designer/backend/Migrations.Dockerfile
       environment: dev # dev environment has push access and doesn't require review
     secrets:

--- a/.github/workflows/deploy-runtime-kubernetes-wrapper.yaml
+++ b/.github/workflows/deploy-runtime-kubernetes-wrapper.yaml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
     paths:
+      - src/common/dotnet/**
       - src/Runtime/kubernetes-wrapper/**
       - infra/studio/syncroot/base/kubernetes-wrapper.yaml
       - infra/runtime/syncroot/base/kubernetes-wrapper.yaml
@@ -52,7 +53,7 @@ jobs:
         run: |
           SHA="${GITHUB_SHA::10}"
           IMAGE_BASE="ghcr.io/altinn/altinn-studio/kubernetes-wrapper"
-          docker build --platform linux/amd64,linux/arm64 src/Runtime/kubernetes-wrapper \
+          docker build --platform linux/amd64,linux/arm64 src \
             -f src/Runtime/kubernetes-wrapper/src/Dockerfile \
             -t "${IMAGE_BASE}:${SHA}"
 

--- a/src/Designer/Dockerfile
+++ b/src/Designer/Dockerfile
@@ -61,8 +61,9 @@ RUN cd src/Designer/frontend && yarn build
 FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine@sha256:d8ee39817ca03a3757288e83c37ed73cc969a286c603b827c7cbe33add1c2d1c AS generate-studio-backend
 ARG DESIGNER_VERSION=''
 WORKDIR /build
-COPY src/Designer/backend .
-RUN dotnet publish src/Designer/Designer.csproj -c Release -o /app_output /p:CSharpier_Bypass=true
+COPY src/common/dotnet/Altinn.Studio.Common ./src/common/dotnet/Altinn.Studio.Common
+COPY src/Designer/backend ./src/Designer/backend
+RUN dotnet publish src/Designer/backend/src/Designer/Designer.csproj -c Release -o /app_output /p:CSharpier_Bypass=true
 RUN rm -f /app_output/Altinn.Studio.Designer.staticwebassets.runtime.json
 # Create version file
 WORKDIR /version

--- a/src/Designer/Dockerfile.dockerignore
+++ b/src/Designer/Dockerfile.dockerignore
@@ -1,0 +1,30 @@
+# Designer's frontend build requires the repository-root Yarn workspace, so this is the deliberate
+# exception to the src/ context convention. Keep the root context as a complete narrow allowlist.
+**
+!package.json
+!yarn.lock
+!.yarnrc.yml
+!.yarn/releases/**
+!.yarn/patches/**
+!src/App/frontend/package.json
+!src/App/template/v8/src
+!src/App/template/v8/src/**
+!src/App/template/v9/src
+!src/App/template/v9/src/**
+!src/common/ts
+!src/common/ts/**
+!src/common/dotnet/Altinn.Studio.Common
+!src/common/dotnet/Altinn.Studio.Common/**
+!src/Designer/backend
+!src/Designer/backend/**
+!src/Designer/development/azure-devops-mock/package.json
+!src/Designer/frontend
+!src/Designer/frontend/**
+**/bin
+**/obj
+**/node_modules
+**/dist
+**/.venv
+**/__pycache__
+**/*.pyc
+**/.pytest_cache

--- a/src/Designer/backend/Migrations.Dockerfile
+++ b/src/Designer/backend/Migrations.Dockerfile
@@ -1,8 +1,9 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine@sha256:d8ee39817ca03a3757288e83c37ed73cc969a286c603b827c7cbe33add1c2d1c AS build
 
-WORKDIR /app
+WORKDIR /src
 
-COPY . .
+COPY common/dotnet/Altinn.Studio.Common ./common/dotnet/Altinn.Studio.Common
+COPY Designer/backend ./Designer/backend
 
 RUN dotnet tool install --version 10.0.10 --global dotnet-ef
 ENV PATH="$PATH:/root/.dotnet/tools"
@@ -11,9 +12,9 @@ ENV StudioOidcLoginSettings__FetchClientIdAndSecretFromRootEnvFile=false
 ENV StudioOidcLoginSettings__ClientId=dummyRequired
 ENV StudioOidcLoginSettings__ClientSecret=dummyRequired
 
-RUN dotnet restore src/Designer/Designer.csproj && \
-    dotnet build src/Designer/Designer.csproj --no-restore && \
-    dotnet ef migrations script --project src/Designer/Designer.csproj --no-build --idempotent -o /app/migrations.sql
+RUN dotnet restore Designer/backend/src/Designer/Designer.csproj && \
+    dotnet build Designer/backend/src/Designer/Designer.csproj --no-restore && \
+    dotnet ef migrations script --project Designer/backend/src/Designer/Designer.csproj --no-build --idempotent -o /app/migrations.sql
 
 FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS final
 COPY --from=build /app/migrations.sql migrations.sql

--- a/src/Designer/backend/Migrations.Dockerfile.dockerignore
+++ b/src/Designer/backend/Migrations.Dockerfile.dockerignore
@@ -1,0 +1,9 @@
+# Keep the src/ build context limited to the Designer backend and its shared dependency.
+**
+!common/dotnet/Altinn.Studio.Common/**
+!Designer/backend/**
+**/bin
+**/obj
+**/tests
+**/docs
+**/.git

--- a/src/Designer/compose.yaml
+++ b/src/Designer/compose.yaml
@@ -299,8 +299,8 @@ services:
       studio_db:
         condition: service_healthy
     build:
-      context: ./backend
-      dockerfile: Migrations.Dockerfile
+      context: ..
+      dockerfile: Designer/backend/Migrations.Dockerfile
     environment:
       - PGHOST=studio_db
       - PGPORT=5432

--- a/src/Runtime/kubernetes-wrapper/.dockerignore
+++ b/src/Runtime/kubernetes-wrapper/.dockerignore
@@ -1,5 +1,0 @@
-.config/
-infra/
-tests/
-**/bin
-**/obj

--- a/src/Runtime/kubernetes-wrapper/Makefile
+++ b/src/Runtime/kubernetes-wrapper/Makefile
@@ -4,7 +4,7 @@ setup-kind:
 
 .PHONY: build-docker-image
 build-docker-image:
-	docker build -f src/Dockerfile . -t altinn-kuberneteswrapper:local
+	docker build -f src/Dockerfile ../.. -t altinn-kuberneteswrapper:local
 
 .PHONY: load-image
 load-image: build-docker-image

--- a/src/Runtime/kubernetes-wrapper/src/Dockerfile
+++ b/src/Runtime/kubernetes-wrapper/src/Dockerfile
@@ -2,17 +2,19 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0.302-alpine3.23@sha256:d8ee39817ca03a37572
 WORKDIR /src
 
 # Copy restore inputs and restore as distinct layer
-COPY Directory.Packages.props ./
-COPY Directory.Build.props ./
-COPY global.json ./
-COPY .csharpierignore ./
-COPY .csharpierrc.yaml ./
-COPY src/*.csproj ./src/
-RUN dotnet restore ./src/Altinn.Studio.KubernetesWrapper.csproj
+COPY Runtime/kubernetes-wrapper/Directory.Packages.props ./Runtime/kubernetes-wrapper/
+COPY Runtime/kubernetes-wrapper/Directory.Build.props ./Runtime/kubernetes-wrapper/
+COPY Runtime/kubernetes-wrapper/global.json ./Runtime/kubernetes-wrapper/
+COPY Runtime/kubernetes-wrapper/.csharpierignore ./Runtime/kubernetes-wrapper/
+COPY Runtime/kubernetes-wrapper/.csharpierrc.yaml ./Runtime/kubernetes-wrapper/
+COPY Runtime/kubernetes-wrapper/src/*.csproj ./Runtime/kubernetes-wrapper/src/
+COPY common/dotnet/Altinn.Studio.Common/Altinn.Studio.Common.csproj ./common/dotnet/Altinn.Studio.Common/
+RUN dotnet restore ./Runtime/kubernetes-wrapper/src/Altinn.Studio.KubernetesWrapper.csproj
 
 # Copy everything else and build
-COPY src/. ./src/
-RUN dotnet publish ./src/Altinn.Studio.KubernetesWrapper.csproj -c Release -o /app/out --no-restore /p:CSharpier_Bypass=true
+COPY Runtime/kubernetes-wrapper/src/. ./Runtime/kubernetes-wrapper/src/
+COPY common/dotnet/Altinn.Studio.Common/src/. ./common/dotnet/Altinn.Studio.Common/src/
+RUN dotnet publish ./Runtime/kubernetes-wrapper/src/Altinn.Studio.KubernetesWrapper.csproj -c Release -o /app/out --no-restore /p:CSharpier_Bypass=true
 
 # Build runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:10.0.10-alpine3.23@sha256:27b6b84beeede74fd16886177d360799c8e4299ceadfbd64eef57bafead7878a AS final

--- a/src/Runtime/kubernetes-wrapper/src/Dockerfile.dockerignore
+++ b/src/Runtime/kubernetes-wrapper/src/Dockerfile.dockerignore
@@ -1,0 +1,12 @@
+# Keep the src/ build context limited to Kubernetes Wrapper and its shared dependency.
+**
+!common/dotnet/Altinn.Studio.Common/Altinn.Studio.Common.csproj
+!common/dotnet/Altinn.Studio.Common/src/**
+!Runtime/kubernetes-wrapper/Directory.Build.props
+!Runtime/kubernetes-wrapper/Directory.Packages.props
+!Runtime/kubernetes-wrapper/global.json
+!Runtime/kubernetes-wrapper/.csharpierignore
+!Runtime/kubernetes-wrapper/.csharpierrc.yaml
+!Runtime/kubernetes-wrapper/src/**
+**/bin
+**/obj


### PR DESCRIPTION
## Description

Part 2 of the graceful-shutdown stack (#19804), and a follow-up to the common-code structure work in #19803.

Builds the Kubernetes Wrapper and Designer migrations from `src/`, allowing their projects to reference shared source under `src/common`. Designer's main image retains the repository-root context because it also consumes the root Yarn workspace, while its backend is copied with the repository layout intact.

Adds complete Dockerfile-specific ignore files so the broader logical context does not become a broad transferred context. CI path filters now rebuild consumers when shared .NET source changes.

Stack: #20001 → **#20002** → #20003

## Docker context report

Fresh local builds transferred approximately:

- Kubernetes Wrapper: 50 kB
- Designer migrations: 15.8 MB
- Designer main image: 72.8 MB

Guidance: use `src/` as the default context for code-sharing consumers, use `<Dockerfile>.dockerignore` as an allowlist for that image, and keep the repository root only for builds that genuinely consume root workspace files.

## Verification

- [x] Related issues are connected: #19803, #19804
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done
- [ ] Relevant automated test added

Commands run:

- Real Docker builds for all three affected images
- `docker build --check` for all three Dockerfiles
- `docker compose config` for Designer
- `actionlint` for affected workflows

