### PR TITLE
feat: add prepared image operations to sandbox

### DIFF
--- a/src/experimental/AGENTS.md
+++ b/src/experimental/AGENTS.md
@@ -20,6 +20,8 @@ This area contains the experimental agent platform described in `README.md`.
   bundle selection, `agentd` and `agentctl`. It builds on the lower crates above.
 - The backend owns Sandbox lifecycle, execution, runtime file transfer, storage and mount behavior; do not split
   those into speculative replaceable component traits.
+- A Provider pairs a Sandbox Backend with an Image Backend over one image materialization domain. Both expose
+  discovery-first, per-Platform capabilities; Backend trait operations are required and have no default behavior.
 - A Network Backend is independently selectable from a Sandbox Backend. They negotiate an owned Network Endpoint:
   raw Ethernet/IP packets, intercepted TCP streams and UDP datagrams, or a jointly implemented versioned control
   protocol. The Network Backend consumes the endpoint and owns host authorization and endpoint driving; a trusted

--- a/src/experimental/Cargo.lock
+++ b/src/experimental/Cargo.lock
@@ -2754,8 +2754,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox"
-version = "0.6.9-digdir.1"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#c704bdb2e445f7e5bada847c560139b6efbc6965"
+version = "0.6.9-digdir.2"
+source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -2809,8 +2809,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-agent-client"
-version = "0.6.9-digdir.1"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#c704bdb2e445f7e5bada847c560139b6efbc6965"
+version = "0.6.9-digdir.2"
+source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
 dependencies = [
  "ciborium",
  "microsandbox-protocol",
@@ -2822,8 +2822,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-db"
-version = "0.6.9-digdir.1"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#c704bdb2e445f7e5bada847c560139b6efbc6965"
+version = "0.6.9-digdir.2"
+source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2834,8 +2834,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-filesystem"
-version = "0.6.9-digdir.1"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#c704bdb2e445f7e5bada847c560139b6efbc6965"
+version = "0.6.9-digdir.2"
+source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -2847,8 +2847,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-image"
-version = "0.6.9-digdir.1"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#c704bdb2e445f7e5bada847c560139b6efbc6965"
+version = "0.6.9-digdir.2"
+source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -2870,12 +2870,13 @@ dependencies = [
  "tokio-util",
  "tracing",
  "windows-sys 0.61.2",
+ "zstd",
 ]
 
 [[package]]
 name = "microsandbox-metrics"
-version = "0.6.9-digdir.1"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#c704bdb2e445f7e5bada847c560139b6efbc6965"
+version = "0.6.9-digdir.2"
+source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
 dependencies = [
  "chrono",
  "libc",
@@ -2886,8 +2887,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-migration"
-version = "0.6.9-digdir.1"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#c704bdb2e445f7e5bada847c560139b6efbc6965"
+version = "0.6.9-digdir.2"
+source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
 dependencies = [
  "sea-orm-migration",
  "serde_json",
@@ -2895,8 +2896,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-network"
-version = "0.6.9-digdir.1"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#c704bdb2e445f7e5bada847c560139b6efbc6965"
+version = "0.6.9-digdir.2"
+source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2940,8 +2941,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.6.9-digdir.1"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#c704bdb2e445f7e5bada847c560139b6efbc6965"
+version = "0.6.9-digdir.2"
+source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
 dependencies = [
  "chrono",
  "ciborium",
@@ -2955,8 +2956,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-runtime"
-version = "0.6.9-digdir.1"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#c704bdb2e445f7e5bada847c560139b6efbc6965"
+version = "0.6.9-digdir.2"
+source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
 dependencies = [
  "bytes",
  "chrono",
@@ -2990,8 +2991,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-types"
-version = "0.6.9-digdir.1"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#c704bdb2e445f7e5bada847c560139b6efbc6965"
+version = "0.6.9-digdir.2"
+source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
 dependencies = [
  "chrono",
  "ipnetwork",
@@ -3004,8 +3005,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-utils"
-version = "0.6.9-digdir.1"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#c704bdb2e445f7e5bada847c560139b6efbc6965"
+version = "0.6.9-digdir.2"
+source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
 dependencies = [
  "dirs",
  "libc",
@@ -3017,8 +3018,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-vsock"
-version = "0.6.9-digdir.1"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#c704bdb2e445f7e5bada847c560139b6efbc6965"
+version = "0.6.9-digdir.2"
+source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
 dependencies = [
  "libc",
  "msb_krun",

--- a/src/experimental/Cargo.lock
+++ b/src/experimental/Cargo.lock
@@ -4316,6 +4316,7 @@ dependencies = [
  "futures-core",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "thiserror",
  "tokio",
  "tokio-util",

--- a/src/experimental/README.md
+++ b/src/experimental/README.md
@@ -104,6 +104,8 @@ ownership model inside a Sandbox.
   versioned control-protocol endpoints
 - SDKs to manage sandboxes and agents
 - OCI images built from user-supplied Dockerfiles or resolved from registry references
+- Provider-neutral prepared-image operations for transporting pristine, pre-materialized derivatives of OCI
+  images; formats remain opaque, Provider-owned and usable only with compatible Sandbox Providers
 
 #### Initial deliverable
 

--- a/src/experimental/sandbox-microsandbox/src/backend.rs
+++ b/src/experimental/sandbox-microsandbox/src/backend.rs
@@ -130,7 +130,7 @@ impl MicrosandboxProvider {
             Err(error) if error.is_not_found() => {}
             Err(error) => return Err(error),
         }
-        self.cached_image_reference(&request.image.digest).await?;
+        self.cached_image_reference(&request.image.manifest_digest).await?;
 
         let record = SandboxRecord::new(
             request.id,
@@ -291,7 +291,7 @@ impl MicrosandboxProvider {
         let started = Instant::now();
         let step = progress.start_step(RESOLVE_RUNTIME_INPUTS).await;
         let mounts = self.resolve_mounts(&record.mounts).await?;
-        let image = self.cached_image_reference(&record.image.digest).await?;
+        let image = self.cached_image_reference(&record.image.manifest_digest).await?;
         step.complete(started.elapsed()).await;
         if record.resources.root_filesystem().mode() == RootFilesystemMode::Direct {
             let started = Instant::now();
@@ -324,17 +324,17 @@ impl MicrosandboxProvider {
         Ok(runtime)
     }
 
-    async fn cached_image_reference(&self, digest: &str) -> Result<String, Error> {
+    async fn cached_image_reference(&self, manifest_digest: &str) -> Result<String, Error> {
         let images = microsandbox::Image::list_local(self.client.local())
             .await
             .map_err(error::microsandbox)?;
         images
             .iter()
-            .find(|image| image.manifest_digest() == Some(digest))
+            .find(|image| image.manifest_digest() == Some(manifest_digest))
             .map(|image| image.reference().to_string())
             .ok_or_else(|| {
                 Error::Backend(format!(
-                    "image digest {digest} is not present in this Microsandbox cache"
+                    "image manifest digest {manifest_digest} is not present in this Microsandbox cache"
                 ))
             })
     }

--- a/src/experimental/sandbox-microsandbox/src/backend.rs
+++ b/src/experimental/sandbox-microsandbox/src/backend.rs
@@ -23,7 +23,7 @@ use crate::{
     client::{Client, RuntimeResources},
     error,
     execution::ExecutionControls,
-    image::MicrosandboxImageResolver,
+    image::MicrosandboxImageBackend,
     network_endpoint, platform,
     state::{SandboxRecord, StateStore},
 };
@@ -36,10 +36,10 @@ const CREATE_RUNTIME: &str = "Create Microsandbox VM";
 const START_RUNTIME: &str = "Start Microsandbox VM";
 const UPDATE_RUNTIME_RESOURCES: &str = "Update Microsandbox VM resources";
 
-/// Microsandbox Provider pairing its Sandbox Backend with its Image Resolver.
+/// Microsandbox Provider pairing its Sandbox Backend with its Image Backend.
 pub struct MicrosandboxProvider {
     pub(crate) client: Client,
-    image_resolver: MicrosandboxImageResolver,
+    image_backend: MicrosandboxImageBackend,
     pub(crate) state: StateStore,
     pub(crate) executions: ExecutionControls,
 }
@@ -48,6 +48,7 @@ pub struct MicrosandboxProvider {
 pub struct MicrosandboxProviderBuilder {
     home: PathBuf,
     cache_directory: Option<PathBuf>,
+    registry_authentication: Option<sandbox::image::RegistryAuthentication>,
     runtime_bundle: Option<RuntimeBundle>,
 }
 
@@ -64,6 +65,7 @@ impl MicrosandboxProvider {
         MicrosandboxProviderBuilder {
             home: home.into(),
             cache_directory: None,
+            registry_authentication: None,
             runtime_bundle: None,
         }
     }
@@ -78,15 +80,10 @@ impl MicrosandboxProvider {
         Self::builder(home.as_ref().to_path_buf()).open().await
     }
 
-    /// Returns the configured shared Microsandbox cache directory.
-    #[must_use]
-    pub fn cache_directory(&self) -> PathBuf {
-        self.client.cache_directory()
-    }
-
     async fn open_configured(
         home: PathBuf,
         cache_directory: Option<PathBuf>,
+        registry_authentication: Option<sandbox::image::RegistryAuthentication>,
         runtime_bundle: Option<RuntimeBundle>,
     ) -> Result<Self, Error> {
         if home.as_os_str().is_empty() {
@@ -111,10 +108,10 @@ impl MicrosandboxProvider {
         }
         let state = StateStore::open(home.join("state")).await?;
         let client = Client::open(home.join("runtime"), cache_directory, runtime_bundle).await?;
-        let image_resolver = MicrosandboxImageResolver::new(client.clone());
+        let image_backend = MicrosandboxImageBackend::new(client.clone(), registry_authentication);
         Ok(Self {
             client,
-            image_resolver,
+            image_backend,
             state,
             executions: Rc::new(RefCell::new(HashMap::new())),
         })
@@ -414,6 +411,13 @@ impl MicrosandboxProviderBuilder {
         self
     }
 
+    /// Supplies transient credentials used to resolve OCI registry references.
+    #[must_use]
+    pub fn registry_authentication(mut self, authentication: sandbox::image::RegistryAuthentication) -> Self {
+        self.registry_authentication = Some(authentication);
+        self
+    }
+
     /// Installs the Microsandbox host runtime from a verified local release bundle.
     ///
     /// The path must identify a platform-compatible Microsandbox `tar.gz`
@@ -434,7 +438,13 @@ impl MicrosandboxProviderBuilder {
     /// Returns an error when a configured path is empty or cannot be
     /// initialized by the Microsandbox runtime.
     pub async fn open(self) -> Result<MicrosandboxProvider, Error> {
-        MicrosandboxProvider::open_configured(self.home, self.cache_directory, self.runtime_bundle).await
+        MicrosandboxProvider::open_configured(
+            self.home,
+            self.cache_directory,
+            self.registry_authentication,
+            self.runtime_bundle,
+        )
+        .await
     }
 }
 
@@ -443,8 +453,8 @@ impl SandboxProvider for MicrosandboxProvider {
         self
     }
 
-    fn image_resolver(&self) -> &dyn sandbox::image::Resolver {
-        &self.image_resolver
+    fn image_backend(&self) -> &dyn sandbox::image::ImageBackend {
+        &self.image_backend
     }
 }
 

--- a/src/experimental/sandbox-microsandbox/src/client.rs
+++ b/src/experimental/sandbox-microsandbox/src/client.rs
@@ -107,10 +107,6 @@ impl Client {
         &self.backend
     }
 
-    pub(crate) fn cache_directory(&self) -> PathBuf {
-        self.backend.cache_dir()
-    }
-
     pub(crate) async fn bind_network_controller(
         &self,
         name: &str,

--- a/src/experimental/sandbox-microsandbox/src/image.rs
+++ b/src/experimental/sandbox-microsandbox/src/image.rs
@@ -582,7 +582,7 @@ fn resolve_image_handle(
 ) -> Result<(String, sandbox::Platform), Error> {
     let manifest_digest = handle
         .manifest_digest()
-        .ok_or_else(|| Error::Backend("Microsandbox did not report the imported image manifest digest".to_string()))?
+        .ok_or_else(|| Error::Backend("Microsandbox did not report the image manifest digest".to_string()))?
         .to_string();
     let actual = sandbox::Platform::new(
         handle.os().unwrap_or(fallback.os.as_str()),

--- a/src/experimental/sandbox-microsandbox/src/image.rs
+++ b/src/experimental/sandbox-microsandbox/src/image.rs
@@ -12,7 +12,9 @@ use bollard::{
 use futures_util::StreamExt as _;
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use sandbox::progress::{ProgressStep, SandboxProgress};
-use sandbox::{Error, OutputStream, PendingOperation, ProgressUnit, SandboxPhase, image};
+use sandbox::{
+    Error, LocalFuture, OutputStream, PendingOperation, ProgressUnit, RootFilesystemMode, SandboxPhase, image,
+};
 use sha2::{Digest as _, Sha256};
 use tokio::io::AsyncWriteExt as _;
 use tokio_util::codec::{BytesCodec, FramedRead};
@@ -29,22 +31,26 @@ const EXPORT_IMAGE: &str = "Export Docker image";
 const IMPORT_IMAGE: &str = "Import Microsandbox image";
 const RETAIN_BUILD_CACHE: &str = "Retain Docker build cache";
 const REMOVE_TEMPORARY_IMAGE: &str = "Remove temporary Docker image";
+const EXPORT_PREPARED_ROOT: &str = "Export prepared root";
+const IMPORT_PREPARED_ROOT: &str = "Import prepared root";
 const EXPORT_PROGRESS_INTERVAL: u64 = 32 * 1024 * 1024;
 const CACHE_REPOSITORY: &str = "sandbox-microsandbox-cache";
 const IMPORT_CACHE_REPOSITORY: &str = "sandbox-microsandbox-import";
 
 /// Resolves Dockerfile builds and OCI references into the Microsandbox cache
 /// used by its paired Backend.
-pub(crate) struct MicrosandboxImageResolver {
+pub(crate) struct MicrosandboxImageBackend {
     client: Client,
     docker: Result<Docker, String>,
+    registry_authentication: Option<sandbox::image::RegistryAuthentication>,
 }
 
-impl MicrosandboxImageResolver {
-    pub(crate) fn new(client: Client) -> Self {
+impl MicrosandboxImageBackend {
+    pub(crate) fn new(client: Client, registry_authentication: Option<sandbox::image::RegistryAuthentication>) -> Self {
         Self {
             client,
             docker: Docker::connect_with_defaults().map_err(|failure| failure.to_string()),
+            registry_authentication,
         }
     }
 
@@ -374,7 +380,16 @@ impl MicrosandboxImageResolver {
         let options = microsandbox_image::PullOptions {
             pull_policy: microsandbox_image::PullPolicy::IfMissing,
             force: false,
-            materialization: microsandbox_image::RootfsMaterialization::Layered,
+            materialization: match request.root_filesystem_mode {
+                RootFilesystemMode::Layered => microsandbox_image::RootfsMaterialization::Layered,
+                RootFilesystemMode::Direct => microsandbox_image::RootfsMaterialization::Flat,
+                mode => {
+                    return Err(Error::UnsupportedImageRootFilesystemMode {
+                        operation: image::ImageOperation::Resolve,
+                        mode,
+                    });
+                }
+            },
         };
 
         let metadata = if let Some((_, metadata)) =
@@ -383,13 +398,21 @@ impl MicrosandboxImageResolver {
             metadata
         } else {
             let config = self.client.local().config();
+            let authentication = match &self.registry_authentication {
+                Some(sandbox::image::RegistryAuthentication::Anonymous) => microsandbox_image::RegistryAuth::Anonymous,
+                Some(sandbox::image::RegistryAuthentication::Basic { username, password }) => {
+                    microsandbox_image::RegistryAuth::Basic {
+                        username: username.clone(),
+                        password: password.clone(),
+                    }
+                }
+                None => config
+                    .resolve_registry_auth(parsed.registry())
+                    .map_err(error::microsandbox)?,
+            };
             let registry =
                 microsandbox_image::Registry::builder(microsandbox_image::Platform::host_linux(), cache.clone())
-                    .auth(
-                        config
-                            .resolve_registry_auth(parsed.registry())
-                            .map_err(error::microsandbox)?,
-                    )
+                    .auth(authentication)
                     .extra_ca_certs(config.resolve_ca_certs().await.map_err(error::microsandbox)?)
                     .add_insecure_registries(config.insecure_registries())
                     .build()
@@ -422,6 +445,113 @@ impl MicrosandboxImageResolver {
             platform: actual,
             digest,
         })
+    }
+
+    async fn export_prepared_root(
+        &self,
+        request: &image::ResolveRequest,
+        destination: &Path,
+        progress: &SandboxProgress,
+    ) -> Result<image::PreparedImage, Error> {
+        let operation = image::ImageOperation::PreparedImageExport;
+        require_direct_prepared_root(request, operation)?;
+        let reference = prepared_root_reference(request, operation)?;
+        let resolved = self
+            .resolve_reference(request, &reference.to_string(), progress)
+            .await?;
+        let cache = microsandbox_image::GlobalCache::new(&self.client.local().cache_dir()).map_err(error::backend)?;
+        let started = Instant::now();
+        let step = progress.start_step(EXPORT_PREPARED_ROOT).await;
+        let prepared = microsandbox_image::export_prepared_root(
+            &cache,
+            &reference,
+            &microsandbox_image::Platform::host_linux(),
+            destination,
+        )
+        .await
+        .map_err(error::backend)?;
+        step.complete(started.elapsed()).await;
+        Ok(prepared_root(resolved, &prepared))
+    }
+
+    async fn import_prepared_root(
+        &self,
+        request: &image::ResolveRequest,
+        source: &Path,
+        progress: &SandboxProgress,
+    ) -> Result<image::PreparedImage, Error> {
+        let operation = image::ImageOperation::PreparedImageImport;
+        require_direct_prepared_root(request, operation)?;
+        let actual = platform::require_supported(&request.platform)?;
+        let reference = prepared_root_reference(request, operation)?;
+        let cache = microsandbox_image::GlobalCache::new(&self.client.local().cache_dir()).map_err(error::backend)?;
+        let started = Instant::now();
+        let step = progress.start_step(IMPORT_PREPARED_ROOT).await;
+        let prepared = microsandbox_image::import_prepared_root(
+            &cache,
+            &reference,
+            &microsandbox_image::Platform::host_linux(),
+            source,
+        )
+        .await
+        .map_err(error::backend)?;
+        step.complete(started.elapsed()).await;
+        Ok(prepared_root(
+            image::ResolvedImage {
+                source: request.source.clone(),
+                platform: actual,
+                digest: prepared.image.manifest_digest.clone(),
+            },
+            &prepared,
+        ))
+    }
+}
+
+fn require_direct_prepared_root(
+    request: &image::ResolveRequest,
+    operation: image::ImageOperation,
+) -> Result<(), Error> {
+    if request.root_filesystem_mode == RootFilesystemMode::Direct {
+        Ok(())
+    } else {
+        Err(Error::UnsupportedImageRootFilesystemMode {
+            operation,
+            mode: request.root_filesystem_mode,
+        })
+    }
+}
+
+fn prepared_root_reference(
+    request: &image::ResolveRequest,
+    operation: image::ImageOperation,
+) -> Result<microsandbox_image::Reference, Error> {
+    let image::ImageSource::Reference { reference } = &request.source else {
+        return Err(Error::UnsupportedImageSourceKind {
+            operation,
+            source_kind: request.source.kind(),
+        });
+    };
+    let reference = reference
+        .parse::<microsandbox_image::Reference>()
+        .map_err(error::backend)?;
+    if reference.digest().is_none() {
+        return Err(Error::invalid(
+            "image.reference",
+            "prepared roots require an immutable digest-pinned OCI reference",
+        ));
+    }
+    Ok(reference)
+}
+
+fn prepared_root(
+    image: image::ResolvedImage,
+    prepared: &microsandbox_image::PreparedRootMetadata,
+) -> image::PreparedImage {
+    image::PreparedImage {
+        image,
+        root_filesystem_mode: RootFilesystemMode::Direct,
+        artifact_digest: prepared.root.artifact_digest.clone(),
+        virtual_size_bytes: prepared.root.virtual_size_bytes,
     }
 }
 
@@ -543,7 +673,31 @@ async fn report_image_progress(step: &ProgressStep, event: microsandbox_image::P
     }
 }
 
-impl image::Resolver for MicrosandboxImageResolver {
+impl image::ImageBackend for MicrosandboxImageBackend {
+    fn capabilities<'a>(
+        &'a self,
+        platform: &'a sandbox::Platform,
+    ) -> LocalFuture<'a, Result<image::ImageBackendCapabilities, Error>> {
+        Box::pin(async move {
+            platform::require_supported(platform)?;
+            // TODO: Add prepared-image transport for Microsandbox's layered
+            // EROFS/VMDK representation. The current artifact format packages
+            // only the flat ext4 representation used by direct roots.
+            let prepared = image::ImageOperationCapabilities::new(
+                [image::ImageSourceKind::Reference].into(),
+                [RootFilesystemMode::Direct].into(),
+            );
+            Ok(image::ImageBackendCapabilities::new(
+                image::ImageOperationCapabilities::new(
+                    [image::ImageSourceKind::Build, image::ImageSourceKind::Reference].into(),
+                    [RootFilesystemMode::Layered, RootFilesystemMode::Direct].into(),
+                ),
+                prepared.clone(),
+                prepared,
+            ))
+        })
+    }
+
     fn resolve<'a>(&'a self, request: &'a image::ResolveRequest) -> PendingOperation<'a, image::ResolvedImage> {
         PendingOperation::run(SandboxPhase::ImageResolve, move |progress| {
             Box::pin(async move {
@@ -556,6 +710,26 @@ impl image::Resolver for MicrosandboxImageResolver {
                     }
                 }
             })
+        })
+    }
+
+    fn export_prepared_image<'a>(
+        &'a self,
+        request: &'a image::ResolveRequest,
+        destination: &'a Path,
+    ) -> PendingOperation<'a, image::PreparedImage> {
+        PendingOperation::run(SandboxPhase::ImagePrepare, move |progress| {
+            Box::pin(async move { self.export_prepared_root(request, destination, &progress).await })
+        })
+    }
+
+    fn import_prepared_image<'a>(
+        &'a self,
+        request: &'a image::ResolveRequest,
+        source: &'a Path,
+    ) -> PendingOperation<'a, image::PreparedImage> {
+        PendingOperation::run(SandboxPhase::ImagePrepare, move |progress| {
+            Box::pin(async move { self.import_prepared_root(request, source, &progress).await })
         })
     }
 }

--- a/src/experimental/sandbox-microsandbox/src/image.rs
+++ b/src/experimental/sandbox-microsandbox/src/image.rs
@@ -82,13 +82,13 @@ impl MicrosandboxImageBackend {
             )
             .await;
         let cleanup = self.remove_temporary_image(&temporary_tag, progress).await;
-        let (digest, actual) = resolution?;
+        let (manifest_digest, actual) = resolution?;
         cleanup?;
 
         Ok(image::ResolvedImage {
             source: request.source.clone(),
             platform: actual,
-            digest,
+            manifest_digest,
         })
     }
 
@@ -438,12 +438,12 @@ impl MicrosandboxImageBackend {
         let handle = microsandbox::Image::get_local(self.client.local(), reference)
             .await
             .map_err(error::microsandbox)?;
-        let (digest, actual) = resolve_image_handle(&handle, &request.platform, &fallback)?;
+        let (manifest_digest, actual) = resolve_image_handle(&handle, &request.platform, &fallback)?;
         step.complete(started.elapsed()).await;
         Ok(image::ResolvedImage {
             source: request.source.clone(),
             platform: actual,
-            digest,
+            manifest_digest,
         })
     }
 
@@ -500,7 +500,7 @@ impl MicrosandboxImageBackend {
             image::ResolvedImage {
                 source: request.source.clone(),
                 platform: actual,
-                digest: prepared.image.manifest_digest.clone(),
+                manifest_digest: prepared.image.manifest_digest.clone(),
             },
             &prepared,
         ))
@@ -580,9 +580,9 @@ fn resolve_image_handle(
     requested: &sandbox::Platform,
     fallback: &sandbox::Platform,
 ) -> Result<(String, sandbox::Platform), Error> {
-    let digest = handle
+    let manifest_digest = handle
         .manifest_digest()
-        .ok_or_else(|| Error::Backend("Microsandbox did not report the imported image digest".to_string()))?
+        .ok_or_else(|| Error::Backend("Microsandbox did not report the imported image manifest digest".to_string()))?
         .to_string();
     let actual = sandbox::Platform::new(
         handle.os().unwrap_or(fallback.os.as_str()),
@@ -594,7 +594,7 @@ fn resolve_image_handle(
             actual: Box::new(actual),
         });
     }
-    Ok((digest, actual))
+    Ok((manifest_digest, actual))
 }
 
 async fn report_buildkit_status(

--- a/src/experimental/sandbox-microsandbox/src/state.rs
+++ b/src/experimental/sandbox-microsandbox/src/state.rs
@@ -316,7 +316,7 @@ mod tests {
                 dockerfile: PathBuf::from("Dockerfile"),
             },
             platform: Platform::new("linux", "amd64"),
-            digest: "sha256:1234".to_string(),
+            manifest_digest: "sha256:1234".to_string(),
         }
     }
 

--- a/src/experimental/sandbox-microsandbox/tests/backend.rs
+++ b/src/experimental/sandbox-microsandbox/tests/backend.rs
@@ -2,9 +2,11 @@
 
 use microsandbox_network::control::NETWORK_CONTROL_PROTOCOL;
 use sandbox::{
-    Platform, SandboxFeature,
+    Platform, RootFilesystemMode, SandboxFeature,
     backend::SandboxBackend as _,
+    image::ImageSourceKind,
     network::{NetworkControlProtocolId, NetworkEndpointSelection},
+    provider::SandboxProvider as _,
 };
 use sandbox_microsandbox::MicrosandboxProvider;
 
@@ -47,6 +49,35 @@ async fn backend_state_and_runtime_are_rooted_in_the_explicit_home() {
                 NETWORK_CONTROL_PROTOCOL
             )))
     );
+
+    let image_capabilities = backend
+        .image_backend()
+        .capabilities(&platform)
+        .await
+        .expect("native Image Backend capabilities should be reported");
+    assert!(image_capabilities.resolve.sources.contains(ImageSourceKind::Build));
+    assert!(image_capabilities.resolve.sources.contains(ImageSourceKind::Reference));
+    assert!(
+        image_capabilities
+            .resolve
+            .root_filesystem_modes
+            .contains(RootFilesystemMode::Layered)
+    );
+    assert!(
+        image_capabilities
+            .resolve
+            .root_filesystem_modes
+            .contains(RootFilesystemMode::Direct)
+    );
+    for prepared in [
+        &image_capabilities.prepared_image_export,
+        &image_capabilities.prepared_image_import,
+    ] {
+        assert!(prepared.sources.contains(ImageSourceKind::Reference));
+        assert!(!prepared.sources.contains(ImageSourceKind::Build));
+        assert!(prepared.root_filesystem_modes.contains(RootFilesystemMode::Direct));
+        assert!(!prepared.root_filesystem_modes.contains(RootFilesystemMode::Layered));
+    }
 }
 
 #[tokio::test(flavor = "local")]
@@ -56,19 +87,17 @@ async fn cache_directory_can_be_shared_without_sharing_provider_state() {
     let first_home = temporary.path().join("first-provider");
     let second_home = temporary.path().join("second-provider");
 
-    let first = MicrosandboxProvider::builder(&first_home)
+    MicrosandboxProvider::builder(&first_home)
         .cache_directory(&shared_cache)
         .open()
         .await
         .expect("first Provider should open with the shared cache");
-    let second = MicrosandboxProvider::builder(&second_home)
+    MicrosandboxProvider::builder(&second_home)
         .cache_directory(&shared_cache)
         .open()
         .await
         .expect("second Provider should open with the shared cache");
 
-    assert_eq!(first.cache_directory(), shared_cache);
-    assert_eq!(second.cache_directory(), shared_cache);
     assert!(shared_cache.is_dir());
     assert!(first_home.join("state/sandboxes").is_dir());
     assert!(second_home.join("state/sandboxes").is_dir());

--- a/src/experimental/sandbox-microsandbox/tests/backend.rs
+++ b/src/experimental/sandbox-microsandbox/tests/backend.rs
@@ -4,11 +4,13 @@ use microsandbox_network::control::NETWORK_CONTROL_PROTOCOL;
 use sandbox::{
     Platform, RootFilesystemMode, SandboxFeature,
     backend::SandboxBackend as _,
-    image::ImageSourceKind,
+    image::{ImageSource, ImageSourceKind, ResolveRequest},
     network::{NetworkControlProtocolId, NetworkEndpointSelection},
     provider::SandboxProvider as _,
 };
 use sandbox_microsandbox::MicrosandboxProvider;
+
+const ALPINE_3_22_INDEX_DIGEST: &str = "sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce";
 
 #[tokio::test(flavor = "local")]
 async fn backend_state_and_runtime_are_rooted_in_the_explicit_home() {
@@ -101,6 +103,42 @@ async fn cache_directory_can_be_shared_without_sharing_provider_state() {
     assert!(shared_cache.is_dir());
     assert!(first_home.join("state/sandboxes").is_dir());
     assert!(second_home.join("state/sandboxes").is_dir());
+}
+
+#[tokio::test(flavor = "local")]
+#[ignore = "requires access to the public Docker registry"]
+async fn multi_platform_index_resolves_to_the_native_image_manifest() {
+    let (architecture, expected_manifest_digest) = match std::env::consts::ARCH {
+        "x86_64" => (
+            "amd64",
+            "sha256:7c8cb692ae09657cbc4a3f3cbd0e8d5a2690ba38386aaaf252dbb060bf5eb2e6",
+        ),
+        "aarch64" => (
+            "arm64",
+            "sha256:2c9d26f410d032d5b1525aa8a873e238b05b90c4ae8618743d4311f0cc827e37",
+        ),
+        _ => return,
+    };
+    let temporary = tempfile::tempdir().expect("temporary home should be created");
+    let provider = MicrosandboxProvider::open(temporary.path().join("provider"))
+        .await
+        .expect("Provider should open");
+    let request = ResolveRequest {
+        source: ImageSource::Reference {
+            reference: format!("docker.io/library/alpine@{ALPINE_3_22_INDEX_DIGEST}"),
+        },
+        platform: Platform::new("linux", architecture),
+        root_filesystem_mode: RootFilesystemMode::Layered,
+    };
+
+    let resolved = provider
+        .image_backend()
+        .resolve(&request)
+        .await
+        .expect("multi-platform index should resolve");
+
+    assert_eq!(resolved.manifest_digest, expected_manifest_digest);
+    assert_ne!(resolved.manifest_digest, ALPINE_3_22_INDEX_DIGEST);
 }
 
 #[tokio::test(flavor = "local")]

--- a/src/experimental/sandbox/Cargo.toml
+++ b/src/experimental/sandbox/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 bytes.workspace = true
 futures-core.workspace = true
 serde.workspace = true
+sha2.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-util = { workspace = true, features = ["rt"] }

--- a/src/experimental/sandbox/src/feature.rs
+++ b/src/experimental/sandbox/src/feature.rs
@@ -4,7 +4,10 @@ use std::collections::BTreeSet;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{mount::MountKindSet, network::NetworkEndpointCapabilities, root_filesystem::RootFilesystemModeSet};
+use crate::{
+    image::ImageOperationCapabilities, mount::MountKindSet, network::NetworkEndpointCapabilities,
+    root_filesystem::RootFilesystemModeSet,
+};
 
 /// Optional functionality that callers may require from a Sandbox implementation.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -86,6 +89,8 @@ pub struct SandboxCapabilities {
     features: SandboxFeatureSet,
     mount_kinds: MountKindSet,
     root_filesystem_modes: RootFilesystemModeSet,
+    prepared_image_export: ImageOperationCapabilities,
+    prepared_image_import: ImageOperationCapabilities,
     network_available: bool,
 }
 
@@ -94,12 +99,16 @@ impl SandboxCapabilities {
         features: SandboxFeatureSet,
         mount_kinds: MountKindSet,
         root_filesystem_modes: RootFilesystemModeSet,
+        prepared_image_export: ImageOperationCapabilities,
+        prepared_image_import: ImageOperationCapabilities,
         network_available: bool,
     ) -> Self {
         Self {
             features,
             mount_kinds,
             root_filesystem_modes,
+            prepared_image_export,
+            prepared_image_import,
             network_available,
         }
     }
@@ -116,10 +125,23 @@ impl SandboxCapabilities {
         &self.mount_kinds
     }
 
-    /// Returns root-filesystem materialization modes accepted during creation.
+    /// Returns root-filesystem modes accepted by both the Sandbox Backend and
+    /// the Image Backend's resolve operation.
     #[must_use]
     pub const fn root_filesystem_modes(&self) -> &RootFilesystemModeSet {
         &self.root_filesystem_modes
+    }
+
+    /// Returns prepared-image export support for this Platform.
+    #[must_use]
+    pub const fn prepared_image_export(&self) -> &ImageOperationCapabilities {
+        &self.prepared_image_export
+    }
+
+    /// Returns prepared-image import support for this Platform.
+    #[must_use]
+    pub const fn prepared_image_import(&self) -> &ImageOperationCapabilities {
+        &self.prepared_image_import
     }
 
     /// Reports whether the configured Network Backend can use this Provider.

--- a/src/experimental/sandbox/src/image.rs
+++ b/src/experimental/sandbox/src/image.rs
@@ -234,11 +234,11 @@ pub struct ResolvedImage {
     pub source: ImageSource,
     /// The actual Platform selected from the image.
     pub platform: Platform,
-    /// Immutable OCI descriptor digest resolved from the source.
+    /// Immutable digest of the platform-specific OCI image manifest.
     ///
-    /// This may identify an image index or an image manifest. The materialized
-    /// Platform is recorded separately by [`Self::platform`].
-    pub digest: String,
+    /// Resolving a multi-platform image index selects its matching manifest;
+    /// an index digest is never returned here.
+    pub manifest_digest: String,
 }
 
 /// Description of a transportable, fully materialized OCI image.
@@ -303,8 +303,8 @@ impl ResolvedImage {
     pub(crate) fn validate(&self) -> Result<(), Error> {
         self.source.validate()?;
         self.platform.validate()?;
-        if self.digest.is_empty() {
-            return Err(Error::invalid("image.digest", "must not be empty"));
+        if self.manifest_digest.is_empty() {
+            return Err(Error::invalid("image.manifestDigest", "must not be empty"));
         }
         Ok(())
     }

--- a/src/experimental/sandbox/src/image.rs
+++ b/src/experimental/sandbox/src/image.rs
@@ -1,10 +1,143 @@
-//! Image resolution is separate from sandbox lifecycle backends.
+//! Image materialization is separate from Sandbox lifecycle backends.
 
-use std::path::PathBuf;
+use std::{
+    collections::BTreeSet,
+    path::{Path, PathBuf},
+};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{Error, PendingOperation, Platform};
+use crate::{Error, LocalFuture, PendingOperation, Platform, RootFilesystemMode, RootFilesystemModeSet};
+
+/// Transient credentials used while resolving an OCI registry reference.
+///
+/// Credentials configure a Provider's image materialization domain. They are
+/// never part of a persisted [`ImageSource`] or [`ResolvedImage`].
+#[derive(Clone, Eq, PartialEq)]
+pub enum RegistryAuthentication {
+    /// Access the registry without credentials.
+    Anonymous,
+    /// Authenticate with a username and password or access token.
+    Basic {
+        /// Registry username.
+        username: String,
+        /// Registry password or access token.
+        password: String,
+    },
+}
+
+/// The portable OCI identity form supplied to an Image Backend.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub enum ImageSourceKind {
+    /// A Dockerfile and build context.
+    Build,
+    /// An OCI registry reference.
+    Reference,
+}
+
+/// Deterministic set of supported OCI Image Source forms.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ImageSourceKindSet(BTreeSet<ImageSourceKind>);
+
+impl ImageSourceKindSet {
+    /// Reports whether no Image Source form is supported.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Reports whether an Image Source form is supported.
+    #[must_use]
+    pub fn contains(&self, kind: ImageSourceKind) -> bool {
+        self.0.contains(&kind)
+    }
+
+    /// Iterates over supported forms in stable order.
+    pub fn iter(&self) -> impl Iterator<Item = ImageSourceKind> + '_ {
+        self.0.iter().copied()
+    }
+}
+
+impl<const N: usize> From<[ImageSourceKind; N]> for ImageSourceKindSet {
+    fn from(kinds: [ImageSourceKind; N]) -> Self {
+        Self(kinds.into_iter().collect())
+    }
+}
+
+/// An operation exposed by an Image Backend.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ImageOperation {
+    /// Resolve an OCI identity into a provider-consumable image.
+    Resolve,
+    /// Export a provider-owned prepared representation.
+    PreparedImageExport,
+    /// Import a provider-owned prepared representation.
+    PreparedImageImport,
+}
+
+/// OCI source forms and materialization modes supported by one Image operation.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ImageOperationCapabilities {
+    /// OCI Image Source forms accepted by the operation.
+    pub sources: ImageSourceKindSet,
+    /// Root filesystem modes accepted by the operation.
+    pub root_filesystem_modes: RootFilesystemModeSet,
+}
+
+impl ImageOperationCapabilities {
+    /// Creates one operation capability report.
+    #[must_use]
+    pub const fn new(sources: ImageSourceKindSet, root_filesystem_modes: RootFilesystemModeSet) -> Self {
+        Self {
+            sources,
+            root_filesystem_modes,
+        }
+    }
+
+    /// Reports whether the operation accepts at least one source and mode pair.
+    ///
+    /// Operation capabilities describe the Cartesian product of the two sets,
+    /// so either set being empty makes the operation unavailable.
+    #[must_use]
+    pub fn is_available(&self) -> bool {
+        !self.sources.is_empty() && !self.root_filesystem_modes.is_empty()
+    }
+}
+
+/// Platform-specific functionality reported by an Image Backend.
+///
+/// An operation is unavailable when either of its capability sets is empty.
+/// Materialization formats are provider-owned and are not transferable between
+/// providers; the portable identity remains the OCI build or registry reference
+/// from which a prepared image is derived.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ImageBackendCapabilities {
+    /// Supported image resolution inputs.
+    pub resolve: ImageOperationCapabilities,
+    /// Supported prepared-image exports.
+    pub prepared_image_export: ImageOperationCapabilities,
+    /// Supported prepared-image imports.
+    pub prepared_image_import: ImageOperationCapabilities,
+}
+
+impl ImageBackendCapabilities {
+    /// Creates one coherent Image Backend capability report.
+    #[must_use]
+    pub const fn new(
+        resolve: ImageOperationCapabilities,
+        prepared_image_export: ImageOperationCapabilities,
+        prepared_image_import: ImageOperationCapabilities,
+    ) -> Self {
+        Self {
+            resolve,
+            prepared_image_export,
+            prepared_image_import,
+        }
+    }
+}
 
 /// Describes how to obtain the immutable image for a sandbox.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -26,6 +159,15 @@ pub enum ImageSource {
 }
 
 impl ImageSource {
+    /// Returns this source's capability kind.
+    #[must_use]
+    pub const fn kind(&self) -> ImageSourceKind {
+        match self {
+            Self::Build { .. } => ImageSourceKind::Build,
+            Self::Reference { .. } => ImageSourceKind::Reference,
+        }
+    }
+
     /// Validates fields understood by the generic image layer.
     ///
     /// # Errors
@@ -73,6 +215,15 @@ pub struct ResolveRequest {
     pub source: ImageSource,
     /// Platform the resulting image must support.
     pub platform: Platform,
+    /// Filesystem representation required by the Sandbox consuming the image.
+    pub root_filesystem_mode: RootFilesystemMode,
+}
+
+impl ResolveRequest {
+    pub(crate) fn validate(&self) -> Result<(), Error> {
+        self.source.validate()?;
+        self.platform.validate()
+    }
 }
 
 /// An image resolved to a backend-consumable immutable digest and Platform.
@@ -83,8 +234,69 @@ pub struct ResolvedImage {
     pub source: ImageSource,
     /// The actual Platform selected from the image.
     pub platform: Platform,
-    /// An immutable content digest.
+    /// Immutable OCI descriptor digest resolved from the source.
+    ///
+    /// This may identify an image index or an image manifest. The materialized
+    /// Platform is recorded separately by [`Self::platform`].
     pub digest: String,
+}
+
+/// Description of a transportable, fully materialized OCI image.
+///
+/// A prepared image is a pristine derivative of [`ResolvedImage`], never a
+/// parallel image identity. The artifact stored at the caller-selected path is
+/// opaque: its representation is owned by the Provider and can only be returned
+/// to a compatible Provider. The generic API assumes neither a guest operating
+/// system nor a concrete filesystem format.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PreparedImage {
+    /// Immutable OCI Image represented by the prepared artifact.
+    pub image: ResolvedImage,
+    /// Root filesystem representation for which the image was materialized.
+    pub root_filesystem_mode: RootFilesystemMode,
+    /// Content digest of the complete filesystem artifact.
+    pub artifact_digest: String,
+    /// Logical size of the uncompressed filesystem artifact.
+    pub virtual_size_bytes: u64,
+}
+
+impl PreparedImage {
+    /// Checks that backend-returned metadata is coherent with the request.
+    ///
+    /// This validates metadata only. Artifact integrity and the binding between
+    /// the opaque artifact and requested OCI identity are Image Backend
+    /// obligations.
+    pub(crate) fn validate_for(&self, request: &ResolveRequest) -> Result<(), Error> {
+        self.image.validate()?;
+        if self.image.source != request.source {
+            return Err(Error::invalid(
+                "preparedImage.image.source",
+                "must match the requested Image Source",
+            ));
+        }
+        if !self.image.platform.satisfies(&request.platform) {
+            return Err(Error::ImagePlatformMismatch {
+                requested: Box::new(request.platform.clone()),
+                actual: Box::new(self.image.platform.clone()),
+            });
+        }
+        if self.root_filesystem_mode != request.root_filesystem_mode {
+            return Err(Error::invalid(
+                "preparedImage.rootFilesystemMode",
+                "must match the requested root filesystem mode",
+            ));
+        }
+        if self.artifact_digest.is_empty() {
+            return Err(Error::invalid("preparedImage.artifactDigest", "must not be empty"));
+        }
+        if self.virtual_size_bytes == 0 {
+            return Err(Error::invalid(
+                "preparedImage.virtualSizeBytes",
+                "must be greater than zero",
+            ));
+        }
+        Ok(())
+    }
 }
 
 impl ResolvedImage {
@@ -98,8 +310,41 @@ impl ResolvedImage {
     }
 }
 
-/// Resolves source descriptions into immutable images.
-pub trait Resolver {
+/// Owns image materialization for a paired Sandbox Backend.
+///
+/// Every operation is capability-discovered per [`Platform`]. Implementations
+/// must define all operations explicitly, including providers for which prepared
+/// transport is unnecessary and therefore reported with empty capability sets.
+pub trait ImageBackend {
+    /// Reports functionality available for one Platform.
+    ///
+    /// Discovery must be side-effect-free and stable for the duration of the
+    /// caller's operation. Implementations may perform asynchronous host discovery.
+    fn capabilities<'a>(&'a self, platform: &'a Platform) -> LocalFuture<'a, Result<ImageBackendCapabilities, Error>>;
+
     /// Builds, fetches, or reuses the requested image.
     fn resolve<'a>(&'a self, request: &'a ResolveRequest) -> PendingOperation<'a, ResolvedImage>;
+
+    /// Exports a resolved, fully materialized image to an opaque artifact.
+    ///
+    /// Returned metadata must be derived from the exported artifact and describe
+    /// the OCI identity and Platform actually materialized.
+    fn export_prepared_image<'a>(
+        &'a self,
+        request: &'a ResolveRequest,
+        destination: &'a Path,
+    ) -> PendingOperation<'a, PreparedImage>;
+
+    /// Validates and imports an opaque prepared image into this Backend's
+    /// materialization domain.
+    ///
+    /// Before returning, the implementation must validate artifact integrity,
+    /// bind the artifact to the requested OCI identity and Platform, and return
+    /// metadata that reflects the validated artifact rather than merely asserting
+    /// values supplied by the request.
+    fn import_prepared_image<'a>(
+        &'a self,
+        request: &'a ResolveRequest,
+        source: &'a Path,
+    ) -> PendingOperation<'a, PreparedImage>;
 }

--- a/src/experimental/sandbox/src/memory.rs
+++ b/src/experimental/sandbox/src/memory.rs
@@ -902,7 +902,7 @@ impl image::ImageBackend for MemoryImageBackend {
                 Ok(image::ResolvedImage {
                     source: request.source.clone(),
                     platform: request.platform.clone(),
-                    digest: format!("sha256:{}:{source}", request.platform),
+                    manifest_digest: format!("sha256:{}:{source}", request.platform),
                 })
             })
         })

--- a/src/experimental/sandbox/src/memory.rs
+++ b/src/experimental/sandbox/src/memory.rs
@@ -32,8 +32,8 @@ impl SandboxProvider for Provider {
         self
     }
 
-    fn image_resolver(&self) -> &dyn image::Resolver {
-        &ImageResolver
+    fn image_backend(&self) -> &dyn image::ImageBackend {
+        &MemoryImageBackend
     }
 }
 
@@ -869,11 +869,27 @@ impl network::NetworkBackend for NetworkBackend {
     }
 }
 
-/// Deterministically resolves source paths to synthetic digests.
+/// Deterministically resolves OCI Image Sources to synthetic digests.
 #[derive(Default)]
-pub struct ImageResolver;
+pub struct MemoryImageBackend;
 
-impl image::Resolver for ImageResolver {
+impl image::ImageBackend for MemoryImageBackend {
+    fn capabilities<'a>(
+        &'a self,
+        _platform: &'a Platform,
+    ) -> LocalFuture<'a, Result<image::ImageBackendCapabilities, Error>> {
+        Box::pin(async {
+            Ok(image::ImageBackendCapabilities::new(
+                image::ImageOperationCapabilities::new(
+                    [image::ImageSourceKind::Build, image::ImageSourceKind::Reference].into(),
+                    [RootFilesystemMode::Layered, RootFilesystemMode::Direct].into(),
+                ),
+                image::ImageOperationCapabilities::default(),
+                image::ImageOperationCapabilities::default(),
+            ))
+        })
+    }
+
     fn resolve<'a>(&'a self, request: &'a image::ResolveRequest) -> PendingOperation<'a, image::ResolvedImage> {
         PendingOperation::run(SandboxPhase::ImageResolve, move |_progress| {
             Box::pin(async move {
@@ -891,6 +907,28 @@ impl image::Resolver for ImageResolver {
             })
         })
     }
+
+    fn export_prepared_image<'a>(
+        &'a self,
+        _request: &'a image::ResolveRequest,
+        _destination: &'a std::path::Path,
+    ) -> PendingOperation<'a, image::PreparedImage> {
+        unsupported_prepared_image(image::ImageOperation::PreparedImageExport)
+    }
+
+    fn import_prepared_image<'a>(
+        &'a self,
+        _request: &'a image::ResolveRequest,
+        _source: &'a std::path::Path,
+    ) -> PendingOperation<'a, image::PreparedImage> {
+        unsupported_prepared_image(image::ImageOperation::PreparedImageImport)
+    }
+}
+
+fn unsupported_prepared_image<'a>(operation: image::ImageOperation) -> PendingOperation<'a, image::PreparedImage> {
+    PendingOperation::run(SandboxPhase::ImagePrepare, move |_progress| {
+        Box::pin(async move { Err(Error::UnsupportedImageOperation(operation)) })
+    })
 }
 
 fn test_platform() -> Platform {

--- a/src/experimental/sandbox/src/memory.rs
+++ b/src/experimental/sandbox/src/memory.rs
@@ -11,6 +11,7 @@ use std::{
 };
 
 use futures_core::Stream;
+use sha2::{Digest as _, Sha256};
 use tokio::{io::AsyncReadExt as _, sync::mpsc};
 use tokio_util::sync::PollSender;
 use zeroize::Zeroizing;
@@ -893,16 +894,10 @@ impl image::ImageBackend for MemoryImageBackend {
     fn resolve<'a>(&'a self, request: &'a image::ResolveRequest) -> PendingOperation<'a, image::ResolvedImage> {
         PendingOperation::run(SandboxPhase::ImageResolve, move |_progress| {
             Box::pin(async move {
-                let source = match &request.source {
-                    image::ImageSource::Build { context, dockerfile } => {
-                        format!("build:{}:{}", context.display(), dockerfile.display())
-                    }
-                    image::ImageSource::Reference { reference } => format!("reference:{reference}"),
-                };
                 Ok(image::ResolvedImage {
                     source: request.source.clone(),
                     platform: request.platform.clone(),
-                    manifest_digest: format!("sha256:{}:{source}", request.platform),
+                    manifest_digest: memory_manifest_digest(request),
                 })
             })
         })
@@ -923,6 +918,52 @@ impl image::ImageBackend for MemoryImageBackend {
     ) -> PendingOperation<'a, image::PreparedImage> {
         unsupported_prepared_image(image::ImageOperation::PreparedImageImport)
     }
+}
+
+fn memory_manifest_digest(request: &image::ResolveRequest) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"sandbox.memory-image-manifest.v1\0");
+    match &request.source {
+        image::ImageSource::Build { context, dockerfile } => {
+            update_digest_part(&mut digest, b"build");
+            update_digest_part(&mut digest, context.as_os_str().as_encoded_bytes());
+            update_digest_part(&mut digest, dockerfile.as_os_str().as_encoded_bytes());
+        }
+        image::ImageSource::Reference { reference } => {
+            update_digest_part(&mut digest, b"reference");
+            update_digest_part(&mut digest, reference.as_bytes());
+        }
+    }
+    update_digest_part(&mut digest, request.platform.os.as_bytes());
+    update_digest_part(&mut digest, request.platform.architecture.as_bytes());
+    update_optional_digest_part(&mut digest, request.platform.variant.as_deref());
+    update_optional_digest_part(&mut digest, request.platform.os_version.as_deref());
+    for feature in &request.platform.os_features {
+        update_digest_part(&mut digest, feature.as_bytes());
+    }
+    let mut encoded = String::with_capacity("sha256:".len() + 64);
+    encoded.push_str("sha256:");
+    for byte in digest.finalize() {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        encoded.push(char::from(HEX[usize::from(byte >> 4)]));
+        encoded.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    encoded
+}
+
+fn update_optional_digest_part(digest: &mut Sha256, value: Option<&str>) {
+    match value {
+        Some(value) => {
+            digest.update([1]);
+            update_digest_part(digest, value.as_bytes());
+        }
+        None => digest.update([0]),
+    }
+}
+
+fn update_digest_part(digest: &mut Sha256, value: &[u8]) {
+    digest.update(value.len().to_le_bytes());
+    digest.update(value);
 }
 
 fn unsupported_prepared_image<'a>(operation: image::ImageOperation) -> PendingOperation<'a, image::PreparedImage> {

--- a/src/experimental/sandbox/src/progress.rs
+++ b/src/experimental/sandbox/src/progress.rs
@@ -29,6 +29,8 @@ pub enum SandboxPhase {
     FeatureDiscovery,
     /// Resolve the immutable Image.
     ImageResolve,
+    /// Export or import a prepared Image.
+    ImagePrepare,
     /// Materialize the Sandbox around the resolved Image.
     SandboxCreate,
     /// Reconcile mutable Sandbox configuration.
@@ -46,8 +48,9 @@ impl fmt::Display for SandboxPhase {
         formatter.write_str(match self {
             Self::Validate => "Validate Sandbox request",
             Self::Lookup => "Look up Sandbox",
-            Self::FeatureDiscovery => "Discover Sandbox Backend Features",
+            Self::FeatureDiscovery => "Discover Sandbox Capabilities",
             Self::ImageResolve => "Resolve Sandbox Image",
+            Self::ImagePrepare => "Prepare Sandbox Image",
             Self::SandboxCreate => "Create Sandbox",
             Self::SandboxUpdate => "Update Sandbox",
             Self::NetworkStart => "Start Sandbox Network",
@@ -178,7 +181,7 @@ pub enum OperationEvent<T> {
 /// Reports progress from inside one implementation-owned operation.
 ///
 /// Callers receive [`PendingOperation`] instead of constructing or passing a
-/// reporter. Backend and Resolver implementations obtain this reporter from
+/// reporter. Sandbox and Image Backend implementations obtain this reporter from
 /// [`PendingOperation::run`].
 #[derive(Clone)]
 pub struct SandboxProgress {

--- a/src/experimental/sandbox/src/provider.rs
+++ b/src/experimental/sandbox/src/provider.rs
@@ -1,16 +1,16 @@
-//! Cohesive Sandbox Backend and Image Resolver composition.
+//! Cohesive Sandbox Backend and Image Backend composition.
 
 use crate::{backend::SandboxBackend, image};
 
 /// Supplies the backend components that share one image materialization domain.
 ///
-/// A provider keeps image resolution paired with the Backend that consumes the
-/// resulting cache entries. Consumers compose a provider with an optional
-/// Network Backend instead of pairing these components independently.
+/// A provider keeps Sandbox lifecycle paired with the Image Backend that owns
+/// its shared image materialization domain. Consumers compose a provider with
+/// an optional Network Backend instead of pairing these components independently.
 pub trait SandboxProvider {
     /// Returns the Sandbox Backend owned by this provider.
     fn backend(&self) -> &dyn SandboxBackend;
 
-    /// Returns the Image Resolver whose results the Backend can consume.
-    fn image_resolver(&self) -> &dyn image::Resolver;
+    /// Returns the Image Backend whose materialized images the Sandbox Backend consumes.
+    fn image_backend(&self) -> &dyn image::ImageBackend;
 }

--- a/src/experimental/sandbox/src/root_filesystem.rs
+++ b/src/experimental/sandbox/src/root_filesystem.rs
@@ -22,6 +22,12 @@ pub enum RootFilesystemMode {
 pub struct RootFilesystemModeSet(BTreeSet<RootFilesystemMode>);
 
 impl RootFilesystemModeSet {
+    /// Reports whether no root filesystem mode is supported.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
     /// Reports whether a root filesystem mode is supported.
     #[must_use]
     pub fn contains(&self, mode: RootFilesystemMode) -> bool {
@@ -31,6 +37,12 @@ impl RootFilesystemModeSet {
     /// Iterates over supported modes in stable order.
     pub fn iter(&self) -> impl Iterator<Item = RootFilesystemMode> + '_ {
         self.0.iter().copied()
+    }
+
+    /// Returns the modes present in both sets.
+    #[must_use]
+    pub fn intersection(&self, other: &Self) -> Self {
+        Self(self.0.intersection(&other.0).copied().collect())
     }
 }
 

--- a/src/experimental/sandbox/src/service.rs
+++ b/src/experimental/sandbox/src/service.rs
@@ -101,6 +101,25 @@ pub enum Error {
     /// A requested root filesystem mode is unavailable.
     #[error("unsupported Sandbox root filesystem mode: {0:?}")]
     UnsupportedRootFilesystemMode(crate::RootFilesystemMode),
+    /// An Image Backend operation is unavailable for the requested Platform.
+    #[error("unsupported Image operation: {0:?}")]
+    UnsupportedImageOperation(image::ImageOperation),
+    /// An Image Backend operation does not accept the requested OCI source form.
+    #[error("unsupported Image Source kind {source_kind:?} for operation {operation:?}")]
+    UnsupportedImageSourceKind {
+        /// Operation being requested.
+        operation: image::ImageOperation,
+        /// OCI source form rejected by the Image Backend.
+        source_kind: image::ImageSourceKind,
+    },
+    /// An Image Backend operation cannot materialize the requested root mode.
+    #[error("unsupported root filesystem mode {mode:?} for Image operation {operation:?}")]
+    UnsupportedImageRootFilesystemMode {
+        /// Operation being requested.
+        operation: image::ImageOperation,
+        /// Root filesystem mode rejected by the Image Backend.
+        mode: crate::RootFilesystemMode,
+    },
     /// A Sandbox Backend cannot materialize the requested Platform.
     #[error("unsupported Sandbox Platform: {0}")]
     UnsupportedPlatform(Platform),
@@ -227,6 +246,9 @@ impl Error {
             Self::UnsupportedFeature(_)
             | Self::UnsupportedMountKind(_)
             | Self::UnsupportedRootFilesystemMode(_)
+            | Self::UnsupportedImageOperation(_)
+            | Self::UnsupportedImageSourceKind { .. }
+            | Self::UnsupportedImageRootFilesystemMode { .. }
             | Self::UnsupportedPlatform(_)
             | Self::UnsupportedResourceValue { .. }
             | Self::UnsupportedResourceChange { .. }
@@ -427,6 +449,7 @@ impl SandboxService {
     /// configured Network Backend cannot use any offered endpoint.
     pub async fn capabilities(&self, platform: &Platform) -> Result<SandboxCapabilities, Error> {
         let capabilities = self.backend_capabilities(platform).await?;
+        let image_capabilities = self.image_backend_capabilities(platform).await?;
         let network_available = match &self.network_backend {
             Some(network) => {
                 let backend_id = network.id();
@@ -437,10 +460,19 @@ impl SandboxService {
             }
             None => false,
         };
+        let root_filesystem_modes = if image_capabilities.resolve.is_available() {
+            capabilities
+                .root_filesystems
+                .intersection(&image_capabilities.resolve.root_filesystem_modes)
+        } else {
+            crate::RootFilesystemModeSet::default()
+        };
         Ok(SandboxCapabilities::new(
             capabilities.features,
             capabilities.mounts,
-            capabilities.root_filesystems,
+            root_filesystem_modes,
+            image_capabilities.prepared_image_export,
+            image_capabilities.prepared_image_import,
             network_available,
         ))
     }
@@ -450,6 +482,14 @@ impl SandboxService {
             .capabilities(platform)
             .await
             .map_err(|error| Error::component("discover Sandbox capabilities", error))
+    }
+
+    async fn image_backend_capabilities(&self, platform: &Platform) -> Result<image::ImageBackendCapabilities, Error> {
+        self.provider
+            .image_backend()
+            .capabilities(platform)
+            .await
+            .map_err(|error| Error::component("discover Image capabilities", error))
     }
 
     /// Attaches every newly materialized Sandbox to this Network Backend.
@@ -471,6 +511,54 @@ impl SandboxService {
     #[must_use]
     pub fn ensure<'a>(&'a self, request: &'a EnsureSandboxRequest) -> PendingSandbox<'a> {
         PendingOperation::with_events(|events| Box::pin(async move { self.ensure_inner(request, &events).await }))
+    }
+
+    /// Exports a prepared Image into an opaque Provider-owned artifact.
+    #[must_use]
+    pub fn export_prepared_image<'a>(
+        &'a self,
+        request: &'a image::ResolveRequest,
+        destination: &'a std::path::Path,
+    ) -> PendingOperation<'a, image::PreparedImage> {
+        PendingOperation::with_events(|events| {
+            Box::pin(async move {
+                request.validate()?;
+                self.require_image_operation(image::ImageOperation::PreparedImageExport, request)
+                    .await?;
+                let prepared = self
+                    .provider
+                    .image_backend()
+                    .export_prepared_image(request, destination)
+                    .forward(&events)
+                    .await?;
+                prepared.validate_for(request)?;
+                Ok(prepared)
+            })
+        })
+    }
+
+    /// Imports a prepared Image into this Provider's materialization domain.
+    #[must_use]
+    pub fn import_prepared_image<'a>(
+        &'a self,
+        request: &'a image::ResolveRequest,
+        source: &'a std::path::Path,
+    ) -> PendingOperation<'a, image::PreparedImage> {
+        PendingOperation::with_events(|events| {
+            Box::pin(async move {
+                request.validate()?;
+                self.require_image_operation(image::ImageOperation::PreparedImageImport, request)
+                    .await?;
+                let prepared = self
+                    .provider
+                    .image_backend()
+                    .import_prepared_image(request, source)
+                    .forward(&events)
+                    .await?;
+                prepared.validate_for(request)?;
+                Ok(prepared)
+            })
+        })
     }
 
     async fn ensure_inner(
@@ -532,28 +620,7 @@ impl SandboxService {
                     .await;
                 self.require_backend_features_observed(&request.spec.platform, request, events)
                     .await?;
-                let started = Instant::now();
-                events.phase_started(SandboxPhase::ImageResolve).await;
-                let image = self
-                    .provider
-                    .image_resolver()
-                    .resolve(&image::ResolveRequest {
-                        source: request.spec.image.clone(),
-                        platform: request.spec.platform.clone(),
-                    })
-                    .forward(events)
-                    .await
-                    .map_err(|error| Error::component("resolve Sandbox Image", error))?;
-                image.validate()?;
-                if !image.platform.satisfies(&request.spec.platform) {
-                    return Err(Error::ImagePlatformMismatch {
-                        requested: Box::new(request.spec.platform.clone()),
-                        actual: Box::new(image.platform),
-                    });
-                }
-                events
-                    .phase_completed(SandboxPhase::ImageResolve, PhaseOutcome::Completed, started.elapsed())
-                    .await;
+                let image = self.resolve_image(request, events).await?;
                 let network = self
                     .require_backend_features_observed(&image.platform, request, events)
                     .await?;
@@ -587,6 +654,37 @@ impl SandboxService {
             }
             Err(error) => Err(Error::component("find Sandbox", error)),
         }
+    }
+
+    async fn resolve_image(
+        &self,
+        request: &EnsureSandboxRequest,
+        events: &SandboxEvents,
+    ) -> Result<image::ResolvedImage, Error> {
+        let started = Instant::now();
+        events.phase_started(SandboxPhase::ImageResolve).await;
+        let image = self
+            .provider
+            .image_backend()
+            .resolve(&image::ResolveRequest {
+                source: request.spec.image.clone(),
+                platform: request.spec.platform.clone(),
+                root_filesystem_mode: request.spec.resources.root_filesystem().mode(),
+            })
+            .forward(events)
+            .await
+            .map_err(|error| Error::component("resolve Sandbox Image", error))?;
+        image.validate()?;
+        if !image.platform.satisfies(&request.spec.platform) {
+            return Err(Error::ImagePlatformMismatch {
+                requested: Box::new(request.spec.platform.clone()),
+                actual: Box::new(image.platform),
+            });
+        }
+        events
+            .phase_completed(SandboxPhase::ImageResolve, PhaseOutcome::Completed, started.elapsed())
+            .await;
+        Ok(image)
     }
 
     async fn ensure_resources(
@@ -653,6 +751,15 @@ impl SandboxService {
         if !capabilities.root_filesystems.contains(root_filesystem_mode) {
             return Err(Error::UnsupportedRootFilesystemMode(root_filesystem_mode));
         }
+        self.require_image_operation(
+            image::ImageOperation::Resolve,
+            &image::ResolveRequest {
+                source: request.spec.image.clone(),
+                platform: platform.clone(),
+                root_filesystem_mode,
+            },
+        )
+        .await?;
         let Some(network_backend) = &self.network_backend else {
             return Ok(None);
         };
@@ -667,6 +774,39 @@ impl SandboxService {
             backend: backend_id,
             endpoint: selection,
         }))
+    }
+
+    async fn require_image_operation(
+        &self,
+        operation: image::ImageOperation,
+        request: &image::ResolveRequest,
+    ) -> Result<(), Error> {
+        let capabilities = self.image_backend_capabilities(&request.platform).await?;
+        let operation_capabilities = match operation {
+            image::ImageOperation::Resolve => &capabilities.resolve,
+            image::ImageOperation::PreparedImageExport => &capabilities.prepared_image_export,
+            image::ImageOperation::PreparedImageImport => &capabilities.prepared_image_import,
+        };
+        if !operation_capabilities.is_available() {
+            return Err(Error::UnsupportedImageOperation(operation));
+        }
+        let source = request.source.kind();
+        if !operation_capabilities.sources.contains(source) {
+            return Err(Error::UnsupportedImageSourceKind {
+                operation,
+                source_kind: source,
+            });
+        }
+        if !operation_capabilities
+            .root_filesystem_modes
+            .contains(request.root_filesystem_mode)
+        {
+            return Err(Error::UnsupportedImageRootFilesystemMode {
+                operation,
+                mode: request.root_filesystem_mode,
+            });
+        }
+        Ok(())
     }
 
     /// Returns the materialized Sandbox for a stable name.

--- a/src/experimental/sandbox/tests/image.rs
+++ b/src/experimental/sandbox/tests/image.rs
@@ -2,7 +2,10 @@
 
 use std::path::{Path, PathBuf};
 
-use sandbox::image::ImageSource;
+use sandbox::{
+    RootFilesystemMode, RootFilesystemModeSet,
+    image::{ImageOperationCapabilities, ImageSource, ImageSourceKind, ImageSourceKindSet},
+};
 
 #[test]
 fn build_source_resolves_only_its_context_from_the_manifest_directory() {
@@ -45,4 +48,20 @@ fn image_source_has_an_explicit_serialized_variant() {
 
     assert!(matches!(build, ImageSource::Build { .. }));
     assert!(matches!(reference, ImageSource::Reference { .. }));
+}
+
+#[test]
+fn image_operation_requires_at_least_one_source_and_mode() {
+    assert!(
+        ImageOperationCapabilities::new([ImageSourceKind::Reference].into(), [RootFilesystemMode::Direct].into(),)
+            .is_available()
+    );
+    assert!(
+        !ImageOperationCapabilities::new([ImageSourceKind::Reference].into(), RootFilesystemModeSet::default(),)
+            .is_available()
+    );
+    assert!(
+        !ImageOperationCapabilities::new(ImageSourceKindSet::default(), [RootFilesystemMode::Direct].into(),)
+            .is_available()
+    );
 }

--- a/src/experimental/sandbox/tests/image.rs
+++ b/src/experimental/sandbox/tests/image.rs
@@ -3,8 +3,11 @@
 use std::path::{Path, PathBuf};
 
 use sandbox::{
-    RootFilesystemMode, RootFilesystemModeSet,
-    image::{ImageOperationCapabilities, ImageSource, ImageSourceKind, ImageSourceKindSet},
+    Platform, RootFilesystemMode, RootFilesystemModeSet,
+    image::{
+        ImageBackend as _, ImageOperationCapabilities, ImageSource, ImageSourceKind, ImageSourceKindSet, ResolveRequest,
+    },
+    memory::MemoryImageBackend,
 };
 
 #[test]
@@ -64,4 +67,51 @@ fn image_operation_requires_at_least_one_source_and_mode() {
         !ImageOperationCapabilities::new(ImageSourceKindSet::default(), [RootFilesystemMode::Direct].into(),)
             .is_available()
     );
+}
+
+#[tokio::test(flavor = "local")]
+async fn memory_images_have_deterministic_sha256_manifest_digests() {
+    let backend = MemoryImageBackend;
+    let request = ResolveRequest {
+        source: ImageSource::Reference {
+            reference: "registry.example/worker:latest".to_string(),
+        },
+        platform: Platform::new("linux", "amd64"),
+        root_filesystem_mode: RootFilesystemMode::Layered,
+    };
+
+    let first = backend.resolve(&request).await.expect("image should resolve");
+    let second = backend.resolve(&request).await.expect("image should resolve again");
+    let digest = first
+        .manifest_digest
+        .strip_prefix("sha256:")
+        .expect("manifest digest should use SHA-256");
+
+    assert_eq!(first.manifest_digest, second.manifest_digest);
+    assert_eq!(digest.len(), 64);
+    assert!(
+        digest
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+    );
+
+    let different_source = backend
+        .resolve(&ResolveRequest {
+            source: ImageSource::Reference {
+                reference: "registry.example/other:latest".to_string(),
+            },
+            platform: request.platform.clone(),
+            root_filesystem_mode: request.root_filesystem_mode,
+        })
+        .await
+        .expect("another image should resolve");
+    let different_platform = backend
+        .resolve(&ResolveRequest {
+            platform: Platform::new("linux", "arm64"),
+            ..request
+        })
+        .await
+        .expect("image should resolve for another platform");
+    assert_ne!(first.manifest_digest, different_source.manifest_digest);
+    assert_ne!(first.manifest_digest, different_platform.manifest_digest);
 }

--- a/src/experimental/sandbox/tests/service.rs
+++ b/src/experimental/sandbox/tests/service.rs
@@ -210,7 +210,7 @@ async fn service_accepts_prepared_image_metadata_coherent_with_the_request() {
         image: image::ResolvedImage {
             source: request.source.clone(),
             platform: request.platform.clone(),
-            digest: "sha256:resolved-oci-descriptor".into(),
+            manifest_digest: "sha256:resolved-oci-manifest".into(),
         },
         root_filesystem_mode: request.root_filesystem_mode,
         artifact_digest: "sha256:opaque-artifact".into(),
@@ -647,7 +647,7 @@ impl image::ImageBackend for IncompatibleImageBackend {
                 Ok(image::ResolvedImage {
                     source: request.source.clone(),
                     platform: Platform::new("windows", "amd64"),
-                    digest: "sha256:incompatible".into(),
+                    manifest_digest: "sha256:incompatible".into(),
                 })
             })
         })

--- a/src/experimental/sandbox/tests/service.rs
+++ b/src/experimental/sandbox/tests/service.rs
@@ -6,8 +6,8 @@ use bytes::Bytes;
 use futures_core::Stream as _;
 use sandbox::{
     ByteQuantity, CpuQuantity, EnsureSandboxRequest, Error, OperationEvent, PendingOperation, Platform,
-    RetentionPolicy, RootFilesystem, SandboxEvent, SandboxFeature, SandboxName, SandboxPath, SandboxPhase,
-    SandboxResources, SandboxService, SandboxSpec,
+    RetentionPolicy, RootFilesystem, RootFilesystemMode, SandboxEvent, SandboxFeature, SandboxName, SandboxPath,
+    SandboxPhase, SandboxResources, SandboxService, SandboxSpec,
     execution::{ExecutionEvent, ExecutionSpec, ExitStatus, StartExecutionRequest},
     image::{self, ImageSource},
     memory,
@@ -86,6 +86,8 @@ async fn capabilities_describe_the_configured_consumer_surface() {
         .await
         .expect("Provider capabilities should be available");
     assert!(without_network.features().contains(SandboxFeature::Execution));
+    assert!(without_network.prepared_image_export().sources.iter().next().is_none());
+    assert!(without_network.prepared_image_import().sources.iter().next().is_none());
     assert!(!without_network.network_available());
 
     let with_network = SandboxService::new(Rc::new(memory::Provider::new())).with_network_backend(Rc::new(
@@ -98,6 +100,140 @@ async fn capabilities_describe_the_configured_consumer_surface() {
             .expect("compatible Network should be discoverable")
             .network_available()
     );
+}
+
+#[tokio::test(flavor = "local")]
+async fn memory_provider_rejects_prepared_image_transport_with_typed_errors() {
+    let service = SandboxService::new(Rc::new(memory::Provider::new()));
+    let spec = spec();
+    let request = image::ResolveRequest {
+        source: spec.image,
+        platform: spec.platform,
+        root_filesystem_mode: spec.resources.root_filesystem().mode(),
+    };
+
+    let export_error = service
+        .export_prepared_image(&request, std::path::Path::new("unused"))
+        .await
+        .expect_err("memory Image Backend should not export prepared images");
+    assert!(matches!(
+        export_error,
+        Error::UnsupportedImageOperation(image::ImageOperation::PreparedImageExport)
+    ));
+
+    let import_error = service
+        .import_prepared_image(&request, std::path::Path::new("unused"))
+        .await
+        .expect_err("memory Image Backend should not import prepared images");
+    assert!(matches!(
+        import_error,
+        Error::UnsupportedImageOperation(image::ImageOperation::PreparedImageImport)
+    ));
+}
+
+struct PreparedImageBackend {
+    prepared: image::PreparedImage,
+}
+
+impl image::ImageBackend for PreparedImageBackend {
+    fn capabilities<'a>(
+        &'a self,
+        _platform: &'a Platform,
+    ) -> sandbox::LocalFuture<'a, Result<image::ImageBackendCapabilities, Error>> {
+        Box::pin(async {
+            let operation = image::ImageOperationCapabilities::new(
+                [image::ImageSourceKind::Build].into(),
+                [RootFilesystemMode::Layered].into(),
+            );
+            Ok(image::ImageBackendCapabilities::new(
+                operation.clone(),
+                operation.clone(),
+                operation,
+            ))
+        })
+    }
+
+    fn resolve<'a>(&'a self, _request: &'a image::ResolveRequest) -> PendingOperation<'a, image::ResolvedImage> {
+        let image = self.prepared.image.clone();
+        PendingOperation::run(SandboxPhase::ImageResolve, move |_progress| {
+            Box::pin(async move { Ok(image) })
+        })
+    }
+
+    fn export_prepared_image<'a>(
+        &'a self,
+        _request: &'a image::ResolveRequest,
+        _destination: &'a std::path::Path,
+    ) -> PendingOperation<'a, image::PreparedImage> {
+        completed_prepared_image(self.prepared.clone())
+    }
+
+    fn import_prepared_image<'a>(
+        &'a self,
+        _request: &'a image::ResolveRequest,
+        _source: &'a std::path::Path,
+    ) -> PendingOperation<'a, image::PreparedImage> {
+        completed_prepared_image(self.prepared.clone())
+    }
+}
+
+fn completed_prepared_image(prepared: image::PreparedImage) -> PendingOperation<'static, image::PreparedImage> {
+    PendingOperation::run(SandboxPhase::ImagePrepare, move |_progress| {
+        Box::pin(async move { Ok(prepared) })
+    })
+}
+
+struct PreparedImageProvider {
+    sandbox_backend: memory::Provider,
+    image_backend: PreparedImageBackend,
+}
+
+impl sandbox::provider::SandboxProvider for PreparedImageProvider {
+    fn backend(&self) -> &dyn sandbox::backend::SandboxBackend {
+        &self.sandbox_backend
+    }
+
+    fn image_backend(&self) -> &dyn image::ImageBackend {
+        &self.image_backend
+    }
+}
+
+#[tokio::test(flavor = "local")]
+async fn service_accepts_prepared_image_metadata_coherent_with_the_request() {
+    let spec = spec();
+    let request = image::ResolveRequest {
+        source: spec.image,
+        platform: spec.platform,
+        root_filesystem_mode: spec.resources.root_filesystem().mode(),
+    };
+    let prepared = image::PreparedImage {
+        image: image::ResolvedImage {
+            source: request.source.clone(),
+            platform: request.platform.clone(),
+            digest: "sha256:resolved-oci-descriptor".into(),
+        },
+        root_filesystem_mode: request.root_filesystem_mode,
+        artifact_digest: "sha256:opaque-artifact".into(),
+        virtual_size_bytes: 4096,
+    };
+    let service = SandboxService::new(Rc::new(PreparedImageProvider {
+        sandbox_backend: memory::Provider::new(),
+        image_backend: PreparedImageBackend {
+            prepared: prepared.clone(),
+        },
+    }));
+
+    let exported = service
+        .export_prepared_image(&request, std::path::Path::new("unused"))
+        .await
+        .expect("coherent exported metadata should be accepted");
+    let imported = service
+        .import_prepared_image(&request, std::path::Path::new("unused"))
+        .await
+        .expect("coherent imported metadata should be accepted");
+
+    assert_eq!(exported, prepared);
+    assert_eq!(imported, prepared);
 }
 
 #[tokio::test(flavor = "local")]
@@ -486,9 +622,25 @@ async fn ensure_rejects_an_unsupported_platform() {
     assert_eq!(backend.count(), 0);
 }
 
-struct IncompatibleImageResolver;
+struct IncompatibleImageBackend;
 
-impl image::Resolver for IncompatibleImageResolver {
+impl image::ImageBackend for IncompatibleImageBackend {
+    fn capabilities<'a>(
+        &'a self,
+        _platform: &'a Platform,
+    ) -> sandbox::LocalFuture<'a, Result<image::ImageBackendCapabilities, Error>> {
+        Box::pin(async {
+            Ok(image::ImageBackendCapabilities::new(
+                image::ImageOperationCapabilities::new(
+                    [image::ImageSourceKind::Build, image::ImageSourceKind::Reference].into(),
+                    [RootFilesystemMode::Layered].into(),
+                ),
+                image::ImageOperationCapabilities::default(),
+                image::ImageOperationCapabilities::default(),
+            ))
+        })
+    }
+
     fn resolve<'a>(&'a self, request: &'a image::ResolveRequest) -> PendingOperation<'a, image::ResolvedImage> {
         PendingOperation::run(SandboxPhase::ImageResolve, move |_progress| {
             Box::pin(async move {
@@ -500,11 +652,33 @@ impl image::Resolver for IncompatibleImageResolver {
             })
         })
     }
+
+    fn export_prepared_image<'a>(
+        &'a self,
+        _request: &'a image::ResolveRequest,
+        _destination: &'a std::path::Path,
+    ) -> PendingOperation<'a, image::PreparedImage> {
+        unsupported_prepared_image(image::ImageOperation::PreparedImageExport)
+    }
+
+    fn import_prepared_image<'a>(
+        &'a self,
+        _request: &'a image::ResolveRequest,
+        _source: &'a std::path::Path,
+    ) -> PendingOperation<'a, image::PreparedImage> {
+        unsupported_prepared_image(image::ImageOperation::PreparedImageImport)
+    }
+}
+
+fn unsupported_prepared_image<'a>(operation: image::ImageOperation) -> PendingOperation<'a, image::PreparedImage> {
+    PendingOperation::run(SandboxPhase::ImagePrepare, move |_progress| {
+        Box::pin(async move { Err(Error::UnsupportedImageOperation(operation)) })
+    })
 }
 
 struct IncompatibleProvider {
     backend: memory::Provider,
-    resolver: IncompatibleImageResolver,
+    image_backend: IncompatibleImageBackend,
 }
 
 impl sandbox::provider::SandboxProvider for IncompatibleProvider {
@@ -512,8 +686,8 @@ impl sandbox::provider::SandboxProvider for IncompatibleProvider {
         &self.backend
     }
 
-    fn image_resolver(&self) -> &dyn image::Resolver {
-        &self.resolver
+    fn image_backend(&self) -> &dyn image::ImageBackend {
+        &self.image_backend
     }
 }
 
@@ -521,7 +695,7 @@ impl sandbox::provider::SandboxProvider for IncompatibleProvider {
 async fn ensure_rejects_an_image_that_does_not_satisfy_the_requested_platform() {
     let provider = Rc::new(IncompatibleProvider {
         backend: memory::Provider::with_platforms(Platform::new("linux", "amd64"), [Platform::new("windows", "amd64")]),
-        resolver: IncompatibleImageResolver,
+        image_backend: IncompatibleImageBackend,
     });
     let service = SandboxService::new(provider.clone());
 
@@ -531,6 +705,54 @@ async fn ensure_rejects_an_image_that_does_not_satisfy_the_requested_platform() 
         .expect_err("Image Platform should be incompatible");
 
     assert!(matches!(error, Error::ImagePlatformMismatch { .. }));
+    assert_eq!(provider.backend.count(), 0);
+}
+
+#[tokio::test(flavor = "local")]
+async fn ensure_rejects_a_root_mode_the_image_backend_cannot_materialize() {
+    let provider = Rc::new(IncompatibleProvider {
+        backend: memory::Provider::new(),
+        image_backend: IncompatibleImageBackend,
+    });
+    let service = SandboxService::new(provider.clone());
+    let mut request = request();
+    request.spec_mut().resources = SandboxResources::new(
+        "2".parse::<CpuQuantity>().expect("test CPU should be valid"),
+        "1Gi".parse::<ByteQuantity>().expect("test memory should be valid"),
+        RootFilesystem::direct(
+            "4Gi"
+                .parse::<ByteQuantity>()
+                .expect("test root filesystem should be valid"),
+        ),
+    );
+
+    let capabilities = service
+        .capabilities(&request.spec().platform)
+        .await
+        .expect("Provider capabilities should be available");
+    assert!(
+        capabilities
+            .root_filesystem_modes()
+            .contains(RootFilesystemMode::Layered)
+    );
+    assert!(
+        !capabilities
+            .root_filesystem_modes()
+            .contains(RootFilesystemMode::Direct)
+    );
+
+    let error = service
+        .ensure(&request)
+        .await
+        .expect_err("Image Backend should reject direct materialization");
+
+    assert!(matches!(
+        error,
+        Error::UnsupportedImageRootFilesystemMode {
+            operation: image::ImageOperation::Resolve,
+            mode: RootFilesystemMode::Direct,
+        }
+    ));
     assert_eq!(provider.backend.count(), 0);
 }
 


### PR DESCRIPTION
## Description

Adds backend-neutral prepared-image transport to the experimental Sandbox SDK. A prepared image remains a provider-owned materialization derived from an OCI image identity; it is not a separate image kind or a portable provider format.

- Replace `image::Resolver` with a capability-bearing `ImageBackend`.
- Add discovery of resolve, prepared-image export, and prepared-image import support by image source kind and root-filesystem mode.
- Report typed unsupported-operation, source-kind, and root-filesystem-mode errors.
- Intersect Sandbox Backend support with Image Backend resolve support in service capabilities and ensure dispatch.
- Implement direct/reference prepared-image transport for Microsandbox and honest resolve-only capabilities for the memory backend.
- Define backend integrity and OCI-identity binding obligations while keeping service validation focused on returned metadata coherence.
- Normalize every `ResolvedImage` to the selected platform-specific OCI image manifest digest, including references resolved through a multi-platform index.

The Microsandbox lockfile update consumes `martinothamar/microsandbox` `main-digdir` version `0.6.9-digdir.2` at `2e98dc56`, which supplies the provider-specific prepared-root transport beneath this generic API.

`feat/sandbox-github-runner` will rebase onto this PR after merge. Its consumer-facing follow-up will rename:

- `github-runner-sandbox-prepared-root` to `github-runner-sandbox-prepared-image`
- `PREPARED_ROOT_DIRECTORY` to `PREPARED_IMAGE_DIRECTORY`
- `Dockerfile.prepared-root` to `Dockerfile.prepared-image`
- the `prepare-root` init container to `prepare-image`
- `ResolvedImage.digest` consumers to `ResolvedImage.manifest_digest`
- related workflow, Kustomize, and README references

## Verification

- [ ] Related issues are connected (not applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (`fmt-check`, Clippy, build, workspace and independent tests, and native Microsandbox/KVM tests)
- [x] Relevant automated test added

The multi-platform regression resolves an immutable Alpine index and verifies that the Microsandbox adapter returns the native child manifest digest rather than the index digest.

The final `cargo machete` step of `make check` reports the pre-existing unused `clap` dependency in the `agent` crate. This PR does not suppress or otherwise change that unrelated finding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider-neutral image backend support for resolving and materialising OCI images.
  * Added prepared-image export and import for compatible providers.
  * Added registry authentication configuration, including anonymous and basic authentication.
  * Added capability discovery for image sources, operations and root filesystem modes.
  * Added progress reporting for image preparation.
* **Bug Fixes**
  * Added validation and clear errors for unsupported image operations, sources and filesystem modes.
  * Improved platform-specific manifest digest handling.
* **Documentation**
  * Updated architecture and usage documentation for image backends and prepared images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->