### PR TITLE
refactor: move `ButtonLayout` komponent to lib

### DIFF
--- a/src/App/frontend/src/layout/Button/ButtonComponent.tsx
+++ b/src/App/frontend/src/layout/Button/ButtonComponent.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { ButtonLayout } from '@app/form-component';
+import type { ValidLanguageKey } from '@app/language';
 
 import { AttachmentReadModel } from 'src/features/attachments/hooks/attachmentReadModel';
 import { FormStore } from 'src/features/form/FormContext';
@@ -8,7 +9,6 @@ import { getUiConfig } from 'src/features/form/ui';
 import { useProcessNext } from 'src/features/instance/useProcessNext';
 import { useProcessQuery, useTaskTypeFromBackend } from 'src/features/instance/useProcessQuery';
 import { Lang } from 'src/features/language/Lang';
-import { useLanguage } from 'src/features/language/useLanguage';
 import { useIsSubformPage } from 'src/hooks/navigation';
 import { getComponentFromMode } from 'src/layout/Button/getComponentFromMode';
 import { ProcessTaskType } from 'src/types';
@@ -18,7 +18,7 @@ import type { AttachmentState } from 'src/features/attachments/types';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { CompInternal } from 'src/layout/layout';
 
-const PENDING_STATUS_MESSAGES: Partial<Record<AttachmentState, string>> = {
+const PENDING_STATUS_MESSAGES: Partial<Record<AttachmentState, ValidLanguageKey>> = {
   Pending: 'general.wait_for_attachments_scanning',
   uploading: 'general.wait_for_attachments',
 };
@@ -30,7 +30,6 @@ export type IButtonProvidedProps =
 export const ButtonComponent = ({ baseComponentId, ...componentProps }: PropsFromGenericComponent<'Button'>) => {
   const item = useItemWhenType(baseComponentId, 'Button');
   const mode = item.type === 'Button' ? item.mode : undefined;
-  const { langAsString } = useLanguage();
   const { innerGrid } = useComponentStructureData(baseComponentId);
   const props: IButtonProvidedProps = { baseComponentId, ...componentProps, ...item };
 
@@ -77,8 +76,7 @@ export const ButtonComponent = ({ baseComponentId, ...componentProps }: PropsFro
     (currentTaskType === ProcessTaskType.Data && !write) ||
     (currentTaskType === ProcessTaskType.Confirm && !actions?.confirm);
 
-  const statusMessageKey = attachmentState.hasPending ? PENDING_STATUS_MESSAGES[attachmentState.state] : undefined;
-  const statusMessage = statusMessageKey ? langAsString(statusMessageKey) : undefined;
+  const statusMessage = attachmentState.hasPending ? PENDING_STATUS_MESSAGES[attachmentState.state] : undefined;
 
   return (
     <ButtonLayout

--- a/src/App/frontend/src/layout/Button/ButtonComponent.tsx
+++ b/src/App/frontend/src/layout/Button/ButtonComponent.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Button } from '@app/form-component';
+import { ButtonLayout } from '@app/form-component';
 
 import { AttachmentReadModel } from 'src/features/attachments/hooks/attachmentReadModel';
 import { FormStore } from 'src/features/form/FormContext';
@@ -11,12 +11,17 @@ import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { useIsSubformPage } from 'src/hooks/navigation';
 import { getComponentFromMode } from 'src/layout/Button/getComponentFromMode';
-import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
-import { alignStyle } from 'src/layout/RepeatingGroup/Container/RepeatingGroupContainer';
 import { ProcessTaskType } from 'src/types';
+import { useComponentStructureData } from 'src/utils/layout/useComponentStructureData';
 import { useItemWhenType } from 'src/utils/layout/useNodeItem';
+import type { AttachmentState } from 'src/features/attachments/types';
 import type { PropsFromGenericComponent } from 'src/layout';
 import type { CompInternal } from 'src/layout/layout';
+
+const PENDING_STATUS_MESSAGES: Partial<Record<AttachmentState, string>> = {
+  Pending: 'general.wait_for_attachments_scanning',
+  uploading: 'general.wait_for_attachments',
+};
 
 export type IButtonProvidedProps =
   | (PropsFromGenericComponent<'Button'> & CompInternal<'Button'>)
@@ -26,6 +31,7 @@ export const ButtonComponent = ({ baseComponentId, ...componentProps }: PropsFro
   const item = useItemWhenType(baseComponentId, 'Button');
   const mode = item.type === 'Button' ? item.mode : undefined;
   const { langAsString } = useLanguage();
+  const { innerGrid } = useComponentStructureData(baseComponentId);
   const props: IButtonProvidedProps = { baseComponentId, ...componentProps, ...item };
 
   const currentTaskType = useTaskTypeFromBackend();
@@ -71,28 +77,22 @@ export const ButtonComponent = ({ baseComponentId, ...componentProps }: PropsFro
     (currentTaskType === ProcessTaskType.Data && !write) ||
     (currentTaskType === ProcessTaskType.Confirm && !actions?.confirm);
 
+  const statusMessageKey = attachmentState.hasPending ? PENDING_STATUS_MESSAGES[attachmentState.state] : undefined;
+  const statusMessage = statusMessageKey ? langAsString(statusMessageKey) : undefined;
+
   return (
-    <ComponentStructureWrapper baseComponentId={baseComponentId}>
-      <Button
-        style={item?.position ? { ...alignStyle(item?.position) } : {}}
-        textAlign={item.textAlign}
-        size={item.size}
-        fullWidth={item.fullWidth}
-        id={item.id}
-        onClick={submitTask}
-        isLoading={isProcessingNext || isConfirming}
-        loadingLabel={langAsString('general.loading')}
-        disabled={disabled}
-        color='success'
-      >
-        <Lang id={item.textResourceBindings?.title} />
-      </Button>
-      {attachmentState.hasPending && attachmentState.state !== 'Infected' && (
-        <span style={{ position: 'absolute' }}>
-          {attachmentState.state === 'Pending' && langAsString('general.wait_for_attachments_scanning')}
-          {attachmentState.state === 'uploading' && langAsString('general.wait_for_attachments')}
-        </span>
-      )}
-    </ComponentStructureWrapper>
+    <ButtonLayout
+      componentId={item.id}
+      title={item.textResourceBindings?.title}
+      size={item.size}
+      fullWidth={item.fullWidth}
+      textAlign={item.textAlign}
+      position={item.position}
+      disabled={disabled}
+      isLoading={isProcessingNext || isConfirming}
+      onClick={submitTask}
+      statusMessage={statusMessage}
+      innerGrid={innerGrid}
+    />
   );
 };

--- a/src/common/ts/form-component/src/layout-components/Button/ButtonLayout.mdx
+++ b/src/common/ts/form-component/src/layout-components/Button/ButtonLayout.mdx
@@ -1,0 +1,9 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+import { LayoutComponentDocs } from '../common/storybook';
+import * as ButtonLayoutStories from './ButtonLayout.stories';
+import { BUTTON_LAYOUT_PROP_CATEGORIES } from './ButtonLayout.stories';
+
+<Meta of={ButtonLayoutStories} />
+
+<LayoutComponentDocs categories={BUTTON_LAYOUT_PROP_CATEGORIES} />

--- a/src/common/ts/form-component/src/layout-components/Button/ButtonLayout.stories.tsx
+++ b/src/common/ts/form-component/src/layout-components/Button/ButtonLayout.stories.tsx
@@ -1,0 +1,85 @@
+import { fn } from 'storybook/test';
+import type { PropCategories } from '@app/form-component/layout-components/common/storybook';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { ButtonLayout } from './ButtonLayout';
+import type { ButtonLayoutProps } from './ButtonLayout';
+
+export const BUTTON_LAYOUT_PROP_CATEGORIES = {
+  title: 'text',
+  componentId: 'content',
+  size: 'content',
+  fullWidth: 'content',
+  textAlign: 'content',
+  position: 'content',
+  disabled: 'runtime',
+  isLoading: 'runtime',
+  onClick: 'runtime',
+  statusMessage: 'runtime',
+  innerGrid: 'content',
+} satisfies PropCategories<ButtonLayoutProps>;
+
+const meta = {
+  title: 'LayoutComponents/Button',
+  component: ButtonLayout,
+  excludeStories: ['BUTTON_LAYOUT_PROP_CATEGORIES'],
+  parameters: {
+    layout: 'padded',
+  },
+  argTypes: {
+    size: {
+      control: 'radio',
+      options: ['sm', 'md', 'lg'],
+    },
+    textAlign: {
+      control: 'radio',
+      options: ['left', 'center', 'right'],
+    },
+    position: {
+      control: 'radio',
+      options: ['left', 'center', 'right'],
+    },
+  },
+  args: {
+    componentId: 'button-preview',
+    title: 'Send inn',
+    size: 'md',
+    onClick: fn(),
+  },
+} satisfies Meta<typeof ButtonLayout>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Preview: Story = {};
+
+export const Small: Story = {
+  args: {
+    title: 'Liten knapp',
+    size: 'sm',
+  },
+};
+
+export const LargeFullWidth: Story = {
+  args: {
+    title: 'Venstrestilt tekst',
+    size: 'lg',
+    fullWidth: true,
+    textAlign: 'left',
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    title: 'Sender inn',
+    isLoading: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    title: 'Send inn',
+    disabled: true,
+  },
+};

--- a/src/common/ts/form-component/src/layout-components/Button/ButtonLayout.test.tsx
+++ b/src/common/ts/form-component/src/layout-components/Button/ButtonLayout.test.tsx
@@ -38,7 +38,7 @@ describe('ButtonLayout', () => {
   });
 
   it('shows a status message when provided', () => {
-    render({ statusMessage: 'Venter på vedlegg' });
-    expect(screen.getByText('Venter på vedlegg')).toBeInTheDocument();
+    render({ statusMessage: 'general.wait_for_attachments' }, { language: 'nb' });
+    expect(screen.getByText('Vent litt, vi prosesserer vedlegg')).toBeInTheDocument();
   });
 });

--- a/src/common/ts/form-component/src/layout-components/Button/ButtonLayout.test.tsx
+++ b/src/common/ts/form-component/src/layout-components/Button/ButtonLayout.test.tsx
@@ -1,0 +1,44 @@
+import type { ComponentProps } from 'react';
+
+import {
+  renderWithTranslations,
+  type RenderWithTranslationsOptions,
+} from '@app/form-component/test/renderWithTranslations';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ButtonLayout } from './ButtonLayout';
+
+const render = (
+  props?: Partial<ComponentProps<typeof ButtonLayout>>,
+  options?: RenderWithTranslationsOptions,
+) =>
+  renderWithTranslations(
+    <ButtonLayout componentId='btn-1' title='my.title' onClick={() => undefined} {...props} />,
+    options,
+  );
+
+describe('ButtonLayout', () => {
+  it('shows the button label', () => {
+    render({ title: 'my.title' }, { overrides: { 'my.title': 'Send inn' } });
+    expect(screen.getByRole('button', { name: 'Send inn' })).toBeInTheDocument();
+  });
+
+  it('calls onClick when the button is pressed', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render({ onClick });
+    await user.click(screen.getByRole('button'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the form-content wrapper for the given componentId', () => {
+    render({ componentId: 'submit-1' });
+    expect(document.getElementById('form-content-submit-1')).toBeInTheDocument();
+  });
+
+  it('shows a status message when provided', () => {
+    render({ statusMessage: 'Venter på vedlegg' });
+    expect(screen.getByText('Venter på vedlegg')).toBeInTheDocument();
+  });
+});

--- a/src/common/ts/form-component/src/layout-components/Button/ButtonLayout.tsx
+++ b/src/common/ts/form-component/src/layout-components/Button/ButtonLayout.tsx
@@ -1,0 +1,71 @@
+import type { CSSProperties } from 'react';
+
+import { Button } from '@app/form-component/app-components/Button';
+import { useTranslation } from '@app/form-component/LanguageTranslatorProvider';
+import { ComponentStructure } from '@app/form-component/layout-components/common/ComponentStructure';
+import type { TextAlign } from '@app/form-component/app-components/Button';
+import type { IGridStyling } from '@app/form-component/app-components/Flex';
+
+export type ButtonLayoutSize = 'sm' | 'md' | 'lg';
+export type ButtonLayoutPosition = 'left' | 'center' | 'right';
+
+export interface ButtonLayoutProps {
+  componentId: string;
+  title?: string;
+  size?: ButtonLayoutSize;
+  fullWidth?: boolean;
+  textAlign?: TextAlign;
+  position?: ButtonLayoutPosition;
+  disabled?: boolean;
+  isLoading?: boolean;
+  onClick: () => void;
+  statusMessage?: string;
+  innerGrid?: IGridStyling;
+}
+
+function alignStyle(align: ButtonLayoutPosition): CSSProperties {
+  switch (align) {
+    case 'right':
+      return { marginLeft: 'auto' };
+    case 'center':
+      return { margin: '0 auto' };
+    default:
+      return {};
+  }
+}
+
+export function ButtonLayout({
+  componentId,
+  title,
+  size,
+  fullWidth,
+  textAlign,
+  position,
+  disabled = false,
+  isLoading = false,
+  onClick,
+  statusMessage,
+  innerGrid,
+}: ButtonLayoutProps) {
+  const { lang, langAsString } = useTranslation();
+
+  return (
+    <ComponentStructure componentId={componentId} innerGrid={innerGrid}>
+      <Button
+        id={componentId}
+        style={position ? alignStyle(position) : {}}
+        textAlign={textAlign}
+        size={size}
+        fullWidth={fullWidth}
+        onClick={onClick}
+        isLoading={isLoading}
+        loadingLabel={langAsString('general.loading')}
+        disabled={disabled}
+        color='success'
+      >
+        {lang(title)}
+      </Button>
+      {statusMessage && <span style={{ position: 'absolute' }}>{statusMessage}</span>}
+    </ComponentStructure>
+  );
+}

--- a/src/common/ts/form-component/src/layout-components/Button/ButtonLayout.tsx
+++ b/src/common/ts/form-component/src/layout-components/Button/ButtonLayout.tsx
@@ -65,7 +65,7 @@ export function ButtonLayout({
       >
         {lang(title)}
       </Button>
-      {statusMessage && <span style={{ position: 'absolute' }}>{statusMessage}</span>}
+      {statusMessage && <span style={{ position: 'absolute' }}>{lang(statusMessage)}</span>}
     </ComponentStructure>
   );
 }

--- a/src/common/ts/form-component/src/layout-components/Button/index.ts
+++ b/src/common/ts/form-component/src/layout-components/Button/index.ts
@@ -1,0 +1,2 @@
+export { ButtonLayout } from './ButtonLayout';
+export type { ButtonLayoutProps, ButtonLayoutSize, ButtonLayoutPosition } from './ButtonLayout';

--- a/src/common/ts/form-component/src/layout-components/index.ts
+++ b/src/common/ts/form-component/src/layout-components/index.ts
@@ -4,6 +4,7 @@ export * from './Address';
 export * from './Alert';
 export * from './AttachmentList';
 export * from './Audio';
+export * from './Button';
 export * from './ButtonGroup';
 export * from './Date';
 export * from './Datepicker';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Moves the presentational parts of the layout Button component into `@app/form-component `as `ButtonLayout`, and leaves a thin runtime wrapper in app-frontend (`ButtonComponent`).

- **Lib:** (`ButtonLayout`): ComponentStructure, success-styled button (size / fullWidth / textAlign / position), loading/disabled, optional attachment status message, onClick as a prop
- **Wrapper:**: process next/confirm, attachment pending/disable logic, mode → InstantiationButton, wires props into ButtonLayout

NOTE: 
I named the `Button` `ButtonLayout` because `@app/form-component` already exports an app-components `Button` (the design-system button used across the app). Exporting another Button from `layout-components` causes a TypeScript error. 

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added a reusable button layout with configurable sizes, alignment, full-width display, loading and disabled states, translated labels, and status messages.
  - Added Storybook examples for standard, small, large, full-width, loading, and disabled button variants.

- **Bug Fixes**
  - Preserved attachment status handling, button interactions, loading behaviour, and task submission functionality.

- **Tests**
  - Added coverage for translated labels, click handling, form identifiers, and optional status messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->