### PR TITLE
chore: migrate remaining test apps to .NET 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ See deployment for notes on how to deploy the project on a live system.
 
 ### Prerequisites
 
-1. Newest [.NET 9 SDK][5]
+1. Newest [.NET 10 SDK][5]
 2. [Node.js][6] (Latest LTS version)
 3. Newest [Git][7]
 4. A code editor - we like [Visual Studio Code][8]
@@ -196,7 +196,7 @@ This project is licensed under the MIT License. See the [LICENSE](LICENSE) file 
 [2]: https://docs.altinn.studio/altinn-studio/getting-started/
 [3]: https://docs.altinn.studio/altinn-studio/getting-started/app-dev-course/
 [4]: https://github.com/Altinn/app-localtest
-[5]: https://dotnet.microsoft.com/download/dotnet/9.0
+[5]: https://dotnet.microsoft.com/download/dotnet/10.0
 [6]: https://nodejs.org
 [7]: https://git-scm.com/downloads
 [8]: https://code.visualstudio.com/Download

--- a/src/App/backend/test/Altinn.App.Analyzers.Tests/testapp/Dockerfile
+++ b/src/App/backend/test/Altinn.App.Analyzers.Tests/testapp/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
 WORKDIR /App
 
 COPY /App/App.csproj .
@@ -8,7 +8,7 @@ COPY /App .
 
 RUN dotnet publish App.csproj --configuration Release --output /app_output
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS final
 EXPOSE 5005
 WORKDIR /App
 COPY --from=build /app_output .

--- a/src/App/backend/test/Altinn.App.Integration.Tests/_testapps/basic/App/App.csproj
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/_testapps/basic/App/App.csproj
@@ -20,8 +20,8 @@
     <PackageReference Include="Altinn.App.Core" Version="*-*" />
 
     <!-- Required for the fixture - compilation of injected services -->
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.10" />
     <Compile Include="../_shared/*.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/App/backend/test/Altinn.App.Integration.Tests/_testapps/basic/Dockerfile
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/_testapps/basic/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
 
 COPY NuGet.config .
 COPY _packages _packages/
@@ -14,7 +14,7 @@ RUN dotnet publish App.csproj --configuration Release --output /app_output
 # Ensure that the config folder is copied to the output folder (policy.xml was missing)
 RUN cp -R config /app_output/
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS final
 EXPOSE 5005
 EXPOSE 5006
 WORKDIR /App

--- a/src/Designer/backend/tests/Designer.Tests/Helpers/_snapshots/PackageVersionHelperTests.TryGetPackageVersionFromCsprojFile_GivenValidCsprojFileWithPinnedVersions_ReturnsTrue_packageName=Altinn.App.Api.verified.txt
+++ b/src/Designer/backend/tests/Designer.Tests/Helpers/_snapshots/PackageVersionHelperTests.TryGetPackageVersionFromCsprojFile_GivenValidCsprojFileWithPinnedVersions_ReturnsTrue_packageName=Altinn.App.Api.verified.txt
@@ -12,11 +12,11 @@
   Outputs: [
     {
       Item1: true,
-      Item2: 8.8.3
+      Item2: 9.0.0-preview.4
     },
     {
       Item1: true,
-      Item2: 8.8.3
+      Item2: 9.0.0-preview.4
     }
   ]
 }

--- a/src/Designer/backend/tests/Designer.Tests/Helpers/_snapshots/PackageVersionHelperTests.TryGetPackageVersionFromCsprojFile_GivenValidCsprojFile_ReturnsTrue_packageName=Altinn.App.Api.verified.txt
+++ b/src/Designer/backend/tests/Designer.Tests/Helpers/_snapshots/PackageVersionHelperTests.TryGetPackageVersionFromCsprojFile_GivenValidCsprojFile_ReturnsTrue_packageName=Altinn.App.Api.verified.txt
@@ -12,11 +12,11 @@
   Outputs: [
     {
       Item1: true,
-      Item2: 8.8.3
+      Item2: 9.0.0-preview.4
     },
     {
       Item1: true,
-      Item2: 8.8.3
+      Item2: 9.0.0-preview.4
     }
   ]
 }

--- a/src/Designer/testdata/App/App.csproj
+++ b/src/Designer/testdata/App/App.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>Altinn.Application</AssemblyName>
     <RootNamespace>Altinn.App</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Altinn.App.Api" Version="[8.8.3]">
+    <PackageReference Include="Altinn.App.Api" Version="[9.0.0-preview.4]">
       <CopyToOutputDirectory>lib\$(TargetFramework)\*.xml</CopyToOutputDirectory>
     </PackageReference>
-    <PackageReference Include="Altinn.App.Core" Version="[8.8.3]" />
+    <PackageReference Include="Altinn.App.Core" Version="[9.0.0-preview.4]" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="wwwroot\css\" />

--- a/src/Runtime/operator/test/app/App/App.csproj
+++ b/src/Runtime/operator/test/app/App/App.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Npgsql" Version="8.0.9" />
-    <PackageReference Include="Altinn.App.Core" Version="8.9.2" />
+    <PackageReference Include="Altinn.App.Core" Version="9.0.0-preview.4" />
   </ItemGroup>
 </Project>

--- a/src/Runtime/operator/test/app/App/Program.cs
+++ b/src/Runtime/operator/test/app/App/Program.cs
@@ -10,7 +10,6 @@ using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 using Npgsql;
 
-const string secretPath = "/mnt/app-secrets/maskinporten-settings.json";
 const string secretDir = "/mnt/app-secrets";
 
 var builder = WebApplication.CreateBuilder(args);

--- a/src/Runtime/operator/test/app/Dockerfile
+++ b/src/Runtime/operator/test/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine@sha256:5f12aa62868b69dcb41de9cd7f8759822f7d1f56c3b31908048ad65df0981e67 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
 WORKDIR /App
 
 COPY /App/App.csproj .
@@ -8,7 +8,7 @@ COPY /App .
 
 RUN dotnet publish App.csproj --configuration Release --output /app_output
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine@sha256:b02ab6637e02dfe07d4205d557cbce7e2ab0e4a1d7d1285868b4f31eed20bd10 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS final
 EXPOSE 5005
 WORKDIR /App
 COPY --from=build /app_output .


### PR DESCRIPTION
## Description

Migrate the remaining non-Localtest test apps from the v8/.NET 8 baseline to the current v9 app template baseline:

- target .NET 10 and use `Altinn.App` v9 packages in the Designer package-version fixture and the runtime operator E2E app
- use .NET 10 SDK/runtime images in the operator, analyzer, and integration test-app Dockerfiles
- align the integration app's runtime-compilation dependencies with the .NET 10 backend
- remove an unused operator test-app constant found by the upgraded build
- document the .NET 10 SDK as the repository prerequisite

The Designer fixture retains its exact-version brackets because that syntax is the behavior under test. Its legacy layout files also remain because Designer tests intentionally cover those formats. The analyzer and integration apps already had the v9 `Program.cs` and layout changes, so no further application-code migration was needed there.

## Verification

- [x] Related issues are connected (not applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test updated and run

Commands/checks:

- `dotnet test tests/Designer.Tests/Designer.Tests.csproj --filter 'FullyQualifiedName~PackageVersionHelperTests'` — 3 passed
- `dotnet build App/App.csproj --configuration Release --no-restore` for the operator test app — clean build
- `docker build` for the operator test app — succeeded with .NET 10 images
- `dotnet test test/Altinn.App.Analyzers.Tests/Altinn.App.Analyzers.Tests.csproj --configuration Release` — 15 passed; existing unrelated NuGet audit warnings remain
- `dotnet build` for the analyzer test app — succeeded
- `dotnet build test/Altinn.App.Integration.Tests/Altinn.App.Integration.Tests.csproj --configuration Release` — clean build
- integration app build against freshly packed local v9 libraries — succeeded
- integration app `docker build` against freshly packed local v9 libraries — succeeded with .NET 10 images
- `docker build --check` for the analyzer and integration Dockerfiles — no warnings
- `git diff --check` — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development and test environments to target .NET 10.
  * Updated container images to use .NET 10 Alpine-based runtimes.
  * Refreshed supporting package versions, including preview 9.0 application packages.
  * Removed an unused test configuration value.

* **Tests**
  * Updated expected test results to reflect the refreshed application package versions.

* **Documentation**
  * Updated the documented prerequisite from the .NET 9 SDK to the .NET 10 SDK.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->