### PR TITLE
fix(app-frontend): stop OrganizationLookup tests racing the live region

### DIFF
--- a/src/App/frontend/src/layout/OrganizationLookup/OrganizationLookupComponent.test.tsx
+++ b/src/App/frontend/src/layout/OrganizationLookup/OrganizationLookupComponent.test.tsx
@@ -23,6 +23,14 @@ const validOrgNr = '043871668';
 const orgName = 'Skog og Fjell Consulting';
 const orgLookupId = 'org-lookup';
 const textSiblingId = 'text-sibling';
+const statusRegionTestId = 'organisation-lookup-status';
+
+/**
+ * Every message is rendered twice: as a visible validation message, and again in the visually hidden
+ * live region, which the component repopulates on a timer. Text queries that do not exclude the live
+ * region race that timer and fail with "Found multiple elements" whenever it wins.
+ */
+const outsideLiveRegion = { ignore: `script, style, [data-testid="${statusRegionTestId}"]` };
 
 const defaultBindings = {
   organization_lookup_orgnr: { field: 'orgNr', dataType: defaultDataTypeMock },
@@ -112,10 +120,10 @@ describe('OrganizationLookupComponent', () => {
     await userEvent.type(screen.getByRole('textbox', { name: /Organisasjonsnummer/i }), '123456789');
     await userEvent.click(screen.getByRole('button', { name: /Hent opplysninger/i }));
 
-    expect(screen.getByText(/Organisasjonsnummeret er ugyldig/i)).toBeInTheDocument();
+    expect(screen.getByText(/Organisasjonsnummeret er ugyldig/i, outsideLiveRegion)).toBeInTheDocument();
     expect(mockedHttpGet).not.toHaveBeenCalled();
 
-    const statusRegion = screen.getByTestId('organisation-lookup-status');
+    const statusRegion = screen.getByTestId(statusRegionTestId);
     await waitFor(() => {
       expect(statusRegion).toHaveTextContent(/Organisasjonsnummeret er ugyldig/i);
     });
@@ -169,7 +177,7 @@ describe('OrganizationLookupComponent', () => {
 
     expect(screen.getByLabelText('Organisasjonsnavn')).toHaveTextContent(orgName);
 
-    const statusRegion = screen.getByTestId('organisation-lookup-status');
+    const statusRegion = screen.getByTestId(statusRegionTestId);
     await waitFor(() => {
       expect(statusRegion).toHaveTextContent(`Organisasjonsnummer ${validOrgNr}`);
       expect(statusRegion).toHaveTextContent('Sibling Name');
@@ -208,7 +216,9 @@ describe('OrganizationLookupComponent', () => {
     await userEvent.type(screen.getByRole('textbox', { name: /Organisasjonsnummer/i }), validOrgNr);
     await userEvent.click(screen.getByRole('button', { name: /Hent opplysninger/i }));
 
-    expect(await screen.findByText(/Organisasjonsnummeret ble ikke funnet i enhetsregisteret/i)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/Organisasjonsnummeret ble ikke funnet i enhetsregisteret/i, outsideLiveRegion),
+    ).toBeInTheDocument();
   });
 
   it('shows invalid response error when lookup response is invalid', async () => {
@@ -219,7 +229,7 @@ describe('OrganizationLookupComponent', () => {
     await userEvent.type(screen.getByRole('textbox', { name: /Organisasjonsnummer/i }), validOrgNr);
     await userEvent.click(screen.getByRole('button', { name: /Hent opplysninger/i }));
 
-    expect(await screen.findByText(/Ugyldig respons fra server/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Ugyldig respons fra server/i, outsideLiveRegion)).toBeInTheDocument();
   });
 
   it('shows unknown error when lookup request fails', async () => {
@@ -230,7 +240,7 @@ describe('OrganizationLookupComponent', () => {
     await userEvent.type(screen.getByRole('textbox', { name: /Organisasjonsnummer/i }), validOrgNr);
     await userEvent.click(screen.getByRole('button', { name: /Hent opplysninger/i }));
 
-    expect(await screen.findByText(/Ukjent feil. Vennligst prøv igjen senere/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Ukjent feil. Vennligst prøv igjen senere/i, outsideLiveRegion)).toBeInTheDocument();
   });
 
   it('does not render action buttons when read only', async () => {


### PR DESCRIPTION
## Description

`OrganizationLookupComponent.test.tsx` fails intermittently in CI with:

```
TestingLibraryElementError: Found multiple elements with the text: /Ugyldig respons fra server/i
```

It has hit a **different test in the file each time**, which is the signature of a race rather than a broken assertion:

| Run | Failing text |
| --- | --- |
| [32342030244](https://github.com/Altinn/altinn-studio/actions/runs/32342030244) | `/Organisasjonsnummeret er ugyldig/i` |
| [32365021151](https://github.com/Altinn/altinn-studio/actions/runs/32365021151) | `/Ugyldig respons fra server/i` |

### Cause

`OrganizationLookupComponent` renders every message twice — once as a visible `ValidationMessage`, and once in the visually hidden live region. The live region is deliberately cleared and repopulated on a timer, so screen readers re-announce a repeated message:

```ts
function announceStatusMessage(message: string) {
  setStatusMessage('');
  window.setTimeout(() => {
    setStatusMessage(message);
    statusRef.current?.focus();
  }, LIVE_REGION_RESET_DELAY_MS); // = 100
}
```

That leaves a 100 ms window in which the text exists once. The assertions queried the whole document, so whichever side won the race decided the outcome: assertion first → one match → green; timer first → two matches → red.

The component behaviour is correct and unchanged; only the assertions were ambiguous.

### Fix

Exclude the live region from the four message queries so they assert the visible message only. The live region keeps its own dedicated assertions further down the file, which is where that behaviour belongs.

## Verification

Forced the race locally by awaiting past the 100 ms timer before each assertion:

- **without this change** — all four assertions fail, with the exact CI error, including both variants CI hit
- **with this change** — 8/8 pass

Normal runs: `OrganizationLookup` 23/23 pass, and the full app-frontend suite is green (3526 passed).

## Notes

Not caused by any product change — nothing has touched `src/App/frontend/src/layout/OrganizationLookup/` since #19848 on 10 August. The failure rate appears to have gone up after #20068 moved this job from `self-hosted-single` to `self-hosted-ubuntu`, but the race predates that. Worth knowing that this workflow only runs on `pull_request`, never on push to `main`, so a latent race like this stays invisible until PRs happen to hit it.

The three sibling assertions were equally exposed and are fixed in the same pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BtmvAydGgkRAcjmBUYRRAk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for organisation lookup validation and error states.
  * Updated status messaging checks to reliably distinguish live-region content from visible text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->