### PR TITLE
chore(experimental): align workspace license with repository (MIT)

### DIFF
--- a/src/experimental/Cargo.toml
+++ b/src/experimental/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "3"
 
 [workspace.package]
 edition = "2024"
-license = "Apache-2.0"
+license = "MIT"
 rust-version = "1.97.1"
 version = "0.1.0"
 


### PR DESCRIPTION
## Description

Align the experimental Rust workspace inherited license metadata with the repository MIT license.

## Verification

- [x] Related issues are connected (not applicable)
- [x] **Your** code builds clean without any errors or warnings (make check)
- [x] Manual testing done (cargo metadata --no-deps --format-version 1 reports only MIT)
- [ ] Relevant automated test added (not applicable for this metadata-only change)

Cargo.lock is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the workspace package licence from Apache-2.0 to MIT.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->