### PR TITLE
chore: replace alert with StudioAlert

### DIFF
--- a/src/Designer/frontend/app-development/features/appPublish/components/Deploy/Deploy.tsx
+++ b/src/Designer/frontend/app-development/features/appPublish/components/Deploy/Deploy.tsx
@@ -3,9 +3,8 @@ import { DeployDropdown } from './DeployDropdown';
 import { useCreateDeploymentMutation } from '../../../../hooks/mutations';
 import { useTranslation } from 'react-i18next';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
-import { Alert } from '@digdir/designsystemet-react';
 import { useDeployPermissionsQuery } from 'app-development/hooks/queries';
-import { StudioSpinner, StudioError } from '@studio/components';
+import { StudioSpinner, StudioError, StudioAlert } from '@studio/components';
 
 export interface DeployProps {
   appDeployedVersion: string;
@@ -47,7 +46,9 @@ export const Deploy = ({
       ? t(`general.production_environment_alt`).toLowerCase()
       : `${t('general.test_environment_alt').toLowerCase()} ${envName?.toUpperCase()}`;
     return (
-      <Alert severity='info'>{t('app_deployment.missing_rights', { envTitle, orgName })}</Alert>
+      <StudioAlert data-color='info'>
+        {t('app_deployment.missing_rights', { envTitle, orgName })}
+      </StudioAlert>
     );
   }
 

--- a/src/Designer/frontend/app-development/features/appPublish/components/DeploymentEnvironmentStatus.tsx
+++ b/src/Designer/frontend/app-development/features/appPublish/components/DeploymentEnvironmentStatus.tsx
@@ -1,7 +1,12 @@
 import React, { type JSX } from 'react';
 import classes from './DeploymentEnvironmentStatus.module.css';
-import { Alert } from '@digdir/designsystemet-react';
-import { StudioLink, StudioParagraph, StudioSpinner, StudioHeading } from '@studio/components';
+import {
+  StudioLink,
+  StudioParagraph,
+  StudioSpinner,
+  StudioHeading,
+  StudioAlert,
+} from '@studio/components';
 import { Trans, useTranslation } from 'react-i18next';
 import type { KubernetesDeployment } from 'app-shared/types/api/KubernetesDeployment';
 import { DateUtils } from '@studio/pure-functions';
@@ -45,7 +50,7 @@ export const DeploymentEnvironmentStatus = ({
   }) => {
     const envTitle = isProduction ? t('general.production') : envName.toUpperCase();
     return (
-      <Alert severity={severity} className={classes.alert}>
+      <StudioAlert data-color={severity} className={classes.alert}>
         <StudioHeading spacing level={2} data-size='xs'>
           {envTitle}
         </StudioHeading>
@@ -55,7 +60,7 @@ export const DeploymentEnvironmentStatus = ({
 
         {content}
         {footer && <StudioParagraph data-size='xs'>{footer}</StudioParagraph>}
-      </Alert>
+      </StudioAlert>
     );
   };
 

--- a/src/Designer/frontend/app-development/features/overview/components/Deployments/DeploymentContainer/DeploymentStatus.tsx
+++ b/src/Designer/frontend/app-development/features/overview/components/Deployments/DeploymentContainer/DeploymentStatus.tsx
@@ -2,8 +2,13 @@ import React, { type JSX } from 'react';
 import classes from './DeploymentStatus.module.css';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { Trans, useTranslation } from 'react-i18next';
-import { Alert } from '@digdir/designsystemet-react';
-import { StudioLink, StudioParagraph, StudioSpinner, StudioHeading } from '@studio/components';
+import {
+  StudioLink,
+  StudioParagraph,
+  StudioSpinner,
+  StudioHeading,
+  StudioAlert,
+} from '@studio/components';
 import { DateUtils } from '@studio/pure-functions';
 import { publishPath } from 'app-shared/api/paths';
 import type { KubernetesDeployment } from 'app-shared/types/api/KubernetesDeployment';
@@ -50,13 +55,13 @@ export const DeploymentStatus = ({
   }) => {
     const envTitle = isProduction ? t('general.production') : envName.toUpperCase();
     return (
-      <Alert severity={severity} className={classes.alert}>
+      <StudioAlert data-color={severity} className={classes.alert}>
         <StudioHeading spacing level={2} data-size='xs'>
           {envTitle}
         </StudioHeading>
         {content}
         <StudioParagraph data-size='xs'>{footer}</StudioParagraph>
-      </Alert>
+      </StudioAlert>
     );
   };
 

--- a/src/Designer/frontend/app-development/features/overview/components/Deployments/NoEnvironmentsAlert/NoEnvironmentsAlert.tsx
+++ b/src/Designer/frontend/app-development/features/overview/components/Deployments/NoEnvironmentsAlert/NoEnvironmentsAlert.tsx
@@ -1,18 +1,17 @@
 import { Trans, useTranslation } from 'react-i18next';
 import cn from 'classnames';
-import type { AlertProps } from '@digdir/designsystemet-react';
-import { StudioParagraph, StudioHeading } from '@studio/components';
-import { Alert } from '@digdir/designsystemet-react';
+import type { StudioAlertProps } from '@studio/components';
+import { StudioParagraph, StudioHeading, StudioAlert } from '@studio/components';
 import { EmailContactProvider } from 'app-shared/getInTouch/providers';
 import { GetInTouchWith } from 'app-shared/getInTouch';
 import { altinnDocsUrl } from 'app-shared/ext-urls';
 
-type NoEnvironmentsAlertProps = AlertProps;
+type NoEnvironmentsAlertProps = StudioAlertProps;
 export const NoEnvironmentsAlert = ({ ...rest }: NoEnvironmentsAlertProps) => {
   const { t } = useTranslation();
   const contactByEmail = new GetInTouchWith(new EmailContactProvider());
   return (
-    <Alert severity='warning' className={cn(rest.className)} {...rest}>
+    <StudioAlert data-color='warning' className={cn(rest.className)} {...rest}>
       <StudioHeading level={2} data-size='sm' spacing>
         {t('app_deployment.no_env_title')}
       </StudioHeading>
@@ -30,6 +29,6 @@ export const NoEnvironmentsAlert = ({ ...rest }: NoEnvironmentsAlertProps) => {
           />
         </Trans>
       </StudioParagraph>
-    </Alert>
+    </StudioAlert>
   );
 };

--- a/src/Designer/frontend/app-development/features/overview/components/Deployments/NoEnvironmentsAlert/NoEnvironmentsAlert.tsx
+++ b/src/Designer/frontend/app-development/features/overview/components/Deployments/NoEnvironmentsAlert/NoEnvironmentsAlert.tsx
@@ -11,7 +11,7 @@ export const NoEnvironmentsAlert = ({ ...rest }: NoEnvironmentsAlertProps) => {
   const { t } = useTranslation();
   const contactByEmail = new GetInTouchWith(new EmailContactProvider());
   return (
-    <StudioAlert data-color='warning' className={cn(rest.className)} {...rest}>
+    <StudioAlert {...rest} data-color='warning' className={cn(rest.className)}>
       <StudioHeading level={2} data-size='sm' spacing>
         {t('app_deployment.no_env_title')}
       </StudioHeading>

--- a/src/Designer/frontend/app-development/features/overview/components/Deployments/RepoOwnedByPersonInfo/RepoOwnedByPersonInfo.tsx
+++ b/src/Designer/frontend/app-development/features/overview/components/Deployments/RepoOwnedByPersonInfo/RepoOwnedByPersonInfo.tsx
@@ -1,5 +1,4 @@
-import { Alert } from '@digdir/designsystemet-react';
-import { StudioParagraph, StudioLink } from '@studio/components';
+import { StudioParagraph, StudioLink, StudioAlert } from '@studio/components';
 import { Trans, useTranslation } from 'react-i18next';
 import classes from './RepoOwnedByPersonInfo.module.css';
 
@@ -7,7 +6,7 @@ export const RepoOwnedByPersonInfo = () => {
   const { t } = useTranslation();
   return (
     <>
-      <Alert>{t('app_deployment.private_app_owner')}</Alert>
+      <StudioAlert>{t('app_deployment.private_app_owner')}</StudioAlert>
       <div className={classes.infoContainer}>
         <div className={classes.textContainer}>
           <StudioParagraph>{t('app_deployment.private_app_owner_info')}</StudioParagraph>

--- a/src/Designer/frontend/dashboard/components/ResourcesRepoList/ResourcesRepoList.tsx
+++ b/src/Designer/frontend/dashboard/components/ResourcesRepoList/ResourcesRepoList.tsx
@@ -7,8 +7,7 @@ import { getResourceDashboardURL, getResourcePageURL } from 'resourceadm/utils/u
 import { getReposLabel } from 'dashboard/utils/repoUtils';
 import type { Organization } from 'app-shared/types/Organization';
 import { useTranslation } from 'react-i18next';
-import { StudioLink, StudioSpinner, StudioHeading } from '@studio/components';
-import { Alert } from '@digdir/designsystemet-react';
+import { StudioLink, StudioSpinner, StudioHeading, StudioAlert } from '@studio/components';
 import { useSearchReposQuery } from 'dashboard/hooks/queries';
 import type { User } from 'app-shared/types/Repository';
 import { getUidFilter } from 'dashboard/utils/filterUtils';
@@ -50,7 +49,7 @@ export const ResourcesRepoList = ({
   }
 
   if (isResourceListError) {
-    return <Alert severity='danger'>{t('dashboard.resource_list_load_error')}</Alert>;
+    return <StudioAlert data-color='danger'>{t('dashboard.resource_list_load_error')}</StudioAlert>;
   }
 
   return (

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioExpression/SimplifiedEditor/SimplifiedEditor.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioExpression/SimplifiedEditor/SimplifiedEditor.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { Expression } from '../types/Expression';
 import { isExpressionSimple } from '../validators/isExpressionSimple';
-import { Alert } from '@digdir/designsystemet-react';
+import { StudioAlert } from '../../StudioAlert';
 import { complexToSimpleExpression } from '../converters/complexToSimpleExpression';
 import type { SimplifiedExpression } from '../types/SimplifiedExpression';
 import { simpleToComplexExpression } from '../converters/simpleToComplexExpression';
@@ -22,7 +22,7 @@ export const SimplifiedEditor = ({
   const { texts } = useStudioExpressionContext();
 
   if (!isExpressionSimple(expression)) {
-    return <Alert data-color='info'>{texts.cannotSimplify}</Alert>;
+    return <StudioAlert data-color='info'>{texts.cannotSimplify}</StudioAlert>;
   }
 
   const simplifiedExpression = complexToSimpleExpression(expression);

--- a/src/Designer/frontend/libs/studio-content-library/src/pages/Images/ImagesPage/ImagesPage.tsx
+++ b/src/Designer/frontend/libs/studio-content-library/src/pages/Images/ImagesPage/ImagesPage.tsx
@@ -1,7 +1,6 @@
 import type { ReactElement } from 'react';
 import classes from './ImagesPage.module.css';
-import { Alert } from '@digdir/designsystemet-react';
-import { StudioHeading } from '@studio/components';
+import { StudioHeading, StudioAlert } from '@studio/components';
 import { useTranslation } from 'react-i18next';
 import { InfoBox } from '../../../components/InfoBox';
 import { PageName } from '../../../types/PageName';
@@ -28,7 +27,7 @@ export function ImagesPage({ images, onUpdateImage }: ImagesPageProps): ReactEle
       </StudioHeading>
       {noExistingImages ? (
         <div className={classes.noImagesWrapper}>
-          <Alert size='small'>{t('app_content_library.images.coming_soon')}</Alert>
+          <StudioAlert data-size='sm'>{t('app_content_library.images.coming_soon')}</StudioAlert>
           <InfoBox pageName={PageName.Images} />
         </div>
       ) : (

--- a/src/Designer/frontend/packages/policy-editor/src/components/PolicyEditorAlert/PolicyEditorAlert.tsx
+++ b/src/Designer/frontend/packages/policy-editor/src/components/PolicyEditorAlert/PolicyEditorAlert.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import classes from './PolicyEditorAlert.module.css';
-import { Alert } from '@digdir/designsystemet-react';
-import { StudioParagraph } from '@studio/components';
+import { StudioParagraph, StudioAlert } from '@studio/components';
 import { usePolicyEditorContext } from '../../contexts/PolicyEditorContext';
 import { useTranslation } from 'react-i18next';
 
@@ -14,13 +13,13 @@ export const PolicyEditorAlert = (): React.ReactElement => {
   }
 
   return (
-    <Alert severity='info' className={classes.alert}>
+    <StudioAlert data-color='info' className={classes.alert}>
       <StudioParagraph>
         {t('policy_editor.alert', {
           usageType:
             usageType === 'app' ? t('policy_editor.alert_app') : t('policy_editor.alert_resource'),
         })}
       </StudioParagraph>
-    </Alert>
+    </StudioAlert>
   );
 };

--- a/src/Designer/frontend/packages/process-editor/src/components/Canvas/BPMNViewer/BPMNViewerErrorAlert/BPMNViewerErrorAlert.tsx
+++ b/src/Designer/frontend/packages/process-editor/src/components/Canvas/BPMNViewer/BPMNViewerErrorAlert/BPMNViewerErrorAlert.tsx
@@ -2,8 +2,7 @@ import type { ReactNode } from 'react';
 import classes from './BPMNViewerErrorAlert.module.css';
 import type { BpmnViewerError } from '../../../../types/BpmnViewerError';
 import { useTranslation } from 'react-i18next';
-import { Alert } from '@digdir/designsystemet-react';
-import { StudioParagraph, StudioHeading } from '@studio/components';
+import { StudioParagraph, StudioHeading, StudioAlert } from '@studio/components';
 
 interface ErrorMessage {
   heading: string;
@@ -51,12 +50,12 @@ export const BPMNViewerErrorAlert = ({ bpmnViewerError }: BPMNViewerErrorAlertPr
 
   return (
     <div className={classes.alertContainer}>
-      <Alert severity='warning'>
+      <StudioAlert data-color='warning'>
         <StudioHeading data-size='md' spacing>
           {errorToDisplay.heading}
         </StudioHeading>
         <StudioParagraph>{errorToDisplay.body}</StudioParagraph>
-      </Alert>
+      </StudioAlert>
     </div>
   );
 };

--- a/src/Designer/frontend/packages/process-editor/src/components/ConfigPanel/ConfigPanel.tsx
+++ b/src/Designer/frontend/packages/process-editor/src/components/ConfigPanel/ConfigPanel.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Alert } from '@digdir/designsystemet-react';
 import { useBpmnContext } from '../../contexts/BpmnContext';
 import { BpmnTypeEnum } from '../../enum/BpmnTypeEnum';
 import { ConfigContent } from './ConfigContent';
@@ -8,7 +7,7 @@ import { ConfigEndEvent } from './ConfigEndEvent';
 import { ConfigSurface } from '../ConfigSurface/ConfigSurface';
 import { ConfigSequenceFlow } from './ConfigSequenceFlow';
 import { ConfigServiceTask } from './ConfigServiceTask';
-import { StudioParagraph, StudioHeading } from '@studio/components';
+import { StudioParagraph, StudioHeading, StudioAlert } from '@studio/components';
 
 export const ConfigPanel = (): React.ReactElement => {
   return (
@@ -66,11 +65,11 @@ type BpmnAlertProps = {
 };
 const BpmnAlert = ({ title, message }: BpmnAlertProps): React.ReactElement => {
   return (
-    <Alert>
+    <StudioAlert>
       <StudioHeading level={3} data-size='xs' spacing>
         {title}
       </StudioHeading>
       <StudioParagraph data-size='md'>{message}</StudioParagraph>
-    </Alert>
+    </StudioAlert>
   );
 };

--- a/src/Designer/frontend/packages/process-editor/src/components/ConfigViewerPanel/ConfigViewerPanel.tsx
+++ b/src/Designer/frontend/packages/process-editor/src/components/ConfigViewerPanel/ConfigViewerPanel.tsx
@@ -4,12 +4,12 @@ import {
   StudioDisplayTile,
   StudioParagraph,
   StudioHeading,
+  StudioAlert,
 } from '@studio/components';
 import { useBpmnContext } from '../../contexts/BpmnContext';
 import { ConfigIcon } from '../ConfigPanel/ConfigContent/ConfigIcon';
 import { getConfigTitleHelpTextKey, getConfigTitleKey } from '../../utils/configPanelUtils';
 import { useTranslation } from 'react-i18next';
-import { Alert } from '@digdir/designsystemet-react';
 import { ConfigSurface } from '../ConfigSurface/ConfigSurface';
 import classes from './ConfigViewerPanel.module.css';
 
@@ -70,13 +70,13 @@ export const ConfigViewerPanelContent = (): React.ReactElement => {
 const ChooseElementToViewAlert = (): React.ReactElement => {
   const { t } = useTranslation();
   return (
-    <Alert>
+    <StudioAlert>
       <StudioHeading level={3} data-size='xs' spacing>
         {t('process_editor.configuration_view_panel_no_task')}
       </StudioHeading>
       <StudioParagraph data-size='md'>
         {t('process_editor.configuration_view_panel_please_choose_task')}
       </StudioParagraph>
-    </Alert>
+    </StudioAlert>
   );
 };

--- a/src/Designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemFieldsTab/ItemFieldsTab.tsx
+++ b/src/Designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemFieldsTab/ItemFieldsTab.tsx
@@ -7,7 +7,7 @@ import { ItemFieldsTable } from './ItemFieldsTable';
 import { useAddProperty } from '@altinn/schema-editor/hooks/useAddProperty';
 import { getLastNameField } from '@altinn/schema-editor/components/SchemaInspector/ItemFieldsTab/domUtils';
 import { AddPropertiesMenu } from '../../AddPropertiesMenu';
-import { Alert } from '@digdir/designsystemet-react';
+import { StudioAlert } from '@studio/components';
 import type { UiSchemaNode } from '@altinn/schema-model/types';
 import { useTranslation } from 'react-i18next';
 
@@ -23,7 +23,7 @@ export function ItemFieldsTab({ selectedItem }: ItemFieldsTabProps): React.React
   return shouldDisplayFieldsTabContent ? (
     <ItemFieldsTabContent selectedItem={selectedItem} />
   ) : (
-    <Alert size='small'>{t('schema_editor.fields_not_available_on_type')}</Alert>
+    <StudioAlert data-size='sm'>{t('schema_editor.fields_not_available_on_type')}</StudioAlert>
   );
 }
 

--- a/src/Designer/frontend/packages/shared/src/components/PreviewLimitationsInfo/PreviewLimitationsInfo.tsx
+++ b/src/Designer/frontend/packages/shared/src/components/PreviewLimitationsInfo/PreviewLimitationsInfo.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import classes from './PreviewLimitationsInfo.module.css';
 import { useTranslation } from 'react-i18next';
-import { Alert } from '@digdir/designsystemet-react';
+import { StudioAlert } from '@studio/components';
 import { typedLocalStorage } from '@studio/pure-functions';
 import { RemindChoiceDialog } from '../RemindChoiceDialog/RemindChoiceDialog';
 
@@ -25,9 +25,9 @@ export const PreviewLimitationsInfo = () => {
   if (!showPreviewLimitationsInfo) return null;
 
   return (
-    <Alert severity='info' className={classes.alert}>
+    <StudioAlert data-color='info' className={classes.alert}>
       {t('preview.limitations_info')}
       <RemindChoiceDialog closeDialog={handleHidePreviewLimitations} />
-    </Alert>
+    </StudioAlert>
   );
 };

--- a/src/Designer/frontend/packages/ux-editor-v3/src/components/Properties/ConditionalRendering.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/components/Properties/ConditionalRendering.tsx
@@ -1,4 +1,4 @@
-import { Alert } from '@digdir/designsystemet-react';
+import { StudioAlert } from '@studio/components';
 import classes from './ConditionalRendering.module.css';
 import { OldDynamicsInfo } from './OldDynamicsInfo';
 import { Trans } from 'react-i18next';
@@ -10,7 +10,7 @@ export const ConditionalRendering = () => {
     <div className={classes.conditionalRendering}>
       <div className={classes.conditionalRenderingWrapper}>
         <div className={classes.dynamicsVersionCheckBox}>
-          <Alert severity='warning' className={classes.alert}>
+          <StudioAlert data-color='warning' className={classes.alert}>
             <span>
               <Trans i18nKey={'right_menu.warning_dynamics_deprecated'}>
                 <a
@@ -22,7 +22,7 @@ export const ConditionalRendering = () => {
                 />
               </Trans>
             </span>
-          </Alert>
+          </StudioAlert>
         </div>
         <div>
           <ConditionalRenderingModal />

--- a/src/Designer/frontend/packages/ux-editor-v3/src/components/UnknownComponentAlert/UnknownComponentAlert.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/components/UnknownComponentAlert/UnknownComponentAlert.tsx
@@ -1,22 +1,22 @@
-import type { AlertProps } from '@digdir/designsystemet-react';
-import { Alert } from '@digdir/designsystemet-react';
+import type { StudioAlertProps } from '@studio/components';
+import { StudioAlert } from '@studio/components';
 import { useTranslation } from 'react-i18next';
 
 import type { JSX } from 'react';
 
 export type UnknownComponentAlertProps = {
   componentName: string;
-} & AlertProps;
+} & StudioAlertProps;
 export const UnknownComponentAlert = ({
   componentName,
   ...rest
 }: UnknownComponentAlertProps): JSX.Element => {
   const { t } = useTranslation();
   return (
-    <Alert severity='warning' {...rest}>
+    <StudioAlert data-color='warning' {...rest}>
       {t('ux_editor.edit_component.unknown_component', {
         componentName,
       })}
-    </Alert>
+    </StudioAlert>
   );
 };

--- a/src/Designer/frontend/packages/ux-editor-v3/src/components/config/EditFormContainer.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/components/config/EditFormContainer.tsx
@@ -5,7 +5,7 @@ import { EditGroupDataModelBindings } from './group/EditGroupDataModelBindings';
 import { getTextResource } from '../../utils/language';
 import { idExists } from '../../utils/formLayoutUtils';
 import type { DataModelFieldElement } from 'app-shared/types/DataModelFieldElement';
-import { Alert, Checkbox } from '@digdir/designsystemet-react';
+import { Checkbox } from '@digdir/designsystemet-react';
 import classes from './EditFormContainer.module.css';
 import { TextResource } from '../TextResource';
 import { useDataModelMetadataQuery } from '../../hooks/queries/useDataModelMetadataQuery';
@@ -21,7 +21,13 @@ import type { FormContainer } from '../../types/FormContainer';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useAppContext } from '../../hooks/useAppContext';
 import { ComponentTypeV3 } from 'app-shared/types/ComponentTypeV3';
-import { StudioProperty, StudioSwitch, StudioTextfield, StudioParagraph } from '@studio/components';
+import {
+  StudioProperty,
+  StudioSwitch,
+  StudioTextfield,
+  StudioParagraph,
+  StudioAlert,
+} from '@studio/components';
 
 export interface IEditFormContainerProps {
   editFormId: string;
@@ -240,8 +246,8 @@ export const EditFormContainer = ({
       )}
     </StudioProperty.Group>
   ) : (
-    <Alert severity='info'>
+    <StudioAlert data-color='info'>
       <StudioParagraph data-size='sm'>{t('ux_editor.container_not_editable_info')}</StudioParagraph>
-    </Alert>
+    </StudioAlert>
   );
 };

--- a/src/Designer/frontend/packages/ux-editor-v3/src/components/config/Expressions/ExpressionContent/ComplexExpression/ComplexExpression.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/components/config/Expressions/ExpressionContent/ComplexExpression/ComplexExpression.tsx
@@ -1,9 +1,8 @@
 import classes from './ComplexExpression.module.css';
-import { Alert } from '@digdir/designsystemet-react';
 import { useTranslation } from 'react-i18next';
 import type { Expression } from '../../../../../types/Expressions';
 import { stringifyData } from '../../../../../utils/jsonUtils';
-import { StudioTextarea } from '@studio/components';
+import { StudioTextarea, StudioAlert } from '@studio/components';
 
 export type ComplexExpressionProps = {
   disabled?: boolean;
@@ -26,7 +25,9 @@ export const ComplexExpression = ({
         onChange={(event) => onChange?.(event.target.value)}
         value={stringifyData(expression.complexExpression)}
       />
-      {!isStudioFriendly && <Alert>{t('right_menu.expressions_complex_expression_message')}</Alert>}
+      {!isStudioFriendly && (
+        <StudioAlert>{t('right_menu.expressions_complex_expression_message')}</StudioAlert>
+      )}
     </div>
   );
 };

--- a/src/Designer/frontend/packages/ux-editor-v3/src/components/config/Expressions/Expressions.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/components/config/Expressions/Expressions.tsx
@@ -1,5 +1,5 @@
 import { useState, useContext } from 'react';
-import { Alert } from '@digdir/designsystemet-react';
+import { StudioAlert } from '@studio/components';
 import { ExpressionContent } from './ExpressionContent';
 import { useText } from '../../../hooks';
 import type { ExpressionProperty } from '../../../types/Expressions';
@@ -70,9 +70,9 @@ export const Expressions = () => {
         />
       ))}
       {isExpressionLimitReached ? (
-        <Alert className={classes.expressionsAlert}>
+        <StudioAlert className={classes.expressionsAlert}>
           {t('right_menu.expressions_expressions_limit_reached_alert')}
-        </Alert>
+        </StudioAlert>
       ) : (
         <>
           {propertiesWithExpressions.length === 0 && (

--- a/src/Designer/frontend/packages/ux-editor-v3/src/components/config/FormComponentConfig.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/components/config/FormComponentConfig.tsx
@@ -1,7 +1,6 @@
 import { Fragment } from 'react';
 import { EditComponentId } from './editModal/EditComponentId';
-import { Alert } from '@digdir/designsystemet-react';
-import { StudioHeading, StudioParagraph } from '@studio/components';
+import { StudioHeading, StudioParagraph, StudioAlert } from '@studio/components';
 import type { FormComponent } from '../../types/FormComponent';
 import { selectedLayoutNameSelector } from '../../selectors/formLayoutSelectors';
 import { EditDataModelBindings } from './editModal/EditDataModelBindings';
@@ -259,7 +258,7 @@ export const FormComponentConfig = ({
       })}
       {/* Show information about unsupported properties if there are any */}
       {unsupportedPropertyKeys.length > 0 && !hideUnsupported && (
-        <Alert severity='info'>
+        <StudioAlert data-color='info'>
           {t('ux_editor.edit_component.unsupported_properties_message')}
           <ul>
             {unsupportedPropertyKeys.length > 0 &&
@@ -267,7 +266,7 @@ export const FormComponentConfig = ({
                 <li key={propertyKey}>{propertyKey}</li>
               ))}
           </ul>
-        </Alert>
+        </StudioAlert>
       )}
     </>
   );

--- a/src/Designer/frontend/packages/ux-editor-v3/src/containers/DesignView/FormLayout.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/containers/DesignView/FormLayout.tsx
@@ -2,8 +2,7 @@ import type { IInternalLayout } from '../../types/global';
 import { FormTree } from './FormTree';
 import { hasMultiPageGroup } from '../../utils/formLayoutUtils';
 import { useTranslation } from 'react-i18next';
-import { Alert } from '@digdir/designsystemet-react';
-import { StudioParagraph } from '@studio/components';
+import { StudioParagraph, StudioAlert } from '@studio/components';
 
 export interface FormLayoutProps {
   layout: IInternalLayout;
@@ -19,8 +18,8 @@ export const FormLayout = ({ layout }: FormLayoutProps) => (
 const MultiPageWarning = () => {
   const { t } = useTranslation();
   return (
-    <Alert severity='warning'>
+    <StudioAlert data-color='warning'>
       <StudioParagraph data-size='sm'>{t('ux_editor.multi_page_warning')}</StudioParagraph>
-    </Alert>
+    </StudioAlert>
   );
 };

--- a/src/Designer/frontend/packages/ux-editor-v4/src/components/Properties/DataModelBindings.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/components/Properties/DataModelBindings.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { EditDataModelBinding } from '../config/editModal/EditDataModelBinding/EditDataModelBinding';
-import { StudioProperty, StudioSwitch } from '@studio/components';
-import { Alert } from '@digdir/designsystemet-react';
+import { StudioProperty, StudioSwitch, StudioAlert } from '@studio/components';
 import { useComponentSchemaQuery } from '../../hooks/queries/useComponentSchemaQuery';
 import { useFormItemContext } from '../../containers/FormItemContext';
 import { useText, useSelectedFormLayout } from '../../hooks';
@@ -54,9 +53,9 @@ export const DataModelBindings = (): React.JSX.Element => {
       {(formItem.type === ComponentType.FileUploadWithTag ||
         formItem.type === ComponentType.FileUpload) &&
         isItemChildOfContainer(layout, formItem.id, ComponentType.RepeatingGroup) && (
-          <Alert size='small' severity='warning' className={classes.alert}>
+          <StudioAlert data-size='sm' data-color='warning' className={classes.alert}>
             {t('ux_editor.modal_properties_data_model_restrictions_attachment_components')}
-          </Alert>
+          </StudioAlert>
         )}
       {dataModelBindings.anyOf && (
         <StudioSwitch

--- a/src/Designer/frontend/packages/ux-editor-v4/src/components/Properties/PropertiesHeader/EditComponentIdRow/EditComponentIdRow.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/components/Properties/PropertiesHeader/EditComponentIdRow/EditComponentIdRow.tsx
@@ -1,6 +1,9 @@
 import { useState } from 'react';
-import { StudioToggleableTextfieldSchema, type SchemaValidationError } from '@studio/components';
-import { Alert } from '@digdir/designsystemet-react';
+import {
+  StudioAlert,
+  StudioToggleableTextfieldSchema,
+  type SchemaValidationError,
+} from '@studio/components';
 import classes from './EditComponentIdRow.module.css';
 import { idExists } from '../../../../utils/formLayoutsUtils';
 import { useTranslation } from 'react-i18next';
@@ -101,9 +104,9 @@ export const EditComponentIdRow = ({
       />
       {!isViewMode && (
         <div className={classes.alert}>
-          <Alert size='small'>
+          <StudioAlert data-size='sm'>
             {t('ux_editor.modal_properties_component_change_id_information')}
-          </Alert>
+          </StudioAlert>
         </div>
       )}
     </div>

--- a/src/Designer/frontend/packages/ux-editor-v4/src/components/config/editModal/EditImage/ConflictingImageSourceAlert/ConflictingImageSourceAlert.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/components/config/editModal/EditImage/ConflictingImageSourceAlert/ConflictingImageSourceAlert.tsx
@@ -1,5 +1,5 @@
 import classes from './ConflictingImageSourceAlert.module.css';
-import { Alert } from '@digdir/designsystemet-react';
+import { StudioAlert } from '@studio/components';
 import { useTranslation } from 'react-i18next';
 
 interface ConflictingImageSourceAlertProps {
@@ -15,11 +15,11 @@ export const ConflictingImageSourceAlert = ({
 
   return (
     showAlert && (
-      <Alert size='small' className={classes.alert}>
+      <StudioAlert data-size='sm' className={classes.alert}>
         {conflictSource === 'external'
           ? t('ux_editor.properties_panel.images.conflicting_image_source_when_entering_url')
           : t('ux_editor.properties_panel.images.conflicting_image_source_when_uploading_image')}
-      </Alert>
+      </StudioAlert>
     )
   );
 };

--- a/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/FormLayout.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignView/FormLayout.tsx
@@ -2,12 +2,11 @@ import type { IInternalLayout } from '../../types/global';
 import { FormTree } from './FormTree';
 import { hasMultiPageGroup } from '../../utils/formLayoutUtils';
 import { useTranslation } from 'react-i18next';
-import { Alert } from '@digdir/designsystemet-react';
 import { FormLayoutWarning } from './FormLayoutWarning';
 import { BASE_CONTAINER_ID } from 'app-shared/constants';
 import { AddItem } from './AddItem';
 import { useFeatureFlag, FeatureFlag } from '@studio/feature-flags';
-import { StudioParagraph } from '@studio/components';
+import { StudioParagraph, StudioAlert } from '@studio/components';
 
 export interface FormLayoutProps {
   layout: IInternalLayout;
@@ -39,8 +38,8 @@ export const FormLayout = ({ layout, isInvalid, duplicateComponents }: FormLayou
 const MultiPageWarning = () => {
   const { t } = useTranslation();
   return (
-    <Alert severity='warning'>
+    <StudioAlert data-color='warning'>
       <StudioParagraph data-size='sm'>{t('ux_editor.multi_page_warning')}</StudioParagraph>
-    </Alert>
+    </StudioAlert>
   );
 };

--- a/src/Designer/frontend/packages/ux-editor/src/components/Properties/DataModelBindings.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/components/Properties/DataModelBindings.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { EditDataModelBinding } from '../config/editModal/EditDataModelBinding/EditDataModelBinding';
-import { StudioProperty, StudioSwitch } from '@studio/components';
-import { Alert } from '@digdir/designsystemet-react';
+import { StudioProperty, StudioSwitch, StudioAlert } from '@studio/components';
 import { useComponentSchemaQuery } from '../../hooks/queries/useComponentSchemaQuery';
 import { useFormItemContext } from '../../containers/FormItemContext';
 import { useText, useSelectedFormLayout } from '../../hooks';
@@ -54,9 +53,9 @@ export const DataModelBindings = (): React.JSX.Element => {
       {(formItem.type === ComponentType.FileUploadWithTag ||
         formItem.type === ComponentType.FileUpload) &&
         isItemChildOfContainer(layout, formItem.id, ComponentType.RepeatingGroup) && (
-          <Alert size='small' severity='warning' className={classes.alert}>
+          <StudioAlert data-size='sm' data-color='warning' className={classes.alert}>
             {t('ux_editor.modal_properties_data_model_restrictions_attachment_components')}
-          </Alert>
+          </StudioAlert>
         )}
       {dataModelBindings.anyOf && (
         <StudioSwitch

--- a/src/Designer/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/EditComponentIdRow/EditComponentIdRow.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/EditComponentIdRow/EditComponentIdRow.tsx
@@ -1,6 +1,9 @@
 import { useState } from 'react';
-import { StudioToggleableTextfieldSchema, type SchemaValidationError } from '@studio/components';
-import { Alert } from '@digdir/designsystemet-react';
+import {
+  StudioAlert,
+  StudioToggleableTextfieldSchema,
+  type SchemaValidationError,
+} from '@studio/components';
 import classes from './EditComponentIdRow.module.css';
 import { idExists } from '../../../../utils/formLayoutsUtils';
 import { useTranslation } from 'react-i18next';
@@ -101,9 +104,9 @@ export const EditComponentIdRow = ({
       />
       {!isViewMode && (
         <div className={classes.alert}>
-          <Alert size='small'>
+          <StudioAlert data-size='sm'>
             {t('ux_editor.modal_properties_component_change_id_information')}
-          </Alert>
+          </StudioAlert>
         </div>
       )}
     </div>

--- a/src/Designer/frontend/packages/ux-editor/src/components/config/editModal/EditImage/ConflictingImageSourceAlert/ConflictingImageSourceAlert.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/components/config/editModal/EditImage/ConflictingImageSourceAlert/ConflictingImageSourceAlert.tsx
@@ -1,5 +1,5 @@
 import classes from './ConflictingImageSourceAlert.module.css';
-import { Alert } from '@digdir/designsystemet-react';
+import { StudioAlert } from '@studio/components';
 import { useTranslation } from 'react-i18next';
 
 interface ConflictingImageSourceAlertProps {
@@ -15,11 +15,11 @@ export const ConflictingImageSourceAlert = ({
 
   return (
     showAlert && (
-      <Alert size='small' className={classes.alert}>
+      <StudioAlert data-size='sm' className={classes.alert}>
         {conflictSource === 'external'
           ? t('ux_editor.properties_panel.images.conflicting_image_source_when_entering_url')
           : t('ux_editor.properties_panel.images.conflicting_image_source_when_uploading_image')}
-      </Alert>
+      </StudioAlert>
     )
   );
 };

--- a/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/FormLayout.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/FormLayout.tsx
@@ -2,8 +2,7 @@ import type { IInternalLayout } from '../../types/global';
 import { FormTree } from './FormTree';
 import { hasMultiPageGroup } from '../../utils/formLayoutUtils';
 import { useTranslation } from 'react-i18next';
-import { Alert } from '@digdir/designsystemet-react';
-import { StudioParagraph } from '@studio/components';
+import { StudioParagraph, StudioAlert } from '@studio/components';
 import { FormLayoutWarning } from './FormLayoutWarning';
 import { BASE_CONTAINER_ID } from 'app-shared/constants';
 import { AddItem } from './AddItem';
@@ -39,8 +38,8 @@ export const FormLayout = ({ layout, isInvalid, duplicateComponents }: FormLayou
 const MultiPageWarning = () => {
   const { t } = useTranslation();
   return (
-    <Alert severity='warning'>
+    <StudioAlert data-color='warning'>
       <StudioParagraph>{t('ux_editor.multi_page_warning')}</StudioParagraph>
-    </Alert>
+    </StudioAlert>
   );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Replace all directly imported alert components with `StudioAlert`


<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Standardised informational, warning and error messages across the application with a consistent alert presentation.
  - Preserved existing alert content, translations, conditional behaviour and dismissal options.
  - Maintained appropriate colour indicators for informational, warning and error states.
  - Updated compact alerts to use the supported small-size styling.
  - Improved consistency across deployment, editing, configuration, preview and content-library screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->