### PR TITLE
ci: migrate Runtime local development workflows to sandbox runners

### DIFF
--- a/.github/workflows/runtime-devenv-build.yml
+++ b/.github/workflows/runtime-devenv-build.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   lint:
     name: Check formatting and lint
-    runs-on: self-hosted-single
+    runs-on: self-hosted-ubuntu
     timeout-minutes: 30
     defaults:
       run:

--- a/.github/workflows/runtime-localtest-build.yml
+++ b/.github/workflows/runtime-localtest-build.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   build:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
-    runs-on: self-hosted-single
+    runs-on: self-hosted-ubuntu
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
Migrates the Runtime devenv and localtest workflows from the legacy self-hosted-single runner to self-hosted-ubuntu.