### PR TITLE
feat: adopt the Digdir Microsandbox runtime distribution

### DIFF
--- a/src/experimental/Cargo.lock
+++ b/src/experimental/Cargo.lock
@@ -2754,8 +2754,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox"
-version = "0.6.9"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=feat%2Fembedded-local-backend#830eb363c2b160afa3429b4db5477a99c6fd950b"
+version = "0.6.9-digdir.1"
+source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#c704bdb2e445f7e5bada847c560139b6efbc6965"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -2809,8 +2809,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-agent-client"
-version = "0.6.9"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=feat%2Fembedded-local-backend#830eb363c2b160afa3429b4db5477a99c6fd950b"
+version = "0.6.9-digdir.1"
+source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#c704bdb2e445f7e5bada847c560139b6efbc6965"
 dependencies = [
  "ciborium",
  "microsandbox-protocol",
@@ -2822,8 +2822,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-db"
-version = "0.6.9"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=feat%2Fembedded-local-backend#830eb363c2b160afa3429b4db5477a99c6fd950b"
+version = "0.6.9-digdir.1"
+source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#c704bdb2e445f7e5bada847c560139b6efbc6965"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2834,8 +2834,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-filesystem"
-version = "0.6.9"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=feat%2Fembedded-local-backend#830eb363c2b160afa3429b4db5477a99c6fd950b"
+version = "0.6.9-digdir.1"
+source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#c704bdb2e445f7e5bada847c560139b6efbc6965"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -2847,8 +2847,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-image"
-version = "0.6.9"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=feat%2Fembedded-local-backend#830eb363c2b160afa3429b4db5477a99c6fd950b"
+version = "0.6.9-digdir.1"
+source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#c704bdb2e445f7e5bada847c560139b6efbc6965"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -2874,8 +2874,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-metrics"
-version = "0.6.9"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=feat%2Fembedded-local-backend#830eb363c2b160afa3429b4db5477a99c6fd950b"
+version = "0.6.9-digdir.1"
+source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#c704bdb2e445f7e5bada847c560139b6efbc6965"
 dependencies = [
  "chrono",
  "libc",
@@ -2886,8 +2886,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-migration"
-version = "0.6.9"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=feat%2Fembedded-local-backend#830eb363c2b160afa3429b4db5477a99c6fd950b"
+version = "0.6.9-digdir.1"
+source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#c704bdb2e445f7e5bada847c560139b6efbc6965"
 dependencies = [
  "sea-orm-migration",
  "serde_json",
@@ -2895,8 +2895,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-network"
-version = "0.6.9"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=feat%2Fembedded-local-backend#830eb363c2b160afa3429b4db5477a99c6fd950b"
+version = "0.6.9-digdir.1"
+source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#c704bdb2e445f7e5bada847c560139b6efbc6965"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2940,8 +2940,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.6.9"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=feat%2Fembedded-local-backend#830eb363c2b160afa3429b4db5477a99c6fd950b"
+version = "0.6.9-digdir.1"
+source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#c704bdb2e445f7e5bada847c560139b6efbc6965"
 dependencies = [
  "chrono",
  "ciborium",
@@ -2955,8 +2955,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-runtime"
-version = "0.6.9"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=feat%2Fembedded-local-backend#830eb363c2b160afa3429b4db5477a99c6fd950b"
+version = "0.6.9-digdir.1"
+source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#c704bdb2e445f7e5bada847c560139b6efbc6965"
 dependencies = [
  "bytes",
  "chrono",
@@ -2990,8 +2990,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-types"
-version = "0.6.9"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=feat%2Fembedded-local-backend#830eb363c2b160afa3429b4db5477a99c6fd950b"
+version = "0.6.9-digdir.1"
+source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#c704bdb2e445f7e5bada847c560139b6efbc6965"
 dependencies = [
  "chrono",
  "ipnetwork",
@@ -3004,8 +3004,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-utils"
-version = "0.6.9"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=feat%2Fembedded-local-backend#830eb363c2b160afa3429b4db5477a99c6fd950b"
+version = "0.6.9-digdir.1"
+source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#c704bdb2e445f7e5bada847c560139b6efbc6965"
 dependencies = [
  "dirs",
  "libc",
@@ -3017,8 +3017,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-vsock"
-version = "0.6.9"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=feat%2Fembedded-local-backend#830eb363c2b160afa3429b4db5477a99c6fd950b"
+version = "0.6.9-digdir.1"
+source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#c704bdb2e445f7e5bada847c560139b6efbc6965"
 dependencies = [
  "libc",
  "msb_krun",

--- a/src/experimental/Cargo.toml
+++ b/src/experimental/Cargo.toml
@@ -23,14 +23,14 @@ clap = { version = "4.6.6", features = ["derive"] }
 futures-core = "0.3.34"
 futures-util = "0.3.34"
 ignore = "0.4.33"
-microsandbox = { git = "https://github.com/martinothamar/microsandbox.git", branch = "feat/embedded-local-backend", default-features = false, features = ["net"] }
-microsandbox-image = { git = "https://github.com/martinothamar/microsandbox.git", branch = "feat/embedded-local-backend", package = "microsandbox-image" }
-microsandbox-network = { git = "https://github.com/martinothamar/microsandbox.git", branch = "feat/embedded-local-backend", package = "microsandbox-network" }
+microsandbox = { git = "https://github.com/martinothamar/microsandbox.git", branch = "main-digdir", default-features = false, features = ["net"] }
+microsandbox-image = { git = "https://github.com/martinothamar/microsandbox.git", branch = "main-digdir", package = "microsandbox-image" }
+microsandbox-network = { git = "https://github.com/martinothamar/microsandbox.git", branch = "main-digdir", package = "microsandbox-network" }
 # Microsandbox does not ship its embedded sandbox agent in the crate.
 # Enabling this transitive feature downloads only that build artifact into
 # Cargo's output directory; the host runtime is installed automatically on
 # first use into the control-plane home.
-microsandbox-filesystem = { git = "https://github.com/martinothamar/microsandbox.git", branch = "feat/embedded-local-backend", default-features = false, features = ["prebuilt"] }
+microsandbox-filesystem = { git = "https://github.com/martinothamar/microsandbox.git", branch = "main-digdir", default-features = false, features = ["prebuilt"] }
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
 serde_yaml_ng = "0.10.0"

--- a/src/experimental/Makefile
+++ b/src/experimental/Makefile
@@ -2,11 +2,6 @@
 .DEFAULT_GOAL := help
 
 PORTABLE_PACKAGES := -p sandbox -p sandbox-authorization -p agent-runtime-protocol -p agent-runtime -p agent
-MICROSANDBOX_DIR ?= ../../../../private/microsandbox
-MICROSANDBOX_BIN := $(abspath $(MICROSANDBOX_DIR)/target/debug/msb)
-ifeq ($(OS),Windows_NT)
-MICROSANDBOX_BIN := $(MICROSANDBOX_BIN).exe
-endif
 
 help: ## Show this help message
 	@echo 'Usage: make [target]'
@@ -40,8 +35,7 @@ test-independent: ## Test reusable lower-layer crates independently
 	cargo test --manifest-path agent-runtime/Cargo.toml --all-targets
 
 test-microsandbox: ## Run the real Docker/Microsandbox integration tests
-	cargo build --manifest-path $(MICROSANDBOX_DIR)/Cargo.toml -p microsandbox-cli
-	MSB_PATH=$(MICROSANDBOX_BIN) cargo test -p sandbox-microsandbox --tests -- --ignored
+	cargo test -p sandbox-microsandbox --tests -- --ignored
 
 deps: ## Print the workspace dependency graph
 	cargo tree --workspace

--- a/src/experimental/sandbox-microsandbox/tests/fixtures/runtime-image/Dockerfile
+++ b/src/experimental/sandbox-microsandbox/tests/fixtures/runtime-image/Dockerfile
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile:1
 FROM alpine:3.22
 
+RUN apk add --no-cache iptables nftables
+
 RUN --mount=type=cache,target=/var/cache true
 
 CMD ["/bin/echo", "default-entrypoint"]

--- a/src/experimental/sandbox-microsandbox/tests/runtime.rs
+++ b/src/experimental/sandbox-microsandbox/tests/runtime.rs
@@ -59,6 +59,7 @@ async fn retained_lifecycle_execution_files_and_volumes() {
     assert_provisioning_progress(&events);
     assert_eq!(sandbox.state, SandboxState::Running);
     assert_direct_root_filesystem(backend.as_ref(), &sandbox).await;
+    assert_nested_container_networking(backend.as_ref(), &sandbox).await;
 
     sandbox = assert_resource_update_and_root_growth(backend.as_ref(), &service, &mut request, sandbox).await;
 
@@ -109,6 +110,34 @@ async fn assert_direct_root_filesystem(backend: &MicrosandboxProvider, sandbox: 
     )
     .await;
     assert_eq!(output.stdout.as_ref(), b"ext4\n");
+}
+
+async fn assert_nested_container_networking(backend: &MicrosandboxProvider, sandbox: &Sandbox) {
+    let output = run(
+        backend,
+        &sandbox.id,
+        shell(
+            r"set -eu
+cleanup() {
+    iptables -t nat -F SBX_KUBE_PROXY_TEST 2>/dev/null || true
+    iptables -t nat -X SBX_KUBE_PROXY_TEST 2>/dev/null || true
+    nft delete table ip sandbox_test 2>/dev/null || true
+}
+trap cleanup EXIT
+iptables -t nat -N SBX_KUBE_PROXY_TEST
+iptables -t nat -A SBX_KUBE_PROXY_TEST -m statistic --mode random --probability 0.5 -j RETURN
+nft add table ip sandbox_test
+nft add chain ip sandbox_test service
+nft add rule ip sandbox_test service meta mark set numgen random mod 2
+",
+        ),
+    )
+    .await;
+    assert!(
+        output.status.success(),
+        "nested container networking kernel probes failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 async fn assert_resource_update_and_root_growth(


### PR DESCRIPTION
## Summary

- adopt `martinothamar/microsandbox:main-digdir` as the downstream source for the Microsandbox Rust SDK integration
- pin the `0.6.9-digdir.1` crates to the exact downstream commit in `Cargo.lock`
- consume the immutable downstream runtime release built with the pinned libkrunfw guest firmware required by nested Docker and Kind
- remove the local Microsandbox source-checkout and CLI-build requirement from integration tests
- verify the iptables statistic matcher and nftables numgen expression required by Kubernetes service networking

## Why this matters

This establishes the maintained downstream Microsandbox distribution consumed by Altinn Studio. The
Kubernetes networking support is the first required downstream kernel delta and the focused microVM
regression proves that the distributed runtime contains it; it is not merely a test-only networking
change.

The generic Sandbox facade remains independent of Microsandbox internals. Fork maintenance, runtime
release ownership and the pinned libkrunfw firmware stay behind the Microsandbox integration.

## Origin of the change

The runtime work originates in
[`martinothamar/libkrunfw@53a08b5`](https://github.com/martinothamar/libkrunfw/commit/53a08b5136dd8471bf9f58a237f1f0fc0d299490).
That commit changes the x86_64, aarch64 and riscv64 guest-kernel configurations to enable:

- `CONFIG_NETFILTER_XT_MATCH_STATISTIC`, used by kube-proxy's iptables backend for probabilistic
  service-endpoint selection
- `CONFIG_NFT_NUMGEN`, the corresponding number generator used by kube-proxy's nftables backend

Without these kernel features, the nested Kind cluster could start and reach external registries,
but traffic through Kubernetes services—including the CoreDNS ClusterIP—failed.

[`martinothamar/microsandbox@6e26630`](https://github.com/martinothamar/microsandbox/commit/6e26630165ed115c2117f3b9bb7a934083d809cb)
then pins its libkrunfw submodule to that exact firmware commit. The downstream runtime release is
built by
[`martinothamar/microsandbox@c704bdb`](https://github.com/martinothamar/microsandbox/commit/c704bdb2e445f7e5bada847c560139b6efbc6965),
which is the exact Microsandbox revision pinned by this PR.

## Stack

Depends on #20041. The PR diff contains only the downstream runtime-consumption and networking
regression changes above.

## Verification

CI is the validation gate for this clean branch. The published downstream runtime previously passed
the focused KVM-backed regression and the complete Kind and Flux fixture.
