### PR TITLE
ci: migrate workflow engine CI to sandbox runners

### DIFF
--- a/.github/workflows/runtime-workflow-engine-app-tests.yaml
+++ b/.github/workflows/runtime-workflow-engine-app-tests.yaml
@@ -27,7 +27,7 @@ jobs:
   build-and-test:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Build and test
-    runs-on: self-hosted-single
+    runs-on: self-hosted-ubuntu
     timeout-minutes: 30
     defaults:
       run:

--- a/.github/workflows/runtime-workflow-engine-docker-build.yaml
+++ b/.github/workflows/runtime-workflow-engine-docker-build.yaml
@@ -34,7 +34,7 @@ jobs:
   docker-build:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Build ${{ matrix.name }} image
-    runs-on: self-hosted-single
+    runs-on: self-hosted-ubuntu
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/runtime-workflow-engine-tests.yaml
+++ b/.github/workflows/runtime-workflow-engine-tests.yaml
@@ -23,7 +23,7 @@ jobs:
   build-and-test:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Build and test
-    runs-on: self-hosted-single
+    runs-on: self-hosted-ubuntu
     timeout-minutes: 30
     defaults:
       run:


### PR DESCRIPTION
Migrates the Workflow Engine tests, Workflow Engine app tests, and Workflow Engine Docker builds from self-hosted-single to self-hosted-ubuntu.