### PR TITLE
feat: support shared Microsandbox cache placement

### DIFF
--- a/src/experimental/sandbox-microsandbox/src/backend.rs
+++ b/src/experimental/sandbox-microsandbox/src/backend.rs
@@ -1,4 +1,10 @@
-use std::{cell::RefCell, collections::HashMap, path::Path, rc::Rc, time::Instant};
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    path::{Path, PathBuf},
+    rc::Rc,
+    time::Instant,
+};
 
 use microsandbox::sandbox::{PullPolicy, SandboxStatus};
 use sandbox::progress::SandboxProgress;
@@ -38,7 +44,22 @@ pub struct MicrosandboxProvider {
     pub(crate) executions: ExecutionControls,
 }
 
+/// Configures the host storage used by a [`MicrosandboxProvider`].
+pub struct MicrosandboxProviderBuilder {
+    home: PathBuf,
+    cache_directory: Option<PathBuf>,
+}
+
 impl MicrosandboxProvider {
+    /// Configures a Microsandbox Provider below its private data directory.
+    #[must_use]
+    pub fn builder(home: impl Into<PathBuf>) -> MicrosandboxProviderBuilder {
+        MicrosandboxProviderBuilder {
+            home: home.into(),
+            cache_directory: None,
+        }
+    }
+
     /// Opens an isolated Microsandbox Provider below its data directory.
     ///
     /// # Errors
@@ -46,12 +67,24 @@ impl MicrosandboxProvider {
     /// Returns an error when the home cannot be initialized or Microsandbox
     /// cannot open its local runtime.
     pub async fn open(home: impl AsRef<Path>) -> Result<Self, Error> {
-        let home = home.as_ref();
+        Self::builder(home.as_ref().to_path_buf()).open().await
+    }
+
+    /// Returns the configured shared Microsandbox cache directory.
+    #[must_use]
+    pub fn cache_directory(&self) -> PathBuf {
+        self.client.cache_directory()
+    }
+
+    async fn open_configured(home: PathBuf, cache_directory: Option<PathBuf>) -> Result<Self, Error> {
         if home.as_os_str().is_empty() {
             return Err(Error::invalid("provider.home", "must not be empty"));
         }
+        if cache_directory.as_ref().is_some_and(|path| path.as_os_str().is_empty()) {
+            return Err(Error::invalid("provider.cacheDirectory", "must not be empty"));
+        }
         let state = StateStore::open(home.join("state")).await?;
-        let client = Client::open(home.join("runtime")).await?;
+        let client = Client::open(home.join("runtime"), cache_directory).await?;
         let image_resolver = MicrosandboxImageResolver::new(client.clone());
         Ok(Self {
             client,
@@ -340,6 +373,29 @@ impl MicrosandboxProvider {
             });
         }
         Ok(resolved)
+    }
+}
+
+impl MicrosandboxProviderBuilder {
+    /// Places reusable Microsandbox cache artifacts in this directory.
+    ///
+    /// Separate Provider instances may share this directory. Sandbox state,
+    /// writable roots and other mutable runtime data remain below the private
+    /// Provider home.
+    #[must_use]
+    pub fn cache_directory(mut self, path: impl Into<PathBuf>) -> Self {
+        self.cache_directory = Some(path.into());
+        self
+    }
+
+    /// Opens the configured Microsandbox Provider.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a configured path is empty or cannot be
+    /// initialized by the Microsandbox runtime.
+    pub async fn open(self) -> Result<MicrosandboxProvider, Error> {
+        MicrosandboxProvider::open_configured(self.home, self.cache_directory).await
     }
 }
 

--- a/src/experimental/sandbox-microsandbox/src/client.rs
+++ b/src/experimental/sandbox-microsandbox/src/client.rs
@@ -75,15 +75,21 @@ fn unsupported_resource(resource: &'static str, value: impl std::fmt::Display, r
 }
 
 impl Client {
-    pub(crate) async fn open(microsandbox_home: PathBuf) -> Result<Self, Error> {
-        let backend = LocalBackend::builder()
+    pub(crate) async fn open(microsandbox_home: PathBuf, cache_directory: Option<PathBuf>) -> Result<Self, Error> {
+        if let Some(cache_directory) = &cache_directory {
+            tokio::fs::create_dir_all(cache_directory)
+                .await
+                .map_err(|source| error::io("create Microsandbox cache directory", source))?;
+        }
+        let mut builder = LocalBackend::builder()
             .ignore_persisted_config()
             .home(&microsandbox_home)
             .disable_metrics_sample(true)
-            .deployment_profile(microsandbox::sandbox::DeploymentProfile::SingleTenant)
-            .build()
-            .await
-            .map_err(error::microsandbox)?;
+            .deployment_profile(microsandbox::sandbox::DeploymentProfile::SingleTenant);
+        if let Some(cache_directory) = cache_directory {
+            builder = builder.cache_dir(cache_directory);
+        }
+        let backend = builder.build().await.map_err(error::microsandbox)?;
         Ok(Self {
             backend: Arc::new(backend),
             microsandbox_home,
@@ -93,6 +99,10 @@ impl Client {
 
     pub(crate) fn local(&self) -> &LocalBackend {
         &self.backend
+    }
+
+    pub(crate) fn cache_directory(&self) -> PathBuf {
+        self.backend.cache_dir()
     }
 
     pub(crate) async fn bind_network_controller(

--- a/src/experimental/sandbox-microsandbox/src/lib.rs
+++ b/src/experimental/sandbox-microsandbox/src/lib.rs
@@ -18,5 +18,5 @@ mod platform;
 mod state;
 mod volumes;
 
-pub use backend::MicrosandboxProvider;
+pub use backend::{MicrosandboxProvider, MicrosandboxProviderBuilder};
 pub use network_backend::{MicrosandboxNetworkBackend, SecretBinding};

--- a/src/experimental/sandbox-microsandbox/tests/backend.rs
+++ b/src/experimental/sandbox-microsandbox/tests/backend.rs
@@ -48,3 +48,44 @@ async fn backend_state_and_runtime_are_rooted_in_the_explicit_home() {
             )))
     );
 }
+
+#[tokio::test(flavor = "local")]
+async fn cache_directory_can_be_shared_without_sharing_provider_state() {
+    let temporary = tempfile::tempdir().expect("temporary home should be created");
+    let shared_cache = temporary.path().join("shared-cache");
+    let first_home = temporary.path().join("first-provider");
+    let second_home = temporary.path().join("second-provider");
+
+    let first = MicrosandboxProvider::builder(&first_home)
+        .cache_directory(&shared_cache)
+        .open()
+        .await
+        .expect("first Provider should open with the shared cache");
+    let second = MicrosandboxProvider::builder(&second_home)
+        .cache_directory(&shared_cache)
+        .open()
+        .await
+        .expect("second Provider should open with the shared cache");
+
+    assert_eq!(first.cache_directory(), shared_cache);
+    assert_eq!(second.cache_directory(), shared_cache);
+    assert!(shared_cache.is_dir());
+    assert!(first_home.join("state/sandboxes").is_dir());
+    assert!(second_home.join("state/sandboxes").is_dir());
+}
+
+#[tokio::test(flavor = "local")]
+async fn cache_directory_must_not_be_empty() {
+    let result = MicrosandboxProvider::builder("private-provider")
+        .cache_directory("")
+        .open()
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(sandbox::Error::Invalid {
+            field: "provider.cacheDirectory",
+            ..
+        })
+    ));
+}


### PR DESCRIPTION
## Summary

- add a MicrosandboxProvider builder with explicit cache-directory configuration
- allow independent providers to share immutable Microsandbox cache artifacts while keeping provider state and writable roots private
- retain MicrosandboxProvider::open as the simple default
- add focused cache isolation and validation tests

## Verification

CI is the validation gate for this clean branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional shared cache directory support for sandbox providers.
  * Added builder-based provider configuration.
  * Added visibility into the active cache directory.

* **Bug Fixes**
  * Improved validation for home and cache paths.
  * Prevented empty cache-directory paths from being accepted.
  * Providers now keep separate state while sharing configured cache data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->