### PR TITLE
feat: install verified local Microsandbox runtime bundles

### DIFF
--- a/src/experimental/sandbox-microsandbox/src/backend.rs
+++ b/src/experimental/sandbox-microsandbox/src/backend.rs
@@ -48,6 +48,13 @@ pub struct MicrosandboxProvider {
 pub struct MicrosandboxProviderBuilder {
     home: PathBuf,
     cache_directory: Option<PathBuf>,
+    runtime_bundle: Option<RuntimeBundle>,
+}
+
+#[derive(Clone)]
+pub(crate) struct RuntimeBundle {
+    pub(crate) path: PathBuf,
+    pub(crate) sha256: String,
 }
 
 impl MicrosandboxProvider {
@@ -57,6 +64,7 @@ impl MicrosandboxProvider {
         MicrosandboxProviderBuilder {
             home: home.into(),
             cache_directory: None,
+            runtime_bundle: None,
         }
     }
 
@@ -76,15 +84,33 @@ impl MicrosandboxProvider {
         self.client.cache_directory()
     }
 
-    async fn open_configured(home: PathBuf, cache_directory: Option<PathBuf>) -> Result<Self, Error> {
+    async fn open_configured(
+        home: PathBuf,
+        cache_directory: Option<PathBuf>,
+        runtime_bundle: Option<RuntimeBundle>,
+    ) -> Result<Self, Error> {
         if home.as_os_str().is_empty() {
             return Err(Error::invalid("provider.home", "must not be empty"));
         }
         if cache_directory.as_ref().is_some_and(|path| path.as_os_str().is_empty()) {
             return Err(Error::invalid("provider.cacheDirectory", "must not be empty"));
         }
+        if let Some(bundle) = &runtime_bundle {
+            if !bundle.path.is_file() {
+                return Err(Error::invalid(
+                    "provider.runtimeBundle.path",
+                    "must identify a regular file",
+                ));
+            }
+            if bundle.sha256.len() != 64 || !bundle.sha256.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+                return Err(Error::invalid(
+                    "provider.runtimeBundle.sha256",
+                    "must be a 64-character hexadecimal SHA-256 digest",
+                ));
+            }
+        }
         let state = StateStore::open(home.join("state")).await?;
-        let client = Client::open(home.join("runtime"), cache_directory).await?;
+        let client = Client::open(home.join("runtime"), cache_directory, runtime_bundle).await?;
         let image_resolver = MicrosandboxImageResolver::new(client.clone());
         Ok(Self {
             client,
@@ -388,6 +414,19 @@ impl MicrosandboxProviderBuilder {
         self
     }
 
+    /// Installs the Microsandbox host runtime from a verified local release bundle.
+    ///
+    /// The path must identify a platform-compatible Microsandbox `tar.gz`
+    /// runtime bundle. The expected digest is checked before extraction.
+    #[must_use]
+    pub fn runtime_bundle(mut self, path: impl Into<PathBuf>, sha256: impl Into<String>) -> Self {
+        self.runtime_bundle = Some(RuntimeBundle {
+            path: path.into(),
+            sha256: sha256.into(),
+        });
+        self
+    }
+
     /// Opens the configured Microsandbox Provider.
     ///
     /// # Errors
@@ -395,7 +434,7 @@ impl MicrosandboxProviderBuilder {
     /// Returns an error when a configured path is empty or cannot be
     /// initialized by the Microsandbox runtime.
     pub async fn open(self) -> Result<MicrosandboxProvider, Error> {
-        MicrosandboxProvider::open_configured(self.home, self.cache_directory).await
+        MicrosandboxProvider::open_configured(self.home, self.cache_directory, self.runtime_bundle).await
     }
 }
 

--- a/src/experimental/sandbox-microsandbox/src/client.rs
+++ b/src/experimental/sandbox-microsandbox/src/client.rs
@@ -4,13 +4,14 @@ use microsandbox::LocalBackend;
 use sandbox::Error;
 use tokio::sync::OnceCell;
 
-use crate::error;
+use crate::{backend::RuntimeBundle, error};
 
 /// Keeps Microsandbox's thread-safe ownership model at the SDK boundary.
 #[derive(Clone)]
 pub(crate) struct Client {
     backend: Arc<LocalBackend>,
     microsandbox_home: PathBuf,
+    runtime_bundle: Option<RuntimeBundle>,
     installation: Rc<OnceCell<()>>,
 }
 
@@ -75,7 +76,11 @@ fn unsupported_resource(resource: &'static str, value: impl std::fmt::Display, r
 }
 
 impl Client {
-    pub(crate) async fn open(microsandbox_home: PathBuf, cache_directory: Option<PathBuf>) -> Result<Self, Error> {
+    pub(crate) async fn open(
+        microsandbox_home: PathBuf,
+        cache_directory: Option<PathBuf>,
+        runtime_bundle: Option<RuntimeBundle>,
+    ) -> Result<Self, Error> {
         if let Some(cache_directory) = &cache_directory {
             tokio::fs::create_dir_all(cache_directory)
                 .await
@@ -93,6 +98,7 @@ impl Client {
         Ok(Self {
             backend: Arc::new(backend),
             microsandbox_home,
+            runtime_bundle,
             installation: Rc::new(OnceCell::new()),
         })
     }
@@ -118,13 +124,27 @@ impl Client {
     pub(crate) async fn ensure_installed(&self) -> Result<(), Error> {
         self.installation
             .get_or_try_init(|| async {
-                microsandbox::setup::Setup::builder()
-                    .base_dir(&self.microsandbox_home)
-                    .allow_ci_local_bundle(false)
-                    .build()
-                    .install()
-                    .await
-                    .map_err(error::microsandbox)
+                match &self.runtime_bundle {
+                    Some(bundle) => {
+                        microsandbox::setup::Setup::builder()
+                            .base_dir(&self.microsandbox_home)
+                            .bundle_path(&bundle.path)
+                            .expected_bundle_sha256(&bundle.sha256)
+                            .allow_ci_local_bundle(false)
+                            .build()
+                            .install()
+                            .await
+                    }
+                    None => {
+                        microsandbox::setup::Setup::builder()
+                            .base_dir(&self.microsandbox_home)
+                            .allow_ci_local_bundle(false)
+                            .build()
+                            .install()
+                            .await
+                    }
+                }
+                .map_err(error::microsandbox)
             })
             .await?;
         Ok(())

--- a/src/experimental/sandbox-microsandbox/tests/backend.rs
+++ b/src/experimental/sandbox-microsandbox/tests/backend.rs
@@ -89,3 +89,39 @@ async fn cache_directory_must_not_be_empty() {
         })
     ));
 }
+
+#[tokio::test(flavor = "local")]
+async fn runtime_bundle_must_be_a_regular_file() {
+    let temporary = tempfile::tempdir().expect("temporary home should be created");
+    let result = MicrosandboxProvider::builder(temporary.path().join("provider"))
+        .runtime_bundle(temporary.path().join("missing.tar.gz"), "0".repeat(64))
+        .open()
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(sandbox::Error::Invalid {
+            field: "provider.runtimeBundle.path",
+            ..
+        })
+    ));
+}
+
+#[tokio::test(flavor = "local")]
+async fn runtime_bundle_digest_must_be_sha256() {
+    let temporary = tempfile::tempdir().expect("temporary home should be created");
+    let bundle = temporary.path().join("runtime.tar.gz");
+    std::fs::write(&bundle, []).expect("placeholder runtime bundle should be written");
+    let result = MicrosandboxProvider::builder(temporary.path().join("provider"))
+        .runtime_bundle(bundle, "not-a-sha256")
+        .open()
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(sandbox::Error::Invalid {
+            field: "provider.runtimeBundle.sha256",
+            ..
+        })
+    ));
+}


### PR DESCRIPTION
## Summary

- allow MicrosandboxProvider callers to supply a local runtime release bundle and expected SHA-256 digest
- keep Microsandbox directory-layout knowledge inside the concrete provider
- validate bundle paths and digests before provider initialization
- pass the verified source through the supported Microsandbox setup API

## Stack

Depends on #20042, which in turn depends on #20041. The PR diff contains only local runtime-bundle support.

## Verification

CI is the validation gate for this clean branch.