### PR TITLE
fix: gh runner avoid disk issues

### DIFF
--- a/src/github-runner/infra/kustomize/base/scaledjob.yaml
+++ b/src/github-runner/infra/kustomize/base/scaledjob.yaml
@@ -138,12 +138,13 @@ spec:
                     key: appPrivateKey
             resources:
               requests:
-                cpu: "4"
+                # Limit each D32 node to four runners to protect shared OS-disk bandwidth.
+                cpu: "7"
                 memory: 14Gi
                 ephemeral-storage: 120Gi
                 devices.altinn.studio/kvm: "1"
               limits:
-                cpu: "4"
+                cpu: "7"
                 memory: 14Gi
                 ephemeral-storage: 120Gi
                 devices.altinn.studio/kvm: "1"

--- a/src/github-runner/run.sh
+++ b/src/github-runner/run.sh
@@ -13,16 +13,29 @@ filesystem_type() {
   df -PT "$1" | awk 'NR == 2 { print $2 }'
 }
 
-require_ext4() {
+require_filesystem() {
   local path="$1"
+  local expected="$2"
   local type
 
   type="$(filesystem_type "${path}")"
-  if [[ "${type}" != "ext4" ]]; then
-    log "${path} is ${type}, expected ext4"
+  if [[ "${type}" != "${expected}" ]]; then
+    log "${path} is ${type}, expected ${expected}"
     return 1
   fi
-  log "${path} is ext4"
+  log "${path} is ${expected}"
+}
+
+configure_runner_tmp() {
+  local type
+
+  type="$(filesystem_type /tmp)"
+  if [[ "${type}" == "tmpfs" ]]; then
+    mount -o remount,size=2G,mode=1777,nosuid,nodev /tmp
+  else
+    mount -t tmpfs -o size=2G,mode=1777,nosuid,nodev tmpfs /tmp
+  fi
+  chmod 1777 /tmp
 }
 
 raise_proc_limit() {
@@ -140,18 +153,15 @@ chown -R runner:runner \
   "${NUGET_PACKAGES}" \
   "${GOMODCACHE}"
 
-# Keep large temporary workloads on the direct ext4 root when the Sandbox
-# runtime provides a memory-backed /tmp.
-if [[ "$(filesystem_type /tmp)" == "tmpfs" ]]; then
-  umount /tmp
-  chmod 1777 /tmp
-fi
+# Match the previous runner's bounded, memory-backed /tmp. Browser workloads
+# use it heavily, while workspaces, caches and Docker data remain on ext4.
+configure_runner_tmp
 
-require_ext4 /
-require_ext4 "${RUNNER_HOME}"
-require_ext4 "${RUNNER_WORKDIR}"
-require_ext4 /tmp
-require_ext4 /var/lib/docker
+require_filesystem / ext4
+require_filesystem "${RUNNER_HOME}" ext4
+require_filesystem "${RUNNER_WORKDIR}" ext4
+require_filesystem /tmp tmpfs
+require_filesystem /var/lib/docker ext4
 
 if ! grep -Eq '^[[:space:]]*127\.0\.0\.1[[:space:]].*\bstudio\.localhost\b' /etc/hosts; then
   printf '127.0.0.1 studio.localhost\n' >> /etc/hosts


### PR DESCRIPTION
## Description

we do a lot more disk IO now which with improved fs perf and non-layered/flat VM images, so this is a temporary workaround essentially. Also restores to memory-backed /tmp in the guest

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Increased coordinator CPU capacity to support more demanding workloads.

* **Reliability**
  * Added filesystem validation for runner and Docker storage.
  * Configured `/tmp` with a dedicated 2 GB temporary filesystem and restricted mount options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->