### PR TITLE
ci: migrate Go tooling workflows to sandbox runners

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -27,7 +27,7 @@ jobs:
   validate-changelogs:
     name: Validate changelogs
     if: github.event_name != 'pull_request' || (!github.event.pull_request.draft && !contains(github.event.pull_request.labels.*.name, 'skip-changelog'))
-    runs-on: self-hosted-single
+    runs-on: self-hosted-ubuntu
     timeout-minutes: 30
     steps:
       - name: Checkout repository

--- a/.github/workflows/runtime-health-build.yml
+++ b/.github/workflows/runtime-health-build.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   lint:
     name: Check formatting and lint
-    runs-on: self-hosted-single
+    runs-on: self-hosted-ubuntu
     timeout-minutes: 30
     defaults:
       run:


### PR DESCRIPTION
Migrates the runtime health and changelog validation workflows from the legacy self-hosted runner to the sandbox-backed Ubuntu runner.