### PR TITLE
ci: migrate Designer tests to sandbox runners

### DIFF
--- a/.github/workflows/designer-backend-dotnet-test.yaml
+++ b/.github/workflows/designer-backend-dotnet-test.yaml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest,windows-latest,macos-latest]
     name: Run dotnet build and test
-    runs-on: ${{ matrix.os == 'ubuntu-latest' && 'self-hosted-single' || matrix.os }}
+    runs-on: ${{ matrix.os == 'ubuntu-latest' && 'self-hosted-ubuntu' || matrix.os }}
     timeout-minutes: 30
     env:
       DOTNET_HOSTBUILDER__RELOADCONFIGONCHANGE: false

--- a/.github/workflows/designer-frontend-unit-tests.yml
+++ b/.github/workflows/designer-frontend-unit-tests.yml
@@ -26,7 +26,7 @@ jobs:
   typecheck:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: 'Typechecking and linting'
-    runs-on: self-hosted-single
+    runs-on: self-hosted-ubuntu
     timeout-minutes: 30
     permissions:
       actions: read
@@ -60,7 +60,7 @@ jobs:
   test:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: 'Testing'
-    runs-on: self-hosted-single
+    runs-on: self-hosted-ubuntu
     timeout-minutes: 30
     steps:
       - name: 'Checking Out Code'


### PR DESCRIPTION
Migrates the Designer frontend typecheck, lint, and unit-test jobs to the Sandbox-backed runner. The Ubuntu leg of the Designer backend test matrix is migrated as well, while its macOS and Windows legs remain on GitHub-hosted runners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated backend tests to run on the standard self-hosted Ubuntu runner.
  - Updated frontend type-checking and unit-test jobs to use the dedicated self-hosted Ubuntu runner.
  - Windows and macOS test environments remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->