### PR TITLE
ci: migrate Designer Playwright to sandbox runners

### DIFF
--- a/.github/workflows/designer-frontend-playwright-staging.yml
+++ b/.github/workflows/designer-frontend-playwright-staging.yml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   playwright-run:
     name: 'Playwright Tests'
-    runs-on: self-hosted-single
+    runs-on: self-hosted-ubuntu
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/designer-frontend-resourceadm-playwright-staging.yml
+++ b/.github/workflows/designer-frontend-resourceadm-playwright-staging.yml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   playwright-run:
     name: 'Resourceadm Playwright Tests'
-    runs-on: self-hosted-single
+    runs-on: self-hosted-ubuntu
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/designer-frontend-resourceadm-run-playwright-on-pr.yml
+++ b/.github/workflows/designer-frontend-resourceadm-run-playwright-on-pr.yml
@@ -19,7 +19,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Playwright
     timeout-minutes: 25
-    runs-on: self-hosted-single
+    runs-on: self-hosted-ubuntu
 
     steps:
       - name: 'Checking Out Code'

--- a/.github/workflows/designer-frontend-run-playwright-on-pr.yaml
+++ b/.github/workflows/designer-frontend-run-playwright-on-pr.yaml
@@ -30,7 +30,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Playwright
     timeout-minutes: 35
-    runs-on: self-hosted-single
+    runs-on: self-hosted-ubuntu
 
     steps:
       - name: 'Checking Out Code'


### PR DESCRIPTION
Migrates the Designer and Resourceadm Playwright workflows for pull requests and staging from `self-hosted-single` to `self-hosted-ubuntu`.