### PR TITLE
feat: real time validation of branch names

### DIFF
--- a/src/Designer/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/components/BranchDropdown/BranchDropdown.tsx
+++ b/src/Designer/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/components/BranchDropdown/BranchDropdown.tsx
@@ -11,7 +11,6 @@ import { DeleteBranchDialog } from './DeleteBranchDialog';
 import classes from './BranchDropdown.module.css';
 import { useBranchData } from '../../hooks/useBranchData';
 import { useBranchOperations } from '../../hooks/useBranchOperations';
-import type { Branch } from 'app-shared/types/api/BranchTypes';
 
 export const BranchDropdown = () => {
   const { t } = useTranslation();
@@ -35,7 +34,8 @@ export const BranchDropdown = () => {
   const triggerButtonText = shouldDisplayText ? currentBranch : undefined;
   const isLoading = isLoadingData || isLoadingOperations;
   const canDeleteCurrentBranch = currentBranch !== DEFAULT_APP_BRANCH;
-  const shouldDisplayBranchList = branchList?.length > 1;
+  const branchNames = branchList?.map((branch) => branch.name) ?? [];
+  const shouldDisplayBranchList = branchNames.length > 1;
 
   if (isLoading) {
     return (
@@ -64,7 +64,7 @@ export const BranchDropdown = () => {
         />
         {shouldDisplayBranchList && (
           <BranchList
-            branchList={branchList}
+            branchNames={branchNames}
             currentBranch={currentBranch}
             onBranchClick={checkoutExistingBranch}
           />
@@ -74,6 +74,7 @@ export const BranchDropdown = () => {
         isOpen={showCreateDialog}
         onClose={() => setShowCreateDialog(false)}
         currentBranch={currentBranch}
+        existingBranchNames={branchNames}
         onCreateBranch={checkoutNewBranch}
         isLoading={isLoading}
         createError={createError}
@@ -133,27 +134,27 @@ const BranchActions = ({
 };
 
 interface BranchListProps {
-  branchList: Array<Branch> | undefined;
+  branchNames: string[];
   currentBranch: string | undefined;
   onBranchClick: (branchName: string) => void;
 }
 
-const BranchList = ({ branchList, currentBranch, onBranchClick }: BranchListProps) => {
+const BranchList = ({ branchNames, currentBranch, onBranchClick }: BranchListProps) => {
   const { t } = useTranslation();
 
   return (
     <>
       <StudioDropdown.Heading>{t('branching.select_branch_heading')}</StudioDropdown.Heading>
       <StudioDropdown.List className={classes.branchList}>
-        {branchList?.map((branch) => (
-          <StudioDropdown.Item key={branch.name}>
+        {branchNames.map((branchName) => (
+          <StudioDropdown.Item key={branchName}>
             <StudioDropdown.Button
-              onClick={() => onBranchClick(branch.name)}
-              disabled={branch.name === currentBranch}
-              title={t('branching.switch_to_branch', { branchName: branch.name })}
+              onClick={() => onBranchClick(branchName)}
+              disabled={branchName === currentBranch}
+              title={t('branching.switch_to_branch', { branchName })}
             >
               <BranchingIcon />
-              {branch.name}
+              {branchName}
             </StudioDropdown.Button>
           </StudioDropdown.Item>
         ))}

--- a/src/Designer/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/components/BranchDropdown/CreateBranchDialog/CreateBranchDialog.test.tsx
+++ b/src/Designer/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/components/BranchDropdown/CreateBranchDialog/CreateBranchDialog.test.tsx
@@ -77,20 +77,62 @@ describe('CreateBranchDialog', () => {
     expect(errorMessage).toBeInTheDocument();
   });
 
-  it('should display error when pressing create button with invalid name', async () => {
+  it('should display a validation error in real time as the user types an invalid name', async () => {
     const user = userEvent.setup();
     renderCreateBranchDialog();
 
-    const textField = getBranchNameTextfield();
-    const createButton = queryCreateButton();
-    await user.type(textField, 'name with spaces');
-    await user.click(createButton);
+    await user.type(getBranchNameTextfield(), 'name with spaces');
 
     const errorMessage = screen.getByText(
       textMock('branching.new_branch_dialog.error_invalid_chars'),
     );
     expect(errorMessage).toBeInTheDocument();
-    expect(onCreateBranch).not.toHaveBeenCalled();
+  });
+
+  it('should disable the create button while the branch name is empty', () => {
+    renderCreateBranchDialog();
+    expect(queryCreateButton()).toBeDisabled();
+  });
+
+  it('should display an error when the branch name already exists', async () => {
+    const user = userEvent.setup();
+    renderCreateBranchDialog({ existingBranchNames: ['existing-branch'] });
+
+    await user.type(getBranchNameTextfield(), 'existing-branch');
+
+    const errorMessage = screen.getByText(
+      textMock('branching.new_branch_dialog.error_already_exists'),
+    );
+    expect(errorMessage).toBeInTheDocument();
+    expect(queryCreateButton()).toBeDisabled();
+  });
+
+  it('should disable the create button while the branch name is invalid', async () => {
+    const user = userEvent.setup();
+    renderCreateBranchDialog();
+
+    await user.type(getBranchNameTextfield(), 'name with spaces');
+
+    expect(queryCreateButton()).toBeDisabled();
+  });
+
+  it('should clear the validation error once the name becomes valid again', async () => {
+    const user = userEvent.setup();
+    renderCreateBranchDialog();
+
+    const textField = getBranchNameTextfield();
+    await user.type(textField, 'name with spaces');
+    expect(
+      screen.getByText(textMock('branching.new_branch_dialog.error_invalid_chars')),
+    ).toBeInTheDocument();
+
+    await user.clear(textField);
+    await user.type(textField, 'valid-branch-name');
+
+    expect(
+      screen.queryByText(textMock('branching.new_branch_dialog.error_invalid_chars')),
+    ).not.toBeInTheDocument();
+    expect(queryCreateButton()).not.toBeDisabled();
   });
 
   it('should alter create button text when isLoading is true', () => {
@@ -109,6 +151,7 @@ const defaultProps: CreateBranchDialogProps = {
   isOpen: true,
   onClose,
   currentBranch: 'master',
+  existingBranchNames: [],
   createError: '',
   isLoading: false,
   onCreateBranch,

--- a/src/Designer/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/components/BranchDropdown/CreateBranchDialog/CreateBranchDialog.tsx
+++ b/src/Designer/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/components/BranchDropdown/CreateBranchDialog/CreateBranchDialog.tsx
@@ -15,6 +15,7 @@ export interface CreateBranchDialogProps {
   onClose: () => void;
   onCreateBranch: (name: string) => void;
   currentBranch: string;
+  existingBranchNames: string[];
   createError: string;
   isLoading: boolean;
 }
@@ -24,6 +25,7 @@ export const CreateBranchDialog = ({
   onClose,
   onCreateBranch,
   currentBranch,
+  existingBranchNames,
   createError,
   isLoading,
 }: CreateBranchDialogProps) => {
@@ -37,20 +39,17 @@ export const CreateBranchDialog = ({
     onClose();
   };
 
-  const handleCreateBranch = () => {
-    const validationResult = BranchNameValidator.validate(newBranchName);
-
-    if (!validationResult.isValid) {
-      setValidationError(t(validationResult.errorKey));
-      return;
-    }
-
-    onCreateBranch(newBranchName);
+  const handleNameChange = (name: string) => {
+    setNewBranchName(name);
+    const validationResult = BranchNameValidator.validate(name, existingBranchNames);
+    setValidationError(validationResult.isValid ? '' : t(validationResult.errorKey));
   };
 
   const createButtonText = isLoading
     ? t('general.loading')
     : t('branching.new_branch_dialog.create');
+
+  const isCreateButtonEnabled = Boolean(newBranchName) && !validationError && !isLoading;
 
   return (
     <StudioDialog open={isOpen} onClose={handleClose} data-color-scheme='light'>
@@ -69,14 +68,17 @@ export const CreateBranchDialog = ({
         <StudioTextfield
           label={t('branching.new_branch_dialog.branch_name_label')}
           value={newBranchName}
-          onChange={(e) => setNewBranchName(e.target.value)}
+          onChange={(e) => handleNameChange(e.target.value)}
           placeholder={t('branching.new_branch_dialog.branch_name_placeholder')}
           error={validationError || createError}
           disabled={isLoading}
         />
         <StudioParagraph>{t('branching.new_branch_dialog.hint')}</StudioParagraph>
         <div className={classes.buttons}>
-          <StudioButton onClick={handleCreateBranch} disabled={isLoading}>
+          <StudioButton
+            onClick={() => onCreateBranch(newBranchName)}
+            disabled={!isCreateButtonEnabled}
+          >
             {createButtonText}
           </StudioButton>
           <StudioButton variant='secondary' onClick={handleClose}>

--- a/src/Designer/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/hooks/useBranchOperations/useBranchOperations.test.ts
+++ b/src/Designer/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/hooks/useBranchOperations/useBranchOperations.test.ts
@@ -111,22 +111,7 @@ describe('useBranchOperations', () => {
       expect(window.location.reload).toHaveBeenCalled();
     });
 
-    it('should set "already exists" error when create fails with 409', () => {
-      createBranchMutate.mockImplementation((_branch, options) =>
-        options?.onError?.(createAxiosError(409)),
-      );
-
-      const { result } = renderHook(() => useBranchOperations(org, app));
-
-      act(() => result.current.checkoutNewBranch('existing-branch'));
-
-      expect(result.current.createError).toBe(
-        textMock('branching.new_branch_dialog.error_already_exists'),
-      );
-      expect(checkoutBranchMutate).not.toHaveBeenCalled();
-    });
-
-    it('should set generic error when create fails with 500', () => {
+    it('should set generic error when create fails', () => {
       createBranchMutate.mockImplementation((_branch, options) =>
         options?.onError?.(createAxiosError(500)),
       );
@@ -157,7 +142,7 @@ describe('useBranchOperations', () => {
 
     it('should reset createError when retrying', () => {
       createBranchMutate
-        .mockImplementationOnce((_branch, options) => options?.onError?.(createAxiosError(409)))
+        .mockImplementationOnce((_branch, options) => options?.onError?.(createAxiosError(500)))
         .mockImplementationOnce((_branch, options) => options?.onSuccess?.());
       checkoutBranchMutate.mockImplementation((_branch, options) => options?.onSuccess?.());
 

--- a/src/Designer/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/hooks/useBranchOperations/useBranchOperations.ts
+++ b/src/Designer/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/hooks/useBranchOperations/useBranchOperations.ts
@@ -59,15 +59,7 @@ export function useBranchOperations(org: string, app: string): UseBranchOperatio
 
     createBranchMutation.mutate(branchName, {
       onSuccess: () => checkoutAndReload(branchName),
-      onError: (error: AxiosError) => {
-        setCreateError(
-          t(
-            HttpResponseUtils.isConflict(error)
-              ? 'branching.new_branch_dialog.error_already_exists'
-              : 'branching.new_branch_dialog.error_generic',
-          ),
-        );
-      },
+      onError: () => setCreateError(t('branching.new_branch_dialog.error_generic')),
     });
   };
 

--- a/src/Designer/frontend/packages/shared/src/utils/BranchNameValidator.test.ts
+++ b/src/Designer/frontend/packages/shared/src/utils/BranchNameValidator.test.ts
@@ -118,6 +118,26 @@ describe('BranchNameValidator', () => {
       });
     });
 
+    describe('existing branch names', () => {
+      it('should reject a name that already exists', () => {
+        const result = BranchNameValidator.validate('feature/test', ['feature/test']);
+        expect(result.isValid).toBe(false);
+        expect(result.errorKey).toBe('branching.new_branch_dialog.error_already_exists');
+      });
+
+      it('should reject a name that already exists regardless of casing', () => {
+        const result = BranchNameValidator.validate('Feature/Test', ['feature/test']);
+        expect(result.isValid).toBe(false);
+        expect(result.errorKey).toBe('branching.new_branch_dialog.error_already_exists');
+      });
+
+      it('should accept a name that is not among the existing branches', () => {
+        const result = BranchNameValidator.validate('feature/new', ['feature/test']);
+        expect(result.isValid).toBe(true);
+        expect(result.errorKey).toBe('');
+      });
+    });
+
     describe('valid branch names', () => {
       it('should accept simple branch name', () => {
         const result = BranchNameValidator.validate('main');
@@ -178,20 +198,6 @@ describe('BranchNameValidator', () => {
           expect(result.errorKey).toBe('');
         });
       });
-    });
-  });
-
-  describe('isValid', () => {
-    it('should return true for valid branch name', () => {
-      expect(BranchNameValidator.isValid('feature/test')).toBe(true);
-    });
-
-    it('should return false for invalid branch name', () => {
-      expect(BranchNameValidator.isValid('feature:test')).toBe(false);
-    });
-
-    it('should return false for empty branch name', () => {
-      expect(BranchNameValidator.isValid('')).toBe(false);
     });
   });
 });

--- a/src/Designer/frontend/packages/shared/src/utils/BranchNameValidator.ts
+++ b/src/Designer/frontend/packages/shared/src/utils/BranchNameValidator.ts
@@ -1,4 +1,5 @@
 import { GIT_BRANCH_VALIDATION } from 'app-shared/constants/gitBranchValidation';
+import { StringUtils } from '@studio/pure-functions';
 
 export interface ValidationResult {
   isValid: boolean;
@@ -6,7 +7,7 @@ export interface ValidationResult {
 }
 
 export class BranchNameValidator {
-  public static validate(name: string): ValidationResult {
+  public static validate(name: string, existingNames: string[] = []): ValidationResult {
     if (!name || name.length === 0) {
       return { isValid: false, errorKey: 'branching.new_branch_dialog.error_empty' };
     }
@@ -23,10 +24,16 @@ export class BranchNameValidator {
       return { isValid: false, errorKey: 'branching.new_branch_dialog.error_reserved_ending' };
     }
 
+    if (this.alreadyExists(name, existingNames)) {
+      return { isValid: false, errorKey: 'branching.new_branch_dialog.error_already_exists' };
+    }
+
     return { isValid: true, errorKey: '' };
   }
 
-  public static isValid(name: string): boolean {
-    return this.validate(name).isValid;
+  private static alreadyExists(name: string, existingNames: string[]): boolean {
+    return existingNames.some((existingName) =>
+      StringUtils.areCaseInsensitiveEqual(existingName, name),
+    );
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently, users have to click the **Opprett gren** button for the name validation to be triggered when creating a new branch. This PR adds real-time validation instead.

https://github.com/user-attachments/assets/1f77caf5-de63-4aeb-9195-ed7015a69b0c

Closes https://github.com/Altinn/altinn-studio/issues/17273.


## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Branch creation now checks names as you type.
  * Duplicate names are detected regardless of capitalisation.
  * The Create button remains disabled for empty, invalid, duplicate, or in-progress submissions.
  * Validation messages clear automatically once the name is corrected.

* **Bug Fixes**
  * Branch creation failures now display a consistent error message.
  * Users can retry branch creation after a general failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->