### PR TITLE
feat: migrate app frontend tests to sandbox runner

### DIFF
--- a/.github/workflows/app-frontend-unit-tests.yml
+++ b/.github/workflows/app-frontend-unit-tests.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   unit-tests:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
-    runs-on: self-hosted-single
+    runs-on: self-hosted-ubuntu
     timeout-minutes: 30
     name: Type-checks, eslint, unit tests and SonarCloud
     defaults:


### PR DESCRIPTION
## Summary

- run App frontend unit tests on `self-hosted-ubuntu`

## Why

This is the first production workflow migration after deploying the sandbox-backed runner in #20045. This workload was used for the cold/warm comparison and passed on the new runner with lower end-to-end runtime than `self-hosted-single`.

Rollback is a one-line change back to `self-hosted-single`.

## Verification

- workflow diff is limited to `runs-on`
- `self-hosted-ubuntu` is registered in `.github/actionlint.yaml`
- `git diff --check` passes
- repository CI will run actionlint because it is not installed locally