### PR TITLE
fix: deploy apps with chart 3.12.0

### DIFF
--- a/src/App/azure-pipelines/deploy-app.yaml
+++ b/src/App/azure-pipelines/deploy-app.yaml
@@ -599,7 +599,7 @@ steps:
               retries: 1
           chart:
             spec:
-              version: 3.11.0
+              version: 3.12.0
               chart: deployment
               sourceRef:
                 kind: HelmRepository

--- a/src/Runtime/operator/test/e2e/__snapshots__/step0-initial-secret.snap
+++ b/src/Runtime/operator/test/e2e/__snapshots__/step0-initial-secret.snap
@@ -44,7 +44,7 @@
   "labels": {
    "app": "ttd-localtestapp-deployment",
    "app.kubernetes.io/managed-by": "Helm",
-   "chart": "deployment-3.11.0",
+   "chart": "deployment-3.12.0",
    "helm.toolkit.fluxcd.io/name": "ttd-localtestapp",
    "helm.toolkit.fluxcd.io/namespace": "default",
    "heritage": "Helm",

--- a/src/Runtime/operator/test/e2e/__snapshots__/step1-reconciled-secret.snap
+++ b/src/Runtime/operator/test/e2e/__snapshots__/step1-reconciled-secret.snap
@@ -96,7 +96,7 @@
   "labels": {
    "app": "ttd-localtestapp-deployment",
    "app.kubernetes.io/managed-by": "Helm",
-   "chart": "deployment-3.11.0",
+   "chart": "deployment-3.12.0",
    "helm.toolkit.fluxcd.io/name": "ttd-localtestapp",
    "helm.toolkit.fluxcd.io/namespace": "default",
    "heritage": "Helm",

--- a/src/Runtime/operator/test/e2e/__snapshots__/step2-scope-removed-secret.snap
+++ b/src/Runtime/operator/test/e2e/__snapshots__/step2-scope-removed-secret.snap
@@ -96,7 +96,7 @@
   "labels": {
    "app": "ttd-localtestapp-deployment",
    "app.kubernetes.io/managed-by": "Helm",
-   "chart": "deployment-3.11.0",
+   "chart": "deployment-3.12.0",
    "helm.toolkit.fluxcd.io/name": "ttd-localtestapp",
    "helm.toolkit.fluxcd.io/namespace": "default",
    "heritage": "Helm",

--- a/src/Runtime/operator/test/e2e/__snapshots__/step2b-jwk-rotated-secret.snap
+++ b/src/Runtime/operator/test/e2e/__snapshots__/step2b-jwk-rotated-secret.snap
@@ -119,7 +119,7 @@
   "labels": {
    "app": "ttd-localtestapp-deployment",
    "app.kubernetes.io/managed-by": "Helm",
-   "chart": "deployment-3.11.0",
+   "chart": "deployment-3.12.0",
    "helm.toolkit.fluxcd.io/name": "ttd-localtestapp",
    "helm.toolkit.fluxcd.io/namespace": "default",
    "heritage": "Helm",

--- a/src/Runtime/operator/test/e2e/__snapshots__/step2c-jwk-rotated-again-secret.snap
+++ b/src/Runtime/operator/test/e2e/__snapshots__/step2c-jwk-rotated-again-secret.snap
@@ -119,7 +119,7 @@
   "labels": {
    "app": "ttd-localtestapp-deployment",
    "app.kubernetes.io/managed-by": "Helm",
-   "chart": "deployment-3.11.0",
+   "chart": "deployment-3.12.0",
    "helm.toolkit.fluxcd.io/name": "ttd-localtestapp",
    "helm.toolkit.fluxcd.io/namespace": "default",
    "heritage": "Helm",

--- a/src/Runtime/operator/test/e2e/__snapshots__/step3-deleted-secret.snap
+++ b/src/Runtime/operator/test/e2e/__snapshots__/step3-deleted-secret.snap
@@ -46,7 +46,7 @@
   "labels": {
    "app": "ttd-localtestapp-deployment",
    "app.kubernetes.io/managed-by": "Helm",
-   "chart": "deployment-3.11.0",
+   "chart": "deployment-3.12.0",
    "helm.toolkit.fluxcd.io/name": "ttd-localtestapp",
    "helm.toolkit.fluxcd.io/namespace": "default",
    "heritage": "Helm",


### PR DESCRIPTION
## Description

Updates the app deployment pipeline to use deployment chart 3.12.0, which contains the Kubernetes and Linkerd shutdown coordination from Altinn/altinn-studio-charts#77.

Updates the operator E2E snapshots that record the rendered chart label so they match the chart consumed by app deployments.

Related to #19804.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

Commands run:

- `git diff --check`
- `yq '.' src/App/azure-pipelines/deploy-app.yaml`
- `go test ./e2e -run '^$'` from `src/Runtime/operator/test`
- Verified no deployment chart 3.11.0 references remain in the app pipeline or operator E2E snapshots


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the deployed Helm chart version to 3.12.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->