### PR TITLE
ci: migrate common TypeScript tests to sandbox runners

### DIFF
--- a/.github/workflows/common-typescript-unit-test.yml
+++ b/.github/workflows/common-typescript-unit-test.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   unit-tests:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
-    runs-on: self-hosted-single
+    runs-on: self-hosted-ubuntu
     timeout-minutes: 30
     name: Unit tests
     defaults:


### PR DESCRIPTION
## Summary

- run Common TypeScript unit tests on the sandbox-backed Ubuntu runners
- replace the legacy `self-hosted-single` runner label

## Verification

- `git diff --check`
- confirmed the workflow contains `self-hosted-ubuntu` and no `self-hosted-single`
- actionlint is not installed locally; GitHub Actions will validate the workflow
