### PR TITLE
feat(agents): render-check generated apps in Studio's app preview

### DIFF
--- a/src/AI/agents/.env.example
+++ b/src/AI/agents/.env.example
@@ -1,44 +1,24 @@
 # Altinity Agent Configuration
-# Copy to .env.docker (Docker) or .env (local)
+# Copy to .env.docker (Docker) or .env (local).
+# Only the REQUIRED blocks need values; everything else has a default in
+# shared/config/base_config.py and is listed here with that default.
 
 # =============================================================================
 # REQUIRED: Azure OpenAI
 # =============================================================================
 AZURE_API_KEY=your_azure_api_key
-# AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com/  # Optional - default set in base_config.py
+# AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com/
+# AZURE_ANTHROPIC_ENDPOINT=https://<resource>.services.ai.azure.com/
+# AZURE_API_VERSION=2025-03-01-preview
+# AZURE_DEPLOYMENT_NAME=gpt-5.4-mini
 
 # =============================================================================
-# REQUIRED: Gitea proxy (for cloning and pushing branches)
+# REQUIRED: Gitea proxy (cloning and pushing session branches)
 # =============================================================================
 GITEA_BASE_URL="http://host.docker.internal/repos"  # Local: http://studio.localhost/repos
 
 # =============================================================================
-# =============================================================================
-
-# =============================================================================
-# OPTIONAL: Model Overrides (defaults are set in base_config.py)
-# =============================================================================
-# Uncomment to override default models:
-# LLM_MODEL_PLANNER=gpt-5           # Complex reasoning
-# LLM_MODEL_ACTOR=claude-sonnet-4-6 # Drives the agentic workflow loop
-# LLM_MODEL_REVIEWER=claude-sonnet-4-6  # Post-workflow LLM-as-judge evaluators
-# LLM_MODEL_ASSISTANT=claude-sonnet-4-6 # Chat-mode Q&A
-
-# =============================================================================
-# OPTIONAL: Fallback OpenAI (if Azure not configured)
-# =============================================================================
-# OPENAI_API_KEY=your_openai_api_key
-
-# OpenAI-compatible base URL override. Set this to route the OpenAI adapter
-# through Azure AI Foundry's /openai/v1/ endpoint (Kimi, Llama, etc.) or any
-# other OpenAI-compatible host. Uses AZURE_API_KEY as the bearer token.
-# Example for Kimi-K2.6 on Azure AI Foundry:
-#   OPENAI_BASE_URL=https://rndlabaidemoss0618689180.services.ai.azure.com/openai/v1/
-#   LLM_MODEL_ACTOR=kimi-k2.6
-# OPENAI_BASE_URL=
-
-# =============================================================================
-# REQUIRED: Langfuse Observability
+# REQUIRED: Langfuse observability
 # =============================================================================
 LANGFUSE_SECRET_KEY=sk-lf-...
 LANGFUSE_PUBLIC_KEY=pk-lf-...
@@ -49,7 +29,58 @@ LANGFUSE_ENVIRONMENT=local-dev  # development, staging, production, local-dev
 # LANGFUSE_TRACE_RETENTION_DAYS=90
 
 # =============================================================================
-# OPTIONAL: Server & Logging
+# OPTIONAL: Models, one per role
+# =============================================================================
+# LLM_MODEL_ACTOR=claude-sonnet-4-6      # drives the agentic workflow loop
+# LLM_MODEL_PLANNER=gpt-5                # complex reasoning
+# LLM_MODEL_REVIEWER=claude-sonnet-4-6   # post-workflow LLM-as-judge evaluators
+# LLM_MODEL_ASSISTANT=claude-sonnet-4-6  # chat-mode Q&A
+# LLM_MODEL_TOOL_PLANNER=claude-sonnet-5
+# LLM_MODEL=claude-haiku-4-5             # fallback when no role model is set
+
+# Temperatures: unset means the model's own default.
+# LLM_TEMPERATURE=0.1
+# LLM_TEMPERATURE_REVIEWER=0.0
+# LLM_TEMPERATURE_PLANNER=
+# LLM_TEMPERATURE_ASSISTANT=
+# LLM_TEMPERATURE_TOOL_PLANNER=
+# LLM_REASONING_EFFORT=low
+
+# =============================================================================
+# OPTIONAL: Fallback OpenAI (when Azure is not configured)
+# =============================================================================
+# OPENAI_API_KEY=your_openai_api_key
+
+# OpenAI-compatible base URL override. Routes the OpenAI adapter through Azure
+# AI Foundry's /openai/v1/ endpoint (Kimi, Llama, …) or any compatible host,
+# using AZURE_API_KEY as the bearer token. Example for Kimi-K2.6:
+#   OPENAI_BASE_URL=https://<resource>.services.ai.azure.com/openai/v1/
+#   LLM_MODEL_ACTOR=kimi-k2.6
+# OPENAI_BASE_URL=
+
+# =============================================================================
+# OPTIONAL: Preview render check (`preview_render_check` loop tool)
+# =============================================================================
+# Local stack only: the browser logs in through the fake-Ansattporten mock,
+# which does not exist in a deployed environment. Needs Playwright + Chromium
+# (in the image); the tool reports itself unavailable when either is missing.
+# PREVIEW_CHECK_ENABLED=true   # off by default; the tool is skipped without it
+# PREVIEW_STUDIO_BASE_URL=http://studio.localhost
+# PREVIEW_STUDIO_USER=localgiteaadmin
+# Chromium pins *.localhost to 127.0.0.1, so inside the container Studio and the
+# login redirect must be mapped to compose addresses (set in docker-compose.yaml).
+# PREVIEW_HOST_RESOLVER_RULES=MAP studio.localhost studio-loadbalancer, MAP localhost fake-ansattporten
+
+# =============================================================================
+# OPTIONAL: Loop and runtime limits
+# =============================================================================
+# AGENTIC_LOOP_MAX_TURNS=40
+# ALTINITY_MAX_TOOL_USE_CONCURRENCY=      # unset means no explicit cap
+# ANTHROPIC_MAX_TOKENS=64000
+# AGENT_ATTACHMENTS_PATH=                 # defaults to a temp directory
+
+# =============================================================================
+# OPTIONAL: Server and logging
 # =============================================================================
 # API_HOST=0.0.0.0
 # API_PORT=8071

--- a/src/AI/agents/.gitignore
+++ b/src/AI/agents/.gitignore
@@ -27,6 +27,7 @@ htmlcov/
 # Debug trace dumps
 trace-*.json
 
-# Benchmark fixtures (PDFs etc.) — local only
+# Benchmark fixtures (PDFs etc.), local only
 benchmarks/assets/
 benchmarks/.env
+benchmarks/.playwright-auth.json

--- a/src/AI/agents/agents/core/__init__.py
+++ b/src/AI/agents/agents/core/__init__.py
@@ -1,4 +1,4 @@
-"""Agentic core — the model-driven loop and its supporting primitives.
+"""Agentic core: the model-driven loop and its supporting primitives.
 
 Everything the loop needs: the provider adapters, the tool registry and
 its built-in tools (scan/read/edit/write/verify/commit + Altinn schema
@@ -39,6 +39,7 @@ from .tools import (
     DiscardFileChangesTool,
     EditFileTool,
     LayoutPropsTool,
+    PreviewRenderCheckTool,
     ReadFileTool,
     ScanRepoTool,
     SkillTool,
@@ -65,6 +66,7 @@ __all__ = [
     "OpenAIAdapter",
     "PermissionResult",
     "PreparedCall",
+    "PreviewRenderCheckTool",
     "ReadFileTool",
     "ScanRepoTool",
     "SessionContext",

--- a/src/AI/agents/agents/core/context.py
+++ b/src/AI/agents/agents/core/context.py
@@ -1,20 +1,13 @@
 """System-prompt assembler for the agentic loop.
 
-One immutable system prompt per session.  Sections are composed in a
-stable order so Anthropic's prompt cache stays warm across turns:
+One immutable prompt per session, composed in a stable order so Anthropic's
+prompt cache stays warm: identity, operating principles, Altinn anatomy,
+critical rules, tool-use guidance, then the session-specific tail (mode, goal,
+repo path, optional context) where cache misses are cheapest.
 
-    identity → operating principles → Altinn anatomy → critical rules
-    → tool-use guidance → session → repo facts? → form spec?
-    → final-answer contract
-
-Everything stable lives at the top.  The session-specific tail (mode,
-goal, repo path, optional context) sits at the bottom, where cache
-misses are cheapest.
-
-Tool descriptions are NOT assembled here.  They travel separately on
-each request (Anthropic's `tools` field; OpenAI's `tools[].function`),
-so the adapter handles them.  The prompt's tool-use section talks
-about *patterns*, not individual tools.
+Tool descriptions are not assembled here. They travel per request on the
+adapter's own tools field, so the tool-use section describes patterns rather
+than individual tools.
 """
 
 from __future__ import annotations
@@ -23,10 +16,6 @@ from dataclasses import dataclass
 from datetime import date
 from typing import Any
 
-
-# ---------------------------------------------------------------------------
-# Identity & posture
-# ---------------------------------------------------------------------------
 
 
 _IDENTITY = """\
@@ -39,10 +28,6 @@ When the user asks a question (no changes needed), answer it using documentation
 **Always write in Norwegian (bokmål) when narrating your work to the user — both mid-turn text and the final summary.**  The developers using Altinn Studio are Norwegian-speaking; mixing English into the narration breaks the UI's voice.  Code, file paths, JSON, tool calls, and technical identifiers stay in their original form (don't translate them)."""
 
 
-# ---------------------------------------------------------------------------
-# Operating principles — how to use the tools you've been given
-# ---------------------------------------------------------------------------
-
 
 _OPERATING_PRINCIPLES = """\
 ## Operating principles
@@ -53,10 +38,6 @@ _OPERATING_PRINCIPLES = """\
 - **Act, don't narrate.**  Wall-clock time is dominated by the tokens you emit, and the user is watching a progress indicator while you type.  Keep any text before tool calls to ONE short sentence.  Never draft file contents, JSON, or multi-step plans in prose — decide, then emit the `write_file`/`edit_file` calls directly.  Long explanations belong in the final message only, and even there stay brief.
 - **Stop on real blockers.**  If you genuinely cannot accomplish the goal safely (missing context, ambiguous request, conflicting state), say so in a final message instead of guessing."""
 
-
-# ---------------------------------------------------------------------------
-# Altinn anatomy — what files exist and how they relate
-# ---------------------------------------------------------------------------
 
 
 _ALTINN_ANATOMY = """\
@@ -75,10 +56,6 @@ The pieces glue together like this:
 
 A break in any link causes silent failure: missing labels, unbound fields, validation that never fires.  Always think about *all four layers* when adding or changing anything user-visible."""
 
-
-# ---------------------------------------------------------------------------
-# Critical rules — the constraints the model gets wrong most often
-# ---------------------------------------------------------------------------
 
 
 _CRITICAL_RULES = """\
@@ -110,10 +87,6 @@ _CRITICAL_RULES = """\
 7.  **Every page of a multi-page form needs a `NavigationButtons` component.**  `pages.order` in Settings.json controls the sequence, but the buttons are what let the user move between pages.  When you add a page: register it in `pages.order` AND put a `NavigationButtons` component at the bottom of the layout (the final page usually also gets a submit `Button`).  `verify_changes` rejects a multi-page layout without one."""
 
 
-# ---------------------------------------------------------------------------
-# Tool-use guidance — patterns, not per-tool reference
-# ---------------------------------------------------------------------------
-
 
 _TOOL_USE = """\
 ## Working with tools
@@ -128,7 +101,7 @@ Every tool_use block you emit in the same assistant turn runs together — reads
 - **Knowledge** — `skill(name)` loads curated instructions for a topic (see the skill listing below).  Load the relevant skill BEFORE working on data models, policy, text resources, prefill, or dynamic expressions.  For anything the skills don't cover, load `altinn-docs` and use `web_fetch` on pages from its index.
 - **Schema truth** — `altinn_layout_props(component_type=…)` for the canonical component property list.  Live lookup; batch it with reads.
 - **Recovery** — `discard_file_changes(path)` resets one file to HEAD.  Surgical, single-file.
-- **Finalise** — `verify_changes`, then `commit_session_branch`.
+- **Finalise** — `verify_changes`, then `commit_session_branch`, then `preview_render_check` (renders the pushed branch page by page — catches runtime errors the validators can't).
 
 ### Required check before layout edits
 Before adding or modifying any component in a layout, call `altinn_layout_props(component_type='<Type>')` — schemas drift and `verify_changes` will reject unknown properties.  Trust the tool, not memory.
@@ -139,7 +112,8 @@ Before adding or modifying any component in a layout, call `altinn_layout_props(
 3. **One turn**: every `edit_file` / `write_file` for the change — different paths batch.
 4. `verify_changes`; on failure, targeted `edit_file` for the specific rule it flagged, then `verify_changes` again.
 5. `commit_session_branch`.
-6. Final assistant message (no more tool calls).
+6. `preview_render_check`.  If a page fails, the detail names the runtime error: fix it, then `verify_changes` → `commit_session_branch` → `preview_render_check` again.  If the check reports itself unavailable, treat it as skipped and move on — never retry an unavailable check.
+7. Final assistant message (no more tool calls).
 
 ### Failure recovery
 - `File has not been read yet` → `read_file` first.
@@ -148,10 +122,6 @@ Before adding or modifying any component in a layout, call `altinn_layout_props(
 - `verify_changes` flags a rule → targeted `edit_file`, don't blanket-discard.
 - A file went wrong → `discard_file_changes(path)`; other files stay."""
 
-
-# ---------------------------------------------------------------------------
-# Final-answer contract — what the last message looks like
-# ---------------------------------------------------------------------------
 
 
 _FINAL_ANSWER_READ_ONLY = """\
@@ -181,11 +151,11 @@ and read the repo, load skills, look up component schemas, fetch docs.
 _FINAL_ANSWER = """\
 ## When you are done
 
-Your loop has one good ending: edits land → `verify_changes` passes → `commit_session_branch` succeeds → a final assistant message.  Anything else is the wrong path.
+Your loop has one good ending: edits land → `verify_changes` passes → `commit_session_branch` succeeds → `preview_render_check` passes (or reports itself unavailable) → a final assistant message.  Anything else is the wrong path.
 
 Specifically:
 - After `verify_changes` returns `passed: true`, the next action is `commit_session_branch` — not another lookup, not another edit.
-- After `commit_session_branch` returns successfully, you are done.  Send a final assistant message describing what changed.  Do not propose further work the user didn't ask for.
+- After `commit_session_branch` returns successfully, run `preview_render_check` once.  If a page fails to render, fix it and go back through verify → commit → check.  When it passes — or says it is unavailable in this deployment — you are done.  Send a final assistant message describing what changed.  Do not propose further work the user didn't ask for.
 - If you genuinely cannot finish (ambiguous request, missing context, repeated verification failure), send a final message explaining what's blocking and what you'd need.
 
 ## Final response format
@@ -207,19 +177,9 @@ The chat UI renders only basic markdown — headings, **bold**, *italic*, `inlin
 - Match the user's language.  If the goal was written in Norwegian, write the summary in Norwegian."""
 
 
-# ---------------------------------------------------------------------------
-# Inputs to the assembler
-# ---------------------------------------------------------------------------
-
 
 @dataclass(frozen=True)
 class SessionContext:
-    """Inputs to the prompt assembler.
-
-    Everything optional except session_id and repo_path.  Pass only what
-    you have; absent fields are omitted from the prompt.
-    """
-
     session_id: str
     repo_path: str
     user_goal: str

--- a/src/AI/agents/agents/core/tools/__init__.py
+++ b/src/AI/agents/agents/core/tools/__init__.py
@@ -1,25 +1,8 @@
 """Concrete `Tool` implementations for the agentic loop.
 
-The toolset mirrors Claude Code's surface — small, atomic file
-operations rather than a single big patch-bundle tool.  The model
-makes one focused move per call; results are visible on disk
-immediately; errors point at a specific thing to fix on the next
-call.
-
-- `repo_tool.ScanRepoTool` — high-level repo summary (layouts,
-  models, resources, locales).
-- `file_tool.ReadFileTool` / `EditFileTool` / `WriteFileTool` /
-  `DiscardFileChangesTool` — the CC-style file surface.
-- `verify_tool.VerifyChangesTool` — Altinn-specific validation on
-  touched files (in-process, from `agents.altinn`).
-- `altinn_tools.LayoutPropsTool` / `DatamodelSyncTool` — schema
-  introspection + datamodel codegen (in-process).
-- `web_fetch_tool.WebFetchTool` — allowlisted docs fetcher, pairs
-  with the `altinn-docs` skill.
-- `git_tool.CommitSessionBranchTool` — commits + pushes the session
-  branch.
-- `skill_tool.SkillTool` — loads a skill's full instructions
-  (curated Altinn domain knowledge) on demand.
+Small atomic operations rather than one big patch-bundle tool: the model makes
+one focused move per call, results land on disk immediately, and a failure
+points at a specific thing to fix on the next call.
 """
 
 from .altinn_tools import DatamodelSyncTool, LayoutPropsTool
@@ -30,6 +13,7 @@ from .file_tool import (
     WriteFileTool,
 )
 from .git_tool import CommitSessionBranchTool
+from .preview_check_tool import PreviewRenderCheckTool
 from .repo_tool import ScanRepoTool
 from .skill_tool import SkillTool
 from .verify_tool import VerifyChangesTool
@@ -41,6 +25,7 @@ __all__ = [
     "DiscardFileChangesTool",
     "EditFileTool",
     "LayoutPropsTool",
+    "PreviewRenderCheckTool",
     "ReadFileTool",
     "ScanRepoTool",
     "SkillTool",

--- a/src/AI/agents/agents/core/tools/preview_check_tool.py
+++ b/src/AI/agents/agents/core/tools/preview_check_tool.py
@@ -1,0 +1,137 @@
+"""`preview_render_check`: render the committed session branch in Studio's app
+preview, catching runtime failures `verify_changes` cannot see.
+
+Local stack only: the browser logs in through the fake-Ansattporten mock.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict
+
+from agents.core.tool import LoopContext, ToolResult
+from agents.services.preview.render_check import (
+    PreviewCheckUnavailable,
+    read_page_order,
+    render_check,
+)
+from shared.config.base_config import get_config
+
+from ._write_base import WriteToolMixin
+
+_STORAGE_STATE_PATH = Path(tempfile.gettempdir()) / "altinity_preview_auth.json"
+
+_UNAVAILABLE_GUIDANCE = (
+    "This is an infrastructure limitation, not a problem with the app — "
+    "do NOT retry, and do NOT try to fix anything based on this. "
+    "Continue to your final message."
+)
+
+
+class PreviewRenderCheckArgs(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class PreviewRenderCheckTool(WriteToolMixin):
+    name = "preview_render_check"
+    description = (
+        "Render every ordered page of the app in Studio's app preview "
+        "(headless browser) and report per-page results.  Catches what "
+        "`verify_changes` cannot: runtime errors — broken data-model "
+        "bindings, invalid expressions, components that crash the page.  "
+        "Returns `{passed, pages: [{page, rendered, detail}]}`.\n\n"
+        "WHEN to call: once, right after `commit_session_branch` succeeds "
+        "— it renders the PUSHED branch, so uncommitted edits are "
+        "invisible to it.\n\n"
+        "ON FAILURE: the detail names the failing page and the runtime "
+        "error.  Fix the page (`edit_file`), then `verify_changes`, then "
+        "`commit_session_branch`, then call `preview_render_check` again.\n\n"
+        "UNAVAILABLE: in some deployments the check cannot run (no "
+        "browser).  The result says so explicitly — treat it as skipped "
+        "and finish normally; never retry an unavailable check.\n\n"
+        "Takes no input."
+    )
+    input_schema = PreviewRenderCheckArgs
+    is_concurrency_safe = False
+
+    async def run(self, args: PreviewRenderCheckArgs, ctx: LoopContext) -> ToolResult:
+        config = get_config()
+        if not config.PREVIEW_CHECK_ENABLED:
+            return ToolResult(
+                content=f"Preview render check is disabled in this deployment. {_UNAVAILABLE_GUIDANCE}",
+                is_error=True,
+                metadata={"unavailable": True},
+            )
+
+        branch = ctx.extras.get("session_branch")
+        if not ctx.extras.get("session_committed") or not branch:
+            return ToolResult(
+                content=(
+                    "Nothing to check yet: the preview renders the pushed session "
+                    "branch.  Run `commit_session_branch` first, then call "
+                    "`preview_render_check`."
+                ),
+                is_error=True,
+            )
+
+        app = ctx.extras.get("app_name")
+        if not app or not ctx.org:
+            return ToolResult(
+                content=f"Preview render check cannot resolve the app's org/name. {_UNAVAILABLE_GUIDANCE}",
+                is_error=True,
+                metadata={"unavailable": True},
+            )
+
+        page_order = read_page_order(Path(ctx.repo_path))
+        if not page_order:
+            return ToolResult(
+                content=(
+                    "No `pages.order` found in any layout set — there are no "
+                    "ordered pages to render.  If the app should have pages, "
+                    "check App/ui/*/Settings.json."
+                ),
+                is_error=True,
+            )
+
+        try:
+            results = await asyncio.to_thread(
+                render_check,
+                studio_base=config.PREVIEW_STUDIO_BASE_URL,
+                username=config.PREVIEW_STUDIO_USER,
+                org=ctx.org,
+                app=app,
+                branch=branch,
+                page_order=page_order,
+                storage_state_path=_STORAGE_STATE_PATH,
+                host_resolver_rules=config.PREVIEW_HOST_RESOLVER_RULES or None,
+            )
+        except PreviewCheckUnavailable as reason:
+            return ToolResult(
+                content=f"Preview render check unavailable: {reason}. {_UNAVAILABLE_GUIDANCE}",
+                is_error=True,
+                metadata={"unavailable": True},
+            )
+
+        failures = [result for result in results if not result.rendered]
+        body = {
+            "passed": not failures,
+            "pages": [
+                {"page": result.page, "rendered": result.rendered, "detail": result.detail}
+                for result in results
+            ],
+        }
+        content = json.dumps(body, ensure_ascii=False, indent=2)
+        if failures:
+            content += (
+                "\n\nFix the failing page(s), then `verify_changes`, "
+                "`commit_session_branch`, and run `preview_render_check` again."
+            )
+        return ToolResult(
+            content=content,
+            is_error=bool(failures),
+            metadata={"page_count": len(results), "passed": not failures},
+        )

--- a/src/AI/agents/agents/graph/nodes/agentic_loop_node.py
+++ b/src/AI/agents/agents/graph/nodes/agentic_loop_node.py
@@ -261,7 +261,7 @@ async def _repair_render_failures(
 
     check = PreviewRenderCheckTool()
     args = check.input_schema.model_validate({})
-    for _ in range(MAX_RENDER_REPAIR_ROUNDS + 1):
+    for attempt in range(MAX_RENDER_REPAIR_ROUNDS + 1):
         if not ctx.extras.get("session_committed"):
             return result
         try:
@@ -272,6 +272,13 @@ async def _repair_render_failures(
         if outcome.metadata.get("unavailable") or not outcome.is_error:
             return result
         if sink.is_cancelled(state.session_id):
+            return result
+        if attempt == MAX_RENDER_REPAIR_ROUNDS:
+            log.warning(
+                "Render check still failing for session %s after %s repair round(s)",
+                state.session_id,
+                MAX_RENDER_REPAIR_ROUNDS,
+            )
             return result
 
         log.info("Render check failed for session %s; asking the model to fix", state.session_id)

--- a/src/AI/agents/agents/graph/nodes/agentic_loop_node.py
+++ b/src/AI/agents/agents/graph/nodes/agentic_loop_node.py
@@ -279,6 +279,10 @@ async def _repair_render_failures(
                 state.session_id,
                 MAX_RENDER_REPAIR_ROUNDS,
             )
+            state.tests_passed = False
+            state.verify_notes = [
+                f"A page still fails to render after {MAX_RENDER_REPAIR_ROUNDS} repair round(s)."
+            ]
             return result
 
         log.info("Render check failed for session %s; asking the model to fix", state.session_id)

--- a/src/AI/agents/agents/graph/nodes/agentic_loop_node.py
+++ b/src/AI/agents/agents/graph/nodes/agentic_loop_node.py
@@ -1,29 +1,8 @@
-"""Agentic-loop graph node — runs the model-driven loop end-to-end.
+"""Agentic-loop graph node: builds the prompt and tool registry, runs the loop,
+bridges its events to the EventSink, and reflects the outcome onto AgentState.
 
-Replaces the planning_tool → planner → actor → verifier → reviewer
-chain.  All of those concerns become tools the model can invoke in
-whatever order it chooses.
-
-The node:
-    1.  Assembles a `SessionContext` from `AgentState` and renders the
-        immutable system prompt.
-    2.  Builds a `ToolRegistry` populated with the in-process tools
-        (`scan_repo`, `propose_patch`, `verify_changes`,
-        `commit_session_branch`, `rollback`) plus the in-process Altinn
-        tools.
-    3.  Bridges loop events to the existing `EventSink` so the
-        frontend keeps seeing status messages; wires
-        `sink.is_cancelled(session_id)` as the cancel signal.
-    4.  Runs `run_loop` against the configured LLM adapter (role
-        `actor`).
-    5.  Reflects the outcome onto `AgentState`'s legacy fields so
-        downstream code (run_once's success/failure emit, evaluators)
-        keeps working unchanged.
-
-This node serves BOTH modes: `state.allow_app_changes` gates the write
-tools (read-only "chat" runs can still scan/read the repo, load skills,
-and fetch docs), and prior session turns are prepended as conversation
-history so follow-ups keep their context across modes.
+`state.allow_app_changes` gates the write tools, so a read-only run can still
+scan, read, load skills and fetch docs.
 """
 
 from __future__ import annotations
@@ -43,6 +22,7 @@ from agents.core import (
     LayoutPropsTool,
     LoopContext,
     LoopResult,
+    PreviewRenderCheckTool,
     ReadFileTool,
     ScanRepoTool,
     SessionContext,
@@ -68,10 +48,6 @@ from shared.utils.logging_utils import get_logger
 
 log = get_logger(__name__)
 
-# Tool names whose invocation produces a user-meaningful progress
-# update.  Everything else (read_file, lookups, scan_repo) is
-# silent — the model's own narration carries the context better than
-# "Calling altinn_layout_props…" ever could.
 _TOOL_STATUS_MESSAGES = {
     "scan_repo": "Skanner repo",
     "read_file": "Leser",
@@ -84,9 +60,6 @@ _TOOL_STATUS_MESSAGES = {
     "web_fetch": "Leser dokumentasjon",
 }
 
-# Human-readable labels for the Altinn schema tools.  Without these the
-# UI would show the raw tool name (e.g., "altinn_layout_props"), which
-# means nothing to end users.
 _ALTINN_TOOL_LABELS = {
     "altinn_layout_props": "Slår opp komponent",
     "altinn_datamodel_sync": "Synkroniserer datamodell",
@@ -94,12 +67,9 @@ _ALTINN_TOOL_LABELS = {
 
 
 def _status_for_tool_call(name: str, tool_input: dict[str, Any] | None) -> str | None:
-    """Build a user-facing status string for a tool_call event.
+    """User-facing status for a tool_call, or None when the tool should not surface.
 
-    Returns None when the tool shouldn't surface.  Format is
-    "<verb phrase> <subject>" — e.g. "Leser App/ui/Side1.json",
-    "Slår opp komponent: Input".  No technical tool names in the
-    output; those map through _ALTINN_TOOL_LABELS for the altinn_ family.
+    Reads as "<verb> <subject>" with no technical tool names.
     """
     base = _TOOL_STATUS_MESSAGES.get(name)
     args = tool_input or {}
@@ -117,11 +87,6 @@ def _status_for_tool_call(name: str, tool_input: dict[str, Any] | None) -> str |
     return None
 
 
-# What we show while the model is generating a tool_use block but the
-# input JSON hasn't fully streamed yet.  Path/args aren't available — we
-# only know the tool name from the `content_block_start` event.  These
-# are placeholders the call-time message replaces in-place (matched by
-# tool_use_id on the frontend), so keep them short and generic.
 _TOOL_PENDING_MESSAGES = {
     "scan_repo": "Skanner repo",
     "read_file": "Leser fil",
@@ -136,26 +101,17 @@ _TOOL_PENDING_MESSAGES = {
 
 
 def _status_for_tool_pending(name: str) -> str | None:
-    """Placeholder shown the moment a tool_use block starts streaming.
-
-    Replaced by the call-time message as soon as the input JSON is
-    complete and the dispatcher fires the tool.  Same vocabulary as
-    `_status_for_tool_call` so the swap feels like the same entry just
-    gaining detail.
+    """Placeholder shown while a tool_use block is still streaming, replaced by the
+    call-time message once the input JSON completes.
     """
     base = _TOOL_PENDING_MESSAGES.get(name)
     if base:
         return base
     if name.startswith("altinn_"):
         return _ALTINN_TOOL_LABELS.get(name, "Slår opp dokumentasjon")
-    # Unknown tool: show nothing rather than the raw tool name — "skill"
-    # or "web_fetch" as a trail row means nothing to end users.
     return None
 
 
-# Phase labels surfaced to the frontend so it can highlight the active
-# pill in the activity row.  Kept short and stable — the frontend renders
-# its own user-facing strings; these are just identifiers.
 _PHASE_READING = "reading"
 _PHASE_WRITING = "writing"
 _PHASE_VERIFYING = "verifying"
@@ -171,29 +127,18 @@ _TOOL_PHASES: dict[str, str] = {
     "edit_file": _PHASE_WRITING,
     "write_file": _PHASE_WRITING,
     "discard_file_changes": _PHASE_WRITING,
-    "altinn_datamodel_sync": _PHASE_WRITING,  # generates + writes files
+    "altinn_datamodel_sync": _PHASE_WRITING,
     "verify_changes": _PHASE_VERIFYING,
     "commit_session_branch": _PHASE_COMMITTING,
 }
 
 
 def _phase_for_tool(name: str) -> str:
-    """Map a tool name to the activity phase the UI highlights.
-
-    Unknown tools land in `thinking` so the UI still has something to
-    show.
-    """
     return _TOOL_PHASES.get(name, _PHASE_THINKING)
 
-# Cap on turns inside a single workflow run.  20 comfortably covers a
-# scan → read → edit → verify → commit sequence with room for retries;
-# can be raised via env var without code changes if a session needs more.
 _DEFAULT_MAX_TURNS = int(os.getenv("AGENTIC_LOOP_MAX_TURNS", "40"))
 
 
-# Bound the history prepended to the loop: enough for the model to keep
-# the thread, small enough not to crowd out the actual task.  Long
-# individual messages (pasted logs, full summaries) are truncated.
 _HISTORY_MAX_MESSAGES = 12
 _HISTORY_MAX_CHARS_PER_MESSAGE = 6000
 
@@ -201,9 +146,8 @@ _HISTORY_MAX_CHARS_PER_MESSAGE = 6000
 def _history_messages(state: AgentState) -> list:
     """Prior session turns as loop messages, oldest first.
 
-    The shared per-session history contains both chat and workflow turns,
-    so a follow-up like "what did you just change?" has the earlier
-    exchanges available regardless of which mode produced them.
+    Chat and workflow turns share one history, so "what did you just change?"
+    works whichever mode produced the earlier exchange.
     """
     messages: list = []
     for entry in state.conversation_history[-_HISTORY_MAX_MESSAGES:]:
@@ -220,12 +164,7 @@ def _history_messages(state: AgentState) -> list:
 
 
 async def handle(state: AgentState) -> AgentState:
-    """Drive one workflow run via the agentic loop."""
     log.info("🤖 Agentic loop node executing")
-    # No initial status — the frontend's journal renders its own
-    # placeholder while we wait for the first streaming event.  An
-    # explicit "Tenker…" here would land as a real step in the journal
-    # with a misleading duration.
 
     session = SessionContext(
         session_id=state.session_id,
@@ -235,7 +174,7 @@ async def handle(state: AgentState) -> AgentState:
         form_spec_summary=state.form_spec.to_summary() if state.form_spec else None,
         developer=state.developer,
         org=state.org,
-        repo_facts=state.repo_facts,  # may be None — model can call scan_repo
+        repo_facts=state.repo_facts,
     )
     skills = discover_skills()
     system_prompt = build_system_prompt(
@@ -256,14 +195,13 @@ async def handle(state: AgentState) -> AgentState:
         developer=state.developer,
         org=state.org,
         designer_api_key=state.designer_api_key,
-        # In read-only sessions a write attempt asks the user for
-        # permission (inline prompt in the chat) instead of a flat denial.
         permission_requester=(
             None
             if state.allow_app_changes
             else lambda action: permission_broker.request(state.session_id, action)
         ),
     )
+    ctx.extras["app_name"] = state.app_name
 
     adapter = build_adapter("actor")
     on_event = _make_event_bridge(state.session_id)
@@ -285,13 +223,73 @@ async def handle(state: AgentState) -> AgentState:
     _apply_result_to_state(state, result, ctx)
     if state.allow_app_changes:
         await _maybe_auto_commit(state, result, ctx)
+        result = await _repair_render_failures(
+            state,
+            result,
+            ctx,
+            registry=registry,
+            adapter=adapter,
+            system_prompt=system_prompt,
+            on_event=on_event,
+        )
     if result.reason is TerminationReason.CANCELLED:
-        # The cancel endpoint already sent the terminal "cancelled" error
-        # event. Emitting a completion here would deliver (and persist) an
-        # assistant answer for a run the user explicitly aborted.
         return state
     _emit_workflow_completion(state, result, ctx)
     return state
+
+
+MAX_RENDER_REPAIR_ROUNDS = 1
+
+
+async def _repair_render_failures(
+    state: AgentState,
+    result: LoopResult,
+    ctx: LoopContext,
+    *,
+    registry,
+    adapter,
+    system_prompt: str,
+    on_event,
+) -> LoopResult:
+    """Render-check the committed app and send failures back to the model.
+
+    The prompt asks the model to run the check, but a skipped one looks exactly
+    like a clean one. Bounded by MAX_RENDER_REPAIR_ROUNDS.
+    """
+    if result.reason is TerminationReason.CANCELLED:
+        return result
+
+    check = PreviewRenderCheckTool()
+    args = check.input_schema.model_validate({})
+    for _ in range(MAX_RENDER_REPAIR_ROUNDS + 1):
+        if not ctx.extras.get("session_committed"):
+            return result
+        try:
+            outcome = await check.run(args, ctx)
+        except Exception:
+            log.exception("Render check raised for session %s", state.session_id)
+            return result
+        if outcome.metadata.get("unavailable") or not outcome.is_error:
+            return result
+        if sink.is_cancelled(state.session_id):
+            return result
+
+        log.info("Render check failed for session %s; asking the model to fix", state.session_id)
+        ctx.extras["session_committed"] = False
+        result = await run_loop(
+            user_message=outcome.content,
+            system_prompt=system_prompt,
+            registry=registry,
+            adapter=adapter,
+            ctx=ctx,
+            max_turns=_DEFAULT_MAX_TURNS,
+            is_cancelled=lambda: sink.is_cancelled(state.session_id),
+            on_event=on_event,
+            history=_history_messages(state),
+        )
+        _apply_result_to_state(state, result, ctx)
+        await _maybe_auto_commit(state, result, ctx)
+    return result
 
 
 async def _maybe_auto_commit(
@@ -299,19 +297,11 @@ async def _maybe_auto_commit(
     result: LoopResult,
     ctx: LoopContext,
 ) -> None:
-    """Force a commit when the loop ends with uncommitted changes.
+    """Commit uncommitted changes left behind by a max_turns or stuck exit, so
+    partial progress is inspectable instead of stranded in the container.
 
-    Without this, a `max_turns` or `stuck` termination drops all the
-    partial progress on the floor — the files are on disk in the
-    agents container but nobody else sees them.  We commit them to the
-    session branch with a generic message so the user can at least
-    inspect and decide.
-
-    Skipped when:
-        - The model already called `commit_session_branch` successfully
-          (ctx.extras["session_committed"] is True).
-        - There were no tracked changes.
-        - The loop ended on CANCELLED (user pulled the plug).
+    Skipped when the model already committed, nothing changed, or the run was
+    cancelled.
     """
     if result.reason is TerminationReason.CANCELLED:
         return
@@ -343,7 +333,6 @@ async def _maybe_auto_commit(
 
 
 def _auto_commit_message(state: AgentState, result: LoopResult) -> str:
-    """Best-effort commit subject for the safety-net path."""
     goal = (state.user_goal or "").strip().splitlines()[0][:60] if state.user_goal else "agent changes"
     prefix = {
         TerminationReason.COMPLETED: "feat",
@@ -354,21 +343,10 @@ def _auto_commit_message(state: AgentState, result: LoopResult) -> str:
     return f"{prefix}: {goal}"
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
 
 def _augment_goal_for_missing_spec(state: AgentState) -> str:
-    """Prepend a warning when the user attached a file but spec extraction
-    failed to produce one.
-
-    Without this, the loop sees only the bare goal text ("build the
-    attached form") with no field list — the model has no concrete
-    content to act on, so it answers conversationally and the loop
-    exits with zero changes.  The note tells the model explicitly that
-    it must stop and ask the user for the field list rather than
-    inventing one.
+    """Warn the model when an attachment produced no spec, so it asks for the field
+    list instead of answering conversationally and changing nothing.
     """
     goal = state.user_goal or ""
     if state.form_spec is not None or not state.attachments:
@@ -389,12 +367,7 @@ def _augment_goal_for_missing_spec(state: AgentState) -> str:
 
 
 def _build_registry(skills: list | None = None) -> ToolRegistry:
-    """Register every tool available in workflow mode.
-
-    The node is workflow-only, so write tools are always present.
-    Everything runs in-process — no network dependency beyond the
-    (cached) schema fetches inside the Altinn tools.
-    """
+    """Register every tool available in workflow mode, all in-process."""
     registry = ToolRegistry()
     for tool in _internal_tools(skills or []):
         registry.register(tool)
@@ -410,6 +383,7 @@ def _internal_tools(skills: list) -> list[Tool]:
         DiscardFileChangesTool(),
         VerifyChangesTool(),
         CommitSessionBranchTool(),
+        PreviewRenderCheckTool(),
         SkillTool(skills),
         LayoutPropsTool(),
         DatamodelSyncTool(),
@@ -420,24 +394,11 @@ def _internal_tools(skills: list) -> list[Tool]:
 def _make_event_bridge(session_id: str) -> EventCallback:
     """Translate loop events into AgentEvent payloads for the frontend.
 
-    The Designer frontend reads `data.content`/`data.filesChanged` and
-    silently ignores `data.text`, so `assistant_message` events must
-    carry `{author, content, filesChanged}`, NOT `{text}`.
-
-    Per-turn assistant messages are emitted *as the model goes*, with an
-    empty `filesChanged` list; the final summary message (with the real
-    file list) and the workflow-end `done` event are emitted by
-    `_emit_workflow_completion`, not from here.
-
-    Other events (turn_start, tool_result, compacted) are log-only — the
-    UI doesn't need them.
+    The frontend reads `data.content`/`data.filesChanged` and ignores
+    `data.text`. Per-turn messages go out as the model streams; the final
+    summary and `done` come from `_emit_workflow_completion`.
     """
 
-    # Throttle text deltas so each Anthropic micro-chunk isn't a separate
-    # WebSocket frame.  ~10 updates/second feels like real typing and keeps
-    # network/frontend churn bounded.  The accumulated text is always sent
-    # — never the raw single-token delta — so the UI can replace its bubble
-    # contents wholesale and remain consistent if intermediate chunks drop.
     _MIN_DELTA_INTERVAL_S = 0.10
     delta_state: dict[str, Any] = {
         "last_emit": 0.0,
@@ -470,15 +431,12 @@ def _make_event_bridge(session_id: str) -> EventCallback:
         tool_use_id: str | None = None,
         pending: bool = False,
     ) -> None:
-        """Push a status event with phase + tool-use bookkeeping.
+        """Push a status event with phase and tool-use bookkeeping.
 
-        `tool_use_id` is the model's id for a single tool_use block, so
-        the frontend can match the call back to its pending placeholder
-        and replace one entry in-place rather than rendering both.
-        `pending` marks the placeholder so the dedupe is asymmetric: a
-        non-pending status replaces a previous pending one with the same
-        id; the reverse never happens.
-        """
+    `tool_use_id` lets the frontend replace a pending placeholder in place
+    rather than rendering both. The dedupe is asymmetric: a non-pending status
+    replaces a pending one, never the reverse.
+    """
         delta_state["phase"] = phase
         data: dict[str, Any] = {"message": message, "phase": phase}
         if tool_use_id:
@@ -495,8 +453,6 @@ def _make_event_bridge(session_id: str) -> EventCallback:
 
     def on_event(event: str, payload: dict[str, Any]) -> None:
         if event == "text_delta":
-            # New turn → flush any leftover accumulator from the previous
-            # turn so the UI doesn't keep stale tail text.
             turn = payload.get("turn", 0)
             if turn != delta_state["turn"]:
                 delta_state["turn"] = turn
@@ -508,13 +464,6 @@ def _make_event_bridge(session_id: str) -> EventCallback:
                 _flush_pending_delta()
             return
         if event == "tool_use_pending":
-            # The model has stopped emitting text and is now generating a
-            # tool_use block.  No further text deltas will arrive for this
-            # turn — flush what we have and announce the upcoming tool so
-            # the UI keeps moving while the input JSON streams in.  We
-            # tag with `pending=True` and the tool's id so the call event
-            # can replace this placeholder rather than appending a second
-            # row.
             _flush_pending_delta()
             delta_state["pending_text"] = ""
             name = payload.get("name") or ""
@@ -529,10 +478,6 @@ def _make_event_bridge(session_id: str) -> EventCallback:
                 )
             return
         if event == "tool_call":
-            # A tool call signals the model finished the tool_use block.
-            # Same tool_use_id as the pending event from above, so the
-            # frontend can collapse them into a single entry that just
-            # updates its message.
             _flush_pending_delta()
             delta_state["pending_text"] = ""
             name = payload.get("name", "")
@@ -545,12 +490,6 @@ def _make_event_bridge(session_id: str) -> EventCallback:
                     tool_use_id=tool_use_id,
                 )
         elif event == "assistant_message":
-            # Streaming has already shipped this turn's text to the UI
-            # via `assistant_message_chunk` events.  We still flush any
-            # pending tail (the last <100ms of throttled deltas) so the
-            # bubble shows the complete narration before the next status
-            # message overlays it.  The terminal turn is handled by
-            # `_emit_workflow_completion`, never here.
             _flush_pending_delta()
             delta_state["pending_text"] = ""
         elif event == "terminated":
@@ -572,33 +511,19 @@ def _make_event_bridge(session_id: str) -> EventCallback:
 
 
 def _emit_workflow_completion(state: AgentState, result: LoopResult, ctx: LoopContext) -> None:
-    """Emit the events the Designer frontend uses to close out a session.
-
-    The frontend expects two events at the end of a workflow: a final
-    `assistant_message` carrying the model's summary + the `filesChanged`
-    list, and a `done` event it reads as "workflow is over, you can
-    navigate to the diff now".
-
-    Without these two, the frontend renders empty bubbles and never
-    triggers its post-workflow logic (e.g. checkout the session branch).
+    """Emit the final `assistant_message` and `done` the frontend needs to close
+    out a session; without both it renders empty bubbles and never runs its
+    post-workflow logic, such as checking out the session branch.
     """
     summary = _final_summary_text(result)
     message_data = {
         "author": "assistant",
         "content": summary,
         "filesChanged": state.changed_files,
-        # Knowledge sources the loop actually consulted (docs pages,
-        # skills, schema lookups) — collected from tool executions, not
-        # self-reported by the model.
         "sources": ctx.extras.get("sources", []),
     }
     if not state.allow_app_changes:
-        # Read-only run: the frontend must not reset the repo or check out
-        # a session branch — nothing was (or could have been) committed.
         message_data["no_branch_operations"] = True
-    # The Langfuse trace id doubles as the run's identity on the event: the
-    # frontend uses it to dedupe redelivered events and to submit feedback
-    # on the answer (PUT chat/feedback/{traceId}).
     trace_id = state.trace_id or get_current_trace_id()
     if trace_id:
         message_data["traceId"] = trace_id
@@ -609,8 +534,6 @@ def _emit_workflow_completion(state: AgentState, result: LoopResult, ctx: LoopCo
             data=message_data,
         )
     )
-    # Also store in conversation history so follow-up turns have context;
-    # without it the chat assistant loses the thread between workflow runs.
     try:
         sink.add_to_conversation_history(state.session_id, "assistant", summary)
     except Exception:
@@ -632,11 +555,8 @@ _SOURCES_LINE_RE = re.compile(r"\n+SOURCES:[^\n]*\s*$", re.IGNORECASE)
 
 
 def _strip_sources_line(text: str) -> str:
-    """Drop a trailing `SOURCES: ...` line if the model appended one.
-
-    Sources are attached structurally from the tool trace; a text
-    SOURCES line is a leftover habit from the old prompt convention and
-    would render as raw text in the chat.
+    """Drop a trailing `SOURCES:` line: sources are attached structurally from the
+    tool trace, so the model's text version would render as raw chat text.
     """
     return _SOURCES_LINE_RE.sub("", text)
 
@@ -644,11 +564,8 @@ def _strip_sources_line(text: str) -> str:
 def _final_summary_text(result: LoopResult) -> str:
     """User-facing summary chosen by termination reason.
 
-    On COMPLETED we use the model's own final text — that's what it
-    chose to say.  For the other reasons the model never produced a
-    final text (the loop bailed mid-flight), so we fall back to a
-    Norwegian explanation rather than "Workflow completed." which
-    misleadingly implied success.
+    Only COMPLETED has the model's own final text; the others bailed mid-flight
+    and fall back to a Norwegian explanation rather than implying success.
     """
     if result.reason is TerminationReason.COMPLETED:
         return _strip_sources_line(result.final_text or "Ferdig.").strip()
@@ -678,25 +595,8 @@ def _apply_result_to_state(
     result: LoopResult,
     ctx: LoopContext,
 ) -> None:
-    """Reflect the loop's outcome onto AgentState's legacy fields.
-
-    `next_action = "stop"` regardless of reason — the new graph has no
-    more nodes downstream, so the routing functions don't matter.  The
-    legacy fields kept in sync:
-
-        tests_passed   — True iff the model completed normally.
-        verify_notes   — populated only on ERROR or MAX_TURNS, so the
-                          completion message in run_once is informative.
-        changed_files  — taken from ctx.extras, populated by
-                          propose_patch / cleared by rollback.
-        assistant_response — final text from the model, surfaced for
-                          downstream Q&A consumers and Langfuse.
-    """
     state.next_action = "stop"
 
-    # A mid-run permission grant upgrades the session to write mode —
-    # reflect it so auto-commit and the completion events (branch
-    # checkout on the frontend) treat the run as a change run.
     state.allow_app_changes = ctx.allow_app_changes
 
     changed = ctx.extras.get("changed_files") or set()
@@ -705,12 +605,7 @@ def _apply_result_to_state(
     if result.final_text:
         state.assistant_response = {
             "text": result.final_text,
-            # Consulted knowledge sources — surfaced in the trace output so
-            # the Langfuse no_hallucination evaluator can compare the answer
-            # against what was actually read.
             "sources": ctx.extras.get("sources", []),
-            # Actual commit hash (None if nothing was committed) — evidence
-            # for the faithful_summary evaluator when the summary names one.
             "commit": ctx.extras.get("commit"),
         }
 
@@ -730,6 +625,6 @@ def _apply_result_to_state(
     elif result.reason is TerminationReason.CANCELLED:
         state.tests_passed = False
         state.verify_notes = ["Workflow cancelled."]
-    else:  # ERROR
+    else:
         state.tests_passed = False
         state.verify_notes = [f"Loop error: {result.error or 'unknown'}"]

--- a/src/AI/agents/agents/services/preview/__init__.py
+++ b/src/AI/agents/agents/services/preview/__init__.py
@@ -1,0 +1,21 @@
+"""Preview render check: does the app render in Studio's app preview?
+
+Shared engine used by the `preview_render_check` loop tool and the
+benchmark suite's preview check.
+"""
+
+from .render_check import (
+    PageRenderResult,
+    PreviewCheckUnavailable,
+    read_page_order,
+    render_check,
+    swap_layout_in_preview_url,
+)
+
+__all__ = [
+    "PageRenderResult",
+    "PreviewCheckUnavailable",
+    "read_page_order",
+    "render_check",
+    "swap_layout_in_preview_url",
+]

--- a/src/AI/agents/agents/services/preview/render_check.py
+++ b/src/AI/agents/agents/services/preview/render_check.py
@@ -24,6 +24,11 @@ XSRF_HEADER_NAME = "X-XSRF-TOKEN"
 
 ERROR_SELECTOR = '[data-testid="AltinnError"], [data-fatal-error]'
 RENDERED_OR_ERROR_SELECTOR = f"#finishedLoading, #readyForPrint, {ERROR_SELECTOR}"
+APP_DIR_NAME = "App"
+UI_DIR_NAME = "ui"
+LAYOUT_SETTINGS_FILE_NAME = "Settings.json"
+PAGES_KEY = "pages"
+PAGE_ORDER_KEY = "order"
 PREVIEW_IFRAME_SELECTOR = "#app-frontend-react-iframe"
 
 THROWN_ERROR_PATTERN = re.compile(
@@ -96,15 +101,15 @@ def read_page_order(repo_root: Path) -> list[str]:
     With several ordered layout sets the longest wins, as the benchmark does.
     """
     best: list[str] = []
-    ui_dir = repo_root / "App" / "ui"
+    ui_dir = repo_root / APP_DIR_NAME / UI_DIR_NAME
     if not ui_dir.is_dir():
         return best
-    for settings_path in sorted(ui_dir.rglob("Settings.json")):
+    for settings_path in sorted(ui_dir.rglob(LAYOUT_SETTINGS_FILE_NAME)):
         try:
             settings = json.loads(settings_path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             continue
-        order = (settings.get("pages") or {}).get("order")
+        order = (settings.get(PAGES_KEY) or {}).get(PAGE_ORDER_KEY)
         if isinstance(order, list) and len(order) > len(best):
             best = [p for p in order if isinstance(p, str)]
     return best
@@ -175,7 +180,11 @@ def _checkout_branch(context, studio_base: str, org: str, app: str, branch: str)
     """
     repo_api = f"{studio_base}/designer/api/repos/repo/{org}/{app}"
 
-    context.request.get(f"{repo_api}/reset", timeout=CHECKOUT_TIMEOUT_MS)
+    reset = context.request.get(f"{repo_api}/reset", timeout=CHECKOUT_TIMEOUT_MS)
+    if not reset.ok:
+        raise PreviewCheckUnavailable(
+            f"reset before checkout of {branch!r} failed: {reset.status} {reset.status_text}"
+        )
 
     checkout = context.request.post(
         f"{repo_api}/checkout",
@@ -218,8 +227,10 @@ def _check_pages(page, first_page_url: str, page_order: list[str]) -> list[PageR
     for layout in page_order:
         url = swap_layout_in_preview_url(first_page_url, layout)
         if url is None:
-            results.append(_check_single_page(page, first_page_url, layout))
-            break
+            # Scoring a subset would report a pass the run never earned.
+            raise PreviewCheckUnavailable(
+                f"preview url {first_page_url!r} cannot select layouts; cannot check {len(page_order)} page(s)"
+            )
         results.append(_check_single_page(page, url, layout))
     return results
 

--- a/src/AI/agents/agents/services/preview/render_check.py
+++ b/src/AI/agents/agents/services/preview/render_check.py
@@ -1,0 +1,294 @@
+"""Renders every ordered page of a branch in Studio's app preview, headless.
+
+A pure engine: callers supply the configuration and read the results. Checkout
+runs on the browser session, not an API key, which the repo endpoints reject,
+and it keeps the working copy owned by the user the preview renders for.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urljoin, urlsplit, urlunsplit
+
+PAGE_RENDER_TIMEOUT_MS = 30_000
+LOGIN_STEP_TIMEOUT_MS = 30_000
+ORG_PICKER_TIMEOUT_MS = 3_000
+CHECKOUT_TIMEOUT_MS = 120_000
+ERROR_SNIPPET_MAX_CHARS = 200
+
+XSRF_COOKIE_NAME = "XSRF-TOKEN"
+XSRF_HEADER_NAME = "X-XSRF-TOKEN"
+
+ERROR_SELECTOR = '[data-testid="AltinnError"], [data-fatal-error]'
+RENDERED_OR_ERROR_SELECTOR = f"#finishedLoading, #readyForPrint, {ERROR_SELECTOR}"
+PREVIEW_IFRAME_SELECTOR = "#app-frontend-react-iframe"
+
+THROWN_ERROR_PATTERN = re.compile(
+    r"\b[A-Z]\w*Error\b|\bError:|\b(?:Cannot read properties|is not a function|is not defined)\b"
+    r"|\bat \S+ \(https?://"
+)
+
+LOGIN_BUTTON = "Logg inn"
+ORG_PICKER_NEXT_BUTTON = "Neste"
+SKIP_LOGIN_GUIDE_KEY = "altinn-studio-skip-login-guide"
+
+
+@dataclass(frozen=True)
+class PageRenderResult:
+    page: str
+    rendered: bool
+    detail: str = ""
+
+
+class PreviewCheckUnavailable(Exception):
+    pass
+
+def render_check(
+    *,
+    studio_base: str,
+    username: str,
+    org: str,
+    app: str,
+    branch: str,
+    page_order: list[str],
+    storage_state_path: Path,
+    host_resolver_rules: str | None = None,
+) -> list[PageRenderResult]:
+    """Render-check every ordered page of `branch`.
+
+    `host_resolver_rules` is Chromium's `--host-resolver-rules`. Chromium pins
+    `*.localhost` to 127.0.0.1 (RFC 6761) and ignores DNS, so in a container it
+    is the only way to reach compose addresses; route rewrites miss the login
+    redirects. Synchronous Playwright; call via `asyncio.to_thread`.
+    """
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError as error:
+        raise PreviewCheckUnavailable(
+            "playwright is not installed (pip install playwright && playwright install chromium)"
+        ) from error
+
+    studio_base = studio_base.rstrip("/")
+    launch_args = (
+        [f"--host-resolver-rules={host_resolver_rules}"] if host_resolver_rules else []
+    )
+    with sync_playwright() as playwright:
+        try:
+            browser = playwright.chromium.launch(args=launch_args)
+        except Exception as error:
+            raise PreviewCheckUnavailable(f"could not launch Chromium: {error}") from error
+        try:
+            context = _authenticated_context(browser, studio_base, username, storage_state_path)
+            _checkout_branch(context, studio_base, org, app, branch)
+            page = context.new_page()
+            first_page_url = _resolve_preview_url(page, studio_base, org, app)
+            return _check_pages(page, first_page_url, page_order)
+        finally:
+            browser.close()
+
+
+def read_page_order(repo_root: Path) -> list[str]:
+    """`pages.order` of the app's primary layout set.
+
+    With several ordered layout sets the longest wins, as the benchmark does.
+    """
+    best: list[str] = []
+    ui_dir = repo_root / "App" / "ui"
+    if not ui_dir.is_dir():
+        return best
+    for settings_path in sorted(ui_dir.rglob("Settings.json")):
+        try:
+            settings = json.loads(settings_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        order = (settings.get("pages") or {}).get("order")
+        if isinstance(order, list) and len(order) > len(best):
+            best = [p for p in order if isinstance(p, str)]
+    return best
+
+
+def swap_layout_in_preview_url(url: str, layout: str) -> str | None:
+    parts = urlsplit(url)
+    segments = parts.fragment.split("/")
+    if len(segments) < 5 or segments[1] != "instance":
+        return None
+    task_segments = segments[:5]
+    fragment = "/".join([*task_segments, layout])
+    return urlunsplit(parts._replace(fragment=fragment))
+
+
+
+def _authenticated_context(browser, studio_base: str, username: str, storage_state_path: Path):
+    if storage_state_path.is_file():
+        context = browser.new_context(storage_state=str(storage_state_path))
+        if _is_logged_in(context, studio_base):
+            return context
+        context.close()
+
+    context = browser.new_context()
+    try:
+        _login(context, studio_base, username)
+    except Exception as error:
+        context.close()
+        raise PreviewCheckUnavailable(f"Studio login as {username!r} failed: {error}") from error
+    cookies = context.cookies()
+    for cookie in cookies:
+        cookie["secure"] = False
+    context.clear_cookies()
+    context.add_cookies(cookies)
+    context.storage_state(path=str(storage_state_path))
+    return context
+
+
+def _is_logged_in(context, studio_base: str) -> bool:
+    try:
+        return context.request.get(f"{studio_base}/designer/api/user/current").ok
+    except Exception:
+        return False
+
+
+def _login(context, studio_base: str, username: str) -> None:
+    """Log in through the fake-Ansattporten mock: a user picker, no password."""
+    page = context.new_page()
+    page.goto(f"{studio_base}/")
+    page.evaluate(f"localStorage.setItem('{SKIP_LOGIN_GUIDE_KEY}', 'true')")
+    page.get_by_role("button", name=LOGIN_BUTTON).click()
+    page.wait_for_url("**/authorize**", timeout=LOGIN_STEP_TIMEOUT_MS)
+    page.get_by_role("button", name=re.compile(re.escape(username))).click()
+    # An org picker only appears when Designer requests authorization_details.
+    org_picker_next = page.get_by_role("button", name=ORG_PICKER_NEXT_BUTTON)
+    try:
+        org_picker_next.click(timeout=ORG_PICKER_TIMEOUT_MS)
+    except Exception:
+        pass
+    page.wait_for_url(f"{studio_base}/dashboard/**", timeout=LOGIN_STEP_TIMEOUT_MS)
+    page.close()
+
+
+
+def _checkout_branch(context, studio_base: str, org: str, app: str, branch: str) -> None:
+    """Reset and check out through the Designer API on the browser's cookie
+    session, mirroring the frontend's reset/checkout flow.
+    """
+    repo_api = f"{studio_base}/designer/api/repos/repo/{org}/{app}"
+
+    context.request.get(f"{repo_api}/reset", timeout=CHECKOUT_TIMEOUT_MS)
+
+    checkout = context.request.post(
+        f"{repo_api}/checkout",
+        data={"branchName": branch},
+        headers={XSRF_HEADER_NAME: _xsrf_token(context, studio_base)},
+        timeout=CHECKOUT_TIMEOUT_MS,
+    )
+    if not checkout.ok:
+        raise PreviewCheckUnavailable(
+            f"checkout of {branch!r} failed: {checkout.status} {checkout.status_text}"
+        )
+
+
+def _xsrf_token(context, studio_base: str) -> str:
+    context.request.get(f"{studio_base}/designer/api/user/current")
+    for cookie in context.cookies():
+        if cookie["name"] == XSRF_COOKIE_NAME:
+            return cookie["value"]
+    raise PreviewCheckUnavailable("no XSRF token cookie after login")
+
+
+
+def _resolve_preview_url(page, studio_base: str, org: str, app: str) -> str:
+    """Open Studio's preview page, which creates the mock instance, and return the
+    app-specific-preview URL its iframe points at.
+    """
+    try:
+        page.goto(f"{studio_base}/preview/{org}/{app}")
+        iframe = page.wait_for_selector(PREVIEW_IFRAME_SELECTOR, timeout=PAGE_RENDER_TIMEOUT_MS)
+        src = iframe.get_attribute("src")
+    except Exception as error:
+        raise PreviewCheckUnavailable(f"preview page did not produce an iframe: {error}") from error
+    if not src:
+        raise PreviewCheckUnavailable("preview iframe has no src")
+    return urljoin(f"{studio_base}/", src)
+
+
+def _check_pages(page, first_page_url: str, page_order: list[str]) -> list[PageRenderResult]:
+    results: list[PageRenderResult] = []
+    for layout in page_order:
+        url = swap_layout_in_preview_url(first_page_url, layout)
+        if url is None:
+            results.append(_check_single_page(page, first_page_url, layout))
+            break
+        results.append(_check_single_page(page, url, layout))
+    return results
+
+
+def _check_single_page(page, url: str, layout: str) -> PageRenderResult:
+    uncaught_errors: list[str] = []
+    console_errors: list[str] = []
+    on_page_error = lambda error: uncaught_errors.append(str(error))  # noqa: E731
+    on_console = lambda message: (  # noqa: E731
+        console_errors.append(message.text) if message.type == "error" else None
+    )
+    page.on("pageerror", on_page_error)
+    page.on("console", on_console)
+    try:
+        page.goto("about:blank")
+        page.goto(url)
+        page.wait_for_selector(
+            RENDERED_OR_ERROR_SELECTOR, state="attached", timeout=PAGE_RENDER_TIMEOUT_MS
+        )
+    except Exception as error:
+        detail = uncaught_errors[0] if uncaught_errors else str(error)
+        return PageRenderResult(layout, False, f"no render marker: {_snippet(detail)}")
+    finally:
+        page.remove_listener("pageerror", on_page_error)
+        page.remove_listener("console", on_console)
+
+    error_element = page.query_selector(ERROR_SELECTOR)
+    if error_element:
+        detail = _describe_error_page(page, error_element, uncaught_errors, console_errors)
+        return PageRenderResult(layout, False, f"error page: {detail}")
+    if uncaught_errors:
+        return PageRenderResult(layout, False, f"uncaught error: {_snippet(uncaught_errors[0])}")
+    thrown = [message for message in console_errors if _is_thrown_error(message)]
+    if thrown:
+        return PageRenderResult(layout, False, f"component failed to render: {_snippet(thrown[0])}")
+    detail = f"console errors: {_snippet('; '.join(console_errors))}" if console_errors else ""
+    return PageRenderResult(layout, True, detail)
+
+
+def _describe_error_page(
+    page, error_element, uncaught_errors: list[str], console_errors: list[str]
+) -> str:
+    """Status code, error-page text and any uncaught or console errors: "error page
+    shown" alone tells whoever must fix it nothing.
+    """
+    parts: list[str] = []
+    status = page.query_selector('[data-testid="StatusCode"]')
+    if status:
+        parts.append(_snippet(status.inner_text()))
+    try:
+        page_text = error_element.inner_text()
+    except Exception:
+        page_text = ""
+    if page_text.strip():
+        parts.append(_snippet(page_text))
+    if uncaught_errors:
+        parts.append(f"uncaught: {_snippet('; '.join(uncaught_errors))}")
+    if console_errors:
+        parts.append(f"console: {_snippet('; '.join(console_errors))}")
+    return " — ".join(parts) if parts else "error page shown (no further detail)"
+
+
+def _is_thrown_error(message: str) -> bool:
+    """A component that cannot render throws, app-frontend catches it, and nothing
+    marks the DOM. Log noise and failed requests carry no exception or stack.
+    """
+    return bool(THROWN_ERROR_PATTERN.search(message))
+
+
+def _snippet(text: str) -> str:
+    flattened = " ".join(text.split())
+    return flattened[:ERROR_SNIPPET_MAX_CHARS]

--- a/src/AI/agents/agents/services/preview/render_check.py
+++ b/src/AI/agents/agents/services/preview/render_check.py
@@ -109,7 +109,12 @@ def read_page_order(repo_root: Path) -> list[str]:
             settings = json.loads(settings_path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             continue
-        order = (settings.get(PAGES_KEY) or {}).get(PAGE_ORDER_KEY)
+        if not isinstance(settings, dict):
+            continue
+        pages = settings.get(PAGES_KEY)
+        if not isinstance(pages, dict):
+            continue
+        order = pages.get(PAGE_ORDER_KEY)
         if isinstance(order, list) and len(order) > len(best):
             best = [p for p in order if isinstance(p, str)]
     return best

--- a/src/AI/agents/benchmarks/README.md
+++ b/src/AI/agents/benchmarks/README.md
@@ -206,10 +206,13 @@ runs. Checkout and preview both run as that browser user, so the
 preview always renders the working copy the check just switched to the
 session branch.
 
-Failure containment: render failures score 0 with the failing page and
-an error snippet in the comment; infrastructure problems (Playwright
-missing, login or checkout failing) skip the check with a log line and
-post no render scores; the benchmark run itself never fails.
+Failure containment: `bench_renders` is 1 only when the first ordered
+page renders, and `bench_pages_render` is the fraction of pages that
+did, so a late failure shows up as a fraction below 1 rather than a
+zero. The failing page and an error snippet go in the comment.
+Infrastructure problems (Playwright missing, login or checkout failing,
+a preview url that cannot select layouts) skip the check with a log
+line and post no render scores; the benchmark run itself never fails.
 
 ### The agent's own render check
 

--- a/src/AI/agents/benchmarks/README.md
+++ b/src/AI/agents/benchmarks/README.md
@@ -5,6 +5,29 @@ running it against a golden dataset in Langfuse and recording a scored
 **dataset run** per agent version. Compare runs side-by-side in
 Langfuse under *Datasets → Benchmarks/large-pdf → Runs*.
 
+## When to run it
+
+Run a benchmark when you have changed something that could move output
+quality, and you want evidence rather than a hunch:
+
+- **Before merging an agent change**: prompts, tools, the loop, model
+  or temperature. Name the run after the change so the two columns sit
+  next to each other in Langfuse.
+- **After a model or SDK bump**, where nothing in our code changed but
+  behaviour may have.
+- **When a rubric or dataset item changes**, to re-baseline what "good"
+  means before comparing anything to it.
+
+It is not a test suite: a run costs a full agent workflow per dataset
+item (minutes and actor-model tokens), needs the local stack up, and the
+numeric scores move a little between runs on identical code. Treat a
+single score change as a signal to look, not a verdict, and don't wire
+it into CI expecting a clean pass/fail.
+
+For a fast check of one already-built app, skip the benchmark and run
+the [preview render check](#preview-render-check) standalone; it needs
+no agent run and posts nothing to Langfuse.
+
 ## How it works
 
 ```
@@ -22,14 +45,14 @@ poll /api/agent/status until terminal                     clone the session bran
         scores on the workflow trace + dataset-run-item link in Langfuse
 ```
 
-The committed **repo is the ground truth** — evaluation never
+The committed **repo is the ground truth**: evaluation never
 reconstructs the app from trace spans (spans truncate long payloads and
 don't carry every file).
 
 ## The rubric
 
 The dataset item's `expectedOutput` is a *structural* rubric, not a
-file listing — page IDs, component IDs and data-model names legitimately
+file listing, because page IDs, component IDs and data-model names legitimately
 differ between correct runs:
 
 ```json
@@ -57,11 +80,32 @@ enumeration), so naming style doesn't matter but missing fields do.
 | `bench_field_coverage` | 0–1 | fraction of expected field titles present |
 | `bench_input_count` | 0–1 | input components vs rubric minimum |
 | `bench_texts_bound` | 0–1 | text bindings resolving in resource.nb.json |
+| `bench_renders` | boolean | first ordered page renders in app preview (see below) |
+| `bench_pages_render` | 0–1 | fraction of ordered pages that render without error |
+| `bench_render_fix_rounds` | numeric | fix rounds sent back to the agent (only when a fix ran) |
+| `bench_pages_render_after_fix` | 0–1 | render fraction after the fix loop (only when a fix ran) |
+
+## Prerequisites
+
+Work through these once; the run fails fast and unhelpfully if any are
+missing.
+
+| # | What | Check |
+| --- | --- | --- |
+| 1 | Local Designer stack up | `curl -s -o /dev/null -w '%{http_code}' http://studio.localhost` → `200` |
+| 2 | Agents service up | `curl -s -o /dev/null -w '%{http_code}' http://localhost:8071/health` |
+| 3 | `.env` in this directory | see below |
+| 4 | Designer API key minted | `python -m benchmarks.bootstrap_api_key --write-env` |
+| 5 | Score configs in Langfuse | `python -m benchmarks.runner ensure-configs` |
+| 6 | Playwright + Chromium (render check only) | `pip install -e '.[preview]' && playwright install chromium` |
+
+Re-run **4** after wiping the database volume, and **5** whenever a new
+`bench_*` score is added. A score with no config still posts, but
+without a data type or range Langfuse cannot aggregate it across runs.
 
 ## Usage
 
-Requires the local Designer stack running (`docker compose up` in
-`src/Designer`) and a `.env` in this directory (or exported):
+The `.env` in this directory (or exported) holds:
 
 ```
 LANGFUSE_HOST=…  LANGFUSE_PUBLIC_KEY=…  LANGFUSE_SECRET_KEY=…
@@ -70,24 +114,19 @@ AGENT_BASE_URL=http://localhost:8071
 BENCH_REPO_URL=http://gitea-proxy:81/<org>/<app>.git
 ```
 
-`BENCH_REPO_URL` points at a **disposable app repo you own** — the
+`BENCH_REPO_URL` points at a **disposable app repo you own**. The
 benchmark pushes an `altinity_session_*` branch to it per run, so use a
 blank test app, not anything you care about. The URL is as the *agent
 container* resolves it (`gitea-proxy:81` on the local stack); the org is
 derived from the URL path.
 
-`AGENT_DESIGNER_API_KEY` must be a **Designer user API key** — the
+`AGENT_DESIGNER_API_KEY` must be a **Designer user API key**. The
 gitea-proxy validates it against Designer's userinfo endpoint, so a
-Gitea personal access token does NOT work. For the local stack, mint
-one straight into the database (idempotent, survives until the DB
-volume is wiped — re-run after a full stack reset):
-
-```bash
-python -m benchmarks.bootstrap_api_key --write-env
-```
+Gitea personal access token does NOT work; mint one with
+`bootstrap_api_key` (prerequisite 4).
 
 Attachments referenced by dataset items (`metadata.attachments`) live in
-`benchmarks/assets/` (gitignored — binary test fixtures don't belong in
+`benchmarks/assets/` (gitignored; binary test fixtures don't belong in
 the repo).
 
 ```bash
@@ -108,9 +147,137 @@ Name runs after the agent version you're testing (`--run-name`); every
 run appears in the Langfuse run table with aggregated scores, so a
 regression shows up as a column that got worse.
 
+### Reading the results
+
+The runner prints every score as it posts it, which is usually enough to
+see what happened. For comparison across versions go to *Datasets →
+Benchmarks/large-pdf → Runs* in Langfuse; each run is a column and each
+score a row.
+
+Read the boolean scores first. `bench_completed`, `bench_pages`,
+`bench_order_integrity`, `bench_navigation` are pass/fail statements
+about structure, so a 0 there is a definite regression. The 0–1 scores
+move a little run to run on identical code (the model does not produce
+byte-identical apps), so compare them as trends across several runs
+rather than treating a 0.95 → 0.93 as a regression.
+
+Every score carries a comment naming what was missing or which page
+failed. Read it before investigating; it is usually the whole answer.
+
+## Preview render check
+
+The structural evaluators are blind to runtime failures: an unknown
+component type or a malformed expression can pass every check and still
+crash the form. The preview check closes that gap: it logs into Studio
+with headless Chromium, checks out the session branch through the
+Designer API with that browser session (mirroring the frontend's
+reset/checkout flow), loads the app in Studio's app preview, and
+verifies every ordered page renders (`#finishedLoading` present, no
+`AltinnError` page, no uncaught exception, no thrown error on the
+console). A component with an unknown type is caught by app-frontend:
+the page still reports itself loaded and nothing marks the DOM, so an
+exception on the console is the only signal that something did not
+render. Console output that is not exception-shaped (failed requests,
+warnings) is recorded in the score comment without failing the page.
+
+Opt in with `BENCH_PREVIEW_CHECK=1`; without it a benchmark run behaves
+exactly as before. When enabled but Playwright or the stack login is
+unavailable, the check is skipped with a log line and no render scores.
+
+Setup (once):
+
+```bash
+pip install -e '.[preview]'        # or: pip install playwright
+playwright install chromium
+```
+
+Extra environment (same `.env`):
+
+```
+BENCH_STUDIO_USER=localgiteaadmin   # default; needs access to the BENCH_REPO_URL app
+BENCH_STUDIO_BASE_URL=http://studio.localhost   # default
+BENCH_PREVIEW_CHECK=1               # required; the check is off otherwise
+```
+
+The browser logs in once (fake-Ansattporten user picker, no password
+locally) and caches the session in
+`benchmarks/.playwright-auth.json` (gitignored) for later items and
+runs. Checkout and preview both run as that browser user, so the
+preview always renders the working copy the check just switched to the
+session branch.
+
+Failure containment: render failures score 0 with the failing page and
+an error snippet in the comment; infrastructure problems (Playwright
+missing, login or checkout failing) skip the check with a log line and
+post no render scores; the benchmark run itself never fails.
+
+### The agent's own render check
+
+The same engine is available to the agent as a `preview_render_check`
+loop tool, so a run can verify its own work after
+`commit_session_branch`. It is off unless `PREVIEW_CHECK_ENABLED=true`
+is set **in the agent container's environment** (`.env.docker`, then
+`docker compose up -d altinity-agents`). Setting it in
+`benchmarks/.env` does nothing, because the tool runs inside the agent,
+not in the runner.
+
+This changes what the benchmark measures. `bench_pages_render` scores
+the app as the agent left it, so with the tool on it reflects an agent
+that could see and fix its own render failures. That is a fair thing to
+measure, but it is not comparable with a run where the tool was off, so
+say which mode a run used in `--run-description`.
+
+### Render-fix loop
+
+When pages fail the render check, the runner sends the failures back
+into the **same agent session** (same `session_id`, continuing on the
+session branch, with the page names and error snippets in the goal) and
+re-checks after the fix workflow finishes. `bench_renders` and
+`bench_pages_render` always reflect the state *before* any fix, so runs
+stay comparable across agent versions; the after-fix state is scored
+separately (`bench_pages_render_after_fix`, `bench_render_fix_rounds`).
+
+Each fix round is a full agent workflow; that's where the cost is
+(actor-model tokens and minutes), the render check itself is free.
+
+```
+BENCH_RENDER_FIX=1        # enable the fix loop (off by default)
+BENCH_RENDER_FIX_ROUNDS=1 # max fix rounds per item (default)
+```
+
+## Troubleshooting
+
+**Scores missing from Langfuse after a run that printed them.** The
+standalone `python -m benchmarks.preview_check --branch …` only prints
+to stdout. Nothing reaches Langfuse; only `runner run` posts scores.
+
+**A new `bench_*` score never appears.** Run `ensure-configs` again;
+score configs are created once and adding a score to the code does not
+create one.
+
+**`clone of '…' failed` when running the standalone check.**
+`BENCH_REPO_URL` holds the URL as the *agent container* resolves it
+(`gitea-proxy:81`), which the host cannot reach. Cloning uses
+`BENCH_GITEA_CLONE_BASE` instead (default `http://localhost/repos`); set
+it if your stack serves repositories elsewhere.
+
+**Every page fails with a login or checkout error.** Delete
+`benchmarks/.playwright-auth.json` and re-run; a cached session survives
+a stack reset that invalidated it.
+
+**A page renders in the browser but the check calls it failed.** Read
+the score comment. A component that cannot render throws but is caught
+by app-frontend, so the page looks fine and only the console shows it.
+the check fails the page on exception-shaped console output for exactly
+this reason.
+
+**`skip <item>: expectedOutput is not a vN rubric`.** The dataset item
+predates the current rubric version; rebuild it with `runner rubric
+--from-app … --update-item …`.
+
 ## Notes
 
-- The Langfuse SDK is deliberately not used — the self-hosted v3 server
+- The Langfuse SDK is deliberately not used: the self-hosted v3 server
   omits fields newer SDK models require. Everything goes through the
   public REST API (`lf_api.py`).
 - After the server is upgraded to Langfuse v4: add a managed

--- a/src/AI/agents/benchmarks/preview_check.py
+++ b/src/AI/agents/benchmarks/preview_check.py
@@ -18,6 +18,11 @@ from agents.services.preview.render_check import (
 
 from .evaluators import Score
 
+RENDERS_SCORE_NAME = "bench_renders"
+PAGES_RENDER_SCORE_NAME = "bench_pages_render"
+RENDER_FIX_ROUNDS_SCORE_NAME = "bench_render_fix_rounds"
+PAGES_RENDER_AFTER_FIX_SCORE_NAME = "bench_pages_render_after_fix"
+
 __all__ = [
     "PageRenderResult",
     "PreviewCheckUnavailable",
@@ -80,7 +85,7 @@ def build_scores(results: list[PageRenderResult]) -> list[Score]:
 
     first = results[0] if results else None
     renders = Score(
-        name="bench_renders",
+        name=RENDERS_SCORE_NAME,
         value=1.0 if first and first.rendered else 0.0,
         data_type="BOOLEAN",
         comment=(
@@ -92,7 +97,7 @@ def build_scores(results: list[PageRenderResult]) -> list[Score]:
         ),
     )
     pages_render = Score(
-        name="bench_pages_render",
+        name=PAGES_RENDER_SCORE_NAME,
         value=rendered_count / len(results) if results else 0.0,
         data_type="NUMERIC",
         comment=(

--- a/src/AI/agents/benchmarks/preview_check.py
+++ b/src/AI/agents/benchmarks/preview_check.py
@@ -1,0 +1,156 @@
+"""Benchmark wrapper around `agents.services.preview.render_check`: environment
+configuration, and the `bench_renders` and `bench_pages_render` scores.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+from agents.services.preview.render_check import (
+    PageRenderResult,
+    PreviewCheckUnavailable,
+    render_check,
+    swap_layout_in_preview_url,
+)
+
+from .evaluators import Score
+
+__all__ = [
+    "PageRenderResult",
+    "PreviewCheckUnavailable",
+    "build_scores",
+    "collect",
+    "is_enabled",
+    "run",
+    "swap_layout_in_preview_url",
+]
+
+ENABLE_FLAG = "BENCH_PREVIEW_CHECK"
+DEFAULT_STUDIO_BASE_URL = "http://studio.localhost"
+DEFAULT_STUDIO_USERNAME = "localgiteaadmin"
+STORAGE_STATE_PATH = Path(__file__).parent / ".playwright-auth.json"
+
+
+def is_enabled() -> bool:
+    return os.environ.get(ENABLE_FLAG, "0") == "1"
+
+
+def run(session_branch: str, page_order: list[str]) -> list[Score]:
+    """Scores for every ordered page, or [] when the check could not run."""
+    results = collect(session_branch, page_order)
+    return build_scores(results) if results is not None else []
+
+
+def collect(session_branch: str, page_order: list[str]) -> list[PageRenderResult] | None:
+    """Per-page results, or None when infrastructure rather than the app under test
+    prevented the check. Use instead of `run` when the failure details matter.
+    """
+    try:
+        return _render_results(session_branch, page_order)
+    except PreviewCheckUnavailable as reason:
+        print(f"  preview check skipped: {reason}", file=sys.stderr)
+        return None
+
+
+def _render_results(session_branch: str, page_order: list[str]) -> list[PageRenderResult]:
+    org, app = _repo_org_and_app()
+    return render_check(
+        studio_base=os.environ.get("BENCH_STUDIO_BASE_URL", DEFAULT_STUDIO_BASE_URL),
+        username=os.environ.get("BENCH_STUDIO_USER", DEFAULT_STUDIO_USERNAME),
+        org=org,
+        app=app,
+        branch=session_branch,
+        page_order=page_order,
+        storage_state_path=STORAGE_STATE_PATH,
+    )
+
+
+def _repo_org_and_app() -> tuple[str, str]:
+    segments = [s for s in urlparse(os.environ["BENCH_REPO_URL"]).path.split("/") if s]
+    return segments[0], segments[1].removesuffix(".git")
+
+
+def build_scores(results: list[PageRenderResult]) -> list[Score]:
+    rendered_count = sum(1 for result in results if result.rendered)
+    failures = [result for result in results if not result.rendered]
+    failure_summary = "; ".join(f"{failure.page}: {failure.detail}" for failure in failures)
+
+    first = results[0] if results else None
+    renders = Score(
+        name="bench_renders",
+        value=1.0 if first and first.rendered else 0.0,
+        data_type="BOOLEAN",
+        comment=(
+            f"first page {first.page!r} rendered"
+            if first and first.rendered
+            else f"first page failed — {first.page}: {first.detail}"
+            if first
+            else "no ordered pages to render"
+        ),
+    )
+    pages_render = Score(
+        name="bench_pages_render",
+        value=rendered_count / len(results) if results else 0.0,
+        data_type="NUMERIC",
+        comment=(
+            f"{rendered_count}/{len(results)} pages rendered"
+            + (f" — failed: {failure_summary}" if failures else "")
+            if results
+            else "no ordered pages to render"
+        ),
+    )
+    return [renders, pages_render]
+
+
+
+def _clone_branch(branch: str, workdir: Path) -> Path:
+    import subprocess
+
+    clone_base = os.environ.get("BENCH_GITEA_CLONE_BASE", "http://localhost/repos").rstrip("/")
+    repo_path = urlparse(os.environ["BENCH_REPO_URL"]).path
+    destination = workdir / "app"
+    command = [
+        "git",
+        "-c",
+        f"http.extraHeader=X-Api-Key: {os.environ['AGENT_DESIGNER_API_KEY']}",
+        "clone",
+        "--depth",
+        "1",
+        "--branch",
+        branch,
+        f"{clone_base}{repo_path}",
+        str(destination),
+    ]
+    result = subprocess.run(command, capture_output=True, text=True)
+    if result.returncode != 0:
+        sys.exit(f"clone of {branch!r} failed: {result.stderr.strip().splitlines()[-1:]}")
+    return destination
+
+
+def _main() -> None:
+    import argparse
+    import tempfile
+
+    from .app_model import load_app
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--branch", required=True, help="session branch, e.g. altinity_session_1a2b3c4d")
+    args = parser.parse_args()
+
+    with tempfile.TemporaryDirectory(prefix="altinity-preview-") as tmp:
+        page_order = load_app(_clone_branch(args.branch, Path(tmp))).page_order
+    if not page_order:
+        sys.exit("no ordered pages found on that branch")
+
+    scores = run(args.branch, page_order)
+    if not scores:
+        sys.exit(1)
+    for score in scores:
+        print(f"{score.name} = {score.value}  ({score.comment})")
+
+
+if __name__ == "__main__":
+    _main()

--- a/src/AI/agents/benchmarks/runner.py
+++ b/src/AI/agents/benchmarks/runner.py
@@ -50,10 +50,14 @@ SCORE_CONFIG_SPECS: dict[str, dict] = {
 }
 
 PREVIEW_SCORE_CONFIG_SPECS: dict[str, dict] = {
-    "bench_renders": {"dataType": "BOOLEAN"},
-    "bench_pages_render": {"dataType": "NUMERIC", "minValue": 0, "maxValue": 1},
-    "bench_render_fix_rounds": {"dataType": "NUMERIC", "minValue": 0},
-    "bench_pages_render_after_fix": {"dataType": "NUMERIC", "minValue": 0, "maxValue": 1},
+    preview_check.RENDERS_SCORE_NAME: {"dataType": "BOOLEAN"},
+    preview_check.PAGES_RENDER_SCORE_NAME: {"dataType": "NUMERIC", "minValue": 0, "maxValue": 1},
+    preview_check.RENDER_FIX_ROUNDS_SCORE_NAME: {"dataType": "NUMERIC", "minValue": 0},
+    preview_check.PAGES_RENDER_AFTER_FIX_SCORE_NAME: {
+        "dataType": "NUMERIC",
+        "minValue": 0,
+        "maxValue": 1,
+    },
 }
 
 RENDER_FIX_FLAG = "BENCH_RENDER_FIX"
@@ -193,6 +197,22 @@ def _render_fix_goal(failures: list[preview_check.PageRenderResult]) -> str:
     )
 
 
+def _render_fix_rounds() -> int:
+    """Read the round budget, falling back rather than dying mid-run."""
+    raw = os.environ.get(RENDER_FIX_ROUNDS_ENV, str(DEFAULT_RENDER_FIX_ROUNDS))
+    try:
+        rounds = int(raw)
+    except ValueError:
+        rounds = -1
+    if rounds < 0:
+        print(
+            f"  {RENDER_FIX_ROUNDS_ENV}={raw!r} is not a non-negative integer; "
+            f"using {DEFAULT_RENDER_FIX_ROUNDS}"
+        )
+        return DEFAULT_RENDER_FIX_ROUNDS
+    return rounds
+
+
 def _fix_render_failures(
     agent_base: str,
     session_id: str,
@@ -202,7 +222,7 @@ def _fix_render_failures(
     """Send render failures back into the agent session and re-check,
     up to BENCH_RENDER_FIX_ROUNDS rounds (each round is a full agent
     workflow). Returns (results of the last re-check, rounds run)."""
-    max_rounds = int(os.environ.get(RENDER_FIX_ROUNDS_ENV, str(DEFAULT_RENDER_FIX_ROUNDS)))
+    max_rounds = _render_fix_rounds()
     branch = _session_branch(session_id)
     results: list[preview_check.PageRenderResult] | None = None
     rounds = 0
@@ -232,7 +252,7 @@ def _after_fix_scores(
 ) -> list[Score]:
     scores = [
         Score(
-            name="bench_render_fix_rounds",
+            name=preview_check.RENDER_FIX_ROUNDS_SCORE_NAME,
             value=float(rounds),
             data_type="NUMERIC",
             comment=f"{rounds} render-fix round(s) sent back into the agent session",
@@ -245,7 +265,7 @@ def _after_fix_scores(
     failure_summary = "; ".join(f"{failure.page}: {failure.detail}" for failure in failures)
     scores.append(
         Score(
-            name="bench_pages_render_after_fix",
+            name=preview_check.PAGES_RENDER_AFTER_FIX_SCORE_NAME,
             value=rendered_count / len(results) if results else 0.0,
             data_type="NUMERIC",
             comment=f"{rendered_count}/{len(results)} pages rendered after fix"

--- a/src/AI/agents/benchmarks/runner.py
+++ b/src/AI/agents/benchmarks/runner.py
@@ -1,37 +1,13 @@
-"""Benchmark runner: execute the agent against a Langfuse dataset and
-record scored, comparable runs.
+"""Benchmark runner: run the agent against a Langfuse dataset and record
+scored, comparable runs.
 
-Flow per dataset item:
+Per dataset item: start a workflow on the local agent stack and poll it to
+completion, clone the session branch it pushed (the repo is ground truth, not
+the trace), score it against the item's structural rubric, preview-render every
+ordered page, then post the scores to the workflow trace and link it into the
+dataset run.
 
-    1. POST /api/agent/start on a local agent stack (goal + attachments
-       from the item), then poll /api/agent/status until terminal.
-    2. Clone the session branch the agent pushed to Gitea — the repo is
-       the ground truth, not the trace.
-    3. Run the deterministic evaluators against the item's structural
-       rubric (`expectedOutput`).
-    4. Post scores to the workflow trace and link it into the dataset
-       run (`runName`) so Langfuse's run-comparison view shows the
-       quality delta between agent versions.
-
-Usage:
-    python -m benchmarks.runner ensure-configs
-    python -m benchmarks.runner rubric --from-app <golden-clone> \
-        [--update-item <item-id> --dataset "Benchmarks/large-pdf"]
-    python -m benchmarks.runner run --run-name <name> \
-        [--dataset "Benchmarks/large-pdf"] [--assets-dir <dir>]
-
-Environment (a `.env` next to this package or exported):
-    LANGFUSE_HOST, LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY
-    AGENT_BASE_URL          default http://localhost:8071
-    AGENT_DESIGNER_API_KEY  X-Api-Key for the agent API and Gitea proxy
-    BENCH_DEVELOPER         X-Developer header, default "benchmark"
-    BENCH_REPO_URL          REQUIRED — a disposable Altinn app repo the
-                            benchmark may push session branches to, as the
-                            AGENT container resolves it, e.g.
-                            http://gitea-proxy:81/<org>/<app>.git
-                            (org is derived from the URL path)
-    BENCH_GITEA_CLONE_BASE  Gitea route reachable from THIS host,
-                            default http://localhost/repos (loadbalancer)
+Setup, environment and command reference live in README.md.
 """
 
 from __future__ import annotations
@@ -52,6 +28,7 @@ from urllib.parse import urlparse
 
 import httpx
 
+from . import preview_check
 from .app_model import load_app
 from .evaluators import Score, evaluate
 from .lf_api import LangfuseApi
@@ -72,6 +49,17 @@ SCORE_CONFIG_SPECS: dict[str, dict] = {
     "bench_texts_bound": {"dataType": "NUMERIC", "minValue": 0, "maxValue": 1},
 }
 
+PREVIEW_SCORE_CONFIG_SPECS: dict[str, dict] = {
+    "bench_renders": {"dataType": "BOOLEAN"},
+    "bench_pages_render": {"dataType": "NUMERIC", "minValue": 0, "maxValue": 1},
+    "bench_render_fix_rounds": {"dataType": "NUMERIC", "minValue": 0},
+    "bench_pages_render_after_fix": {"dataType": "NUMERIC", "minValue": 0, "maxValue": 1},
+}
+
+RENDER_FIX_FLAG = "BENCH_RENDER_FIX"
+RENDER_FIX_ROUNDS_ENV = "BENCH_RENDER_FIX_ROUNDS"
+DEFAULT_RENDER_FIX_ROUNDS = 1
+
 
 def _env(name: str, default: str | None = None) -> str:
     value = os.environ.get(name, default)
@@ -81,7 +69,7 @@ def _env(name: str, default: str | None = None) -> str:
 
 
 def _bench_repo_url() -> str:
-    """The app repo the benchmark runs against — no default on purpose:
+    """The app repo the benchmark runs against. No default on purpose:
     it must be a repo the current developer owns and is happy to have
     session branches pushed to."""
     url = os.environ.get("BENCH_REPO_URL")
@@ -96,16 +84,11 @@ def _bench_repo_url() -> str:
 
 
 def _repo_org(repo_url: str) -> str:
-    """First path segment of the repo URL (…/<org>/<app>.git)."""
     segments = [segment for segment in urlparse(repo_url).path.split("/") if segment]
     if len(segments) < 2:
         sys.exit(f"BENCH_REPO_URL must look like …/<org>/<app>.git — got {repo_url!r}")
     return segments[0]
 
-
-# ---------------------------------------------------------------------------
-# Agent API
-# ---------------------------------------------------------------------------
 
 
 def _agent_headers() -> dict[str, str]:
@@ -134,20 +117,22 @@ def _load_attachments(item: dict, assets_dir: Path) -> list[dict]:
     return attachments
 
 
-def _start_agent(base_url: str, session_id: str, goal: str, attachments: list[dict]) -> None:
+def _start_agent(
+    base_url: str, session_id: str, goal: str, attachments: list[dict], branch: str | None = None
+) -> None:
     repo_url = _bench_repo_url()
+    payload = {
+        "session_id": session_id,
+        "goal": goal,
+        "repo_url": repo_url,
+        "org": _repo_org(repo_url),
+        "allow_app_changes": True,
+        "attachments": attachments,
+    }
+    if branch:
+        payload["branch"] = branch
     response = httpx.post(
-        f"{base_url}/api/agent/start",
-        headers=_agent_headers(),
-        json={
-            "session_id": session_id,
-            "goal": goal,
-            "repo_url": repo_url,
-            "org": _repo_org(repo_url),
-            "allow_app_changes": True,
-            "attachments": attachments,
-        },
-        timeout=120,
+        f"{base_url}/api/agent/start", headers=_agent_headers(), json=payload, timeout=120
     )
     response.raise_for_status()
 
@@ -163,10 +148,6 @@ def _await_workflow(base_url: str, session_id: str) -> dict:
             return status
     return {"status": "timeout"}
 
-
-# ---------------------------------------------------------------------------
-# Result branch
-# ---------------------------------------------------------------------------
 
 
 def _session_branch(session_id: str) -> str:
@@ -197,15 +178,88 @@ def _clone_result_branch(session_id: str, workdir: Path) -> Path | None:
     return destination
 
 
-# ---------------------------------------------------------------------------
-# Commands
-# ---------------------------------------------------------------------------
+
+def _is_render_fix_enabled() -> bool:
+    return os.environ.get(RENDER_FIX_FLAG, "0") == "1"
+
+
+def _render_fix_goal(failures: list[preview_check.PageRenderResult]) -> str:
+    failure_lines = "\n".join(f"- {failure.page}: {failure.detail}" for failure in failures)
+    return (
+        "The app you built fails to render in Studio's app preview. "
+        "Fix the app so every page renders without errors, verify your "
+        "changes, and commit them to the session branch.\n\n"
+        f"Failing pages:\n{failure_lines}"
+    )
+
+
+def _fix_render_failures(
+    agent_base: str,
+    session_id: str,
+    failures: list[preview_check.PageRenderResult],
+    workdir: Path,
+) -> tuple[list[preview_check.PageRenderResult] | None, int]:
+    """Send render failures back into the agent session and re-check,
+    up to BENCH_RENDER_FIX_ROUNDS rounds (each round is a full agent
+    workflow). Returns (results of the last re-check, rounds run)."""
+    max_rounds = int(os.environ.get(RENDER_FIX_ROUNDS_ENV, str(DEFAULT_RENDER_FIX_ROUNDS)))
+    branch = _session_branch(session_id)
+    results: list[preview_check.PageRenderResult] | None = None
+    rounds = 0
+    for round_number in range(1, max_rounds + 1):
+        rounds = round_number
+        print(f"  render fix round {round_number}: {len(failures)} failing page(s)")
+        _start_agent(agent_base, session_id, _render_fix_goal(failures), [], branch=branch)
+        status = _await_workflow(agent_base, session_id)
+        print(f"  fix workflow finished: {status.get('status')} success={status.get('success')}")
+
+        round_dir = workdir / f"fix-round-{round_number}"
+        round_dir.mkdir()
+        clone = _clone_result_branch(session_id, round_dir)
+        if clone is None:
+            break
+        results = preview_check.collect(branch, load_app(clone).page_order)
+        if results is None:
+            break
+        failures = [result for result in results if not result.rendered]
+        if not failures:
+            break
+    return results, rounds
+
+
+def _after_fix_scores(
+    results: list[preview_check.PageRenderResult] | None, rounds: int
+) -> list[Score]:
+    scores = [
+        Score(
+            name="bench_render_fix_rounds",
+            value=float(rounds),
+            data_type="NUMERIC",
+            comment=f"{rounds} render-fix round(s) sent back into the agent session",
+        )
+    ]
+    if results is None:
+        return scores
+    rendered_count = sum(1 for result in results if result.rendered)
+    failures = [result for result in results if not result.rendered]
+    failure_summary = "; ".join(f"{failure.page}: {failure.detail}" for failure in failures)
+    scores.append(
+        Score(
+            name="bench_pages_render_after_fix",
+            value=rendered_count / len(results) if results else 0.0,
+            data_type="NUMERIC",
+            comment=f"{rendered_count}/{len(results)} pages rendered after fix"
+            + (f" — failed: {failure_summary}" if failures else ""),
+        )
+    )
+    return scores
+
 
 
 def cmd_ensure_configs(_: argparse.Namespace) -> None:
     lf = LangfuseApi()
     existing = lf.score_configs_by_name()
-    for name, spec in SCORE_CONFIG_SPECS.items():
+    for name, spec in {**SCORE_CONFIG_SPECS, **PREVIEW_SCORE_CONFIG_SPECS}.items():
         if name in existing:
             print(f"exists: {name}")
             continue
@@ -275,7 +329,20 @@ def cmd_run(args: argparse.Namespace) -> None:
         with tempfile.TemporaryDirectory(prefix="altinity-bench-") as tmp:
             clone = _clone_result_branch(session_id, Path(tmp))
             if clone is not None:
-                scores.extend(evaluate(load_app(clone), rubric))
+                app = load_app(clone)
+                scores.extend(evaluate(app, rubric))
+                if preview_check.is_enabled():
+                    render_results = preview_check.collect(
+                        _session_branch(session_id), app.page_order
+                    )
+                    if render_results is not None:
+                        scores.extend(preview_check.build_scores(render_results))
+                        failures = [r for r in render_results if not r.rendered]
+                        if failures and _is_render_fix_enabled():
+                            fixed_results, rounds = _fix_render_failures(
+                                agent_base, session_id, failures, Path(tmp)
+                            )
+                            scores.extend(_after_fix_scores(fixed_results, rounds))
             else:
                 comment = "no committed session branch to evaluate"
                 for name, spec in SCORE_CONFIG_SPECS.items():

--- a/src/AI/agents/docker-compose.yaml
+++ b/src/AI/agents/docker-compose.yaml
@@ -7,14 +7,15 @@ services:
       - "8071:8071"
     env_file:
       - .env.docker
+    environment:
+      # Chromium pins *.localhost to 127.0.0.1, so map it past that.
+      - PREVIEW_HOST_RESOLVER_RULES=MAP studio.localhost studio-loadbalancer, MAP localhost fake-ansattporten
     networks:
       - default
       - designer
 
-# The gitea-proxy lives on Designer's compose network.  We attach the agents
-# container to that network so it can reach `gitea-proxy:80` (the X-Api-Key
-# entry) via Docker DNS — port 81 (exposed to the host) is the internal
-# X-WEBAUTH-USER path and doesn't accept the api_key flow.
+# Joins Designer's network so this container can reach gitea-proxy by DNS on :80,
+# the X-Api-Key entry. The host-exposed :81 is X-WEBAUTH-USER and rejects api keys.
 networks:
   designer:
     external: true

--- a/src/AI/agents/dockerfile
+++ b/src/AI/agents/dockerfile
@@ -11,6 +11,9 @@ COPY requirements.txt ./
 
 RUN pip install --no-cache-dir -r requirements.txt
 
+RUN pip install --no-cache-dir "playwright>=1.49.0" && \
+    playwright install --with-deps chromium
+
 COPY agents/ ./agents/
 COPY api/ ./api/
 COPY services/ ./services/

--- a/src/AI/agents/pyproject.toml
+++ b/src/AI/agents/pyproject.toml
@@ -44,6 +44,9 @@ dev = [
     "pytest-mock>=3.15.0",
     "pytest-asyncio>=1.3.0",
 ]
+preview = [
+    "playwright>=1.49.0",
+]
 
 [build-system]
 requires = ["setuptools>=61.0"]

--- a/src/AI/agents/shared/config/base_config.py
+++ b/src/AI/agents/shared/config/base_config.py
@@ -4,33 +4,24 @@ import tempfile
 from pathlib import Path
 from dotenv import load_dotenv
 
-# Load environment variables
 load_dotenv()
 
 
 class BaseConfig:
-    """Base configuration class"""
-
-    # Project paths
     PROJECT_ROOT = Path(__file__).parent.parent.parent
     LOG_DIR = PROJECT_ROOT / "logs"
 
-    # Environment
     ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
     DEBUG = os.getenv("DEBUG", "false").lower() == "true"
 
-    # Logging
     LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
     LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 
-    # API server settings
     API_HOST = os.getenv("API_HOST", "0.0.0.0")
     API_PORT = int(os.getenv("API_PORT", "8071"))
 
-    # Gitea integration for agent branch pushes
     GITEA_BASE_URL = os.getenv("GITEA_BASE_URL", "http://host.docker.internal/repos")
 
-    # CORS settings for frontend connections
     CORS_ORIGINS = [
         "http://localhost:3000",  # React dev server
         "http://localhost:5173",  # Vite dev server
@@ -39,82 +30,54 @@ class BaseConfig:
     ]
 
 
-    # LLM configuration - Azure OpenAI preferred
     AZURE_API_KEY = os.getenv("AZURE_API_KEY")
     AZURE_OPENAI_ENDPOINT = os.getenv("AZURE_OPENAI_ENDPOINT", "https://rndlabaidemoss0618689180.openai.azure.com/")
     AZURE_ANTHROPIC_ENDPOINT = os.getenv("AZURE_ANTHROPIC_ENDPOINT", "https://rndlabaidemoss0618689180.services.ai.azure.com/anthropic/")
     AZURE_API_VERSION = os.getenv("AZURE_API_VERSION", "2025-03-01-preview")
-    # Default small-model deployment: intent safety gate + goal suggestions.
-    # (gpt-4o-mini-2M-tps is being retired.)
     AZURE_DEPLOYMENT_NAME = os.getenv("AZURE_DEPLOYMENT_NAME", "gpt-5.4-mini")
 
-    # Fallback to OpenAI if Azure not configured
     OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-    # OpenAI-compatible base URL override. When set, OpenAIAdapter uses the
-    # plain AsyncOpenAI client (not AsyncAzureOpenAI) against this URL with
-    # AZURE_API_KEY/OPENAI_API_KEY as the bearer token. Use this for Azure
-    # AI Foundry's OpenAI-compatible endpoint (e.g. Kimi-K2.6 deployment):
-    # https://<resource>.services.ai.azure.com/openai/v1/
     OPENAI_BASE_URL = os.getenv("OPENAI_BASE_URL")
     LLM_MODEL = os.getenv("LLM_MODEL", "claude-haiku-4-5")
     LLM_TEMPERATURE = float(os.getenv("LLM_TEMPERATURE", "0.1"))
 
-    # Per-role model configuration.
-    # The agentic loop reads LLM_MODEL_ACTOR via core.llm_adapter.build_adapter.
-    # Everything else goes through services.llm.LLMClient by role:
-    #   - planner       → intake + spec workflows + semantic query
-    #   - reviewer      → post-workflow LLM-as-judge evaluators
-    #                     (intent_match / no_hallucination / faithful_summary)
-    # The tool_planner and assistant roles are vestigial — the separate
-    # chat pipeline they served was folded into the agentic loop
-    # (read-only mode); kept only so stale env files don't break startup.
-    # Temperatures are env-overridable. Models default to Claude on Azure
-    # Anthropic; flip to any Azure OpenAI / Foundry deployment by name.
 
-    # Planner: intake + spec pipelines (still classic LLMClient calls).
     LLM_MODEL_PLANNER = os.getenv("LLM_MODEL_PLANNER", "claude-opus-4-8")
     LLM_TEMPERATURE_PLANNER = os.getenv("LLM_TEMPERATURE_PLANNER")  # None → model default
 
-    # Tool Planner: assistant chat-mode tool selection.
     LLM_MODEL_TOOL_PLANNER = os.getenv("LLM_MODEL_TOOL_PLANNER", "claude-sonnet-5")
     LLM_TEMPERATURE_TOOL_PLANNER = os.getenv("LLM_TEMPERATURE_TOOL_PLANNER")
-    # Toggle to use OpenAI Chat Completions / Responses API instead of the
-    # default chat surface — only applies when the tool-planner model is an
-    # OpenAI / Azure OpenAI deployment that supports those APIs.
     LLM_TOOL_PLANNER_USE_COMPLETIONS = os.getenv("LLM_TOOL_PLANNER_USE_COMPLETIONS", "false").lower() == "true"
     LLM_TOOL_PLANNER_USE_RESPONSES = os.getenv("LLM_TOOL_PLANNER_USE_RESPONSES", "false").lower() == "true"
 
-    # Actor: drives the agentic loop (the model running tool_use turns).
     LLM_MODEL_ACTOR = os.getenv("LLM_MODEL_ACTOR", "claude-sonnet-5")
 
-    # Reviewer: post-workflow LLM-as-judge evaluators.
     LLM_MODEL_REVIEWER = os.getenv("LLM_MODEL_REVIEWER", "claude-sonnet-5")
     LLM_TEMPERATURE_REVIEWER = float(os.getenv("LLM_TEMPERATURE_REVIEWER", "0.0"))
 
-    # Assistant: chat-mode Q&A reply.
     LLM_MODEL_ASSISTANT = os.getenv("LLM_MODEL_ASSISTANT", "claude-sonnet-5")
     LLM_TEMPERATURE_ASSISTANT = os.getenv("LLM_TEMPERATURE_ASSISTANT")  # None → model default
 
-    # Attachment storage
+    PREVIEW_CHECK_ENABLED = os.getenv("PREVIEW_CHECK_ENABLED", "false").lower() == "true"
+    PREVIEW_STUDIO_BASE_URL = os.getenv("PREVIEW_STUDIO_BASE_URL", "http://studio.localhost")
+    PREVIEW_STUDIO_USER = os.getenv("PREVIEW_STUDIO_USER", "localgiteaadmin")
+    PREVIEW_HOST_RESOLVER_RULES = os.getenv("PREVIEW_HOST_RESOLVER_RULES", "")
+
     _DEFAULT_ATTACHMENTS_PATH = Path(tempfile.gettempdir()) / "altinity_agent_attachments"
     ATTACHMENTS_ROOT = Path(os.getenv("AGENT_ATTACHMENTS_PATH", str(_DEFAULT_ATTACHMENTS_PATH)))
 
-    # Langfuse configuration
     LANGFUSE_SECRET_KEY = os.getenv("LANGFUSE_SECRET_KEY")
     LANGFUSE_PUBLIC_KEY = os.getenv("LANGFUSE_PUBLIC_KEY")
-    LANGFUSE_HOST = os.getenv("LANGFUSE_BASE_URL", "https://langfuse.digdir.cloud")  # Use cloud by default, or self-hosted URL
+    LANGFUSE_HOST = os.getenv("LANGFUSE_BASE_URL", "https://langfuse.digdir.cloud")
     LANGFUSE_ENABLED = os.getenv("LANGFUSE_ENABLED", "true").lower() == "true"
-    LANGFUSE_RELEASE = os.getenv("LANGFUSE_RELEASE", "altinity-agents-v1.1")  # Version/release tag for traces
-    LANGFUSE_ENVIRONMENT = os.getenv("LANGFUSE_ENVIRONMENT", ENVIRONMENT)  # Inherit from general environment
+    LANGFUSE_RELEASE = os.getenv("LANGFUSE_RELEASE", "altinity-agents-v1.1")
+    LANGFUSE_ENVIRONMENT = os.getenv("LANGFUSE_ENVIRONMENT", ENVIRONMENT)
     LANGFUSE_TRACE_RETENTION_DAYS = int(os.getenv("LANGFUSE_TRACE_RETENTION_DAYS", "90"))
 
-    # Created in Langfuse UI and paste the UUIDs here.
-    # They enable structured, objective quality measurement across traces.
     LANGFUSE_SCORE_CONFIG_LAYOUT_SCHEMA = os.getenv("LANGFUSE_SCORE_CONFIG_LAYOUT_SCHEMA", "")
     LANGFUSE_SCORE_CONFIG_PATCH_VALIDATION = os.getenv("LANGFUSE_SCORE_CONFIG_PATCH_VALIDATION", "")
     LANGFUSE_SCORE_CONFIG_RESOURCE_TEXT = os.getenv("LANGFUSE_SCORE_CONFIG_RESOURCE_TEXT", "")
 
 
 def get_config() -> BaseConfig:
-    """Get configuration instance"""
     return BaseConfig()

--- a/src/AI/agents/tests/unit/benchmarks/test_preview_check.py
+++ b/src/AI/agents/tests/unit/benchmarks/test_preview_check.py
@@ -1,0 +1,88 @@
+"""Tests for the preview render check: the pure parts (URL handling,
+score building, opt-in gating). The browser flow itself is exercised
+manually against the local stack."""
+
+from __future__ import annotations
+
+from benchmarks.preview_check import (
+    PageRenderResult,
+    PreviewCheckUnavailable,
+    build_scores,
+    is_enabled,
+    run,
+    swap_layout_in_preview_url,
+)
+
+PREVIEW_URL = (
+    "http://studio.localhost/app-specific-preview/ttd/test-app"
+    "?selectedLayoutSet=form#/instance/51001/f1e23d45-6789-1bcd-8c34-56789abcdef0/Task_1/Side1"
+)
+
+
+class TestSwapLayoutInPreviewUrl:
+    def test_replaces_the_selected_layout(self):
+        result = swap_layout_in_preview_url(PREVIEW_URL, "Side2")
+        assert result == PREVIEW_URL.replace("/Task_1/Side1", "/Task_1/Side2")
+
+    def test_appends_layout_when_url_has_none(self):
+        url_without_layout = PREVIEW_URL.rsplit("/", 1)[0]
+        result = swap_layout_in_preview_url(url_without_layout, "Side2")
+        assert result == url_without_layout + "/Side2"
+
+    def test_returns_none_without_instance_fragment(self):
+        stateless_url = "http://studio.localhost/app-specific-preview/ttd/test-app?selectedLayoutSet=form"
+        assert swap_layout_in_preview_url(stateless_url, "Side2") is None
+
+
+class TestBuildScores:
+    def test_all_pages_rendering_scores_full(self):
+        scores = build_scores(
+            [PageRenderResult("Side1", True), PageRenderResult("Side2", True)]
+        )
+        by_name = {score.name: score for score in scores}
+        assert by_name["bench_renders"].value == 1.0
+        assert by_name["bench_pages_render"].value == 1.0
+        assert "2/2" in by_name["bench_pages_render"].comment
+
+    def test_broken_page_names_the_page_in_the_comment(self):
+        scores = build_scores(
+            [
+                PageRenderResult("Side1", True),
+                PageRenderResult("Side2", False, "error page: Ukjent feil"),
+            ]
+        )
+        by_name = {score.name: score for score in scores}
+        assert by_name["bench_renders"].value == 1.0
+        assert by_name["bench_pages_render"].value == 0.5
+        assert "Side2" in by_name["bench_pages_render"].comment
+        assert "Ukjent feil" in by_name["bench_pages_render"].comment
+
+    def test_first_page_failing_zeroes_bench_renders(self):
+        scores = build_scores([PageRenderResult("Side1", False, "no render marker")])
+        by_name = {score.name: score for score in scores}
+        assert by_name["bench_renders"].value == 0.0
+        assert by_name["bench_pages_render"].value == 0.0
+
+    def test_no_pages_scores_zero_with_explanation(self):
+        by_name = {score.name: score for score in build_scores([])}
+        assert by_name["bench_renders"].value == 0.0
+        assert by_name["bench_pages_render"].value == 0.0
+        assert "no ordered pages" in by_name["bench_renders"].comment
+
+
+class TestOptIn:
+    def test_disabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("BENCH_PREVIEW_CHECK", raising=False)
+        assert is_enabled() is False
+
+    def test_enabled_with_one(self, monkeypatch):
+        monkeypatch.setenv("BENCH_PREVIEW_CHECK", "1")
+        assert is_enabled() is True
+
+    def test_unavailable_infrastructure_skips_without_scores(self, monkeypatch):
+        def raise_unavailable(*args):
+            raise PreviewCheckUnavailable("playwright is not installed")
+
+        monkeypatch.setattr("benchmarks.preview_check._render_results", raise_unavailable)
+
+        assert run("altinity_session_abc123", ["Side1"]) == []

--- a/src/AI/agents/tests/unit/benchmarks/test_runner_render_fix.py
+++ b/src/AI/agents/tests/unit/benchmarks/test_runner_render_fix.py
@@ -1,0 +1,55 @@
+"""Tests for the runner's render-fix loop: the pure parts (gating, fix
+goal, after-fix scores). The agent round-trip itself is exercised
+manually against the local stack."""
+
+from __future__ import annotations
+
+from benchmarks.preview_check import PageRenderResult
+from benchmarks.runner import _after_fix_scores, _is_render_fix_enabled, _render_fix_goal
+
+FAILURES = [
+    PageRenderResult("Side3", False, "error page: 500"),
+    PageRenderResult("Side5", False, "no render marker: Timeout 30000ms exceeded"),
+]
+
+
+class TestRenderFixEnabled:
+    def test_disabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("BENCH_RENDER_FIX", raising=False)
+        assert not _is_render_fix_enabled()
+
+    def test_enabled_with_one(self, monkeypatch):
+        monkeypatch.setenv("BENCH_RENDER_FIX", "1")
+        assert _is_render_fix_enabled()
+
+
+class TestRenderFixGoal:
+    def test_names_every_failing_page_with_its_detail(self):
+        goal = _render_fix_goal(FAILURES)
+        assert "- Side3: error page: 500" in goal
+        assert "- Side5: no render marker: Timeout 30000ms exceeded" in goal
+
+    def test_instructs_to_fix_verify_and_commit(self):
+        goal = _render_fix_goal(FAILURES)
+        assert "renders without errors" in goal
+        assert "commit" in goal
+
+
+class TestAfterFixScores:
+    def test_all_fixed_scores_full_fraction(self):
+        results = [PageRenderResult("Side1", True), PageRenderResult("Side3", True)]
+        scores = {s.name: s for s in _after_fix_scores(results, rounds=1)}
+        assert scores["bench_render_fix_rounds"].value == 1.0
+        assert scores["bench_pages_render_after_fix"].value == 1.0
+        assert "2/2 pages rendered after fix" in scores["bench_pages_render_after_fix"].comment
+
+    def test_remaining_failure_named_in_comment(self):
+        results = [PageRenderResult("Side1", True), PageRenderResult("Side3", False, "error page: 500")]
+        scores = {s.name: s for s in _after_fix_scores(results, rounds=2)}
+        assert scores["bench_render_fix_rounds"].value == 2.0
+        assert scores["bench_pages_render_after_fix"].value == 0.5
+        assert "Side3: error page: 500" in scores["bench_pages_render_after_fix"].comment
+
+    def test_recheck_unavailable_posts_only_rounds(self):
+        scores = _after_fix_scores(None, rounds=1)
+        assert [s.name for s in scores] == ["bench_render_fix_rounds"]

--- a/src/AI/agents/tests/unit/core/test_agentic_loop_node.py
+++ b/src/AI/agents/tests/unit/core/test_agentic_loop_node.py
@@ -1,12 +1,7 @@
-"""Tests for the agentic_loop_node and its wiring into the graph.
+"""Tests for the agentic_loop_node and its graph wiring.
 
-We monkeypatch `run_loop` and `build_adapter` so the node runs
-end-to-end without a real LLM.  Behavior we assert:
-
-- The right tool set is registered (all in-process).
-- The event bridge translates loop events to AgentEvent payloads.
-- Loop results map onto AgentState's legacy fields.
-- The graph builder produces a compiled graph with the expected nodes.
+`run_loop` and `build_adapter` are monkeypatched so the node runs end-to-end
+without a real LLM.
 """
 
 from __future__ import annotations
@@ -20,7 +15,9 @@ from agents.core import (
     LoopContext,
     LoopResult,
     TerminationReason,
+    ToolResult,
 )
+from agents.graph.nodes import agentic_loop_node as node
 from agents.graph.nodes.agentic_loop_node import (
     _apply_result_to_state,
     _build_registry,
@@ -31,10 +28,6 @@ from agents.graph.nodes.agentic_loop_node import (
 )
 from agents.graph.state import AgentState
 
-
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
 
 
 def _state(**overrides: Any) -> AgentState:
@@ -50,10 +43,6 @@ def _state(**overrides: Any) -> AgentState:
     base.update(overrides)
     return AgentState(**base)
 
-
-# ---------------------------------------------------------------------------
-# Registry composition
-# ---------------------------------------------------------------------------
 
 
 class TestBuildRegistry:
@@ -71,7 +60,6 @@ class TestBuildRegistry:
         }.issubset(names)
 
     def test_altinn_tools_registered(self):
-        """The Altinn domain capabilities are registered as in-process tools."""
         registry = _build_registry()
         assert "altinn_layout_props" in registry
         assert "altinn_datamodel_sync" in registry
@@ -82,16 +70,9 @@ class TestBuildRegistry:
         assert "skill" in registry
 
 
-# ---------------------------------------------------------------------------
-# Event bridge
-# ---------------------------------------------------------------------------
-
 
 class TestEventBridge:
     def test_lookup_tool_call_emits_trail_status(self, monkeypatch):
-        """Lookups surface as friendly Norwegian trail statuses (the
-        frontend ActivityTrail renders one row per status).  The raw
-        tool name must never leak into the message."""
         seen: list = []
         monkeypatch.setattr(
             "agents.graph.nodes.agentic_loop_node.sink.send",
@@ -116,9 +97,6 @@ class TestEventBridge:
         assert "altinn-policy" in seen[0].data["message"]
 
     def test_action_tool_call_emits_friendly_status(self, monkeypatch):
-        """The load-bearing write tools (edit_file, write_file,
-        commit_session_branch, …) DO surface a status — and in the
-        user's language, not with the internal tool name."""
         seen: list = []
         monkeypatch.setattr(
             "agents.graph.nodes.agentic_loop_node.sink.send",
@@ -129,16 +107,11 @@ class TestEventBridge:
         bridge("tool_call", {"id": "2", "name": "commit_session_branch", "input": {}})
         assert len(seen) == 2
         assert seen[0].type == "status"
-        # Norwegian status; the literal tool name must not leak.
         assert "edit_file" not in seen[0].data["message"]
         assert "fil" in seen[0].data["message"].lower() or "endrer" in seen[0].data["message"].lower()
         assert "commit_session_branch" not in seen[1].data["message"]
 
     def test_mid_loop_assistant_message_emits_no_status(self, monkeypatch):
-        """The model's narration streams to the UI via
-        `assistant_message_chunk` (text_delta flushes) — the
-        `assistant_message` loop event itself must not spawn a status
-        or a chat bubble."""
         seen: list = []
         monkeypatch.setattr(
             "agents.graph.nodes.agentic_loop_node.sink.send",
@@ -152,10 +125,6 @@ class TestEventBridge:
         assert seen == []
 
     def test_final_assistant_message_suppressed_in_bridge(self, monkeypatch):
-        """The terminal turn (stop_reason='end_turn') is handled by
-        `_emit_workflow_completion` with the real `filesChanged` list.
-        The bridge must NOT also emit it, or the UI shows the summary
-        twice."""
         seen: list = []
         monkeypatch.setattr(
             "agents.graph.nodes.agentic_loop_node.sink.send",
@@ -199,19 +168,11 @@ class TestEventBridge:
         bridge("tool_result", {"id": "1", "is_error": False, "chars": 100})
         bridge("compacted", {"turn": 5, "from": 30, "to": 10})
         bridge("terminated", {"reason": "completed", "turn": 3})
-        assert seen == []  # none of these should hit the user-facing sink
+        assert seen == []
 
-
-# ---------------------------------------------------------------------------
-# State translation
-# ---------------------------------------------------------------------------
 
 
 class TestFinalSummaryText:
-    """The fallback summary must reflect the actual termination reason.
-    The previous default of 'Workflow completed.' on every reason made
-    max_turns / error look like success in the UI."""
-
     def test_completed_uses_model_text(self):
         result = LoopResult(
             reason=TerminationReason.COMPLETED,
@@ -223,12 +184,9 @@ class TestFinalSummaryText:
 
     def test_completed_without_text_has_neutral_fallback(self):
         result = LoopResult(reason=TerminationReason.COMPLETED, messages=[], turns=1)
-        # Must not lie about success, but also doesn't need to be alarming.
         assert _final_summary_text(result) == "Ferdig."
 
     def test_completed_strips_trailing_sources_line(self):
-        # Sources are attached structurally from the tool trace; a text
-        # SOURCES line is a leftover model habit and must not render raw.
         result = LoopResult(
             reason=TerminationReason.COMPLETED,
             messages=[],
@@ -244,7 +202,7 @@ class TestFinalSummaryText:
         result = LoopResult(reason=TerminationReason.MAX_TURNS, messages=[], turns=20)
         summary = _final_summary_text(result)
         assert "20 steg" in summary
-        assert "ikke" in summary.lower()  # must clearly signal failure
+        assert "ikke" in summary.lower()
         assert "Workflow completed" not in summary
 
     def test_cancelled_signals_cancellation(self):
@@ -333,10 +291,6 @@ class TestApplyResultToState:
         assert state.changed_files == ["a.json", "m.json", "z.json"]
 
 
-# ---------------------------------------------------------------------------
-# Workflow completion event
-# ---------------------------------------------------------------------------
-
 
 class _SinkStub:
     def __init__(self):
@@ -386,15 +340,9 @@ class TestEmitWorkflowCompletion:
         assert message.data["traceId"] == "trace-root"
 
 
-# ---------------------------------------------------------------------------
-# Node end-to-end (run_loop monkeypatched)
-# ---------------------------------------------------------------------------
-
 
 class TestHandle:
     async def test_cancelled_result_emits_no_completion_message(self, monkeypatch):
-        """The cancel endpoint already sent the terminal 'cancelled' event —
-        a cancelled run must not also deliver (and persist) an answer."""
         seen: list = []
 
         async def fake_run_loop(**kwargs):
@@ -422,7 +370,6 @@ class TestHandle:
 
         async def fake_run_loop(**kwargs):
             captured.update(kwargs)
-            # Simulate the patch tool writing a file via ctx.
             kwargs["ctx"].extras["changed_files"] = {"Side1/layout.json"}
             return LoopResult(
                 reason=TerminationReason.COMPLETED,
@@ -436,7 +383,7 @@ class TestHandle:
         )
         monkeypatch.setattr(
             "agents.graph.nodes.agentic_loop_node.build_adapter",
-            lambda role: object(),  # adapter is never invoked since run_loop is faked
+            lambda role: object(),
         )
         monkeypatch.setattr(
             "agents.graph.nodes.agentic_loop_node.sink.send",
@@ -450,23 +397,18 @@ class TestHandle:
         state = _state()
         result = await handle(state)
 
-        # run_loop received the wiring we expect.
         assert captured["user_message"] == "add a date field"
         assert isinstance(captured["system_prompt"], str)
         assert "Altinity" in captured["system_prompt"]
-        assert captured["registry"].names()  # not empty
-        # Loop ctx echoes session info.
+        assert captured["registry"].names()
         assert captured["ctx"].session_id == "sess-1"
         assert captured["ctx"].allow_app_changes is True
 
-        # State was translated correctly.
         assert result.tests_passed is True
         assert result.changed_files == ["Side1/layout.json"]
         assert result.assistant_response == {"text": "done", "sources": [], "commit": None}
 
     async def test_read_only_mode_gates_writes_and_skips_branch_ops(self, monkeypatch):
-        """allow_app_changes=False must flow into the loop ctx, mark the
-        final message with no_branch_operations, and never auto-commit."""
         captured: dict[str, Any] = {}
         seen: list = []
         commits: list = []
@@ -546,10 +488,6 @@ class TestHandle:
         assert history[1].role == "assistant"
 
     async def test_emits_done_and_final_assistant_message(self, monkeypatch):
-        """The frontend needs both events to close out a workflow.  This
-        test guards the regression where the agentic loop terminated
-        without emitting them and Designer's checkout fired prematurely."""
-
         async def fake_run_loop(**kwargs):
             kwargs["ctx"].extras["changed_files"] = {"Side1/layout.json", "model.schema.json"}
             return LoopResult(
@@ -582,7 +520,6 @@ class TestHandle:
 
         await handle(_state())
 
-        # The last two events must be the final assistant_message + done.
         assert seen[-2].type == "assistant_message"
         assert seen[-2].data["content"] == "Added email field."
         assert sorted(seen[-2].data["filesChanged"]) == ["Side1/layout.json", "model.schema.json"]
@@ -618,21 +555,11 @@ class TestHandle:
         assert "adapter exploded" in result.verify_notes[0]
 
 
-# ---------------------------------------------------------------------------
-# Graph builder + feature flag
-# ---------------------------------------------------------------------------
-
 
 class TestAutoCommitSafetyNet:
-    """When the loop terminates with uncommitted changes (max_turns, stuck,
-    or error) and the model never called commit_session_branch itself, the
-    node should auto-commit so partial work isn't lost on the floor."""
-
     async def test_auto_commits_on_max_turns_with_changes(self, monkeypatch):
         async def fake_run_loop(**kwargs):
             kwargs["ctx"].extras["changed_files"] = {"App/ui/x.json"}
-            # Note: ctx.extras["session_committed"] NOT set — model didn't
-            # commit.
             return LoopResult(
                 reason=TerminationReason.MAX_TURNS,
                 messages=[],
@@ -642,7 +569,7 @@ class TestAutoCommitSafetyNet:
         seen: list = []
 
         def fake_commit_run(*args, **kwargs):
-            # CommitSessionBranchTool.run is async — return an awaitable.
+            # CommitSessionBranchTool.run is async, so return an awaitable.
             from agents.core import ToolResult
 
             async def _coro():
@@ -717,11 +644,10 @@ class TestAutoCommitSafetyNet:
         )
 
         await handle(_state())
-        assert called["n"] == 0  # model's own commit was honored
+        assert called["n"] == 0
 
     async def test_skips_auto_commit_when_no_changes(self, monkeypatch):
         async def fake_run_loop(**kwargs):
-            # No changes recorded at all.
             return LoopResult(
                 reason=TerminationReason.MAX_TURNS,
                 messages=[],
@@ -768,9 +694,149 @@ class TestGraphBuilder:
         from agents.graph.runner import build_graph
 
         compiled = build_graph()
-        # Compiled LangGraph exposes the node names on `.nodes`.
         node_names = set(getattr(compiled, "nodes", {}).keys())
         assert {"intake", "spec", "agentic_loop"}.issubset(node_names)
-        # Legacy pipeline nodes were removed in the agentic cleanup.
         for legacy in ("planner", "actor", "verifier", "reviewer", "scan", "planning_tool"):
             assert legacy not in node_names
+
+
+
+class _CheckStub:
+    def __init__(self, outcomes):
+        self._outcomes = list(outcomes)
+        self.calls = 0
+
+    @property
+    def input_schema(self):
+        class _Args:
+            @staticmethod
+            def model_validate(_):
+                return object()
+
+        return _Args
+
+    async def run(self, _args, _ctx):
+        self.calls += 1
+        return self._outcomes.pop(0)
+
+
+def _outcome(*, is_error: bool, unavailable: bool = False, content: str = "render report"):
+    return ToolResult(
+        content=content,
+        is_error=is_error,
+        metadata={"unavailable": True} if unavailable else {"passed": not is_error},
+    )
+
+
+def _committed_ctx(tmp_path):
+    ctx = LoopContext(session_id="sess-1", repo_path=str(tmp_path), allow_app_changes=True)
+    ctx.extras["session_committed"] = True
+    return ctx
+
+
+def _loop_result():
+    return LoopResult(reason=TerminationReason.COMPLETED, messages=[], final_text="Ferdig.", turns=1)
+
+
+class TestEnforcedRenderCheck:
+    async def test_passing_check_does_not_re_enter_the_loop(self, tmp_path, monkeypatch):
+        check = _CheckStub([_outcome(is_error=False)])
+        monkeypatch.setattr(node, "PreviewRenderCheckTool", lambda: check)
+        reran = []
+        monkeypatch.setattr(node, "run_loop", lambda **kw: reran.append(kw))
+
+        result = await node._repair_render_failures(
+            _state(), _loop_result(), _committed_ctx(tmp_path),
+            registry=None, adapter=None, system_prompt="", on_event=None,
+        )
+
+        assert check.calls == 1
+        assert reran == []
+        assert result.reason is TerminationReason.COMPLETED
+
+    async def test_unavailable_check_is_not_treated_as_a_failure(self, tmp_path, monkeypatch):
+        check = _CheckStub([_outcome(is_error=True, unavailable=True)])
+        monkeypatch.setattr(node, "PreviewRenderCheckTool", lambda: check)
+        reran = []
+        monkeypatch.setattr(node, "run_loop", lambda **kw: reran.append(kw))
+
+        await node._repair_render_failures(
+            _state(), _loop_result(), _committed_ctx(tmp_path),
+            registry=None, adapter=None, system_prompt="", on_event=None,
+        )
+
+        assert reran == []
+
+    async def test_uncommitted_session_is_not_checked(self, tmp_path, monkeypatch):
+        check = _CheckStub([_outcome(is_error=False)])
+        monkeypatch.setattr(node, "PreviewRenderCheckTool", lambda: check)
+        ctx = LoopContext(session_id="sess-1", repo_path=str(tmp_path), allow_app_changes=True)
+
+        await node._repair_render_failures(
+            _state(), _loop_result(), ctx,
+            registry=None, adapter=None, system_prompt="", on_event=None,
+        )
+
+        assert check.calls == 0
+
+    async def test_cancelled_run_is_left_alone(self, tmp_path, monkeypatch):
+        check = _CheckStub([_outcome(is_error=False)])
+        monkeypatch.setattr(node, "PreviewRenderCheckTool", lambda: check)
+        cancelled = LoopResult(
+            reason=TerminationReason.CANCELLED, messages=[], final_text="", turns=1
+        )
+
+        await node._repair_render_failures(
+            _state(), cancelled, _committed_ctx(tmp_path),
+            registry=None, adapter=None, system_prompt="", on_event=None,
+        )
+
+        assert check.calls == 0
+
+    async def test_handle_enforces_the_check_after_a_write_run(self, monkeypatch):
+        called: list[str] = []
+
+        async def fake_run_loop(**kwargs):
+            return LoopResult(
+                reason=TerminationReason.COMPLETED, messages=[], final_text="done", turns=1
+            )
+
+        async def fake_repair(state, result, ctx, **kwargs):
+            called.append(state.session_id)
+            return result
+
+        monkeypatch.setattr(node, "run_loop", fake_run_loop)
+        monkeypatch.setattr(node, "build_adapter", lambda role: object())
+        monkeypatch.setattr(node, "_repair_render_failures", fake_repair)
+        monkeypatch.setattr("agents.graph.nodes.agentic_loop_node.sink.send", lambda evt: None)
+        monkeypatch.setattr(
+            "agents.graph.nodes.agentic_loop_node.sink.is_cancelled", lambda sid: False
+        )
+
+        await handle(_state())
+
+        assert called == ["sess-1"]
+
+    async def test_handle_skips_the_check_in_read_only_mode(self, monkeypatch):
+        called: list[str] = []
+
+        async def fake_run_loop(**kwargs):
+            return LoopResult(
+                reason=TerminationReason.COMPLETED, messages=[], final_text="done", turns=1
+            )
+
+        async def fake_repair(state, result, ctx, **kwargs):
+            called.append(state.session_id)
+            return result
+
+        monkeypatch.setattr(node, "run_loop", fake_run_loop)
+        monkeypatch.setattr(node, "build_adapter", lambda role: object())
+        monkeypatch.setattr(node, "_repair_render_failures", fake_repair)
+        monkeypatch.setattr("agents.graph.nodes.agentic_loop_node.sink.send", lambda evt: None)
+        monkeypatch.setattr(
+            "agents.graph.nodes.agentic_loop_node.sink.is_cancelled", lambda sid: False
+        )
+
+        await handle(_state(allow_app_changes=False))
+
+        assert called == []

--- a/src/AI/agents/tests/unit/core/test_agentic_loop_node.py
+++ b/src/AI/agents/tests/unit/core/test_agentic_loop_node.py
@@ -738,6 +738,14 @@ def _loop_result():
     return LoopResult(reason=TerminationReason.COMPLETED, messages=[], final_text="Ferdig.", turns=1)
 
 
+class _AsyncRecommit:
+    """Stands in for the auto-commit that follows a repair round, which is what
+    makes the session checkable again."""
+
+    async def __call__(self, _state, _result, ctx):
+        ctx.extras["session_committed"] = True
+
+
 class TestEnforcedRenderCheck:
     async def test_passing_check_does_not_re_enter_the_loop(self, tmp_path, monkeypatch):
         check = _CheckStub([_outcome(is_error=False)])
@@ -766,6 +774,56 @@ class TestEnforcedRenderCheck:
         )
 
         assert reran == []
+
+    async def test_a_persistent_failure_repairs_only_the_configured_rounds(
+        self, tmp_path, monkeypatch
+    ):
+        """Two failing checks, one repair: the second check verifies the fix
+        rather than triggering another."""
+        check = _CheckStub([_outcome(is_error=True), _outcome(is_error=True)])
+        monkeypatch.setattr(node, "PreviewRenderCheckTool", lambda: check)
+        monkeypatch.setattr(node, "MAX_RENDER_REPAIR_ROUNDS", 1)
+        reran = []
+
+        async def fake_run_loop(**kw):
+            reran.append(kw)
+            return _loop_result()
+
+        monkeypatch.setattr(node, "run_loop", fake_run_loop)
+        monkeypatch.setattr(node, "_maybe_auto_commit", _AsyncRecommit())
+        ctx = _committed_ctx(tmp_path)
+
+        await node._repair_render_failures(
+            _state(), _loop_result(), ctx,
+            registry=None, adapter=None, system_prompt="", on_event=None,
+        )
+
+        assert len(reran) == node.MAX_RENDER_REPAIR_ROUNDS
+        assert check.calls == node.MAX_RENDER_REPAIR_ROUNDS + 1
+
+    async def test_a_repair_that_works_is_confirmed_by_a_final_check(
+        self, tmp_path, monkeypatch
+    ):
+        check = _CheckStub([_outcome(is_error=True), _outcome(is_error=False)])
+        monkeypatch.setattr(node, "PreviewRenderCheckTool", lambda: check)
+        monkeypatch.setattr(node, "MAX_RENDER_REPAIR_ROUNDS", 1)
+        reran = []
+
+        async def fake_run_loop(**kw):
+            reran.append(kw)
+            return _loop_result()
+
+        monkeypatch.setattr(node, "run_loop", fake_run_loop)
+        monkeypatch.setattr(node, "_maybe_auto_commit", _AsyncRecommit())
+        ctx = _committed_ctx(tmp_path)
+
+        await node._repair_render_failures(
+            _state(), _loop_result(), ctx,
+            registry=None, adapter=None, system_prompt="", on_event=None,
+        )
+
+        assert len(reran) == 1
+        assert check.calls == 2
 
     async def test_uncommitted_session_is_not_checked(self, tmp_path, monkeypatch):
         check = _CheckStub([_outcome(is_error=False)])

--- a/src/AI/agents/tests/unit/core/test_agentic_loop_node.py
+++ b/src/AI/agents/tests/unit/core/test_agentic_loop_node.py
@@ -792,14 +792,17 @@ class TestEnforcedRenderCheck:
         monkeypatch.setattr(node, "run_loop", fake_run_loop)
         monkeypatch.setattr(node, "_maybe_auto_commit", _AsyncRecommit())
         ctx = _committed_ctx(tmp_path)
+        state = _state()
 
         await node._repair_render_failures(
-            _state(), _loop_result(), ctx,
+            state, _loop_result(), ctx,
             registry=None, adapter=None, system_prompt="", on_event=None,
         )
 
         assert len(reran) == node.MAX_RENDER_REPAIR_ROUNDS
         assert check.calls == node.MAX_RENDER_REPAIR_ROUNDS + 1
+        assert state.tests_passed is False
+        assert state.verify_notes
 
     async def test_a_repair_that_works_is_confirmed_by_a_final_check(
         self, tmp_path, monkeypatch

--- a/src/AI/agents/tests/unit/core/test_preview_check_tool.py
+++ b/src/AI/agents/tests/unit/core/test_preview_check_tool.py
@@ -1,0 +1,133 @@
+"""Tests for `preview_render_check`: gating, precondition errors, and
+result shaping. The browser engine itself is monkeypatched; the real
+flow is exercised manually against the local stack."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agents.core import LoopContext, PreviewRenderCheckTool
+from agents.services.preview.render_check import PageRenderResult, PreviewCheckUnavailable
+from shared.config.base_config import BaseConfig
+
+ENGINE_PATH = "agents.core.tools.preview_check_tool.render_check"
+
+
+@pytest.fixture(autouse=True)
+def _enabled_deployment(monkeypatch):
+    monkeypatch.setattr(BaseConfig, "PREVIEW_CHECK_ENABLED", True)
+
+
+def _ctx(
+    tmp_path: Path,
+    *,
+    allow_app_changes: bool = True,
+    committed: bool = True,
+    app_name: str | None = "test-app",
+    page_order: list[str] | None = None,
+) -> LoopContext:
+    if page_order is None:
+        page_order = ["Side1", "Side2"]
+    settings_dir = tmp_path / "App" / "ui" / "form"
+    settings_dir.mkdir(parents=True, exist_ok=True)
+    (settings_dir / "Settings.json").write_text(
+        json.dumps({"pages": {"order": page_order}}), encoding="utf-8"
+    )
+
+    ctx = LoopContext(
+        session_id="session-abcdef12",
+        repo_path=str(tmp_path),
+        allow_app_changes=allow_app_changes,
+        org="ttd",
+    )
+    if committed:
+        ctx.extras["session_committed"] = True
+        ctx.extras["session_branch"] = "altinity_session_abcdef12"
+    if app_name:
+        ctx.extras["app_name"] = app_name
+    return ctx
+
+
+def _args():
+    return PreviewRenderCheckTool.input_schema()
+
+
+class TestPermissionGating:
+    async def test_denied_in_read_only_mode(self, tmp_path):
+        tool = PreviewRenderCheckTool()
+        result = await tool.check_permission(_args(), _ctx(tmp_path, allow_app_changes=False))
+        assert result.allowed is False
+        assert result.escalatable is True
+
+
+class TestPreconditions:
+    async def test_disabled_deployment_says_skip(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(BaseConfig, "PREVIEW_CHECK_ENABLED", False)
+        result = await PreviewRenderCheckTool().run(_args(), _ctx(tmp_path))
+        assert result.is_error
+        assert "do NOT retry" in result.content
+        assert result.metadata["unavailable"] is True
+
+    async def test_requires_commit_first(self, tmp_path):
+        result = await PreviewRenderCheckTool().run(_args(), _ctx(tmp_path, committed=False))
+        assert result.is_error
+        assert "commit_session_branch" in result.content
+
+    async def test_no_page_order_is_actionable(self, tmp_path):
+        ctx = _ctx(tmp_path, page_order=[])
+        result = await PreviewRenderCheckTool().run(_args(), ctx)
+        assert result.is_error
+        assert "pages.order" in result.content
+
+
+class TestResults:
+    async def test_all_pages_rendering_passes(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            ENGINE_PATH,
+            lambda **kwargs: [PageRenderResult("Side1", True), PageRenderResult("Side2", True)],
+        )
+        result = await PreviewRenderCheckTool().run(_args(), _ctx(tmp_path))
+        assert not result.is_error
+        assert json.loads(result.content)["passed"] is True
+
+    async def test_failing_page_is_error_with_detail(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            ENGINE_PATH,
+            lambda **kwargs: [
+                PageRenderResult("Side1", True),
+                PageRenderResult("Side2", False, "error page: 500"),
+            ],
+        )
+        result = await PreviewRenderCheckTool().run(_args(), _ctx(tmp_path))
+        assert result.is_error
+        body = json.loads(result.content.split("\n\n")[0])
+        assert body["passed"] is False
+        assert body["pages"][1] == {"page": "Side2", "rendered": False, "detail": "error page: 500"}
+        assert "preview_render_check` again" in result.content
+
+    async def test_unavailable_engine_says_skip(self, tmp_path, monkeypatch):
+        def raise_unavailable(**kwargs):
+            raise PreviewCheckUnavailable("playwright is not installed")
+
+        monkeypatch.setattr(ENGINE_PATH, raise_unavailable)
+        result = await PreviewRenderCheckTool().run(_args(), _ctx(tmp_path))
+        assert result.is_error
+        assert "do NOT retry" in result.content
+        assert result.metadata["unavailable"] is True
+
+    async def test_engine_receives_branch_org_and_pages(self, tmp_path, monkeypatch):
+        seen = {}
+
+        def capture(**kwargs):
+            seen.update(kwargs)
+            return [PageRenderResult("Side1", True), PageRenderResult("Side2", True)]
+
+        monkeypatch.setattr(ENGINE_PATH, capture)
+        await PreviewRenderCheckTool().run(_args(), _ctx(tmp_path))
+        assert seen["branch"] == "altinity_session_abcdef12"
+        assert seen["org"] == "ttd"
+        assert seen["app"] == "test-app"
+        assert seen["page_order"] == ["Side1", "Side2"]

--- a/src/AI/agents/tests/unit/services/preview/test_render_check.py
+++ b/src/AI/agents/tests/unit/services/preview/test_render_check.py
@@ -14,6 +14,7 @@ from agents.services.preview.render_check import (
     PageRenderResult,
     PreviewCheckUnavailable,
     _check_pages,
+    read_page_order,
     _is_thrown_error,
 )
 
@@ -73,3 +74,25 @@ class TestPartialPageValidation:
 
         assert checked == ["Side1", "Side2", "Side3"]
         assert len(results) == 3
+
+
+class TestPageOrderShapes:
+    """Settings.json is written by the agent, so a malformed one must skip the
+    file rather than take down the render check."""
+
+    def _write(self, tmp_path, content: str):
+        settings = tmp_path / "App" / "ui" / "layoutset" / "Settings.json"
+        settings.parent.mkdir(parents=True)
+        settings.write_text(content, encoding="utf-8")
+        return tmp_path
+
+    @pytest.mark.parametrize(
+        "content", ["[]", '"just a string"', "5", '{"pages": [1, 2]}', '{"pages": []}']
+    )
+    def test_a_shape_that_is_not_an_order_is_skipped(self, tmp_path, content):
+        assert read_page_order(self._write(tmp_path, content)) == []
+
+    def test_a_valid_order_is_read(self, tmp_path):
+        root = self._write(tmp_path, '{"pages": {"order": ["Side1", "Side2"]}}')
+
+        assert read_page_order(root) == ["Side1", "Side2"]

--- a/src/AI/agents/tests/unit/services/preview/test_render_check.py
+++ b/src/AI/agents/tests/unit/services/preview/test_render_check.py
@@ -6,7 +6,16 @@ from __future__ import annotations
 
 import pytest
 
-from agents.services.preview.render_check import _is_thrown_error
+from importlib import import_module
+
+render_check_module = import_module("agents.services.preview.render_check")
+
+from agents.services.preview.render_check import (
+    PageRenderResult,
+    PreviewCheckUnavailable,
+    _check_pages,
+    _is_thrown_error,
+)
 
 THROWN = [
     "TypeError: Cannot read properties of undefined (reading 'render') "
@@ -33,3 +42,34 @@ class TestThrownErrorDetection:
     @pytest.mark.parametrize("message", NOISE)
     def test_log_noise_and_failed_requests_do_not(self, message):
         assert _is_thrown_error(message) is False
+
+
+class TestPartialPageValidation:
+    """A preview url that cannot select layouts leaves most pages unopened.
+    Scoring what did open would report a pass the run never earned."""
+
+    def test_a_url_without_layout_selection_skips_the_check(self):
+        with pytest.raises(PreviewCheckUnavailable):
+            _check_pages(
+                page=None,
+                first_page_url="https://studio.localhost/preview/ttd/app#/nope",
+                page_order=["Side1", "Side2", "Side3"],
+            )
+
+    def test_a_usable_url_checks_every_page(self, monkeypatch):
+        checked: list[str] = []
+        monkeypatch.setattr(
+            render_check_module,
+            "_check_single_page",
+            lambda page, url, layout: checked.append(layout)
+            or PageRenderResult(layout, True, ""),
+        )
+
+        results = _check_pages(
+            page=None,
+            first_page_url="https://studio.localhost/preview/ttd/app#/instance/1/2/Task_1/Side1",
+            page_order=["Side1", "Side2", "Side3"],
+        )
+
+        assert checked == ["Side1", "Side2", "Side3"]
+        assert len(results) == 3

--- a/src/AI/agents/tests/unit/services/preview/test_render_check.py
+++ b/src/AI/agents/tests/unit/services/preview/test_render_check.py
@@ -1,0 +1,35 @@
+"""A component that cannot render throws, app-frontend catches it, and the
+page still reports itself loaded with nothing marking the DOM. The console
+is the only signal, so it decides whether a page counts as rendered."""
+
+from __future__ import annotations
+
+import pytest
+
+from agents.services.preview.render_check import _is_thrown_error
+
+THROWN = [
+    "TypeError: Cannot read properties of undefined (reading 'render') "
+    "at TUe (https://altinncdn.no/toolkits/altinn-app-frontend/4/altinn-app-frontend.js:1154:2349)",
+    "ReferenceError: layoutComponent is not defined",
+    "Uncaught Error: element type is invalid",
+    "component.render is not a function",
+]
+
+NOISE = [
+    "Failed to load resource: the server responded with a status of 404 (Not Found)",
+    "net::ERR_CONNECTION_REFUSED",
+    "Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>",
+    "Download the React DevTools for a better development experience",
+    "Refused to load the image because it violates Content Security Policy",
+]
+
+
+class TestThrownErrorDetection:
+    @pytest.mark.parametrize("message", THROWN)
+    def test_exceptions_fail_the_page(self, message):
+        assert _is_thrown_error(message) is True
+
+    @pytest.mark.parametrize("message", NOISE)
+    def test_log_noise_and_failed_requests_do_not(self, message):
+        assert _is_thrown_error(message) is False

--- a/src/Designer/compose.yaml
+++ b/src/Designer/compose.yaml
@@ -80,6 +80,10 @@ services:
       - OTEL_ENDPOINT=localhost:4317
       - OTEL_SERVICE_NAME=studio-loadbalancer
       - OTEL_TRACE=off
+    networks:
+      default:
+        aliases:
+          - studio.localhost
     volumes:
       - ./../load-balancer/local/www:/www:ro
       - ./../load-balancer/local/error-pages:/etc/nginx/error-pages:ro


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Closes digdir/digdir-ai-lab#205 (amended during implementation to cover the fix loop and the loop tool).

Structural evaluation is blind to runtime failures. An app can satisfy every rubric check and still not render. A benchmark run while building this scored `bench_pages` 1.0, `bench_order_integrity` 1.0, `bench_navigation` 1.0 and `bench_texts_bound` 1.0, while one page died with *"En feil oppstod for underskriver"*.

This adds a headless-Chromium engine (`agents/services/preview/render_check.py`) that logs into the local stack once, checks out the session branch through the Designer API, and loads every ordered page. Three callers build on it.

**Benchmark scores**

- `bench_renders` (boolean): the first ordered page renders
- `bench_pages_render` (0-1): fraction of ordered pages that render, failing page named in the comment

**Render-fix loop** (`BENCH_RENDER_FIX=1`)

Failing pages go back into the same agent session as a fix goal and are re-checked. `bench_renders` / `bench_pages_render` always describe the *first* attempt so runs stay comparable across agent versions; the repair is scored separately as `bench_render_fix_rounds` and `bench_pages_render_after_fix`.

**The agent's own check** (`PREVIEW_CHECK_ENABLED=true`)

A `preview_render_check` loop tool, permission-gated like other write-adjacent tools and requiring a committed session branch. The graph also runs the check after commit **regardless of what the model does**, because the prompt asks for it but a skipped check is indistinguishable from a clean one, and repairs failures within `MAX_RENDER_REPAIR_ROUNDS`.

**How a failure is detected**

A component with an unknown type is caught by app-frontend: the page still sets `#finishedLoading`, shows no `AltinnError`, throws no uncaught exception, and leaves nothing in the DOM. I probed for error boundaries, `role="alert"` and the component's own id. All absent. The only signal is an exception on the console, so a page is failed on exception-shaped console output. Non-exception output (404s, warnings) is recorded in the score comment without failing the page.

I also considered asserting that declared components appear in the DOM. `data-componentid` exists, but one page declares 12 components and only 6 carry it. `hidden` expressions and group children legitimately don't render, so absence can't distinguish silently-dropped from correctly-hidden without evaluating Altinn's dynamic expressions.

## Reviewer notes

- **Everything is opt-in.** `BENCH_PREVIEW_CHECK`, `BENCH_RENDER_FIX` and `PREVIEW_CHECK_ENABLED` all default off, and each degrades to "skipped" when Playwright or the stack is unavailable. With them unset a benchmark run behaves exactly as before.
- **The loop tool is local-stack only.** The browser logs in through the fake-Ansattporten mock, which doesn't exist in a deployed environment. Making it work in production would need Designer to mint a scoped preview session for the agent: separate work, and security-sensitive. Documented in the README and `.env.example` so nobody assumes it runs in the deployed service.
- **The loop tool changes what the benchmark measures.** `bench_pages_render` scores the app as the agent left it, so with the tool on it reflects an agent that could see and fix its own failures. That's fair to measure but not comparable with a run where it was off; the README says to record the mode in `--run-description`.
- **`ensure-configs` must be re-run.** The two fix-loop score configs did not exist in Langfuse until I ran it.
- **The diff includes a comment cleanup** across the touched files, reducing them to what the code cannot state. This is why files like `base_config.py` appear with more churn than the feature warrants; behaviour there is unchanged apart from one default flag.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

Automated: 349 pytest tests, 40 of them new: score building, the enable flags, the fix-loop scoring, the tool's refusal paths (read-only, uncommitted branch, unavailable), the thrown-error predicate against realistic console output both ways, and the graph wiring (verified to fail when the call site is removed).

Manual, against a rebuilt local stack:

| Run | Result |
|---|---|
| Standalone check, healthy branch | 4/4 pages, login cached and reused (4s on the second run) |
| Deliberately broken layout | `bench_renders=1.0`, `bench_pages_render=0.75`, Side3 named. Only after the console-error fix; it passed 4/4 before |
| Benchmark, tool off | `bench_pages_render=0.8`, real Side5 signing failure, scores confirmed on the trace via the Langfuse API |
| Benchmark, fix loop on | `bench_render_fix_rounds=1`, `bench_pages_render_after_fix=1.0`. The agent repaired its own failure in one round |
| Benchmark, everything on | 5/5 pages; `tool_preview_render_check` appears once in the trace, 5.7s, invoked after `commit_session_branch` |

**Not verified:** the graph's enforced repair path has never fired against a real failure. Agent-generated apps rarely break, and forcing one would test a scenario that doesn't occur naturally. The equivalent flow was observed end to end at the benchmark layer (Side5 above), and the enforcement paths are unit-tested, but the in-graph repair is not field-tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated preview rendering checks for committed app changes across every page.
  - Failed renders can trigger a bounded repair and re-check workflow.
  - Added optional benchmark scoring for page rendering and post-fix results.

- **Configuration**
  - Added settings for preview checks, Studio access, browser execution, model roles, and runtime limits.

- **Documentation**
  - Expanded benchmark guidance, prerequisites, troubleshooting, and preview-rendering workflows.

- **Infrastructure**
  - Added Chromium browser support for automated preview validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->