### PR TITLE
fix: stop the search field from freezing while typing in text editor

### DIFF
--- a/src/Designer/frontend/app-development/features/textEditor/TextEditor.test.tsx
+++ b/src/Designer/frontend/app-development/features/textEditor/TextEditor.test.tsx
@@ -67,7 +67,28 @@ describe('TextEditor', () => {
     });
     await user.type(searchInput, search);
 
-    expect(mockSetSearchParams).toHaveBeenCalledWith({ search });
+    await waitFor(() =>
+      expect(mockSetSearchParams).toHaveBeenCalledWith({ search }, { replace: true }),
+    );
+  });
+
+  it('updates the search field immediately, but the search query only once per typing burst', async () => {
+    const user = userEvent.setup();
+
+    renderTextEditorWithData();
+
+    const search = 'abcd';
+    const searchInput = screen.getByRole('searchbox', {
+      name: textMock('text_editor.search_for_text'),
+    });
+    await user.type(searchInput, search);
+
+    expect(searchInput).toHaveValue(search);
+
+    await waitFor(() =>
+      expect(mockSetSearchParams).toHaveBeenCalledWith({ search }, { replace: true }),
+    );
+    expect(mockSetSearchParams).toHaveBeenCalledTimes(1);
   });
 
   it('adds new text resource when clicking add button', async () => {

--- a/src/Designer/frontend/app-development/features/textEditor/TextEditor.tsx
+++ b/src/Designer/frontend/app-development/features/textEditor/TextEditor.tsx
@@ -30,7 +30,7 @@ export default function TextEditor() {
   const { data: textResources, isPending: isInitialLoadingLang } = useTextResourcesQuery(org, app);
 
   const setSearchQuery = (search: string) => {
-    setSearchParams(search.length > 0 ? { search } : {}, { replace: true });
+    setSearchParams(search.length > 0 ? { search } : '', { replace: true });
   };
 
   const { mutate: addLanguageMutation } = useAddLanguageMutation(org, app);

--- a/src/Designer/frontend/app-development/features/textEditor/TextEditor.tsx
+++ b/src/Designer/frontend/app-development/features/textEditor/TextEditor.tsx
@@ -30,7 +30,7 @@ export default function TextEditor() {
   const { data: textResources, isPending: isInitialLoadingLang } = useTextResourcesQuery(org, app);
 
   const setSearchQuery = (search: string) => {
-    setSearchParams(search.length > 0 ? { search } : {});
+    setSearchParams(search.length > 0 ? { search } : {}, { replace: true });
   };
 
   const { mutate: addLanguageMutation } = useAddLanguageMutation(org, app);

--- a/src/Designer/frontend/libs/studio-hooks/src/hooks/useDebounce.test.ts
+++ b/src/Designer/frontend/libs/studio-hooks/src/hooks/useDebounce.test.ts
@@ -43,4 +43,34 @@ describe('useDebounce', () => {
     jest.advanceTimersByTime(debounceTimeInMs);
     expect(callback).not.toHaveBeenCalled();
   });
+  it('should not call the callback if the debounce is cancelled', () => {
+    const debounceTimeInMs = 1000;
+    const callback = jest.fn();
+    const { result } = renderHook(() => useDebounce({ debounceTimeInMs }));
+
+    result.current.debounce(callback);
+    jest.advanceTimersByTime(debounceTimeInMs / 2);
+    result.current.cancelDebounce();
+
+    jest.advanceTimersByTime(debounceTimeInMs);
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('should allow debouncing again after a cancellation', () => {
+    const debounceTimeInMs = 1000;
+    const callback = jest.fn();
+    const { result } = renderHook(() => useDebounce({ debounceTimeInMs }));
+
+    result.current.debounce(callback);
+    result.current.cancelDebounce();
+    result.current.debounce(callback);
+
+    jest.advanceTimersByTime(debounceTimeInMs);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('should be safe to cancel when nothing is pending', () => {
+    const { result } = renderHook(() => useDebounce({ debounceTimeInMs: 1000 }));
+    expect(() => result.current.cancelDebounce()).not.toThrow();
+  });
 });

--- a/src/Designer/frontend/libs/studio-hooks/src/hooks/useDebounce.ts
+++ b/src/Designer/frontend/libs/studio-hooks/src/hooks/useDebounce.ts
@@ -10,7 +10,10 @@ type DebounceOptions = {
 
 export const useDebounce = ({
   debounceTimeInMs,
-}: UseDebounceOptions): { debounce: (callback: Function, options?: DebounceOptions) => void } => {
+}: UseDebounceOptions): {
+  debounce: (callback: Function, options?: DebounceOptions) => void;
+  cancelDebounce: () => void;
+} => {
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   const debounce = useCallback(
@@ -26,9 +29,14 @@ export const useDebounce = ({
     [debounceTimeInMs],
   );
 
+  const cancelDebounce = useCallback((): void => {
+    clearTimeout(debounceRef.current);
+    debounceRef.current = undefined;
+  }, []);
+
   useEffect(() => {
     return () => clearTimeout(debounceRef.current);
   }, []);
 
-  return { debounce };
+  return { debounce, cancelDebounce };
 };

--- a/src/Designer/frontend/packages/text-editor/src/TextEditor.test.tsx
+++ b/src/Designer/frontend/packages/text-editor/src/TextEditor.test.tsx
@@ -1,6 +1,6 @@
 import { TextEditor } from './TextEditor';
 import type { TextEditorProps } from './TextEditor';
-import { render as rtlRender, screen } from '@testing-library/react';
+import { act, render as rtlRender, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { textMock } from '@studio/testing/mocks/i18nMock';
 import type { ITextResource, ITextResources } from 'app-shared/types/global';
@@ -9,6 +9,7 @@ import { queriesMock } from 'app-shared/mocks/queriesMock';
 import { ServicesContextProvider } from 'app-shared/contexts/ServicesContext';
 import { QueryKey } from 'app-shared/types/QueryKey';
 import { queryClientMock } from 'app-shared/mocks/queryClientMock';
+import { searchDebounceTimeInMs } from './constants';
 
 const user = userEvent.setup();
 let mockScrollIntoView = jest.fn();
@@ -30,23 +31,24 @@ describe('TextEditor', () => {
   ];
   const textResourceFiles: ITextResources = { nb };
 
+  const defaultTextEditorProps: TextEditorProps = {
+    addLanguage: jest.fn(),
+    availableLanguages: ['nb', 'en'],
+    deleteLanguage: jest.fn(),
+    searchQuery: undefined,
+    selectedLangCodes: ['nb'],
+    setSearchQuery: jest.fn(),
+    setSelectedLangCodes: jest.fn(),
+    textResourceFiles,
+    updateTextId: jest.fn(),
+    upsertTextResource: jest.fn(),
+  };
+
   const renderTextEditor = (props: Partial<TextEditorProps> = {}) => {
-    const defaultProps: TextEditorProps = {
-      addLanguage: jest.fn(),
-      availableLanguages: ['nb', 'en'],
-      deleteLanguage: jest.fn(),
-      searchQuery: undefined,
-      selectedLangCodes: ['nb'],
-      setSearchQuery: jest.fn(),
-      setSelectedLangCodes: jest.fn(),
-      textResourceFiles,
-      updateTextId: jest.fn(),
-      upsertTextResource: jest.fn(),
-    };
     queryClientMock.setQueryData([QueryKey.LayoutNames, org, app], []);
     return rtlRender(
       <ServicesContextProvider {...queriesMock} client={queryClientMock}>
-        <TextEditor {...defaultProps} {...props} />
+        <TextEditor {...defaultTextEditorProps} {...props} />
       </ServicesContextProvider>,
     );
   };
@@ -268,6 +270,65 @@ describe('TextEditor', () => {
         name: textMock('schema_editor.delete'),
       });
       expect(resultAfter).toHaveLength(2);
+    });
+  });
+
+  describe('search', () => {
+    beforeEach(() => jest.useFakeTimers());
+
+    afterEach(() => {
+      jest.runOnlyPendingTimers();
+      jest.useRealTimers();
+    });
+
+    const getSearchInput = (): HTMLElement =>
+      screen.getByRole('searchbox', { name: textMock('text_editor.search_for_text') });
+
+    const setupSearch = (searchQuery: string = '') => {
+      const setSearchQuery = jest.fn();
+      const searchUser = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const renderResult = renderTextEditor({ searchQuery, setSearchQuery });
+      return { setSearchQuery, searchUser, renderResult };
+    };
+
+    it('does not apply a pending search after the search has been cleared', async () => {
+      const { setSearchQuery, searchUser } = setupSearch();
+
+      await searchUser.type(getSearchInput(), 'abc');
+      expect(setSearchQuery).not.toHaveBeenCalled();
+
+      await searchUser.click(
+        screen.getByRole('button', { name: textMock('text_editor.new_text') }),
+      );
+      expect(setSearchQuery).toHaveBeenCalledWith('');
+      setSearchQuery.mockClear();
+
+      act(() => jest.advanceTimersByTime(searchDebounceTimeInMs * 2));
+      expect(setSearchQuery).not.toHaveBeenCalled();
+      expect(getSearchInput()).toHaveValue('');
+    });
+
+    it('applies the search query once the debounce time has passed', async () => {
+      const { setSearchQuery, searchUser } = setupSearch();
+
+      await searchUser.type(getSearchInput(), 'abc');
+      act(() => jest.advanceTimersByTime(searchDebounceTimeInMs));
+
+      expect(setSearchQuery).toHaveBeenCalledTimes(1);
+      expect(setSearchQuery).toHaveBeenCalledWith('abc');
+    });
+
+    it('updates the search field when the search query changes externally', () => {
+      const { renderResult } = setupSearch('external query');
+      expect(getSearchInput()).toHaveValue('external query');
+
+      renderResult.rerender(
+        <ServicesContextProvider {...queriesMock} client={queryClientMock}>
+          <TextEditor {...defaultTextEditorProps} searchQuery='' />
+        </ServicesContextProvider>,
+      );
+
+      expect(getSearchInput()).toHaveValue('');
     });
   });
 });

--- a/src/Designer/frontend/packages/text-editor/src/TextEditor.test.tsx
+++ b/src/Designer/frontend/packages/text-editor/src/TextEditor.test.tsx
@@ -287,8 +287,8 @@ describe('TextEditor', () => {
     const setupSearch = (searchQuery: string = '') => {
       const setSearchQuery = jest.fn();
       const searchUser = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-      const renderResult = renderTextEditor({ searchQuery, setSearchQuery });
-      return { setSearchQuery, searchUser, renderResult };
+      const { rerender } = renderTextEditor({ searchQuery, setSearchQuery });
+      return { setSearchQuery, searchUser, rerender };
     };
 
     it('does not apply a pending search after the search has been cleared', async () => {
@@ -319,10 +319,10 @@ describe('TextEditor', () => {
     });
 
     it('updates the search field when the search query changes externally', () => {
-      const { renderResult } = setupSearch('external query');
+      const { rerender } = setupSearch('external query');
       expect(getSearchInput()).toHaveValue('external query');
 
-      renderResult.rerender(
+      rerender(
         <ServicesContextProvider {...queriesMock} client={queryClientMock}>
           <TextEditor {...defaultTextEditorProps} searchQuery='' />
         </ServicesContextProvider>,

--- a/src/Designer/frontend/packages/text-editor/src/TextEditor.tsx
+++ b/src/Designer/frontend/packages/text-editor/src/TextEditor.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { ChangeEvent } from 'react';
 import classes from './TextEditor.module.css';
 import type { LangCode, TextResourceEntryDeletion, TextResourceIdMutation } from './types';
 import type { UpsertTextResourceMutation } from 'app-shared/hooks/mutations/useUpsertTextResourceMutation';
@@ -7,11 +8,12 @@ import { ArrowsUpDownIcon } from '@studio/icons';
 import { StudioButton, StudioSearch } from '@studio/components';
 import { RightMenu } from './RightMenu';
 import { getRandNumber, mapResourceFilesToTableRows } from './utils';
-import { defaultLangCode } from './constants';
 import { TextList } from './TextList';
 import ISO6391 from 'iso-639-1';
 import type { ITextResources } from 'app-shared/types/global';
 import { useTranslation } from 'react-i18next';
+import { useDebounce } from '@studio/hooks';
+import { searchDebounceTimeInMs, defaultLangCode } from './constants';
 
 export interface TextEditorProps {
   addLanguage: (language: LangCode) => void;
@@ -40,7 +42,12 @@ export const TextEditor = ({
 }: TextEditorProps) => {
   const { t } = useTranslation();
   const [sortTextsAlphabetically, setSortTextsAlphabetically] = useState<boolean>(false);
-  const resourceRows = mapResourceFilesToTableRows(textResourceFiles, sortTextsAlphabetically);
+  const [searchInputValue, setSearchInputValue] = useState<string>(searchQuery ?? '');
+  const { debounce } = useDebounce({ debounceTimeInMs: searchDebounceTimeInMs });
+  const resourceRows = useMemo(
+    () => mapResourceFilesToTableRows(textResourceFiles, sortTextsAlphabetically),
+    [textResourceFiles, sortTextsAlphabetically],
+  );
   const previousSelectedLanguages = useRef<string[]>([]);
 
   const availableLangCodesFiltered = useMemo(
@@ -67,25 +74,40 @@ export const TextEditor = ({
     availableLangCodesFiltered.forEach((language) =>
       upsertTextResource({ language, textId, translation: '' }),
     );
+    clearSearch();
+  };
+
+  const clearSearch = (): void => {
+    setSearchInputValue('');
     setSearchQuery('');
   };
 
-  const removeEntry = ({ textId }: TextResourceEntryDeletion) => {
-    try {
-      updateTextId({ oldId: textId });
-    } catch (e: unknown) {
-      console.error('Deleting text failed:\n', e);
-    }
-  };
+  const removeEntry = useCallback(
+    ({ textId }: TextResourceEntryDeletion) => {
+      try {
+        updateTextId({ oldId: textId });
+      } catch (e: unknown) {
+        console.error('Deleting text failed:\n', e);
+      }
+    },
+    [updateTextId],
+  );
 
-  const updateEntryId = ({ oldId, newId }: TextResourceIdMutation) => {
-    try {
-      updateTextId({ oldId, newId });
-    } catch (e: unknown) {
-      console.error('Renaming text-id failed:\n', e);
-    }
+  const updateEntryId = useCallback(
+    ({ oldId, newId }: TextResourceIdMutation) => {
+      try {
+        updateTextId({ oldId, newId });
+      } catch (e: unknown) {
+        console.error('Renaming text-id failed:\n', e);
+      }
+    },
+    [updateTextId],
+  );
+  const handleSearchChange = (event: ChangeEvent<HTMLInputElement>): void => {
+    const { value } = event.target;
+    setSearchInputValue(value);
+    debounce(() => setSearchQuery(value));
   };
-  const handleSearchChange = (event: any) => setSearchQuery(event.target.value);
 
   return (
     <div className={classes.textEditor}>
@@ -110,7 +132,7 @@ export const TextEditor = ({
             <StudioSearch
               className={classes.search}
               label={t('text_editor.search_for_text')}
-              value={searchQuery}
+              value={searchInputValue}
               onChange={handleSearchChange}
               clearButtonLabel={t('general.search_clear_button_title')}
             />

--- a/src/Designer/frontend/packages/text-editor/src/TextEditor.tsx
+++ b/src/Designer/frontend/packages/text-editor/src/TextEditor.tsx
@@ -58,8 +58,9 @@ export const TextEditor = ({
   );
 
   useEffect(() => {
+    cancelDebounce();
     setSearchInputValue(searchQuery ?? '');
-  }, [searchQuery]);
+  }, [searchQuery, cancelDebounce]);
 
   useEffect(() => {
     const addedLanguage = selectedLangCodes.find(

--- a/src/Designer/frontend/packages/text-editor/src/TextEditor.tsx
+++ b/src/Designer/frontend/packages/text-editor/src/TextEditor.tsx
@@ -43,7 +43,9 @@ export const TextEditor = ({
   const { t } = useTranslation();
   const [sortTextsAlphabetically, setSortTextsAlphabetically] = useState<boolean>(false);
   const [searchInputValue, setSearchInputValue] = useState<string>(searchQuery ?? '');
-  const { debounce } = useDebounce({ debounceTimeInMs: searchDebounceTimeInMs });
+  const { debounce, cancelDebounce } = useDebounce({
+    debounceTimeInMs: searchDebounceTimeInMs,
+  });
   const resourceRows = useMemo(
     () => mapResourceFilesToTableRows(textResourceFiles, sortTextsAlphabetically),
     [textResourceFiles, sortTextsAlphabetically],
@@ -54,6 +56,10 @@ export const TextEditor = ({
     () => availableLanguages?.filter((code) => ISO6391.validate(code)),
     [availableLanguages],
   );
+
+  useEffect(() => {
+    setSearchInputValue(searchQuery ?? '');
+  }, [searchQuery]);
 
   useEffect(() => {
     const addedLanguage = selectedLangCodes.find(
@@ -78,6 +84,7 @@ export const TextEditor = ({
   };
 
   const clearSearch = (): void => {
+    cancelDebounce();
     setSearchInputValue('');
     setSearchQuery('');
   };

--- a/src/Designer/frontend/packages/text-editor/src/TextList.tsx
+++ b/src/Designer/frontend/packages/text-editor/src/TextList.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { memo, useMemo } from 'react';
 import { TextRow } from './TextRow';
 import type { TextResourceEntryDeletion, TextResourceIdMutation, TextTableRow } from './types';
 import type { UpsertTextResourceMutation } from 'app-shared/hooks/mutations/useUpsertTextResourceMutation';
@@ -18,12 +18,7 @@ export type TextListProps = {
   removeEntry: ({ textId }: TextResourceEntryDeletion) => void;
   updateEntryId: ({ oldId, newId }: TextResourceIdMutation) => void;
 };
-export const TextList = ({
-  resourceRows,
-  searchQuery,
-  selectedLanguages,
-  ...rest
-}: TextListProps) => {
+const TextListImpl = ({ resourceRows, searchQuery, selectedLanguages, ...rest }: TextListProps) => {
   const { org, app } = useStudioEnvironmentParams();
   const { t } = useTranslation();
   const { data: layoutNames, isPending: layoutNamesPending } = useLayoutNamesQuery(org, app);
@@ -81,3 +76,5 @@ export const TextList = ({
     </StudioTable>
   );
 };
+
+export const TextList = memo(TextListImpl);

--- a/src/Designer/frontend/packages/text-editor/src/constants.ts
+++ b/src/Designer/frontend/packages/text-editor/src/constants.ts
@@ -1,1 +1,2 @@
 export const defaultLangCode = 'nb';
+export const searchDebounceTimeInMs = 300;


### PR DESCRIPTION
Issue: https://digdir.slack.com/archives/C09BLD1CRK8/p1787231379057949

Typing in the text editor search field re-rendered every row on every keystroke, which made the field freeze on apps with many texts. Deleting characters was worst, since each backspace widened the filter and remounted large parts of the list.

The search field now updates immediately while the actual search is debounced by 300 ms, and the text list only re-renders when the search query or the texts change.

- Keep the input value in local state and debounce the propagation to searchQuery, so intermediate states never reach the list.
- Memoize TextList, with useCallback on removeEntry/updateEntryId and useMemo on resourceRows so the memoization actually holds. Debouncing alone did not help, because updating the input still re-rendered every row.
- Pass replace: true to setSearchParams, so searching no longer adds one history entry per character.

Measured with 400 texts, typing six characters: 2449 ms -> 422 ms, of which 191 ms is test harness overhead. Clearing the field: 306 ms -> 16 ms.

Mounting the full list is unchanged and still costly on large apps. That needs pagination or virtualisation and is left for a separate change.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Text search responds immediately while updating the URL after typing pauses.
  * Search stays synchronised when the query changes externally.
  * Clearing search resets both the search field and URL query.

* **Bug Fixes**
  * Search updates replace the current browser history entry, preventing unnecessary history entries.
  * Clearing a search cancels pending updates.

* **Performance**
  * Optimised text-list rendering and resource updates for smoother interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->