### PR TITLE
fix: fixed displayed error icons in policy rules

### DIFF
--- a/src/Designer/frontend/packages/policy-editor/src/components/PolicyCardRules/PolicyRule/PolicyRuleErrorMessage/PolicyRuleErrorMessage.test.tsx
+++ b/src/Designer/frontend/packages/policy-editor/src/components/PolicyCardRules/PolicyRule/PolicyRuleErrorMessage/PolicyRuleErrorMessage.test.tsx
@@ -68,6 +68,11 @@ describe('PolicyRuleErrorMessage', () => {
     expect(screen.queryByText(errorText2)).not.toBeInTheDocument();
     expect(screen.queryByText(errorText3)).not.toBeInTheDocument();
   });
+
+  it('renders nothing at all when no errors exist, so no empty error icon is left behind', () => {
+    const { container } = renderPolicyRuleErrorMessage();
+    expect(container).toBeEmptyDOMElement();
+  });
 });
 
 const renderPolicyRuleErrorMessage = (

--- a/src/Designer/frontend/packages/policy-editor/src/components/PolicyCardRules/PolicyRule/PolicyRuleErrorMessage/PolicyRuleErrorMessage.tsx
+++ b/src/Designer/frontend/packages/policy-editor/src/components/PolicyCardRules/PolicyRule/PolicyRuleErrorMessage/PolicyRuleErrorMessage.tsx
@@ -3,7 +3,7 @@ import { usePolicyRuleContext } from '../../../../contexts/PolicyRuleContext';
 import { useTranslation } from 'react-i18next';
 import { StudioValidationMessage } from '@studio/components';
 
-export const PolicyRuleErrorMessage = (): React.ReactElement => {
+export const PolicyRuleErrorMessage = (): React.ReactElement | null => {
   const { t } = useTranslation();
   const { policyRule, policyError } = usePolicyRuleContext();
   const { resourceError, actionsError, subjectsError } = policyError;
@@ -38,5 +38,7 @@ export const PolicyRuleErrorMessage = (): React.ReactElement => {
     return '';
   };
 
-  return <StudioValidationMessage data-size='sm'>{getRuleErrorText()}</StudioValidationMessage>;
+  const ruleErrorText: string = getRuleErrorText();
+  if (!ruleErrorText) return null;
+  return <StudioValidationMessage data-size='sm'>{ruleErrorText}</StudioValidationMessage>;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Policy rule error messages are now hidden when no error text is available, preventing empty validation elements from appearing.

* **Tests**
  * Added coverage to confirm that no DOM content is rendered when a policy rule has no errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->