### PR TITLE
chore: replace dropdown with StudioDropDown

### DIFF
--- a/src/Designer/frontend/app-development/layout/PageHeader/SmallHeaderMenu/SmallHeaderMenu.test.tsx
+++ b/src/Designer/frontend/app-development/layout/PageHeader/SmallHeaderMenu/SmallHeaderMenu.test.tsx
@@ -23,15 +23,12 @@ describe('SmallHeaderMenu', () => {
     const user = userEvent.setup();
     renderSmallHeaderMenu();
 
-    expect(
-      screen.queryByRole('menuitem', {
-        name: textMock(pageHeaderContextMock.menuItems[0].key),
-      }),
-    ).not.toBeInTheDocument();
-
     const button = screen.getByRole('button', { name: textMock('top_menu.menu') });
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+
     await user.click(button);
 
+    expect(button).toHaveAttribute('aria-expanded', 'true');
     expect(
       screen.getByRole('menuitem', {
         name: textMock(pageHeaderContextMock.menuItems[0].key),
@@ -52,11 +49,7 @@ describe('SmallHeaderMenu', () => {
     expect(menuItem).toBeInTheDocument();
     await user.click(menuItem);
 
-    expect(
-      screen.queryByRole('menuitem', {
-        name: textMock(pageHeaderContextMock.menuItems[0].key),
-      }),
-    ).not.toBeInTheDocument();
+    expect(button).toHaveAttribute('aria-expanded', 'false');
   });
 
   it('should display user name and organization in the profile section', async () => {

--- a/src/Designer/frontend/app-development/layout/PageHeader/SmallHeaderMenu/SmallHeaderMenu.tsx
+++ b/src/Designer/frontend/app-development/layout/PageHeader/SmallHeaderMenu/SmallHeaderMenu.tsx
@@ -1,10 +1,9 @@
 import type { ReactElement } from 'react';
-import { useState } from 'react';
+import { Fragment } from 'react';
 import classes from './SmallHeaderMenu.module.css';
 import { useTranslation } from 'react-i18next';
 import { type StudioProfileMenuItem } from '@studio/components';
-import { StudioButton, StudioParagraph, StudioAvatar } from '@studio/components';
-import { DropdownMenu } from '@digdir/designsystemet-react';
+import { StudioDropdown, StudioParagraph, StudioAvatar } from '@studio/components';
 import { type NavigationMenuSmallItem } from 'app-development/types/HeaderMenu/NavigationMenuSmallItem';
 import { type NavigationMenuSmallGroup } from 'app-development/types/HeaderMenu/NavigationMenuSmallGroup';
 import { MenuHamburgerIcon } from '@studio/icons';
@@ -27,35 +26,17 @@ export const SmallHeaderMenu = (): ReactElement => {
 
   const userNameAndOrg = useUserNameAndOrg(user, org, repository);
 
-  const [open, setOpen] = useState<boolean>(false);
-
-  const toggleMenu = () => {
-    setOpen((isOpen) => !isOpen);
-  };
-
-  const close = () => {
-    setOpen(false);
-  };
-
   return (
-    <DropdownMenu onClose={close} open={open}>
-      <DropdownMenu.Trigger asChild>
-        <StudioButton
-          aria-expanded={open}
-          aria-haspopup='menu'
-          onClick={toggleMenu}
-          icon={<MenuHamburgerIcon />}
-          variant='tertiary'
-          data-color='neutral'
-        >
-          {t('top_menu.menu')}
-        </StudioButton>
-      </DropdownMenu.Trigger>
-      <DropdownMenu.Content data-color-scheme='light'>
-        <DropdownContentProfile profileText={userNameAndOrg} />
-        <DropdownMenuGroups profileText={userNameAndOrg} onClickMenuItem={close} />
-      </DropdownMenu.Content>
-    </DropdownMenu>
+    <StudioDropdown
+      icon={<MenuHamburgerIcon />}
+      triggerButtonText={t('top_menu.menu')}
+      triggerButtonVariant='tertiary'
+      data-color='neutral'
+      data-color-scheme='light'
+    >
+      <DropdownContentProfile profileText={userNameAndOrg} />
+      <DropdownMenuGroups profileText={userNameAndOrg} />
+    </StudioDropdown>
   );
 };
 
@@ -82,12 +63,8 @@ const DropdownContentProfile = ({ profileText }: DropdownContentProfileProps): R
 
 type DropdownMenuGroupsProps = {
   profileText: string;
-  onClickMenuItem: () => void;
 };
-const DropdownMenuGroups = ({
-  profileText,
-  onClickMenuItem,
-}: DropdownMenuGroupsProps): ReactElement[] => {
+const DropdownMenuGroups = ({ profileText }: DropdownMenuGroupsProps): ReactElement[] => {
   const { t } = useTranslation();
   const { menuItems, profileMenuItems } = usePageHeaderContext();
 
@@ -108,14 +85,13 @@ const DropdownMenuGroups = ({
   ];
 
   return menuGroups.map((menuGroup: NavigationMenuSmallGroup) => (
-    <DropdownMenu.Group
-      heading={menuGroup.showName && t(menuGroup.name)}
-      className={classes.dropDownMenuGroup}
-      key={menuGroup.name}
-    >
-      {menuGroup.items.map((menuItem: NavigationMenuSmallItem) => (
-        <SmallHeaderMenuItem key={menuItem.name} menuItem={menuItem} onClick={onClickMenuItem} />
-      ))}
-    </DropdownMenu.Group>
+    <Fragment key={menuGroup.name}>
+      {menuGroup.showName && <StudioDropdown.Heading>{t(menuGroup.name)}</StudioDropdown.Heading>}
+      <StudioDropdown.List className={classes.dropDownMenuGroup}>
+        {menuGroup.items.map((menuItem: NavigationMenuSmallItem) => (
+          <SmallHeaderMenuItem key={menuItem.name} menuItem={menuItem} />
+        ))}
+      </StudioDropdown.List>
+    </Fragment>
   ));
 };

--- a/src/Designer/frontend/app-development/layout/PageHeader/SmallHeaderMenu/SmallHeaderMenuItem/SmallHeaderMenuItem.test.tsx
+++ b/src/Designer/frontend/app-development/layout/PageHeader/SmallHeaderMenu/SmallHeaderMenuItem/SmallHeaderMenuItem.test.tsx
@@ -5,9 +5,12 @@ import { MemoryRouter } from 'react-router-dom';
 import { type NavigationMenuSmallItem } from 'app-development/types/HeaderMenu/NavigationMenuSmallItem';
 import { PageHeaderContext } from 'app-development/contexts/PageHeaderContext';
 import userEvent from '@testing-library/user-event';
+import type { UserEvent } from '@testing-library/user-event';
+import { StudioDropdown } from '@studio/components';
 
 const menuItemName: string = 'testMenuItem';
 const menuItemLink: string = '/test-path';
+const triggerButtonText: string = 'openMenu';
 const mockMenuItem: NavigationMenuSmallItem = {
   name: menuItemName,
   action: {
@@ -18,70 +21,57 @@ const mockMenuItem: NavigationMenuSmallItem = {
   isBeta: false,
 };
 
-const mockOnClick = jest.fn();
 const defaultProps: SmallHeaderMenuItemProps = {
   menuItem: mockMenuItem,
-  onClick: mockOnClick,
 };
 
 describe('SmallHeaderMenuItem', () => {
   afterEach(() => jest.clearAllMocks());
 
-  it('should render a NavLink when the menuItem action type is "link"', () => {
-    renderSmallHeaderMenuItem();
+  it('should render a NavLink when the menuItem action type is "link"', async () => {
+    await renderSmallHeaderMenuItem();
 
-    const linkElement = screen.getByRole('menuitem', {
-      name: textMock(menuItemName),
-    });
+    const linkElement = getMenuItem();
     expect(linkElement).toBeInTheDocument();
     expect(linkElement).toHaveAttribute('href', menuItemLink);
   });
 
-  it('should add "active" class when the current route matches the menuItem href', () => {
-    renderSmallHeaderMenuItem({
+  it('should add "active" class when the current route matches the menuItem href', async () => {
+    await renderSmallHeaderMenuItem({
       routerInitialEntries: [menuItemLink],
     });
 
-    const linkElement = screen.getByRole('menuitem', {
-      name: textMock(menuItemName),
-    });
-    expect(linkElement).toHaveClass('active');
+    expect(getMenuItem()).toHaveClass('active');
   });
 
-  it('should add "isBeta" class when menuItem is beta', () => {
-    renderSmallHeaderMenuItem({
+  it('should add "isBeta" class when menuItem is beta', async () => {
+    await renderSmallHeaderMenuItem({
       componentProps: { menuItem: { ...mockMenuItem, isBeta: true } },
     });
 
-    const linkElement = screen.getByRole('menuitem', {
-      name: textMock(menuItemName),
-    });
-    expect(linkElement).toHaveClass('isBeta');
+    expect(getMenuItem()).toHaveClass('isBeta');
   });
 
-  it('should not add "isBeta" class by default', () => {
-    renderSmallHeaderMenuItem();
+  it('should not add "isBeta" class by default', async () => {
+    await renderSmallHeaderMenuItem();
 
-    const linkElement = screen.getByRole('menuitem', {
-      name: textMock(menuItemName),
-    });
-    expect(linkElement).not.toHaveClass('isBeta');
+    expect(getMenuItem()).not.toHaveClass('isBeta');
   });
 
-  it('should call onClick when the NavLink is clicked', async () => {
+  it('should close the menu when the NavLink is clicked', async () => {
     const user = userEvent.setup();
-    renderSmallHeaderMenuItem();
+    await renderSmallHeaderMenuItem({ user });
 
-    const linkElement = screen.getByRole('menuitem', {
-      name: textMock(menuItemName),
-    });
-    await user.click(linkElement);
+    const trigger = screen.getByRole('button', { name: triggerButtonText });
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
 
-    expect(mockOnClick).toHaveBeenCalledTimes(1);
+    await user.click(getMenuItem());
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
   });
 
-  it('should open the link in a new tab when openInNewTab is true', () => {
-    renderSmallHeaderMenuItem({
+  it('should open the link in a new tab when openInNewTab is true', async () => {
+    await renderSmallHeaderMenuItem({
       componentProps: {
         menuItem: {
           ...mockMenuItem,
@@ -94,28 +84,36 @@ describe('SmallHeaderMenuItem', () => {
       },
     });
 
-    const linkElement = screen.getByRole('menuitem', {
-      name: textMock('testMenuItem'),
-    });
+    const linkElement = getMenuItem();
     expect(linkElement).toHaveAttribute('target', '_blank');
     expect(linkElement).toHaveAttribute('rel', 'noopener noreferrer');
   });
 });
 
+const getMenuItem = (): HTMLElement =>
+  screen.getByRole('menuitem', { name: textMock(menuItemName) });
+
 type Props = {
   componentProps: Partial<SmallHeaderMenuItemProps>;
   routerInitialEntries?: string[];
+  user: UserEvent;
 };
 
-const renderSmallHeaderMenuItem = ({
+const renderSmallHeaderMenuItem = async ({
   componentProps,
   routerInitialEntries = ['/'],
-}: Partial<Props> = {}) => {
-  return render(
+  user = userEvent.setup(),
+}: Partial<Props> = {}): Promise<void> => {
+  render(
     <MemoryRouter initialEntries={routerInitialEntries}>
       <PageHeaderContext.Provider value={{ variant: 'regular' }}>
-        <SmallHeaderMenuItem {...defaultProps} {...componentProps} />
+        <StudioDropdown triggerButtonText={triggerButtonText}>
+          <StudioDropdown.List>
+            <SmallHeaderMenuItem {...defaultProps} {...componentProps} />
+          </StudioDropdown.List>
+        </StudioDropdown>
       </PageHeaderContext.Provider>
     </MemoryRouter>,
   );
+  await user.click(screen.getByRole('button', { name: triggerButtonText }));
 };

--- a/src/Designer/frontend/app-development/layout/PageHeader/SmallHeaderMenu/SmallHeaderMenuItem/SmallHeaderMenuItem.tsx
+++ b/src/Designer/frontend/app-development/layout/PageHeader/SmallHeaderMenu/SmallHeaderMenuItem/SmallHeaderMenuItem.tsx
@@ -2,20 +2,16 @@ import type { ReactElement } from 'react';
 import classes from './SmallHeaderMenuItem.module.css';
 import { NavLink, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { DropdownMenu } from '@digdir/designsystemet-react';
+import { StudioDropdown } from '@studio/components';
 import { UrlUtils } from '@studio/pure-functions';
 import { type NavigationMenuSmallItem } from 'app-development/types/HeaderMenu/NavigationMenuSmallItem';
 import { studioBetaTagClasses } from '@studio/components-legacy';
 
 export type SmallHeaderMenuItemProps = {
   menuItem: NavigationMenuSmallItem;
-  onClick: () => void;
 };
 
-export const SmallHeaderMenuItem = ({
-  menuItem,
-  onClick,
-}: SmallHeaderMenuItemProps): ReactElement => {
+export const SmallHeaderMenuItem = ({ menuItem }: SmallHeaderMenuItemProps): ReactElement => {
   const { t } = useTranslation();
 
   const location = useLocation();
@@ -23,9 +19,11 @@ export const SmallHeaderMenuItem = ({
 
   if (menuItem.action.type === 'button') {
     return (
-      <DropdownMenu.Item key={menuItem.name} onClick={menuItem.action.onClick}>
-        {menuItem.name}
-      </DropdownMenu.Item>
+      <StudioDropdown.Item>
+        <StudioDropdown.Button role='menuitem' onClick={menuItem.action.onClick}>
+          {menuItem.name}
+        </StudioDropdown.Button>
+      </StudioDropdown.Item>
     );
   }
 
@@ -35,16 +33,18 @@ export const SmallHeaderMenuItem = ({
       : '';
 
   return (
-    <DropdownMenu.Item key={menuItem.name} asChild className={linkItemClassName}>
-      <NavLink
-        className={menuItem.isBeta && studioBetaTagClasses.isBeta}
-        to={menuItem.action.href}
-        onClick={onClick}
-        target={menuItem.action.openInNewTab ? '_blank' : ''}
-        rel={menuItem.action.openInNewTab ? 'noopener noreferrer' : ''}
-      >
-        {t(menuItem.name)}
-      </NavLink>
-    </DropdownMenu.Item>
+    <StudioDropdown.Item>
+      <StudioDropdown.Button asChild>
+        <NavLink
+          className={`${linkItemClassName} ${menuItem.isBeta ? studioBetaTagClasses.isBeta : ''}`}
+          to={menuItem.action.href}
+          role='menuitem'
+          target={menuItem.action.openInNewTab ? '_blank' : ''}
+          rel={menuItem.action.openInNewTab ? 'noopener noreferrer' : ''}
+        >
+          {t(menuItem.name)}
+        </NavLink>
+      </StudioDropdown.Button>
+    </StudioDropdown.Item>
   );
 };

--- a/src/Designer/frontend/dashboard/pages/PageLayout/DashboardHeader/SmallHeaderMenu/SmallHeaderMenu.test.tsx
+++ b/src/Designer/frontend/dashboard/pages/PageLayout/DashboardHeader/SmallHeaderMenu/SmallHeaderMenu.test.tsx
@@ -22,14 +22,12 @@ describe('SmallHeaderMenu', () => {
     const user = userEvent.setup();
     renderSmallHeaderMenu();
 
-    expect(
-      screen.queryByRole('menuitem', {
-        name: textMock(headerContextValueMock.menuItems[0].key),
-      }),
-    ).not.toBeInTheDocument();
+    const button = getTopMenuButton();
+    expect(button).toHaveAttribute('aria-expanded', 'false');
 
-    await user.click(getTopMenuButton());
+    await user.click(button);
 
+    expect(button).toHaveAttribute('aria-expanded', 'true');
     expect(getMenuItem(0)).toBeInTheDocument();
   });
 
@@ -37,12 +35,14 @@ describe('SmallHeaderMenu', () => {
     const user = userEvent.setup();
     renderSmallHeaderMenu();
 
-    await user.click(getTopMenuButton());
+    const button = getTopMenuButton();
+    await user.click(button);
 
     const menuItem = getMenuItem(0);
     expect(menuItem).toBeInTheDocument();
     await user.click(menuItem);
-    expect(menuItem).not.toBeInTheDocument();
+
+    expect(button).toHaveAttribute('aria-expanded', 'false');
   });
 
   it('should display user name in the profile section', async () => {

--- a/src/Designer/frontend/dashboard/pages/PageLayout/DashboardHeader/SmallHeaderMenu/SmallHeaderMenu.tsx
+++ b/src/Designer/frontend/dashboard/pages/PageLayout/DashboardHeader/SmallHeaderMenu/SmallHeaderMenu.tsx
@@ -1,10 +1,9 @@
-import { useState } from 'react';
+import { Fragment } from 'react';
 import type { ReactElement } from 'react';
 import classes from './SmallHeaderMenu.module.css';
 import { useTranslation } from 'react-i18next';
-import { StudioButton, StudioParagraph, StudioAvatar } from '@studio/components';
+import { StudioDropdown, StudioParagraph, StudioAvatar } from '@studio/components';
 import { MenuHamburgerIcon } from '@studio/icons';
-import { DropdownMenu } from '@digdir/designsystemet-react';
 import { useHeaderContext } from '../../../../context/HeaderContext';
 import type { HeaderMenuGroup } from '../../../../types/HeaderMenuGroup';
 import { SmallHeaderMenuItem } from './SmallHeaderMenuItem';
@@ -19,35 +18,18 @@ import { useSelectedContext } from '../../../../hooks/useSelectedContext';
 
 export function SmallHeaderMenu(): ReactElement {
   const { t } = useTranslation();
-  const [open, setOpen] = useState<boolean>(false);
-
-  const toggleMenu = () => {
-    setOpen((isOpen) => !isOpen);
-  };
-
-  const handleClose = () => {
-    setOpen(false);
-  };
 
   return (
-    <DropdownMenu onClose={handleClose} open={open}>
-      <DropdownMenu.Trigger asChild>
-        <StudioButton
-          aria-expanded={open}
-          aria-haspopup='menu'
-          onClick={toggleMenu}
-          icon={<MenuHamburgerIcon />}
-          variant='tertiary'
-          data-color='neutral'
-        >
-          {t('top_menu.menu')}
-        </StudioButton>
-      </DropdownMenu.Trigger>
-      <DropdownMenu.Content>
-        <DropdownContentProfile />
-        <DropdownMenuGroups onClickMenuItem={handleClose} />
-      </DropdownMenu.Content>
-    </DropdownMenu>
+    <StudioDropdown
+      icon={<MenuHamburgerIcon />}
+      triggerButtonText={t('top_menu.menu')}
+      triggerButtonVariant='tertiary'
+      data-color='neutral'
+      data-color-scheme='light'
+    >
+      <DropdownContentProfile />
+      <DropdownMenuGroups />
+    </StudioDropdown>
   );
 }
 
@@ -70,10 +52,7 @@ const DropdownContentProfile = (): ReactElement => {
   );
 };
 
-type DropdownMenuGroupsProps = {
-  onClickMenuItem: () => void;
-};
-const DropdownMenuGroups = ({ onClickMenuItem }: DropdownMenuGroupsProps): ReactElement[] => {
+const DropdownMenuGroups = (): ReactElement[] => {
   const { t } = useTranslation();
   const { menuItems, profileMenuGroups } = useHeaderContext();
   const selectedContext = useSelectedContext();
@@ -87,18 +66,13 @@ const DropdownMenuGroups = ({ onClickMenuItem }: DropdownMenuGroupsProps): React
   ];
 
   return menuGroups.map((menuGroup: NavigationMenuGroup) => (
-    <DropdownMenu.Group
-      heading={menuGroup.showName && t(menuGroup.name)}
-      className={classes.dropDownMenuGroup}
-      key={menuGroup.items.map((item) => item.itemName).join('-')}
-    >
-      {menuGroup.items.map((menuItem: NavigationMenuItem) => (
-        <SmallHeaderMenuItem
-          key={menuItem.itemName}
-          menuItem={menuItem}
-          onClick={onClickMenuItem}
-        />
-      ))}
-    </DropdownMenu.Group>
+    <Fragment key={menuGroup.items.map((item) => item.itemName).join('-')}>
+      {menuGroup.showName && <StudioDropdown.Heading>{t(menuGroup.name)}</StudioDropdown.Heading>}
+      <StudioDropdown.List className={classes.dropDownMenuGroup}>
+        {menuGroup.items.map((menuItem: NavigationMenuItem) => (
+          <SmallHeaderMenuItem key={menuItem.itemName} menuItem={menuItem} />
+        ))}
+      </StudioDropdown.List>
+    </Fragment>
   ));
 };

--- a/src/Designer/frontend/dashboard/pages/PageLayout/DashboardHeader/SmallHeaderMenu/SmallHeaderMenuItem/SmallHeaderMenuItem.test.tsx
+++ b/src/Designer/frontend/dashboard/pages/PageLayout/DashboardHeader/SmallHeaderMenu/SmallHeaderMenuItem/SmallHeaderMenuItem.test.tsx
@@ -2,6 +2,8 @@ import { screen, render } from '@testing-library/react';
 import { SmallHeaderMenuItem, type SmallHeaderMenuItemProps } from './SmallHeaderMenuItem';
 import { textMock } from '@studio/testing/mocks/i18nMock';
 import userEvent from '@testing-library/user-event';
+import type { UserEvent } from '@testing-library/user-event';
+import { StudioDropdown } from '@studio/components';
 import type { NavigationMenuItem } from '../../../../../types/NavigationMenuItem';
 import { HeaderContext, type HeaderContextProps } from '../../../../../context/HeaderContext';
 import { MockServicesContextWrapper } from '../../../../../dashboardTestUtils';
@@ -11,6 +13,7 @@ const origin: string = window.location.origin;
 const menuItemName: string = 'testMenuItem';
 const menuItemLink: string = '/test-path';
 const path: string = `${origin}${menuItemLink}`;
+const triggerButtonText: string = 'openMenu';
 const mockMenuItem: NavigationMenuItem = {
   itemName: menuItemName,
   action: {
@@ -20,41 +23,38 @@ const mockMenuItem: NavigationMenuItem = {
   },
 };
 
-const mockOnClick = jest.fn();
 const defaultProps: SmallHeaderMenuItemProps = {
   menuItem: mockMenuItem,
-  onClick: mockOnClick,
 };
 
 describe('SmallHeaderMenuItem', () => {
   afterEach(() => jest.clearAllMocks());
 
-  it('should render a NavLink when the menuItem action type is "link"', () => {
-    renderSmallHeaderMenuItem();
+  it('should render a NavLink when the menuItem action type is "link"', async () => {
+    await renderSmallHeaderMenuItem();
 
-    const linkElement = screen.getByRole('menuitem', {
-      name: textMock(menuItemName),
-    });
+    const linkElement = getMenuItem(textMock(menuItemName));
     expect(linkElement).toBeInTheDocument();
     expect(linkElement).toHaveAttribute('href', path);
   });
 
-  it('should call onClick when the NavLink is clicked', async () => {
+  it('should close the menu when the NavLink is clicked', async () => {
     const user = userEvent.setup();
-    renderSmallHeaderMenuItem();
+    await renderSmallHeaderMenuItem({ user });
 
-    const linkElement = screen.getByRole('menuitem', {
-      name: textMock(menuItemName),
-    });
-    await user.click(linkElement);
+    const trigger = getTriggerButton();
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
 
-    expect(mockOnClick).toHaveBeenCalledTimes(1);
+    await user.click(getMenuItem(textMock(menuItemName)));
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
   });
 
-  it('should call onClick when the NavLink is clicked when it is a button', async () => {
+  it('should call the action and close the menu when the item is a button', async () => {
     const user = userEvent.setup();
     const menuItemButtonOnClick = jest.fn();
-    renderSmallHeaderMenuItem({
+    await renderSmallHeaderMenuItem({
+      user,
       componentProps: {
         menuItem: {
           ...mockMenuItem,
@@ -66,17 +66,15 @@ describe('SmallHeaderMenuItem', () => {
       },
     });
 
-    const buttonElement = screen.getByRole('menuitem', {
-      name: menuItemName,
-    });
-    await user.click(buttonElement);
+    const trigger = getTriggerButton();
+    await user.click(getMenuItem(menuItemName));
 
-    expect(mockOnClick).toHaveBeenCalledTimes(1);
     expect(menuItemButtonOnClick).toHaveBeenCalledTimes(1);
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
   });
 
-  it('should open the link in a new tab when openInNewTab is true', () => {
-    renderSmallHeaderMenuItem({
+  it('should open the link in a new tab when openInNewTab is true', async () => {
+    await renderSmallHeaderMenuItem({
       componentProps: {
         menuItem: {
           ...mockMenuItem,
@@ -89,30 +87,39 @@ describe('SmallHeaderMenuItem', () => {
       },
     });
 
-    const linkElement = screen.getByRole('menuitem', {
-      name: textMock('testMenuItem'),
-    });
+    const linkElement = getMenuItem(textMock(menuItemName));
     expect(linkElement).toHaveAttribute('target', '_blank');
     expect(linkElement).toHaveAttribute('rel', 'noopener noreferrer');
   });
 });
 
+const getMenuItem = (name: string): HTMLElement => screen.getByRole('menuitem', { name });
+
+const getTriggerButton = (): HTMLElement => screen.getByRole('button', { name: triggerButtonText });
+
 type Props = {
   componentProps: Partial<SmallHeaderMenuItemProps>;
   contextProps: Partial<HeaderContextProps>;
   routerInitialEntries?: string[];
+  user: UserEvent;
 };
 
-const renderSmallHeaderMenuItem = ({
+const renderSmallHeaderMenuItem = async ({
   componentProps,
   routerInitialEntries = ['/'],
   contextProps,
-}: Partial<Props> = {}) => {
-  return render(
+  user = userEvent.setup(),
+}: Partial<Props> = {}): Promise<void> => {
+  render(
     <MockServicesContextWrapper initialEntries={routerInitialEntries}>
       <HeaderContext.Provider value={{ ...headerContextValueMock, ...contextProps }}>
-        <SmallHeaderMenuItem {...defaultProps} {...componentProps} />
+        <StudioDropdown triggerButtonText={triggerButtonText}>
+          <StudioDropdown.List>
+            <SmallHeaderMenuItem {...defaultProps} {...componentProps} />
+          </StudioDropdown.List>
+        </StudioDropdown>
       </HeaderContext.Provider>
     </MockServicesContextWrapper>,
   );
+  await user.click(getTriggerButton());
 };

--- a/src/Designer/frontend/dashboard/pages/PageLayout/DashboardHeader/SmallHeaderMenu/SmallHeaderMenuItem/SmallHeaderMenuItem.tsx
+++ b/src/Designer/frontend/dashboard/pages/PageLayout/DashboardHeader/SmallHeaderMenu/SmallHeaderMenuItem/SmallHeaderMenuItem.tsx
@@ -2,37 +2,30 @@ import type { ReactElement } from 'react';
 import classes from './SmallHeaderMenuItem.module.css';
 import { NavLink } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { DropdownMenu } from '@digdir/designsystemet-react';
+import { StudioDropdown } from '@studio/components';
 import type { NavigationMenuItem } from '../../../../../types/NavigationMenuItem';
 
 export type SmallHeaderMenuItemProps = {
   menuItem: NavigationMenuItem;
-  onClick: () => void;
 };
 
-export const SmallHeaderMenuItem = ({
-  menuItem,
-  onClick,
-}: SmallHeaderMenuItemProps): ReactElement => {
+export const SmallHeaderMenuItem = ({ menuItem }: SmallHeaderMenuItemProps): ReactElement => {
   const { t } = useTranslation();
   const origin = window.location.origin;
 
   if (menuItem.action.type === 'button') {
-    const handleClick = () => {
-      onClick();
-      menuItem.action.type === 'button' && menuItem.action.onClick();
-    };
-
     const buttonItemClassName: string = menuItem.isActive ? classes.active : '';
 
     return (
-      <DropdownMenu.Item
-        key={menuItem.itemName}
-        onClick={handleClick}
-        className={buttonItemClassName}
-      >
-        {menuItem.itemName}
-      </DropdownMenu.Item>
+      <StudioDropdown.Item>
+        <StudioDropdown.Button
+          role='menuitem'
+          className={buttonItemClassName}
+          onClick={menuItem.action.onClick}
+        >
+          {menuItem.itemName}
+        </StudioDropdown.Button>
+      </StudioDropdown.Item>
     );
   }
 
@@ -40,15 +33,17 @@ export const SmallHeaderMenuItem = ({
   const linkRel: string = menuItem.action.openInNewTab ? 'noopener noreferrer' : '';
 
   return (
-    <DropdownMenu.Item key={menuItem.itemName} asChild>
-      <NavLink
-        to={`${origin}${menuItem.action.href}`}
-        onClick={onClick}
-        target={linkTarget}
-        rel={linkRel}
-      >
-        {t(menuItem.itemName)}
-      </NavLink>
-    </DropdownMenu.Item>
+    <StudioDropdown.Item>
+      <StudioDropdown.Button asChild>
+        <NavLink
+          to={`${origin}${menuItem.action.href}`}
+          role='menuitem'
+          target={linkTarget}
+          rel={linkRel}
+        >
+          {t(menuItem.itemName)}
+        </NavLink>
+      </StudioDropdown.Button>
+    </StudioDropdown.Item>
   );
 };

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioDropdown/StudioDropdown.test.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioDropdown/StudioDropdown.test.tsx
@@ -17,6 +17,16 @@ describe('StudioDropdown', () => {
     expect(triggerButton).toHaveAttribute('aria-expanded', 'true');
   });
 
+  it('Closes the dropdown menu when the trigger button is clicked again', async () => {
+    const user = userEvent.setup();
+    renderStudioDropdown();
+    const triggerButton = getButton(triggerButtonText);
+    await openDropdown(user);
+    expect(triggerButton).toHaveAttribute('aria-expanded', 'true');
+    await user.click(triggerButton);
+    expect(triggerButton).toHaveAttribute('aria-expanded', 'false');
+  });
+
   it('Renders all headings', async () => {
     const user = userEvent.setup();
     renderStudioDropdown();

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioDropdown/StudioDropdown.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioDropdown/StudioDropdown.tsx
@@ -19,7 +19,7 @@ export type StudioDropdownProps = {
   triggerButtonClassName?: string;
 
   'data-color-scheme'?: 'light' | 'dark';
-} & Omit<WithoutAsChild<DropdownProps>, 'anchorEl' | 'open' | 'onClose'>;
+} & Omit<WithoutAsChild<DropdownProps>, 'anchorEl' | 'open' | 'onClose' | 'onOpen'>;
 
 export function StudioDropdown({
   icon,
@@ -37,16 +37,11 @@ export function StudioDropdown({
 }: StudioDropdownProps): ReactElement {
   const [open, setOpen] = useState<boolean>(false);
 
-  const handleClick = (): void => {
-    setOpen((oldValue: boolean) => !oldValue);
-  };
-
   return (
     <Dropdown.TriggerContext>
       <Dropdown.Trigger
         data-color={dataColor}
         variant={triggerButtonVariant}
-        onClick={handleClick}
         icon={!triggerButtonText}
         disabled={triggerButtonDisabled}
         aria-label={triggerButtonAriaLabel}
@@ -59,8 +54,9 @@ export function StudioDropdown({
         </TextWithIcon>
       </Dropdown.Trigger>
       <Dropdown
-        onClose={() => setOpen(false)}
         open={open}
+        onOpen={() => setOpen(true)}
+        onClose={() => setOpen(false)}
         data-color-scheme={dataColorScheme}
         {...rest}
       >

--- a/src/Designer/frontend/packages/policy-editor/src/components/PolicyCardRules/PolicyRule/ExpandablePolicyElement/ExpandablePolicyElement.tsx
+++ b/src/Designer/frontend/packages/policy-editor/src/components/PolicyCardRules/PolicyRule/ExpandablePolicyElement/ExpandablePolicyElement.tsx
@@ -30,14 +30,9 @@ export const ExpandablePolicyElement = ({
   const { usageType } = usePolicyEditorContext();
 
   const [isOpen, setIsOpen] = useState(usageType !== 'app');
-  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
   const [isButtonFocused, setIsButtonFocused] = useState(false);
   const [isButtonHovered, setIsButtonHovered] = useState(false);
-
-  const handleClickMoreButton = () => {
-    setIsDropdownOpen((prev) => !prev);
-  };
 
   const getTopWrapperErrorClassName = () => {
     if (isCard && hasError) {
@@ -93,17 +88,8 @@ export const ExpandablePolicyElement = ({
           )}
         </button>
         <PolicyEditorDropdownMenu
-          isOpen={isDropdownOpen}
-          handleClickMoreIcon={handleClickMoreButton}
-          handleCloseMenu={() => setIsDropdownOpen(false)}
-          handleClone={() => {
-            handleCloneElement();
-            setIsDropdownOpen(false);
-          }}
-          handleDelete={() => {
-            handleRemoveElement();
-            setIsDropdownOpen(false);
-          }}
+          handleClone={handleCloneElement}
+          handleDelete={handleRemoveElement}
           isError={hasError}
         />
       </div>

--- a/src/Designer/frontend/packages/policy-editor/src/components/PolicyCardRules/PolicyRule/ExpandablePolicyElement/PolicyEditorDropdownMenu/PolicyEditorDropdownMenu.test.tsx
+++ b/src/Designer/frontend/packages/policy-editor/src/components/PolicyCardRules/PolicyRule/ExpandablePolicyElement/PolicyEditorDropdownMenu/PolicyEditorDropdownMenu.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { UserEvent } from '@testing-library/user-event';
 import type { PolicyEditorDropdownMenuProps } from './PolicyEditorDropdownMenu';
 import { PolicyEditorDropdownMenu } from './PolicyEditorDropdownMenu';
 import { textMock } from '@studio/testing/mocks/i18nMock';
@@ -7,59 +8,61 @@ import { textMock } from '@studio/testing/mocks/i18nMock';
 describe('PolicyEditorDropdownMenu', () => {
   afterEach(jest.clearAllMocks);
 
-  const mockHandleClickMoreIcon = jest.fn();
-  const mockHandleCloseMenu = jest.fn();
   const mockHandleClone = jest.fn();
   const mockHandleDelete = jest.fn();
 
   const defaultProps: PolicyEditorDropdownMenuProps = {
-    isOpen: true,
-    handleClickMoreIcon: mockHandleClickMoreIcon,
-    handleCloseMenu: mockHandleCloseMenu,
     handleClone: mockHandleClone,
     handleDelete: mockHandleDelete,
   };
 
-  it('calls handleClickMoreIcon when the menu icon is clicked', async () => {
+  it('keeps the menu closed until the menu icon is clicked', async () => {
     const user = userEvent.setup();
     render(<PolicyEditorDropdownMenu {...defaultProps} />);
 
-    const menuButton = screen.getByRole('button', { name: textMock('policy_editor.more') });
-    await user.click(menuButton);
+    expect(getMenuButton()).toHaveAttribute('aria-expanded', 'false');
 
-    expect(mockHandleClickMoreIcon).toHaveBeenCalledTimes(1);
-  });
+    await user.click(getMenuButton());
 
-  it('does not render the dropdown menu when isOpen is false', () => {
-    render(<PolicyEditorDropdownMenu {...defaultProps} isOpen={false} />);
-
-    const dropdownMenu = screen.queryByRole('button', {
-      name: textMock('policy_editor.expandable_card_dropdown_copy'),
-    });
-    expect(dropdownMenu).not.toBeInTheDocument();
+    expect(getMenuButton()).toHaveAttribute('aria-expanded', 'true');
   });
 
   it('calls handleClone when the "Copy" button is clicked', async () => {
     const user = userEvent.setup();
-    render(<PolicyEditorDropdownMenu {...defaultProps} />);
+    await renderAndOpenMenu(user);
 
-    const copyButton = screen.getByRole('menuitem', {
-      name: textMock('policy_editor.expandable_card_dropdown_copy'),
-    });
-    await user.click(copyButton);
+    await user.click(
+      screen.getByRole('menuitem', {
+        name: textMock('policy_editor.expandable_card_dropdown_copy'),
+      }),
+    );
 
     expect(mockHandleClone).toHaveBeenCalledTimes(1);
   });
 
   it('calls handleDelete when the "Delete" button is clicked', async () => {
     const user = userEvent.setup();
-    render(<PolicyEditorDropdownMenu {...defaultProps} />);
+    await renderAndOpenMenu(user);
 
-    const deleteButton = screen.getByRole('menuitem', {
-      name: textMock('general.delete'),
-    });
-    await user.click(deleteButton);
+    await user.click(screen.getByRole('menuitem', { name: textMock('general.delete') }));
 
     expect(mockHandleDelete).toHaveBeenCalledTimes(1);
   });
+
+  it('closes the menu when an item is clicked', async () => {
+    const user = userEvent.setup();
+    await renderAndOpenMenu(user);
+
+    await user.click(screen.getByRole('menuitem', { name: textMock('general.delete') }));
+
+    expect(getMenuButton()).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  const getMenuButton = (): HTMLElement =>
+    screen.getByRole('button', { name: textMock('policy_editor.more') });
+
+  const renderAndOpenMenu = async (user: UserEvent): Promise<void> => {
+    render(<PolicyEditorDropdownMenu {...defaultProps} />);
+    await user.click(getMenuButton());
+  };
 });

--- a/src/Designer/frontend/packages/policy-editor/src/components/PolicyCardRules/PolicyRule/ExpandablePolicyElement/PolicyEditorDropdownMenu/PolicyEditorDropdownMenu.tsx
+++ b/src/Designer/frontend/packages/policy-editor/src/components/PolicyCardRules/PolicyRule/ExpandablePolicyElement/PolicyEditorDropdownMenu/PolicyEditorDropdownMenu.tsx
@@ -1,23 +1,16 @@
 import React from 'react';
 import classes from './PolicyEditorDropdownMenu.module.css';
-import { DropdownMenu } from '@digdir/designsystemet-react';
 import { MenuElipsisVerticalIcon, TabsIcon, TrashIcon } from '@studio/icons';
 import { useTranslation } from 'react-i18next';
-import { StudioButton } from '@studio/components';
+import { StudioDropdown } from '@studio/components';
 
 export type PolicyEditorDropdownMenuProps = {
-  isOpen: boolean;
-  handleClickMoreIcon: () => void;
-  handleCloseMenu: () => void;
   handleClone: () => void;
   handleDelete: () => void;
   isError?: boolean;
 };
 
 export const PolicyEditorDropdownMenu = ({
-  isOpen,
-  handleClickMoreIcon,
-  handleCloseMenu,
   handleClone,
   handleDelete,
   isError = false,
@@ -25,31 +18,33 @@ export const PolicyEditorDropdownMenu = ({
   const { t } = useTranslation();
 
   return (
-    <DropdownMenu onClose={handleCloseMenu} placement='bottom-end' size='small' open={isOpen}>
-      <DropdownMenu.Trigger asChild>
-        <StudioButton
-          aria-expanded={isOpen}
-          aria-haspopup='menu'
-          className={isError && classes.errorButton}
-          data-color={isError ? 'danger' : 'second'}
-          icon={<MenuElipsisVerticalIcon fontSize='1.8rem' />}
-          onClick={handleClickMoreIcon}
-          title={t('policy_editor.more')}
-          variant='tertiary'
-        />
-      </DropdownMenu.Trigger>
-      <DropdownMenu.Content>
-        <DropdownMenu.Group>
-          <DropdownMenu.Item onClick={handleClone}>
+    <StudioDropdown
+      icon={<MenuElipsisVerticalIcon fontSize='1.8rem' />}
+      triggerButtonVariant='tertiary'
+      triggerButtonTitle={t('policy_editor.more')}
+      triggerButtonClassName={isError ? classes.errorButton : undefined}
+      data-color={isError ? 'danger' : 'second'}
+      data-size='sm'
+      placement='bottom-end'
+    >
+      <StudioDropdown.List>
+        <StudioDropdown.Item>
+          <StudioDropdown.Button role='menuitem' onClick={handleClone}>
             <TabsIcon className={classes.icon} />
             {t('policy_editor.expandable_card_dropdown_copy')}
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className={classes.deleteButton} onClick={handleDelete}>
+          </StudioDropdown.Button>
+        </StudioDropdown.Item>
+        <StudioDropdown.Item>
+          <StudioDropdown.Button
+            role='menuitem'
+            className={classes.deleteButton}
+            onClick={handleDelete}
+          >
             <TrashIcon className={classes.icon} />
             {t('general.delete')}
-          </DropdownMenu.Item>
-        </DropdownMenu.Group>
-      </DropdownMenu.Content>
-    </DropdownMenu>
+          </StudioDropdown.Button>
+        </StudioDropdown.Item>
+      </StudioDropdown.List>
+    </StudioDropdown>
   );
 };

--- a/src/Designer/frontend/packages/shared/src/components/PageHeader/PageHeader.test.tsx
+++ b/src/Designer/frontend/packages/shared/src/components/PageHeader/PageHeader.test.tsx
@@ -107,8 +107,12 @@ describe('PageHeader', () => {
   it('hides the center navigation on mobile', () => {
     (useMediaQuery as jest.Mock).mockReturnValue(true);
     renderPageHeader();
-    expect(screen.queryByText(textMock('dashboard.header_item_dashboard'))).not.toBeInTheDocument();
-    expect(screen.queryByText(textMock('dashboard.header_item_library'))).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: textMock('dashboard.header_item_dashboard') }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: textMock('dashboard.header_item_library') }),
+    ).not.toBeInTheDocument();
   });
 
   it('renders the dashboard nav link with correct href', () => {

--- a/src/Designer/frontend/packages/shared/src/components/PageHeader/ProfileMenu/SmallProfileMenu/Items.tsx
+++ b/src/Designer/frontend/packages/shared/src/components/PageHeader/ProfileMenu/SmallProfileMenu/Items.tsx
@@ -1,56 +1,55 @@
 import type { ReactElement } from 'react';
-import { StudioLink } from '@studio/components';
+import { Fragment } from 'react';
+import { StudioDropdown, StudioLink } from '@studio/components';
 import type { StudioProfileMenuGroup } from '@studio/components';
-import { DropdownMenu } from '@digdir/designsystemet-react';
 import classes from './Items.module.css';
 
 type ItemsProps = {
   items: StudioProfileMenuGroup[];
-  onClose: () => void;
 };
 
-export const Items = ({ items, onClose }: ItemsProps): ReactElement => {
+export const Items = ({ items }: ItemsProps): ReactElement => {
   return (
     <>
       {items.map((group, groupIndex) => (
-        <DropdownMenu.Group
-          key={groupIndex}
-          heading={group.name}
-          className={classes.dropDownMenuGroup}
-        >
-          {group.items.map((item) => {
-            const itemKey = `${groupIndex}-${item.itemName}`;
-            const { action } = item;
+        <Fragment key={groupIndex}>
+          <StudioDropdown.Heading>{group.name}</StudioDropdown.Heading>
+          <StudioDropdown.List className={classes.dropDownMenuGroup}>
+            {group.items.map((item) => {
+              const itemKey = `${groupIndex}-${item.itemName}`;
+              const { action } = item;
 
-            if (action.type === 'link') {
+              if (action.type === 'link') {
+                return (
+                  <StudioDropdown.Item key={itemKey}>
+                    <StudioDropdown.Button asChild>
+                      <StudioLink
+                        href={action.href}
+                        role='menuitem'
+                        target={action.openInNewTab ? '_blank' : undefined}
+                        rel={action.openInNewTab ? 'noopener noreferrer' : undefined}
+                      >
+                        {item.itemName}
+                      </StudioLink>
+                    </StudioDropdown.Button>
+                  </StudioDropdown.Item>
+                );
+              }
+
               return (
-                <DropdownMenu.Item key={itemKey} asChild>
-                  <StudioLink
-                    href={action.href}
-                    target={action.openInNewTab ? '_blank' : undefined}
-                    rel={action.openInNewTab ? 'noopener noreferrer' : undefined}
-                    onClick={onClose}
+                <StudioDropdown.Item key={itemKey}>
+                  <StudioDropdown.Button
+                    role='menuitem'
+                    onClick={action.onClick}
+                    className={item.isActive ? classes.active : undefined}
                   >
                     {item.itemName}
-                  </StudioLink>
-                </DropdownMenu.Item>
+                  </StudioDropdown.Button>
+                </StudioDropdown.Item>
               );
-            }
-
-            return (
-              <DropdownMenu.Item
-                key={itemKey}
-                onClick={() => {
-                  action.onClick();
-                  onClose();
-                }}
-                className={item.isActive ? classes.active : undefined}
-              >
-                {item.itemName}
-              </DropdownMenu.Item>
-            );
-          })}
-        </DropdownMenu.Group>
+            })}
+          </StudioDropdown.List>
+        </Fragment>
       ))}
     </>
   );

--- a/src/Designer/frontend/packages/shared/src/components/PageHeader/ProfileMenu/SmallProfileMenu/SmallProfileMenu.test.tsx
+++ b/src/Designer/frontend/packages/shared/src/components/PageHeader/ProfileMenu/SmallProfileMenu/SmallProfileMenu.test.tsx
@@ -60,9 +60,13 @@ describe('SmallProfileMenu', () => {
     expect(getTriggerButton()).toBeInTheDocument();
   });
 
-  it('does not show menu items before the trigger is clicked', () => {
+  it('keeps the menu closed until the trigger is clicked', async () => {
+    const user = userEvent.setup();
     renderSmallMenu();
-    expect(screen.queryByText(textMock('dashboard.header_item_dashboard'))).not.toBeInTheDocument();
+
+    expect(getTriggerButton()).toHaveAttribute('aria-expanded', 'false');
+    await user.click(getTriggerButton());
+    expect(getTriggerButton()).toHaveAttribute('aria-expanded', 'true');
   });
 
   it('shows the trigger profile text and menu items after opening the menu', async () => {
@@ -116,7 +120,7 @@ describe('SmallProfileMenu', () => {
     await user.click(screen.getByRole('menuitem', { name: 'Skatteetaten' }));
 
     expect(mockMenuAction).toHaveBeenCalledTimes(1);
-    expect(screen.queryByRole('menuitem', { name: 'Skatteetaten' })).not.toBeInTheDocument();
+    expect(getTriggerButton()).toHaveAttribute('aria-expanded', 'false');
   });
 
   it('renders links with expected href and target attributes', async () => {

--- a/src/Designer/frontend/packages/shared/src/components/PageHeader/ProfileMenu/SmallProfileMenu/SmallProfileMenu.tsx
+++ b/src/Designer/frontend/packages/shared/src/components/PageHeader/ProfileMenu/SmallProfileMenu/SmallProfileMenu.tsx
@@ -1,10 +1,8 @@
-import { useState } from 'react';
 import type { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
-import { StudioButton } from '@studio/components';
+import { StudioDropdown } from '@studio/components';
 import type { StudioProfileMenuGroup } from '@studio/components';
 import { MenuHamburgerIcon } from '@studio/icons';
-import { DropdownMenu } from '@digdir/designsystemet-react';
 import { TriggerButton } from './TriggerButton';
 import { Items } from './Items';
 
@@ -18,34 +16,16 @@ export const SmallProfileMenu = ({
   items,
 }: SmallProfileMenuProps): ReactElement => {
   const { t } = useTranslation();
-  const [open, setOpen] = useState<boolean>(false);
-
-  const toggleMenu = () => {
-    setOpen((isOpen) => !isOpen);
-  };
-
-  const handleClose = () => {
-    setOpen(false);
-  };
 
   return (
-    <DropdownMenu onClose={handleClose} open={open}>
-      <DropdownMenu.Trigger asChild>
-        <StudioButton
-          aria-expanded={open}
-          aria-haspopup='menu'
-          onClick={toggleMenu}
-          icon={<MenuHamburgerIcon />}
-          variant='tertiary'
-          data-color='neutral'
-        >
-          {t('top_menu.menu')}
-        </StudioButton>
-      </DropdownMenu.Trigger>
-      <DropdownMenu.Content>
-        <TriggerButton triggerButtonText={triggerButtonText} />
-        <Items items={items} onClose={handleClose} />
-      </DropdownMenu.Content>
-    </DropdownMenu>
+    <StudioDropdown
+      icon={<MenuHamburgerIcon />}
+      triggerButtonText={t('top_menu.menu')}
+      triggerButtonVariant='tertiary'
+      data-color='neutral'
+    >
+      <TriggerButton triggerButtonText={triggerButtonText} />
+      <Items items={items} />
+    </StudioDropdown>
   );
 };

--- a/src/Designer/frontend/packages/ux-editor-v3/src/containers/DesignView/PageAccordion/NavigationMenu/InputPopover/InputPopover.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/containers/DesignView/PageAccordion/NavigationMenu/InputPopover/InputPopover.tsx
@@ -1,11 +1,11 @@
 import type { ReactNode, ChangeEvent, KeyboardEvent } from 'react';
 import React, { useState, useRef } from 'react';
 import classes from './InputPopover.module.css';
-import { DropdownMenu } from '@digdir/designsystemet-react';
 import { useTranslation } from 'react-i18next';
 import { getPageNameErrorKey } from '../../../../../utils/designViewUtils';
 import { PencilIcon } from '@studio/icons';
 import {
+  StudioDropdown,
   StudioPopover,
   StudioTextfield,
   StudioButton,
@@ -17,7 +17,7 @@ export type InputPopoverProps = {
   oldName: string;
   layoutOrder: string[];
   saveNewName: (newName: string) => void;
-  onClose: () => void;
+  onClose?: () => void;
 };
 
 /**
@@ -68,22 +68,26 @@ export const InputPopover = ({
   };
 
   const handleClose = () => {
-    onClose();
+    onClose?.();
     setIsEditDialogOpen(false);
   };
 
   return (
     <>
-      <DropdownMenu.Item
-        onClick={() => setIsEditDialogOpen(true)}
-        id='edit-page-button'
-        disabled={disabled}
-        ref={newNameRef}
-        aria-expanded={isEditDialogOpen}
-      >
-        <PencilIcon />
-        {t('ux_editor.page_menu_edit')}
-      </DropdownMenu.Item>
+      <StudioDropdown.Item>
+        <StudioButton
+          variant='tertiary'
+          onClick={() => setIsEditDialogOpen(true)}
+          id='edit-page-button'
+          disabled={disabled}
+          ref={newNameRef}
+          role='menuitem'
+          aria-expanded={isEditDialogOpen}
+        >
+          <PencilIcon />
+          {t('ux_editor.page_menu_edit')}
+        </StudioButton>
+      </StudioDropdown.Item>
       {isEditDialogOpen && (
         <StudioPopover.TriggerContext>
           <StudioPopover.Trigger>

--- a/src/Designer/frontend/packages/ux-editor-v3/src/containers/DesignView/PageAccordion/NavigationMenu/NavigationMenu.test.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/containers/DesignView/PageAccordion/NavigationMenu/NavigationMenu.test.tsx
@@ -42,47 +42,34 @@ describe('NavigationMenu', () => {
     const user = userEvent.setup();
     await render();
 
-    const elementInMenu = screen.queryByText(textMock('ux_editor.page_menu_up'));
-    expect(elementInMenu).not.toBeInTheDocument();
-    const menuButtons = screen.getAllByRole('button', { name: textMock('general.options') });
+    const menuButtons = getMenuButtons();
+    expect(menuButtons[0]).toHaveAttribute('aria-expanded', 'false');
 
     await user.click(menuButtons[0]);
 
-    const elementInMenuAfter = screen.getByRole('menuitem', {
-      name: textMock('ux_editor.page_menu_up'),
-    });
-    expect(elementInMenuAfter).toBeInTheDocument();
+    expect(menuButtons[0]).toHaveAttribute('aria-expanded', 'true');
+    expect(getMenuItem(textMock('ux_editor.page_menu_up'))).toBeInTheDocument();
   });
 
-  it('should close the menu when clicking the menu icon twice', async () => {
+  it('should close the menu when clicking outside it', async () => {
     const user = userEvent.setup();
     await render();
 
-    const elementInMenu = screen.queryByText(textMock('ux_editor.page_menu_up'));
-    expect(elementInMenu).not.toBeInTheDocument();
-
-    const menuButtons = screen.getAllByRole('button', { name: textMock('general.options') });
+    const menuButtons = getMenuButtons();
     await user.click(menuButtons[0]);
+    expect(menuButtons[0]).toHaveAttribute('aria-expanded', 'true');
 
-    const elementInMenuAfter = screen.getByRole('menuitem', {
-      name: textMock('ux_editor.page_menu_up'),
-    });
-    expect(elementInMenuAfter).toBeInTheDocument();
+    await user.click(document.body);
 
-    await user.click(menuButtons[0]);
-
-    const elementInMenuAfterClose = screen.queryByRole('menuitem', {
-      name: textMock('ux_editor.page_menu_up'),
-    });
-    expect(elementInMenuAfterClose).not.toBeInTheDocument();
+    expect(menuButtons[0]).toHaveAttribute('aria-expanded', 'false');
   });
 
   it('Calls updateFormLayoutName with new name when name is changed by the user', async () => {
     const user = userEvent.setup();
     await render();
-    const menuButtons = screen.getAllByRole('button', { name: textMock('general.options') });
+    const menuButtons = getMenuButtons();
     await user.click(menuButtons[0]);
-    await user.click(screen.getByRole('menuitem', { name: textMock('ux_editor.page_menu_edit') }));
+    await user.click(getMenuItem(textMock('ux_editor.page_menu_edit')));
 
     const inputField = screen.getByLabelText(textMock('ux_editor.input_popover_label'));
     expect(inputField).toHaveValue(mockPageName1);
@@ -109,9 +96,9 @@ describe('NavigationMenu', () => {
   it('should close the menu when clicking cancel in the edit name popover', async () => {
     const user = userEvent.setup();
     await render();
-    const menuButtons = screen.getAllByRole('button', { name: textMock('general.options') });
+    const menuButtons = getMenuButtons();
     await user.click(menuButtons[0]);
-    await user.click(screen.getByRole('menuitem', { name: textMock('ux_editor.page_menu_edit') }));
+    await user.click(getMenuItem(textMock('ux_editor.page_menu_edit')));
 
     const cancelButton = screen.getByRole('button', {
       name: textMock('general.cancel'),
@@ -125,7 +112,7 @@ describe('NavigationMenu', () => {
   it('hides the up and down button when page is receipt', async () => {
     const user = userEvent.setup();
     await render({ pageIsReceipt: true });
-    const menuButtons = screen.getAllByRole('button', { name: textMock('general.options') });
+    const menuButtons = getMenuButtons();
     await user.click(menuButtons[0]);
 
     const upButton = screen.queryByRole('menuitem', { name: textMock('ux_editor.page_menu_up') });
@@ -140,13 +127,11 @@ describe('NavigationMenu', () => {
   it('shows the up and down button by default', async () => {
     const user = userEvent.setup();
     await render();
-    const menuButtons = screen.getAllByRole('button', { name: textMock('general.options') });
+    const menuButtons = getMenuButtons();
     await user.click(menuButtons[0]);
 
-    const upButton = screen.getByRole('menuitem', { name: textMock('ux_editor.page_menu_up') });
-    const downButton = screen.getByRole('menuitem', {
-      name: textMock('ux_editor.page_menu_down'),
-    });
+    const upButton = getMenuItem(textMock('ux_editor.page_menu_up'));
+    const downButton = getMenuItem(textMock('ux_editor.page_menu_down'));
 
     expect(upButton).toBeInTheDocument();
     expect(downButton).toBeInTheDocument();
@@ -155,11 +140,9 @@ describe('NavigationMenu', () => {
     const user = userEvent.setup();
     await render();
 
-    const menuButtons = screen.getAllByRole('button', { name: textMock('general.options') });
+    const menuButtons = getMenuButtons();
     await user.click(menuButtons[0]);
-    const menuItemDown = screen.getByRole('menuitem', {
-      name: textMock('ux_editor.page_menu_down'),
-    });
+    const menuItemDown = getMenuItem(textMock('ux_editor.page_menu_down'));
     await user.click(menuItemDown);
 
     expect(queriesMock.saveFormLayoutSettings).toHaveBeenCalledTimes(1);
@@ -169,12 +152,10 @@ describe('NavigationMenu', () => {
       mockSelectedLayoutSet,
       { pages: { order: [layout2NameMock, layout1NameMock] }, receiptLayoutName: 'Kvittering' },
     );
-    expect(menuItemDown).not.toBeInTheDocument();
+    expect(menuButtons[0]).toHaveAttribute('aria-expanded', 'false');
 
     await user.click(menuButtons[1]);
-    const menuItemUp = screen.getByRole('menuitem', {
-      name: textMock('ux_editor.page_menu_up'),
-    });
+    const menuItemUp = getMenuItem(textMock('ux_editor.page_menu_up'), 1);
     await user.click(menuItemUp);
     expect(queriesMock.saveFormLayoutSettings).toHaveBeenCalledTimes(2);
     expect(queriesMock.saveFormLayoutSettings).toHaveBeenCalledWith(
@@ -185,6 +166,12 @@ describe('NavigationMenu', () => {
     );
   });
 });
+
+const getMenuButtons = (): HTMLElement[] =>
+  screen.getAllByRole('button', { name: textMock('general.options') });
+
+const getMenuItem = (name: string, index: number = 0): HTMLElement =>
+  screen.getAllByRole('menuitem', { name })[index];
 
 const waitForData = async () => {
   const getFormLayoutSettings = jest

--- a/src/Designer/frontend/packages/ux-editor-v3/src/containers/DesignView/PageAccordion/NavigationMenu/NavigationMenu.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/containers/DesignView/PageAccordion/NavigationMenu/NavigationMenu.tsx
@@ -1,6 +1,5 @@
-import { useState, type JSX } from 'react';
+import type { JSX } from 'react';
 import { useTranslation } from 'react-i18next';
-import { DropdownMenu } from '@digdir/designsystemet-react';
 import { MenuElipsisVerticalIcon, ArrowUpIcon, ArrowDownIcon } from '@studio/icons';
 import { useFormLayoutSettingsQuery } from '../../../../hooks/queries/useFormLayoutSettingsQuery';
 import { useUpdateLayoutOrderMutation } from '../../../../hooks/mutations/useUpdateLayoutOrderMutation';
@@ -12,7 +11,7 @@ import { useSearchParams } from 'react-router-dom';
 import { InputPopover } from './InputPopover';
 import { ObjectUtils } from '@studio/pure-functions';
 import { useAppContext } from '../../../../hooks/useAppContext';
-import { StudioButton } from '@studio/components';
+import { StudioDropdown } from '@studio/components';
 
 export type NavigationMenuProps = {
   pageName: string;
@@ -50,13 +49,10 @@ export const NavigationMenu = ({ pageName, pageIsReceipt }: NavigationMenuProps)
 
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const [dropdownOpen, setDropdownOpen] = useState(false);
-
   const moveLayout = (action: 'up' | 'down') => {
     if (action === 'up' || action === 'down') {
       updateLayoutOrder({ layoutName: pageName, direction: action });
     }
-    setDropdownOpen(false);
   };
 
   const handleSaveNewName = (newName: string) => {
@@ -66,49 +62,47 @@ export const NavigationMenu = ({ pageName, pageIsReceipt }: NavigationMenuProps)
 
   return (
     <div>
-      <DropdownMenu open={dropdownOpen} onClose={() => setDropdownOpen(false)} portal size='small'>
-        <DropdownMenu.Trigger asChild>
-          <StudioButton
-            icon={<MenuElipsisVerticalIcon />}
-            onClick={() => setDropdownOpen((v) => !v)}
-            aria-haspopup='menu'
-            aria-expanded={dropdownOpen}
-            variant='tertiary'
-            title={t('general.options')}
-          />
-        </DropdownMenu.Trigger>
-        <DropdownMenu.Content>
-          <DropdownMenu.Group>
-            {!pageIsReceipt && (
-              <>
-                <DropdownMenu.Item
+      <StudioDropdown
+        icon={<MenuElipsisVerticalIcon />}
+        triggerButtonVariant='tertiary'
+        triggerButtonTitle={t('general.options')}
+        data-size='sm'
+      >
+        <StudioDropdown.List>
+          {!pageIsReceipt && (
+            <>
+              <StudioDropdown.Item>
+                <StudioDropdown.Button
+                  role='menuitem'
                   onClick={() => !(disableUp || invalid) && moveLayout('up')}
                   disabled={disableUp || invalid}
                   id='move-page-up-button'
                 >
                   <ArrowUpIcon />
                   {t('ux_editor.page_menu_up')}
-                </DropdownMenu.Item>
-                <DropdownMenu.Item
+                </StudioDropdown.Button>
+              </StudioDropdown.Item>
+              <StudioDropdown.Item>
+                <StudioDropdown.Button
+                  role='menuitem'
                   onClick={() => !(disableDown || invalid) && moveLayout('down')}
                   disabled={disableDown || invalid}
                   id='move-page-down-button'
                 >
                   <ArrowDownIcon />
                   {t('ux_editor.page_menu_down')}
-                </DropdownMenu.Item>
-              </>
-            )}
-            <InputPopover
-              oldName={pageName}
-              disabled={invalid}
-              layoutOrder={layoutOrder}
-              saveNewName={handleSaveNewName}
-              onClose={() => setDropdownOpen(false)}
-            />
-          </DropdownMenu.Group>
-        </DropdownMenu.Content>
-      </DropdownMenu>
+                </StudioDropdown.Button>
+              </StudioDropdown.Item>
+            </>
+          )}
+          <InputPopover
+            oldName={pageName}
+            disabled={invalid}
+            layoutOrder={layoutOrder}
+            saveNewName={handleSaveNewName}
+          />
+        </StudioDropdown.List>
+      </StudioDropdown>
     </div>
   );
 };

--- a/src/Designer/frontend/packages/ux-editor-v3/src/containers/DesignView/PageAccordion/PageAccordion.test.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v3/src/containers/DesignView/PageAccordion/PageAccordion.test.tsx
@@ -67,14 +67,15 @@ describe('PageAccordion', () => {
     const user = userEvent.setup();
     await render();
 
-    const elementInMenu = screen.queryByText(textMock('ux_editor.page_menu_up'));
-    expect(elementInMenu).not.toBeInTheDocument();
-
     const menuButton = screen.getByRole('button', { name: textMock('general.options') });
+    expect(menuButton).toHaveAttribute('aria-expanded', 'false');
+
     await user.click(menuButton);
 
-    const elementInMenuAfter = screen.getByText(textMock('ux_editor.page_menu_up'));
-    expect(elementInMenuAfter).toBeInTheDocument();
+    expect(menuButton).toHaveAttribute('aria-expanded', 'true');
+    expect(
+      screen.getByRole('menuitem', { name: textMock('ux_editor.page_menu_up') }),
+    ).toBeInTheDocument();
   });
 
   it('Calls deleteLayout with pageName when delete button is clicked and deletion is confirmed, and updates the url correctly', async () => {

--- a/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignViewNavigation/DesignViewNavigation.test.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignViewNavigation/DesignViewNavigation.test.tsx
@@ -26,12 +26,6 @@ describe('DesignViewNavigation', () => {
     expect(menuButton).toBeInTheDocument();
   });
 
-  it('should have aria-haspopup attribute set to "menu"', () => {
-    renderDesignViewNavigation({});
-    const menuButton = screen.getByRole('button', { name: textMock('general.options') });
-    expect(menuButton).toHaveAttribute('aria-haspopup', 'menu');
-  });
-
   it('should be possible to toggle dropdown menu', async () => {
     const user = userEvent.setup();
     renderDesignViewNavigation({});

--- a/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignViewNavigation/DesignViewNavigation.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/containers/DesignViewNavigation/DesignViewNavigation.tsx
@@ -1,19 +1,16 @@
-import { useState } from 'react';
 import classes from './DesignViewNavigation.module.css';
 import { EyeClosedIcon, EyeIcon, MenuElipsisVerticalIcon } from '@studio/icons';
-import { DropdownMenu } from '@digdir/designsystemet-react';
 import { useTranslation } from 'react-i18next';
 import { useConvertToPageOrder } from '../../hooks/mutations/useConvertToPageOrder';
 import { useConvertToPageGroups } from '../../hooks/mutations/useConvertToPageGroups';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { usePagesQuery } from '../../hooks/queries/usePagesQuery';
 import { isPagesModelWithGroups } from 'app-shared/types/api/dto/PagesModel';
-import { StudioSpinner, StudioSectionHeader, StudioButton } from '@studio/components';
+import { StudioSpinner, StudioSectionHeader, StudioDropdown } from '@studio/components';
 import useUxEditorParams from '@altinn/ux-editor-v4/hooks/useUxEditorParams';
 
 export const DesignViewNavigation = () => {
   const { t } = useTranslation();
-  const [dropdownOpen, setDropdownOpen] = useState(false);
   const { org, app } = useStudioEnvironmentParams();
   const { layoutSet } = useUxEditorParams();
 
@@ -35,20 +32,16 @@ export const DesignViewNavigation = () => {
         }}
         menu={
           <div className={classes.menu}>
-            <DropdownMenu open={dropdownOpen} onClose={() => setDropdownOpen(false)} portal>
-              <DropdownMenu.Trigger asChild>
-                <StudioButton
-                  icon={<MenuElipsisVerticalIcon />}
-                  onClick={() => setDropdownOpen((prevState) => !prevState)}
-                  aria-haspopup='menu'
-                  variant='tertiary'
-                  title={t('general.options')}
-                />
-              </DropdownMenu.Trigger>
-              <DropdownMenu.Content>
-                <DropdownMenu.Group>
-                  {isUsingPageGroups ? (
-                    <DropdownMenu.Item
+            <StudioDropdown
+              icon={<MenuElipsisVerticalIcon />}
+              triggerButtonVariant='tertiary'
+              triggerButtonTitle={t('general.options')}
+            >
+              <StudioDropdown.List>
+                {isUsingPageGroups ? (
+                  <StudioDropdown.Item>
+                    <StudioDropdown.Button
+                      role='menuitem'
                       onClick={() => {
                         if (confirm(t('ux_editor.page_layout_convert_to_pages_confirm')))
                           convertToPageOrder();
@@ -56,9 +49,12 @@ export const DesignViewNavigation = () => {
                     >
                       <EyeClosedIcon className={classes.deleteGroupIcon} />
                       {t('ux_editor.page_layout_remove_group_division')}
-                    </DropdownMenu.Item>
-                  ) : (
-                    <DropdownMenu.Item
+                    </StudioDropdown.Button>
+                  </StudioDropdown.Item>
+                ) : (
+                  <StudioDropdown.Item>
+                    <StudioDropdown.Button
+                      role='menuitem'
                       onClick={() => {
                         if (confirm(t('ux_editor.page_layout_convert_to_group_confirm')))
                           convertToPageGroups();
@@ -66,11 +62,11 @@ export const DesignViewNavigation = () => {
                     >
                       <EyeIcon className={classes.groupPagesIcon} />
                       {t('ux_editor.page_layout_add_group_division')}
-                    </DropdownMenu.Item>
-                  )}
-                </DropdownMenu.Group>
-              </DropdownMenu.Content>
-            </DropdownMenu>
+                    </StudioDropdown.Button>
+                  </StudioDropdown.Item>
+                )}
+              </StudioDropdown.List>
+            </StudioDropdown>
           </div>
         }
       />

--- a/src/Designer/frontend/packages/ux-editor/src/components/Properties/CommonElements/MainSettingsHeader/MainSettingsHeader.module.css
+++ b/src/Designer/frontend/packages/ux-editor/src/components/Properties/CommonElements/MainSettingsHeader/MainSettingsHeader.module.css
@@ -1,5 +1,5 @@
 .wrapper {
-  padding: var(--ds-size-5) var(--ds-size-11);
+  padding: var(--ds-size-4) var(--ds-size-11);
   background-color: var(--ds-color-surface-tinted);
   margin-bottom: var(--ds-size-2);
 }

--- a/src/Designer/frontend/packages/ux-editor/src/containers/DesignViewNavigation/DesignViewNavigation.test.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/containers/DesignViewNavigation/DesignViewNavigation.test.tsx
@@ -26,12 +26,6 @@ describe('DesignViewNavigation', () => {
     expect(menuButton).toBeInTheDocument();
   });
 
-  it('should have aria-haspopup attribute set to "menu"', () => {
-    renderDesignViewNavigation({});
-    const menuButton = screen.getByRole('button', { name: textMock('general.options') });
-    expect(menuButton).toHaveAttribute('aria-haspopup', 'menu');
-  });
-
   it('should be possible to toggle dropdown menu', async () => {
     const user = userEvent.setup();
     renderDesignViewNavigation({});

--- a/src/Designer/frontend/packages/ux-editor/src/containers/DesignViewNavigation/DesignViewNavigation.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/containers/DesignViewNavigation/DesignViewNavigation.tsx
@@ -1,19 +1,16 @@
-import { useState } from 'react';
 import classes from './DesignViewNavigation.module.css';
 import { EyeClosedIcon, EyeIcon, MenuElipsisVerticalIcon } from '@studio/icons';
-import { DropdownMenu } from '@digdir/designsystemet-react';
 import { useTranslation } from 'react-i18next';
 import { useConvertToPageOrder } from '../../hooks/mutations/useConvertToPageOrder';
 import { useConvertToPageGroups } from '../../hooks/mutations/useConvertToPageGroups';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { usePagesQuery } from 'app-shared/hooks/queries/usePagesQuery';
 import { isPagesModelWithGroups } from 'app-shared/types/api/dto/PagesModel';
-import { StudioSpinner, StudioSectionHeader, StudioButton } from '@studio/components';
+import { StudioSpinner, StudioSectionHeader, StudioDropdown } from '@studio/components';
 import useUxEditorParams from '@altinn/ux-editor/hooks/useUxEditorParams';
 
 export const DesignViewNavigation = () => {
   const { t } = useTranslation();
-  const [dropdownOpen, setDropdownOpen] = useState(false);
   const { org, app } = useStudioEnvironmentParams();
   const { layoutSet } = useUxEditorParams();
 
@@ -35,20 +32,16 @@ export const DesignViewNavigation = () => {
         }}
         menu={
           <div className={classes.menu}>
-            <DropdownMenu open={dropdownOpen} onClose={() => setDropdownOpen(false)} portal>
-              <DropdownMenu.Trigger asChild>
-                <StudioButton
-                  icon={<MenuElipsisVerticalIcon />}
-                  onClick={() => setDropdownOpen((prevState) => !prevState)}
-                  aria-haspopup='menu'
-                  variant='tertiary'
-                  title={t('general.options')}
-                />
-              </DropdownMenu.Trigger>
-              <DropdownMenu.Content>
-                <DropdownMenu.Group>
-                  {isUsingPageGroups ? (
-                    <DropdownMenu.Item
+            <StudioDropdown
+              icon={<MenuElipsisVerticalIcon />}
+              triggerButtonVariant='tertiary'
+              triggerButtonTitle={t('general.options')}
+            >
+              <StudioDropdown.List>
+                {isUsingPageGroups ? (
+                  <StudioDropdown.Item>
+                    <StudioDropdown.Button
+                      role='menuitem'
                       onClick={() => {
                         if (confirm(t('ux_editor.page_layout_convert_to_pages_confirm')))
                           convertToPageOrder();
@@ -56,9 +49,12 @@ export const DesignViewNavigation = () => {
                     >
                       <EyeClosedIcon className={classes.deleteGroupIcon} />
                       {t('ux_editor.page_layout_remove_group_division')}
-                    </DropdownMenu.Item>
-                  ) : (
-                    <DropdownMenu.Item
+                    </StudioDropdown.Button>
+                  </StudioDropdown.Item>
+                ) : (
+                  <StudioDropdown.Item>
+                    <StudioDropdown.Button
+                      role='menuitem'
                       onClick={() => {
                         if (confirm(t('ux_editor.page_layout_convert_to_group_confirm')))
                           convertToPageGroups();
@@ -66,11 +62,11 @@ export const DesignViewNavigation = () => {
                     >
                       <EyeIcon className={classes.groupPagesIcon} />
                       {t('ux_editor.page_layout_add_group_division')}
-                    </DropdownMenu.Item>
-                  )}
-                </DropdownMenu.Group>
-              </DropdownMenu.Content>
-            </DropdownMenu>
+                    </StudioDropdown.Button>
+                  </StudioDropdown.Item>
+                )}
+              </StudioDropdown.List>
+            </StudioDropdown>
           </div>
         }
       />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description


Replaced Dropdowns with `StudioDropdown` and fixed toggling, ref. https://digdir.slack.com/archives/C09BLD1CRK8/p1787222473741479

<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated menus across navigation, profiles, policy editing and design views for more consistent opening, closing and selection behaviour.
  * Menus now close automatically after an action is selected and when users click outside.
  * Improved accessibility semantics and state announcements for menu controls and items.
  * Reduced spacing in the main settings header for a more compact layout.

* **Bug Fixes**
  * Improved menu interaction reliability for links, buttons, page actions, cloning and deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->