### PR TITLE
chore(cli): bump the pinned workflow-engine image to 760d94635e

### DIFF
--- a/src/Runtime/workflow-engine-app/README.md
+++ b/src/Runtime/workflow-engine-app/README.md
@@ -56,7 +56,7 @@ No Docker Compose setup needed — tests use Testcontainers for PostgreSQL and W
 
 ```yaml
 image: ghcr.io/altinn/altinn-studio/runtime-workflow-engine-app
-tag: "5e537dc6d3"
+tag: "760d94635e"
 ```
 
 > Passing `--dev-workflow-engine` instead **disables** that container and routes the engine binding to a local host process (so you can run it yourself with `dotnet run`). In that mode the pinned tag is not used — only the default `studioctl env up` consumes it.

--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -23,6 +23,7 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ### Fixed
 
+- `studioctl env up` now starts a workflow engine that matches the v9 app libraries. The pinned engine image predated a change to the app callback contract, so an app on `Altinn.App.Api`/`Altinn.App.Core` `9.0.0-preview.4` failed as soon as an instance was created, with `AppCommand failed with client error BadRequest` and a complaint about a missing `executionReferenceTime` property. Apps on earlier v9 previews were unaffected and stay working.
 - Relax rules for validating Altinn.App.Api and Altinn.App.Core nuget versions to allow missing Core reference and range versions `8.*`, `[8.11.3]` and `[8.0,9.0)`
 
 ## [0.1.0-preview.21] - 2026-08-11

--- a/src/cli/internal/config/config.yaml
+++ b/src/cli/internal/config/config.yaml
@@ -12,7 +12,7 @@ images:
       tag: "694406e93c"
     workflow-engine:
       image: ghcr.io/altinn/altinn-studio/runtime-workflow-engine-app
-      tag: "5e537dc6d3"
+      tag: "760d94635e"
     workflow-engine-db:
       image: postgres
       tag: "18.3"


### PR DESCRIPTION
## Description

`studioctl env up` pinned the workflow-engine image at `5e537dc6d3`, built six hours before `0331a534a7` (#19762) added the required `executionReferenceTime` property to the AppCommand callback contract. Both sides of that contract changed in one commit, but they ship on independent release trains, and the studioctl pin never moved forward.

The result is that an app on `Altinn.App.Api`/`Altinn.App.Core` `9.0.0-preview.4` — which requires the property — fails as soon as an instance is created against a local `studioctl env up` environment:

```
Altinn.App.Core.Internal.WorkflowEngine.WorkflowExecutionFailedException:
AppCommand failed with client error BadRequest:
  "JSON deserialization for type '...AppCommand.AppCallbackPayload'
   was missing required properties including: 'executionReferenceTime'."
```

This pins the newest `main` build of the engine, `760d94635e`, whose GHCR push job completed and whose manifest resolves. The engine wire contract has exactly one addition between the two builds, so this is the only skew.

Deployed environments were never affected — they track `main` — and apps on earlier v9 previews ignore the extra property, so the bump is safe in both directions.

The `workflow-engine-app` README quotes the pinned tag verbatim, so it is updated to match.

## Related Issue(s)

Reported by a consumer running `brg/konkursbo-meldingkr` on `9.0.0-preview.4` with studioctl `v0.1.0-preview.21`.

## Verification

- [x] Confirmed `760d94635e` emits `executionReferenceTime`, and that `5e537dc6d3` does not
- [x] Confirmed the image exists on GHCR (manifest resolves; the deploy run's push job succeeded)
- [x] `make build`, `make lint` (0 issues) and `make test` green in `src/cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the workflow engine used by `studioctl env up` to support v9 application libraries.
  * Resolved failures affecting apps using version `9.0.0-preview.4`, including missing `executionReferenceTime` data.

* **Documentation**
  * Added a changelog entry describing the compatibility fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->