### PR TITLE
fix: align Go service shutdown budgets

### DIFF
--- a/src/Runtime/operator/cmd/main.go
+++ b/src/Runtime/operator/cmd/main.go
@@ -47,6 +47,11 @@ var (
 	setupLog = ctrl.Log.WithName("setup")
 )
 
+const (
+	managerGracefulShutdownTimeout = 30 * time.Second
+	telemetryShutdownTimeout       = 5 * time.Second
+)
+
 //nolint:gochecknoinits // Scheme registration follows controller-runtime/Kubebuilder conventions.
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
@@ -56,6 +61,14 @@ func init() {
 	utilruntime.Must(sourcev1.AddToScheme(scheme))
 	utilruntime.Must(cnpgapi.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
+}
+
+func shutdownTelemetry(shutdown func(context.Context) error) {
+	ctx, cancel := context.WithTimeout(context.Background(), telemetryShutdownTimeout)
+	defer cancel()
+	if err := shutdown(ctx); err != nil {
+		setupLog.Error(err, "unable to shut down OTel")
+	}
 }
 
 //nolint:funlen,gocyclo,gocognit,gocritic // Keeping Kubebuilder's scaffolded manager setup shape intact is more important here.
@@ -102,9 +115,7 @@ func main() {
 	}
 
 	// Handle shutdown properly so nothing leaks.
-	defer func() {
-		err = errors.Join(err, otelShutdown(context.Background()))
-	}()
+	defer shutdownTelemetry(otelShutdown)
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
 	// due to its vulnerabilities. More specifically, disabling http/2 will
@@ -148,9 +159,10 @@ func main() {
 		LeaderElectionID:       "ec156e4c.altinn.studio",
 		// Stretch the lease timings to reduce steady-state renewal chatter while
 		// keeping multiple renewal attempts before leadership is lost.
-		LeaseDuration: ptr.To(leaderElectionLeaseDuration),
-		RenewDeadline: ptr.To(leaderElectionRenewDeadline),
-		RetryPeriod:   ptr.To(leaderElectionRetryPeriod),
+		LeaseDuration:           ptr.To(leaderElectionLeaseDuration),
+		RenewDeadline:           ptr.To(leaderElectionRenewDeadline),
+		RetryPeriod:             ptr.To(leaderElectionRetryPeriod),
+		GracefulShutdownTimeout: new(managerGracefulShutdownTimeout),
 		BaseContext: func() context.Context {
 			return managerCtx
 		},

--- a/src/Runtime/operator/config/manager/manager.yaml
+++ b/src/Runtime/operator/config/manager/manager.yaml
@@ -98,7 +98,7 @@ spec:
             cpu: 100m
             memory: 128Mi
       serviceAccountName: controller-manager
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: 40
       volumes:
         - name: config
           configMap:

--- a/src/Runtime/pdf3/infra/kustomize/base/proxy.yaml
+++ b/src/Runtime/pdf3/infra/kustomize/base/proxy.yaml
@@ -135,6 +135,9 @@ spec:
         # linkerd provides automatic mTLS and some nice features
         # such as topology aware routing
         linkerd.io/inject: enabled
+        # Linkerd uses regular sidecars; mirror the proxy's 5s readiness drain + 45s connection drain.
+        config.alpha.linkerd.io/proxy-wait-before-exit-seconds: "5"
+        config.linkerd.io/shutdown-grace-period: "45s"
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
     spec:
       topologySpreadConstraints:


### PR DESCRIPTION
## Description

Align the remaining Go service shutdown profiles with Kubernetes and Linkerd as part of #19804.

- Coordinate the PDF3 proxy's Linkerd regular sidecar with its existing 5-second readiness drain and 45-second connection drain inside the 60-second pod budget.
- Give the operator an explicit 30-second controller-runtime shutdown timeout.
- Bound operator OpenTelemetry shutdown to 5 seconds and raise the pod termination grace period to 40 seconds, leaving a final 5-second safety margin.

Related to #19804.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

Commands run:

- `make check` in `src/Runtime/pdf3`
- `make build`, `make test`, and `make lint` in `src/Runtime/operator`
- `go test ./...` in `src/Runtime/operator` after the final cleanup refactor
- `kubectl kustomize infra/kustomize/base` in `src/Runtime/pdf3`; verified Linkerd 5s/45s annotations and 60s pod grace
- `kubectl kustomize config/default` in `src/Runtime/operator`; verified 40s pod grace


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved graceful shutdown handling for the controller manager and telemetry services.
  - Increased shutdown grace periods to allow in-progress operations to complete reliably.
  - Added controlled proxy shutdown behaviour to reduce interrupted requests during deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->