### PR TITLE
ci: migrate studioctl CI to sandbox runners

### DIFF
--- a/.github/workflows/cli-build-test.yaml
+++ b/.github/workflows/cli-build-test.yaml
@@ -19,7 +19,7 @@ jobs:
   verify-release-artifacts:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Verify studioctl release artifacts
-    runs-on: self-hosted-single
+    runs-on: self-hosted-ubuntu
     timeout-minutes: 30
     steps:
       - name: Checkout repository
@@ -63,7 +63,7 @@ jobs:
           - os: windows-latest
             runner: windows-latest
           - os: ubuntu-latest
-            runner: self-hosted-single
+            runner: self-hosted-ubuntu
     name: Build and test
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30

--- a/.github/workflows/cli-changelog.yaml
+++ b/.github/workflows/cli-changelog.yaml
@@ -26,7 +26,7 @@ jobs:
   require-changelog-entry:
     name: Require studioctl changelog entry
     if: ${{ !github.event.pull_request.draft && !contains(github.event.pull_request.labels.*.name, 'skip-changelog') }}
-    runs-on: self-hosted-single
+    runs-on: self-hosted-ubuntu
     timeout-minutes: 10
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Migrates the studioctl Linux build, release-artifact verification, and changelog validation jobs from self-hosted-single to self-hosted-ubuntu. The hosted Windows matrix job is unchanged.