### PR TITLE
ci: migrate Altinity tests to sandbox runners

### DIFF
--- a/.github/workflows/altinity-build-test.yaml
+++ b/.github/workflows/altinity-build-test.yaml
@@ -18,7 +18,7 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     permissions:
       contents: read
-    runs-on: self-hosted-single
+    runs-on: self-hosted-ubuntu
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/altinity-build-test.yaml
+++ b/.github/workflows/altinity-build-test.yaml
@@ -5,6 +5,7 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'src/AI/agents/**'
+      - '.github/workflows/altinity-build-test.yaml'
       - '!**/AGENTS.md'
       - '!**/CLAUDE.md'
 


### PR DESCRIPTION
## Summary

- run the Altinity build and tests on the sandbox-backed Ubuntu runner
- replace the final `self-hosted-single` workflow outside the open Designer migration

## Verification

- `git diff --check`
- confirmed the workflow contains `self-hosted-ubuntu` and no `self-hosted-single`
- actionlint is not installed locally; GitHub Actions will validate the workflow
