### PR TITLE
feat(agents): migrate the Langfuse client to v4

### DIFF
--- a/src/AI/agents/agents/graph/runner.py
+++ b/src/AI/agents/agents/graph/runner.py
@@ -2,6 +2,7 @@
 import asyncio
 
 from langgraph.graph import StateGraph, END
+from opentelemetry import trace as otel_trace
 
 from .state import AgentState
 from .nodes.agentic_loop_node import handle as agentic_loop_node
@@ -234,6 +235,17 @@ async def _validate_intent(state: AgentState):
         state.session_id, parsed.action, parsed.component, parsed.confidence,
     )
 
+def _mark_as_experiment_item(state: AgentState, root_span) -> None:
+    """Declare this trace one item of a dataset run."""
+    if not state.experiment:
+        return
+    span = otel_trace.get_current_span()
+    if not span.is_recording():
+        return
+    for key, value in state.experiment.span_attributes(root_span.id).items():
+        span.set_attribute(key, value)
+
+
 async def run_once(state: AgentState, event_sink: EventSink = None):
     """Run one complete workflow loop with unified tracing"""
     if event_sink is None:
@@ -268,6 +280,7 @@ async def run_once(state: AgentState, event_sink: EventSink = None):
             },
         ) as root_span:
             state.trace_id = get_current_trace_id()
+            _mark_as_experiment_item(state, root_span)
             with propagate_attributes(user_id=state.org):
                 try:
                     decline_text = await _gate_goal(state, event_sink)

--- a/src/AI/agents/agents/graph/runner.py
+++ b/src/AI/agents/agents/graph/runner.py
@@ -2,6 +2,7 @@
 import asyncio
 
 from langgraph.graph import StateGraph, END
+from opentelemetry import trace as otel_trace
 
 from .state import AgentState
 from .nodes.agentic_loop_node import handle as agentic_loop_node
@@ -247,6 +248,17 @@ async def _validate_intent(state: AgentState):
         state.session_id, parsed.action, parsed.component, parsed.confidence,
     )
 
+def _mark_as_experiment_item(state: AgentState, root_span) -> None:
+    """Declare this trace one item of a dataset run."""
+    if not state.experiment:
+        return
+    span = otel_trace.get_current_span()
+    if not span.is_recording():
+        return
+    for key, value in state.experiment.span_attributes(root_span.id).items():
+        span.set_attribute(key, value)
+
+
 async def run_once(state: AgentState, event_sink: EventSink = None):
     """Run one complete workflow loop with unified tracing"""
     if event_sink is None:
@@ -281,6 +293,7 @@ async def run_once(state: AgentState, event_sink: EventSink = None):
             },
         ) as root_span:
             state.trace_id = get_current_trace_id()
+            _mark_as_experiment_item(state, root_span)
             with propagate_attributes(user_id=state.org):
                 try:
                     decline_text = await _gate_goal(state, event_sink)

--- a/src/AI/agents/agents/graph/state.py
+++ b/src/AI/agents/agents/graph/state.py
@@ -1,3 +1,4 @@
+from shared.models.experiment import ExperimentContext
 from typing import List, Optional, Literal, Dict, Any
 from pydantic import BaseModel, Field, field_validator
 from shared.models import AgentAttachment
@@ -129,6 +130,7 @@ class AgentState(BaseModel):
     repo_path: str
     app_name: str
     developer: str
+    experiment: Optional["ExperimentContext"] = None
     org: str
     designer_api_key: Optional[str] = None  # Designer API key for git operations through Gitea proxy
     trace_id: Optional[str] = None  # Langfuse trace id, captured once at the root span

--- a/src/AI/agents/api/routes/agent.py
+++ b/src/AI/agents/api/routes/agent.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Optional, List
 from shared.models import AttachmentUpload, AgentAttachment
 from shared.models.attachments import get_session_dir, cleanup_session_attachments
+from shared.models.experiment import ExperimentContext
 
 router = APIRouter()
 log = get_logger(__name__)
@@ -46,6 +47,7 @@ class StartReq(BaseModel):
     allow_app_changes: bool = False
     org: str
     attachments: List[AttachmentUpload] = Field(default_factory=list)
+    experiment: Optional[ExperimentContext] = None
 
     @field_validator("session_id")
     @classmethod
@@ -133,6 +135,7 @@ async def start_agent(
             attachments=saved_attachments,
             designer_api_key=designer_api_key,
             conversation_history=conversation_history,
+            experiment=req.experiment,
         )
 
         sink.add_to_conversation_history(req.session_id, "user", req.goal)

--- a/src/AI/agents/benchmarks/lf_api.py
+++ b/src/AI/agents/benchmarks/lf_api.py
@@ -9,9 +9,17 @@ from __future__ import annotations
 
 import os
 import uuid
+from datetime import datetime, timezone
 from typing import Any
 
 import httpx
+
+MAX_OBSERVATION_PAGES = 10
+OBSERVATION_PAGE_SIZE = 50
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
 
 
 class LangfuseApi:
@@ -87,19 +95,6 @@ class LangfuseApi:
             body["metadata"] = metadata
         return self._post("/api/public/dataset-items", body)
 
-    def create_dataset_run_item(
-        self, run_name: str, dataset_item_id: str, trace_id: str, run_description: str = ""
-    ) -> dict:
-        return self._post(
-            "/api/public/dataset-run-items",
-            {
-                "runName": run_name,
-                "datasetItemId": dataset_item_id,
-                "traceId": trace_id,
-                "runDescription": run_description,
-            },
-        )
-
     # -- scores -----------------------------------------------------------
 
     def score_configs_by_name(self) -> dict[str, dict]:
@@ -132,30 +127,29 @@ class LangfuseApi:
             body["configId"] = config_id
         self._post("/api/public/scores", body)
 
-    # -- traces -----------------------------------------------------------
+    # -- observations -----------------------------------------------------
 
     def find_trace_for_session(
         self, session_id: str, trace_name: str, from_timestamp: str
     ) -> str | None:
-        """Find the workflow trace whose metadata carries `session_id`.
-
-        The workflow root span doesn't set a Langfuse session, so we page
-        recent traces by name and match on metadata client-side.
-        """
-        page = 1
-        while page <= 10:
-            data = self._get(
-                "/api/public/traces",
-                name=trace_name,
-                fromTimestamp=from_timestamp,
-                orderBy="timestamp.desc",
-                page=page,
-                limit=50,
-            )
-            for trace in data.get("data") or []:
-                if (trace.get("metadata") or {}).get("session_id") == session_id:
-                    return trace.get("id")
-            if page >= (data.get("meta") or {}).get("totalPages", 1):
+        """Find the trace whose root span metadata carries `session_id`."""
+        cursor: str | None = None
+        for _ in range(MAX_OBSERVATION_PAGES):
+            params: dict[str, Any] = {
+                "name": trace_name,
+                "fields": "core,basic,metadata",
+                "fromStartTime": from_timestamp,
+                "toStartTime": _now_iso(),
+                "limit": OBSERVATION_PAGE_SIZE,
+            }
+            if cursor:
+                params["cursor"] = cursor
+            data = self._get("/api/public/v2/observations", **params)
+            rows = data.get("data") or []
+            for row in rows:
+                if (row.get("metadata") or {}).get("session_id") == session_id:
+                    return row.get("traceId")
+            cursor = (data.get("meta") or {}).get("cursor")
+            if not cursor or not rows:
                 break
-            page += 1
         return None

--- a/src/AI/agents/benchmarks/lf_api.py
+++ b/src/AI/agents/benchmarks/lf_api.py
@@ -14,6 +14,8 @@ from typing import Any
 
 import httpx
 
+from shared.utils.langfuse_public_api import root_span_filter
+
 MAX_OBSERVATION_PAGES = 10
 OBSERVATION_PAGE_SIZE = 50
 
@@ -141,6 +143,8 @@ class LangfuseApi:
                 "fromStartTime": from_timestamp,
                 "toStartTime": _now_iso(),
                 "limit": OBSERVATION_PAGE_SIZE,
+                # Child observations would otherwise consume the page budget.
+                "filter": root_span_filter(),
             }
             if cursor:
                 params["cursor"] = cursor

--- a/src/AI/agents/benchmarks/runner.py
+++ b/src/AI/agents/benchmarks/runner.py
@@ -122,7 +122,12 @@ def _load_attachments(item: dict, assets_dir: Path) -> list[dict]:
 
 
 def _start_agent(
-    base_url: str, session_id: str, goal: str, attachments: list[dict], branch: str | None = None
+    base_url: str,
+    session_id: str,
+    goal: str,
+    attachments: list[dict],
+    branch: str | None = None,
+    experiment: dict | None = None,
 ) -> None:
     repo_url = _bench_repo_url()
     payload = {
@@ -133,6 +138,8 @@ def _start_agent(
         "allow_app_changes": True,
         "attachments": attachments,
     }
+    if experiment:
+        payload["experiment"] = experiment
     if branch:
         payload["branch"] = branch
     response = httpx.post(
@@ -276,6 +283,22 @@ def _after_fix_scores(
 
 
 
+def _experiment_context(args, dataset_id: str, item_id: str) -> dict:
+    """The agent stamps this on its trace, so it is passed at start."""
+    return {
+        "experimentId": _experiment_id(args.run_name, dataset_id),
+        "experimentName": args.run_name,
+        "datasetId": dataset_id,
+        "itemId": item_id,
+        "description": args.run_description or None,
+    }
+
+
+def _experiment_id(run_name: str, dataset_id: str) -> str:
+    """Stable across the items of one run, distinct between runs."""
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"langfuse-experiment/{dataset_id}/{run_name}"))
+
+
 def cmd_ensure_configs(_: argparse.Namespace) -> None:
     lf = LangfuseApi()
     existing = lf.score_configs_by_name()
@@ -328,7 +351,13 @@ def cmd_run(args: argparse.Namespace) -> None:
         started_at = datetime.now(timezone.utc).isoformat()
         print(f"item {item['id']}: session {session_id}")
 
-        _start_agent(agent_base, session_id, goal, _load_attachments(item, assets_dir))
+        _start_agent(
+            agent_base,
+            session_id,
+            goal,
+            _load_attachments(item, assets_dir),
+            experiment=_experiment_context(args, item["datasetId"], item["id"]),
+        )
         status = _await_workflow(agent_base, session_id)
         completed = status.get("status") == "done" and bool(status.get("success", False))
         print(f"  workflow finished: {status.get('status')} success={status.get('success')}")
@@ -381,13 +410,7 @@ def cmd_run(args: argparse.Namespace) -> None:
             )
             print(f"  {score.name} = {score.value}  ({score.comment[:80]})")
 
-        lf.create_dataset_run_item(
-            run_name=args.run_name,
-            dataset_item_id=item["id"],
-            trace_id=trace_id,
-            run_description=args.run_description,
-        )
-        print(f"  linked trace {trace_id} into run {args.run_name!r}")
+        print(f"  trace {trace_id} is item {item['id']} of run {args.run_name!r}")
 
 
 def main() -> None:

--- a/src/AI/agents/benchmarks/runner.py
+++ b/src/AI/agents/benchmarks/runner.py
@@ -118,7 +118,12 @@ def _load_attachments(item: dict, assets_dir: Path) -> list[dict]:
 
 
 def _start_agent(
-    base_url: str, session_id: str, goal: str, attachments: list[dict], branch: str | None = None
+    base_url: str,
+    session_id: str,
+    goal: str,
+    attachments: list[dict],
+    branch: str | None = None,
+    experiment: dict | None = None,
 ) -> None:
     repo_url = _bench_repo_url()
     payload = {
@@ -129,6 +134,8 @@ def _start_agent(
         "allow_app_changes": True,
         "attachments": attachments,
     }
+    if experiment:
+        payload["experiment"] = experiment
     if branch:
         payload["branch"] = branch
     response = httpx.post(
@@ -256,6 +263,22 @@ def _after_fix_scores(
 
 
 
+def _experiment_context(args, dataset_id: str, item_id: str) -> dict:
+    """The agent stamps this on its trace, so it is passed at start."""
+    return {
+        "experimentId": _experiment_id(args.run_name, dataset_id),
+        "experimentName": args.run_name,
+        "datasetId": dataset_id,
+        "itemId": item_id,
+        "description": args.run_description or None,
+    }
+
+
+def _experiment_id(run_name: str, dataset_id: str) -> str:
+    """Stable across the items of one run, distinct between runs."""
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"langfuse-experiment/{dataset_id}/{run_name}"))
+
+
 def cmd_ensure_configs(_: argparse.Namespace) -> None:
     lf = LangfuseApi()
     existing = lf.score_configs_by_name()
@@ -308,7 +331,13 @@ def cmd_run(args: argparse.Namespace) -> None:
         started_at = datetime.now(timezone.utc).isoformat()
         print(f"item {item['id']}: session {session_id}")
 
-        _start_agent(agent_base, session_id, goal, _load_attachments(item, assets_dir))
+        _start_agent(
+            agent_base,
+            session_id,
+            goal,
+            _load_attachments(item, assets_dir),
+            experiment=_experiment_context(args, item["datasetId"], item["id"]),
+        )
         status = _await_workflow(agent_base, session_id)
         completed = status.get("status") == "done" and bool(status.get("success", False))
         print(f"  workflow finished: {status.get('status')} success={status.get('success')}")
@@ -361,13 +390,7 @@ def cmd_run(args: argparse.Namespace) -> None:
             )
             print(f"  {score.name} = {score.value}  ({score.comment[:80]})")
 
-        lf.create_dataset_run_item(
-            run_name=args.run_name,
-            dataset_item_id=item["id"],
-            trace_id=trace_id,
-            run_description=args.run_description,
-        )
-        print(f"  linked trace {trace_id} into run {args.run_name!r}")
+        print(f"  trace {trace_id} is item {item['id']} of run {args.run_name!r}")
 
 
 def main() -> None:

--- a/src/AI/agents/services/token_usage/langfuse_client.py
+++ b/src/AI/agents/services/token_usage/langfuse_client.py
@@ -1,12 +1,15 @@
-"""Fetches raw traces and observations from the Langfuse public API."""
+"""Fetches trace and generation rows from the Langfuse public API."""
 
 import asyncio
 from datetime import datetime
 from typing import Any
 
-import httpx
-
-from shared.utils.langfuse_public_api import PAGE_SIZE, create_public_api_client
+from shared.utils.langfuse_public_api import (
+    create_public_api_client,
+    fetch_observations,
+    root_span_filter,
+    type_filter,
+)
 
 
 async def fetch_traces_and_observations(
@@ -15,44 +18,34 @@ async def fetch_traces_and_observations(
     window_end: datetime,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     async with create_public_api_client() as client:
-        traces, observations = await asyncio.gather(
-            _fetch_all_pages(
+        root_spans, observations = await asyncio.gather(
+            fetch_observations(
                 client,
-                "/api/public/traces",
                 {
-                    "fromTimestamp": trace_window_start.isoformat(),
-                    "toTimestamp": window_end.isoformat(),
+                    "filter": root_span_filter(),
+                    "fields": "core,basic,metadata",
+                    "fromStartTime": trace_window_start.isoformat(),
+                    "toStartTime": window_end.isoformat(),
                 },
             ),
-            _fetch_all_pages(
+            fetch_observations(
                 client,
-                "/api/public/observations",
                 {
-                    "type": "GENERATION",
+                    "filter": type_filter("GENERATION"),
+                    "fields": "core,basic,usage,model",
                     "fromStartTime": observation_window_start.isoformat(),
                     "toStartTime": window_end.isoformat(),
                 },
             ),
         )
 
-    return traces, observations
+    return [_as_trace_payload(span) for span in root_spans], observations
 
 
-async def _fetch_all_pages(
-    client: httpx.AsyncClient,
-    path: str,
-    params: dict[str, Any],
-) -> list[dict[str, Any]]:
-    items: list[dict[str, Any]] = []
-    page_number = 1
-    while True:
-        response = await client.get(
-            path, params={**params, "limit": PAGE_SIZE, "page": page_number}
-        )
-        response.raise_for_status()
-        page_items = response.json().get("data") or []
-        items.extend(page_items)
-        if len(page_items) < PAGE_SIZE:
-            break
-        page_number += 1
-    return items
+def _as_trace_payload(root_span: dict[str, Any]) -> dict[str, Any]:
+    """A trace is represented by its root span, under a different id."""
+    return {
+        "id": root_span.get("traceId"),
+        "userId": root_span.get("userId"),
+        "metadata": root_span.get("metadata"),
+    }

--- a/src/AI/agents/services/traces/delete_expired_traces.py
+++ b/src/AI/agents/services/traces/delete_expired_traces.py
@@ -5,7 +5,11 @@ from datetime import datetime, timedelta, timezone
 import httpx
 
 from shared.config import get_config
-from shared.utils.langfuse_public_api import PAGE_SIZE, create_public_api_client
+from shared.utils.langfuse_public_api import (
+    create_public_api_client,
+    fetch_observations,
+    root_span_filter,
+)
 from shared.utils.logging_utils import get_logger
 
 log = get_logger(__name__)
@@ -13,6 +17,8 @@ log = get_logger(__name__)
 # Langfuse docs advises against more than 30-50 trace ids per DELETE request.
 DELETE_BATCH_SIZE = 30
 TRACES_PATH = "/api/public/traces"
+# The listing API requires a lower bound; the cutoff drives what is deleted.
+EARLIEST_START_TIME = "2020-01-01T00:00:00Z"
 
 
 async def delete_expired_traces() -> int:
@@ -39,31 +45,23 @@ async def _delete_traces_before(client: httpx.AsyncClient, cutoff: datetime) -> 
 async def _fetch_expired_trace_ids(
     client: httpx.AsyncClient, cutoff: datetime
 ) -> list[str]:
-    trace_ids: list[str] = []
-    page_number = 1
-    while True:
-        page_trace_ids = await _fetch_trace_id_page(client, cutoff, page_number)
-        trace_ids.extend(page_trace_ids)
-        if len(page_trace_ids) < PAGE_SIZE:
-            return trace_ids
-        page_number += 1
-
-
-async def _fetch_trace_id_page(
-    client: httpx.AsyncClient, cutoff: datetime, page_number: int
-) -> list[str]:
-    response = await client.get(
-        TRACES_PATH,
-        params={
-            "toTimestamp": cutoff.isoformat(),
-            "limit": PAGE_SIZE,
-            "page": page_number,
+    """One id per expired trace. Root spans repeat per trace, so dedupe."""
+    root_spans = await fetch_observations(
+        client,
+        {
+            "filter": root_span_filter(),
+            "fields": "core",
+            "fromStartTime": EARLIEST_START_TIME,
+            "toStartTime": cutoff.isoformat(),
             "environment": ["prod", "production"],
         },
     )
-    response.raise_for_status()
-    page_items = response.json().get("data") or []
-    return [item["id"] for item in page_items]
+    seen: dict[str, None] = {}
+    for span in root_spans:
+        trace_id = span.get("traceId")
+        if trace_id:
+            seen.setdefault(trace_id, None)
+    return list(seen)
 
 
 async def _delete_trace_batch(client: httpx.AsyncClient, trace_ids: list[str]) -> None:

--- a/src/AI/agents/shared/models/experiment.py
+++ b/src/AI/agents/shared/models/experiment.py
@@ -1,0 +1,43 @@
+"""Experiment identity for a benchmark run.
+
+A trace declares its own dataset-run membership through OTel attributes on its
+root span, so the caller that owns the dataset passes this in at session start.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+EXPERIMENT_ID = "langfuse.experiment.id"
+EXPERIMENT_NAME = "langfuse.experiment.name"
+EXPERIMENT_DATASET_ID = "langfuse.experiment.dataset.id"
+EXPERIMENT_DESCRIPTION = "langfuse.experiment.description"
+EXPERIMENT_ITEM_ID = "langfuse.experiment.item.id"
+EXPERIMENT_ITEM_ROOT_OBSERVATION_ID = "langfuse.experiment.item.root_observation_id"
+
+
+class ExperimentContext(BaseModel):
+    """One dataset item, run once."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    experiment_id: str = Field(alias="experimentId")
+    experiment_name: str = Field(alias="experimentName")
+    dataset_id: str = Field(alias="datasetId")
+    item_id: str = Field(alias="itemId")
+    description: Optional[str] = None
+
+    def span_attributes(self, root_observation_id: str) -> dict[str, str]:
+        """`root_observation_id` must be the root span's own id, per the spec."""
+        attributes = {
+            EXPERIMENT_ID: self.experiment_id,
+            EXPERIMENT_NAME: self.experiment_name,
+            EXPERIMENT_DATASET_ID: self.dataset_id,
+            EXPERIMENT_ITEM_ID: self.item_id,
+            EXPERIMENT_ITEM_ROOT_OBSERVATION_ID: root_observation_id,
+        }
+        if self.description:
+            attributes[EXPERIMENT_DESCRIPTION] = self.description
+        return attributes

--- a/src/AI/agents/shared/utils/langfuse_public_api.py
+++ b/src/AI/agents/shared/utils/langfuse_public_api.py
@@ -46,10 +46,19 @@ def type_filter(observation_type: str) -> str:
     )
 
 
+class ObservationsTruncated(RuntimeError):
+    """The window holds more rows than the page cap allows."""
+
+
 async def fetch_observations(
     client: httpx.AsyncClient, params: dict[str, Any]
 ) -> list[dict[str, Any]]:
-    """Page the observations API, which is cursor-based."""
+    """Page the observations API, which is cursor-based.
+
+    Raises `ObservationsTruncated` rather than returning a partial list: a
+    caller that deletes or reports on what it gets back cannot tell the
+    difference, and would under-delete or under-report in silence.
+    """
     items: list[dict[str, Any]] = []
     cursor: str | None = None
     for _ in range(MAX_PAGES):
@@ -63,5 +72,8 @@ async def fetch_observations(
         items.extend(page_items)
         cursor = (body.get("meta") or {}).get("cursor")
         if not cursor or not page_items:
-            break
-    return items
+            return items
+    raise ObservationsTruncated(
+        f"more than {MAX_PAGES * PAGE_SIZE} observations in the requested window; "
+        "narrow the time range"
+    )

--- a/src/AI/agents/shared/utils/langfuse_public_api.py
+++ b/src/AI/agents/shared/utils/langfuse_public_api.py
@@ -1,6 +1,8 @@
 """Builds an authenticated httpx client for the Langfuse public REST API."""
 
 import base64
+import json
+from typing import Any
 
 import httpx
 
@@ -8,6 +10,8 @@ from shared.config import get_config
 
 PAGE_SIZE = 50
 REQUEST_TIMEOUT_SECONDS = 30
+OBSERVATIONS_PATH = "/api/public/v2/observations"
+MAX_PAGES = 1000
 
 
 def create_public_api_client() -> httpx.AsyncClient:
@@ -27,3 +31,37 @@ def _basic_auth_header(public_key: str | None, secret_key: str | None) -> str:
         raise RuntimeError("Langfuse credentials are not configured")
     token = base64.b64encode(f"{public_key}:{secret_key}".encode()).decode()
     return f"Basic {token}"
+
+
+def root_span_filter() -> str:
+    """One row per trace: the root span carries its id, user and metadata."""
+    return json.dumps(
+        [{"column": "isRootObservation", "operator": "=", "value": True, "type": "boolean"}]
+    )
+
+
+def type_filter(observation_type: str) -> str:
+    return json.dumps(
+        [{"column": "type", "operator": "=", "value": observation_type, "type": "string"}]
+    )
+
+
+async def fetch_observations(
+    client: httpx.AsyncClient, params: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Page the observations API, which is cursor-based."""
+    items: list[dict[str, Any]] = []
+    cursor: str | None = None
+    for _ in range(MAX_PAGES):
+        page_params = {**params, "limit": PAGE_SIZE}
+        if cursor:
+            page_params["cursor"] = cursor
+        response = await client.get(OBSERVATIONS_PATH, params=page_params)
+        response.raise_for_status()
+        body = response.json()
+        page_items = body.get("data") or []
+        items.extend(page_items)
+        cursor = (body.get("meta") or {}).get("cursor")
+        if not cursor or not page_items:
+            break
+    return items

--- a/src/AI/agents/tests/api/routes/test_traces_delete_expired.py
+++ b/src/AI/agents/tests/api/routes/test_traces_delete_expired.py
@@ -7,7 +7,7 @@ import httpx
 from fastapi.testclient import TestClient
 
 from api.main import app
-from services.traces.delete_expired_traces import PAGE_SIZE
+from shared.utils.langfuse_public_api import PAGE_SIZE
 
 TRACE_CLEANUP_PATH = "/api/traces/delete-expired"
 LANGFUSE_CONFIG = SimpleNamespace(
@@ -47,8 +47,11 @@ def _stateful_handler(remaining: list[str], deleted_batches: list[list[str]]):
             for trace_id in batch:
                 remaining.remove(trace_id)
             return httpx.Response(200, json={})
-        page = [{"id": trace_id} for trace_id in remaining[:PAGE_SIZE]]
-        return httpx.Response(200, json={"data": page})
+        page = [
+            {"id": f"span-{trace_id}", "traceId": trace_id}
+            for trace_id in remaining[:PAGE_SIZE]
+        ]
+        return httpx.Response(200, json={"data": page, "meta": {}})
 
     return handler
 

--- a/src/AI/agents/tests/services/token_usage/test_langfuse_client.py
+++ b/src/AI/agents/tests/services/token_usage/test_langfuse_client.py
@@ -3,7 +3,14 @@ import json
 import httpx
 
 from services.token_usage.langfuse_client import _as_trace_payload
-from shared.utils.langfuse_public_api import PAGE_SIZE, fetch_observations
+import pytest
+
+from shared.utils.langfuse_public_api import (
+    MAX_PAGES,
+    PAGE_SIZE,
+    ObservationsTruncated,
+    fetch_observations,
+)
 
 
 class TestFetchObservations:
@@ -33,6 +40,17 @@ class TestFetchObservations:
 
         assert items == []
         assert cursors == [None]
+
+
+    async def test_hitting_the_page_cap_raises_instead_of_truncating(self):
+        """A caller that deletes or reports on the result cannot tell a partial
+        list from a complete one."""
+        client, _ = _create_client_mock(
+            [(_rows(PAGE_SIZE), f"CUR{i}") for i in range(MAX_PAGES)]
+        )
+
+        with pytest.raises(ObservationsTruncated):
+            await fetch_observations(client, {})
 
 
 class TestAsTracePayload:

--- a/src/AI/agents/tests/services/token_usage/test_langfuse_client.py
+++ b/src/AI/agents/tests/services/token_usage/test_langfuse_client.py
@@ -1,45 +1,78 @@
+import json
+
 import httpx
 
-from services.token_usage.langfuse_client import PAGE_SIZE, _fetch_all_pages
+from services.token_usage.langfuse_client import _as_trace_payload
+from shared.utils.langfuse_public_api import PAGE_SIZE, fetch_observations
 
 
-class TestFetchAllPages:
-    async def test_stops_on_a_short_page(self):
-        client, requested_pages = _create_client_mock(
-            {1: _make_page_items(PAGE_SIZE - 1)}
+class TestFetchObservations:
+    async def test_stops_when_no_cursor_comes_back(self):
+        client, cursors = _create_client_mock([(_rows(3), None)])
+
+        items = await fetch_observations(client, {})
+
+        assert len(items) == 3
+        assert cursors == [None]
+
+    async def test_follows_the_cursor_across_pages(self):
+        client, cursors = _create_client_mock(
+            [(_rows(PAGE_SIZE), "CUR1"), (_rows(2), None)]
         )
 
-        items = await _fetch_all_pages(client, "/api/public/traces", {})
+        items = await fetch_observations(client, {})
 
-        assert len(items) == PAGE_SIZE - 1
-        assert requested_pages == [1]
+        assert len(items) == PAGE_SIZE + 2
+        assert cursors == [None, "CUR1"]
 
-    async def test_advances_on_a_full_page(self):
-        client, requested_pages = _create_client_mock(
-            {1: _make_page_items(PAGE_SIZE), 2: _make_page_items(3)}
+    async def test_stops_on_an_empty_page_even_with_a_cursor(self):
+        """A cursor that never clears must not page forever."""
+        client, cursors = _create_client_mock([([], "CUR1")])
+
+        items = await fetch_observations(client, {})
+
+        assert items == []
+        assert cursors == [None]
+
+
+class TestAsTracePayload:
+    def test_maps_the_root_span_onto_a_trace(self):
+        """A trace is its root span, so the id lives in traceId."""
+        payload = _as_trace_payload(
+            {
+                "id": "span-1",
+                "traceId": "trace-1",
+                "userId": "dev",
+                "metadata": {"session_id": "s1"},
+            }
         )
 
-        items = await _fetch_all_pages(client, "/api/public/traces", {})
+        assert payload == {
+            "id": "trace-1",
+            "userId": "dev",
+            "metadata": {"session_id": "s1"},
+        }
 
-        assert len(items) == PAGE_SIZE + 3
-        assert requested_pages == [1, 2]
+    def test_missing_fields_do_not_raise(self):
+        assert _as_trace_payload({}) == {"id": None, "userId": None, "metadata": None}
 
 
-def _make_page_items(count: int) -> list[dict]:
-    return [{"id": i} for i in range(count)]
+def _rows(count: int) -> list[dict]:
+    return [{"id": f"span-{i}", "traceId": f"trace-{i}"} for i in range(count)]
 
 
-def _create_client_mock(
-    pages_by_number: dict[int, list[dict]],
-) -> tuple[httpx.AsyncClient, list[int]]:
-    requested_pages: list[int] = []
+def _create_client_mock(pages) -> tuple[httpx.AsyncClient, list]:
+    seen_cursors: list = []
+    remaining = list(pages)
 
     def handler(request: httpx.Request) -> httpx.Response:
-        page = int(request.url.params["page"])
-        requested_pages.append(page)
-        return httpx.Response(200, json={"data": pages_by_number.get(page, [])})
+        seen_cursors.append(request.url.params.get("cursor"))
+        rows, cursor = remaining.pop(0) if remaining else ([], None)
+        return httpx.Response(
+            200, json={"data": rows, "meta": {"cursor": cursor} if cursor else {}}
+        )
 
     client = httpx.AsyncClient(
         base_url="https://langfuse.test", transport=httpx.MockTransport(handler)
     )
-    return client, requested_pages
+    return client, seen_cursors

--- a/src/AI/agents/tests/services/traces/test_delete_expired_traces.py
+++ b/src/AI/agents/tests/services/traces/test_delete_expired_traces.py
@@ -5,10 +5,10 @@ import httpx
 
 from services.traces.delete_expired_traces import (
     DELETE_BATCH_SIZE,
-    PAGE_SIZE,
     _delete_traces_before,
-    _fetch_trace_id_page,
+    _fetch_expired_trace_ids,
 )
+from shared.utils.langfuse_public_api import PAGE_SIZE
 
 CUTOFF = datetime(2026, 4, 2, 12, 0, tzinfo=timezone.utc)
 
@@ -53,9 +53,10 @@ class TestFetchTraceIdPage:
 
         client = _client_with_handler(handler)
 
-        await _fetch_trace_id_page(client, CUTOFF, page_number=1)
+        await _fetch_expired_trace_ids(client, CUTOFF)
 
-        assert captured_params["toTimestamp"] == CUTOFF.isoformat()
+        assert captured_params["toStartTime"] == CUTOFF.isoformat()
+        assert "isRootObservation" in captured_params["filter"]
 
     async def test_filters_on_production_environments_only(self):
         captured_environments: list[str] = []
@@ -68,7 +69,7 @@ class TestFetchTraceIdPage:
 
         client = _client_with_handler(handler)
 
-        await _fetch_trace_id_page(client, CUTOFF, page_number=1)
+        await _fetch_expired_trace_ids(client, CUTOFF)
 
         assert captured_environments == ["prod", "production"]
 
@@ -89,15 +90,24 @@ def _create_client_mock(
         if request.method == "DELETE":
             deleted_batches.append(_read_trace_ids(request))
             return httpx.Response(200, json={})
-        page = _page_of(all_trace_ids, int(request.url.params["page"]))
-        return httpx.Response(200, json={"data": [{"id": tid} for tid in page]})
+        cursor = request.url.params.get("cursor")
+        page, next_cursor = _page_of(all_trace_ids, cursor)
+        return httpx.Response(
+            200,
+            json={
+                "data": [{"id": f"span-{tid}", "traceId": tid} for tid in page],
+                "meta": {"cursor": next_cursor} if next_cursor else {},
+            },
+        )
 
     return _client_with_handler(handler), deleted_batches
 
 
-def _page_of(trace_ids: list[str], page_number: int) -> list[str]:
-    start = (page_number - 1) * PAGE_SIZE
-    return trace_ids[start : start + PAGE_SIZE]
+def _page_of(trace_ids: list[str], cursor: str | None) -> tuple[list[str], str | None]:
+    start = int(cursor) if cursor else 0
+    page = trace_ids[start : start + PAGE_SIZE]
+    nxt = start + PAGE_SIZE
+    return page, str(nxt) if nxt < len(trace_ids) else None
 
 
 def _read_trace_ids(request: httpx.Request) -> list[str]:

--- a/src/AI/agents/tests/unit/benchmarks/test_lf_api.py
+++ b/src/AI/agents/tests/unit/benchmarks/test_lf_api.py
@@ -1,0 +1,71 @@
+"""The trace lookup reads observation rows and takes `traceId` off the root span."""
+
+from __future__ import annotations
+
+import pytest
+
+from benchmarks.lf_api import LangfuseApi
+
+
+class _Api(LangfuseApi):
+    """Bypass __init__ so no credentials or HTTP client are needed."""
+
+    def __init__(self, pages):
+        self._pages = list(pages)
+        self.calls = []
+
+    def _get(self, path, **params):
+        self.calls.append((path, params))
+        return self._pages.pop(0) if self._pages else {"data": [], "meta": {}}
+
+
+def _row(session_id, trace_id, name="Altinity Agent Workflow"):
+    return {"traceId": trace_id, "name": name, "metadata": {"session_id": session_id}}
+
+
+class TestFindTraceForSession:
+    def test_reads_the_trace_id_off_the_matching_root_span(self):
+        api = _Api([{"data": [_row("sess-a", "trace-a"), _row("sess-b", "trace-b")], "meta": {}}])
+
+        assert api.find_trace_for_session("sess-b", "Altinity Agent Workflow", "2026-01-01") == "trace-b"
+
+    def test_queries_the_observations_endpoint(self):
+        api = _Api([{"data": [_row("sess-a", "trace-a")], "meta": {}}])
+        api.find_trace_for_session("sess-a", "Altinity Agent Workflow", "2026-01-01")
+
+        path, params = api.calls[0]
+        assert path == "/api/public/v2/observations"
+
+    def test_asks_for_metadata_and_a_bounded_window(self):
+        """metadata is outside the default field set, and the window is required."""
+        api = _Api([{"data": [_row("sess-a", "trace-a")], "meta": {}}])
+        api.find_trace_for_session("sess-a", "Altinity Agent Workflow", "2026-01-01")
+
+        _, params = api.calls[0]
+        assert "metadata" in params["fields"]
+        assert params["fromStartTime"] == "2026-01-01"
+        assert params["toStartTime"]
+        assert params["name"] == "Altinity Agent Workflow"
+
+    def test_follows_the_cursor_to_the_next_page(self):
+        api = _Api(
+            [
+                {"data": [_row("other", "trace-x")], "meta": {"cursor": "CURSOR1"}},
+                {"data": [_row("sess-a", "trace-a")], "meta": {}},
+            ]
+        )
+
+        assert api.find_trace_for_session("sess-a", "Altinity Agent Workflow", "2026-01-01") == "trace-a"
+        assert api.calls[1][1]["cursor"] == "CURSOR1"
+
+    def test_no_match_returns_none(self):
+        api = _Api([{"data": [_row("other", "trace-x")], "meta": {}}])
+
+        assert api.find_trace_for_session("missing", "Altinity Agent Workflow", "2026-01-01") is None
+
+    def test_stops_instead_of_paging_forever(self):
+        """A cursor that never clears must not loop indefinitely."""
+        api = _Api([{"data": [_row("other", "t")], "meta": {"cursor": "SAME"}} for _ in range(50)])
+
+        assert api.find_trace_for_session("missing", "Altinity Agent Workflow", "2026-01-01") is None
+        assert len(api.calls) <= 10

--- a/src/AI/agents/tests/unit/benchmarks/test_lf_api.py
+++ b/src/AI/agents/tests/unit/benchmarks/test_lf_api.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from benchmarks.lf_api import LangfuseApi
@@ -46,6 +48,17 @@ class TestFindTraceForSession:
         assert params["fromStartTime"] == "2026-01-01"
         assert params["toStartTime"]
         assert params["name"] == "Altinity Agent Workflow"
+
+    def test_restricts_the_query_to_root_observations(self):
+        """Child observations would otherwise use up the page budget before the
+        root span carrying the session id is reached."""
+        api = _Api([{"data": [_row("sess-a", "trace-a")], "meta": {}}])
+        api.find_trace_for_session("sess-a", "Altinity Agent Workflow", "2026-01-01")
+
+        _, params = api.calls[0]
+        assert json.loads(params["filter"]) == [
+            {"column": "isRootObservation", "operator": "=", "value": True, "type": "boolean"}
+        ]
 
     def test_follows_the_cursor_to_the_next_page(self):
         api = _Api(

--- a/src/AI/agents/tests/unit/test_experiment_context.py
+++ b/src/AI/agents/tests/unit/test_experiment_context.py
@@ -1,0 +1,103 @@
+"""A benchmark trace declares its own dataset-run membership."""
+
+from __future__ import annotations
+
+import pytest
+
+from shared.models.experiment import (
+    EXPERIMENT_DATASET_ID,
+    EXPERIMENT_DESCRIPTION,
+    EXPERIMENT_ID,
+    EXPERIMENT_ITEM_ID,
+    EXPERIMENT_ITEM_ROOT_OBSERVATION_ID,
+    EXPERIMENT_NAME,
+    ExperimentContext,
+)
+
+
+def _context(**overrides) -> ExperimentContext:
+    base = dict(
+        experimentId="exp-1",
+        experimentName="nightly-2026-08-21",
+        datasetId="ds-1",
+        itemId="item-1",
+    )
+    base.update(overrides)
+    return ExperimentContext(**base)
+
+
+class TestSpanAttributes:
+    def test_emits_the_attribute_names_langfuse_reads(self):
+        attributes = _context().span_attributes("root-span-id")
+
+        assert attributes[EXPERIMENT_ID] == "exp-1"
+        assert attributes[EXPERIMENT_NAME] == "nightly-2026-08-21"
+        assert attributes[EXPERIMENT_DATASET_ID] == "ds-1"
+        assert attributes[EXPERIMENT_ITEM_ID] == "item-1"
+
+    def test_root_observation_id_is_the_span_it_sits_on(self):
+        """Langfuse requires this to equal the root span's own id."""
+        attributes = _context().span_attributes("root-span-id")
+
+        assert attributes[EXPERIMENT_ITEM_ROOT_OBSERVATION_ID] == "root-span-id"
+
+    def test_description_is_omitted_rather_than_sent_empty(self):
+        assert EXPERIMENT_DESCRIPTION not in _context().span_attributes("r")
+        assert EXPERIMENT_DESCRIPTION not in _context(description="").span_attributes("r")
+
+    def test_description_is_included_when_set(self):
+        attributes = _context(description="all benchmarks").span_attributes("r")
+
+        assert attributes[EXPERIMENT_DESCRIPTION] == "all benchmarks"
+
+    def test_every_value_is_a_string(self):
+        """OTel attributes are typed; a non-string would be dropped."""
+        attributes = _context(description="d").span_attributes("r")
+
+        assert all(isinstance(v, str) for v in attributes.values())
+
+    def test_the_identifying_fields_are_required(self):
+        with pytest.raises(Exception):
+            ExperimentContext(experimentName="n", datasetId="d", itemId="i")
+
+
+class TestRunnerWiring:
+    def test_the_agent_stamps_the_attributes_on_the_root_span(self, monkeypatch):
+        """Without this the trace is never part of the run."""
+        from types import SimpleNamespace
+        from agents.graph import runner
+
+        recorded: dict[str, str] = {}
+        span = SimpleNamespace(
+            is_recording=lambda: True,
+            set_attribute=lambda k, v: recorded.__setitem__(k, v),
+        )
+        monkeypatch.setattr(runner.otel_trace, "get_current_span", lambda: span)
+
+        state = SimpleNamespace(experiment=_context())
+        runner._mark_as_experiment_item(state, SimpleNamespace(id="root-1"))
+
+        assert recorded[EXPERIMENT_NAME] == "nightly-2026-08-21"
+        assert recorded[EXPERIMENT_ITEM_ROOT_OBSERVATION_ID] == "root-1"
+
+    def test_an_ordinary_run_stamps_nothing(self, monkeypatch):
+        from types import SimpleNamespace
+        from agents.graph import runner
+
+        recorded: dict[str, str] = {}
+        span = SimpleNamespace(
+            is_recording=lambda: True,
+            set_attribute=lambda k, v: recorded.__setitem__(k, v),
+        )
+        monkeypatch.setattr(runner.otel_trace, "get_current_span", lambda: span)
+
+        runner._mark_as_experiment_item(SimpleNamespace(experiment=None), SimpleNamespace(id="r"))
+
+        assert recorded == {}
+
+    def test_run_once_actually_calls_it(self):
+        """Guards the call site: the helper is useless if nothing invokes it."""
+        import inspect
+        from agents.graph import runner
+
+        assert "_mark_as_experiment_item(state, root_span)" in inspect.getsource(runner.run_once)

--- a/src/AI/agents/tests/unit/test_experiment_context.py
+++ b/src/AI/agents/tests/unit/test_experiment_context.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
 from shared.models.experiment import (
     EXPERIMENT_DATASET_ID,
@@ -57,7 +58,7 @@ class TestSpanAttributes:
         assert all(isinstance(v, str) for v in attributes.values())
 
     def test_the_identifying_fields_are_required(self):
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             ExperimentContext(experimentName="n", datasetId="d", itemId="i")
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Moves every Langfuse consumer in the agent onto the APIs that replace the ones being retired. Behaviour is unchanged; this is a swap of read paths plus one mechanism that had to be rebuilt.

`langfuse.digdir.cloud` was upgraded from 3.225.4 to 4.4.0 and currently serves both old and new APIs, so nothing breaks today either way. This lands the code so the final switchover is a config change rather than a scramble.

**Stacked on #20096**, so it inherits #19710 → #20092 → #20096 and cannot merge before them.

## What changed in Langfuse, and what it buys us

v4 replaces a trace-and-observation model with an observations-first one, built on a wide, mostly immutable ClickHouse table. Reads no longer join and deduplicate, which is why the read APIs were redesigned rather than extended, and why the old ones are going away instead of being kept as aliases.

| | Before | After |
| --- | --- | --- |
| Read shape | full rows, every column scanned | field groups, only what you ask for |
| Paging | page numbers | cursors |
| Trace object | first-class | represented by its root span |
| Dataset runs | trace linked in afterwards | trace declares its own membership |
| Scores | v1 and v2 read APIs | v3 read API, writes unchanged |

Three things this actually gives us:

**Faster reads.** On our own instance, an equivalent listing query over the same 7-day window took 443 ms on the old endpoint and 82 ms on the new one. That is a single sample rather than a controlled benchmark, and the new call requested only the `core` field group, which is exactly the point: we now ask for the columns we use. The token usage job reads two field groups instead of whole rows.

**Paging that cannot skip rows.** Page-number paging over a dataset that is being written to can miss or repeat rows between pages. That matters most for the retention job, where a skipped row is a trace that never gets deleted. Cursors remove the failure mode.

**Features that need the new model.** Full-text search across inputs, outputs and metadata, the filter search bar, alerts, and the Metrics API v2 are only available on it. Alerts are the interesting one for us: benchmark scores are booleans and ratios, so a regression in `bench_*` or a drop in judge scores can page us instead of waiting to be noticed in a run table.

There is also a deadline. Langfuse v3 receives security patches only until the end of January 2027.

## Reads move to the observations API

`GET /api/public/traces` and `GET /api/public/observations` are going away. The replacement returns observation rows rather than trace objects, so a trace is represented by its root span and the id, user and metadata are read from there.

Three details the API imposes, all easy to get wrong:

- `metadata` sits outside the default field set and has to be requested
- the time window is mandatory
- paging is cursor-based, not page numbers

Three consumers were affected, and the paging and filter helpers now live in `shared/utils/langfuse_public_api.py` so they cannot drift apart:

| Consumer | What it does |
| --- | --- |
| `benchmarks/lf_api.py` | finds the trace for a session |
| `services/token_usage/langfuse_client.py` | token and cost reporting |
| `services/traces/delete_expired_traces.py` | trace retention |

The retention job is the one worth a second look. Its listing call was going to start returning nothing, and because the job then simply finds no traces to delete, retention would have stopped silently and data would have accumulated indefinitely.

## Dataset run membership had to be rebuilt

This part is not a URL swap. There is no endpoint that links an existing trace into a dataset run. `POST /api/public/dataset-run-items` is retained as a compatibility path that **accepts the call and returns a stale object**, so a benchmark run would keep looking successful while the link was silently wrong. I confirmed that against the live instance: the write reported success with an id, and three minutes later the run was still invisible to the experiments API. `POST` on both experiment endpoints returns 405.

So a trace now declares its own membership. The benchmark runner passes an experiment context when it starts a session, and the agent stamps `langfuse.experiment.*` attributes on the workflow root span, with the item's root observation id set to that span's own id as the spec requires. `experimentId` is a UUID5 of dataset plus run name, stable across the items of one run and distinct between runs.

`create_dataset_run_item` is deleted rather than left as a trap.

## Deliberately unchanged

**Score writes.** `POST /api/public/v3/scores` returns 405; that surface is read-only. `POST /api/public/scores` keeps its contract and was confirmed working, so `create_score` is untouched.

**Trace deletion.** `DELETE /api/public/traces` is unaffected and verified. Only the listing side changed.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

367 tests pass, 17 of them new: cursor paging including a guard against a cursor that never clears, the field groups and bounded window, root-span-to-trace mapping, trace id deduplication, the experiment attribute names and the root observation id constraint, and a guard that fails if the agent stops stamping the attributes.

Manual, against a live instance:

| Check | Result |
| --- | --- |
| Benchmark run | experiment created, trace linked, 7/7 bench scores, `benchmark-rubric-match` 0.9 |
| Assistant session | trace found by the migrated lookup, all four judges fired |
| Token usage | 175 traces and 581 generations, every consumed field populated, aggregation correct |
| Retention listing | expected traces listed, ids unique |

## Note for reviewers

Two tests in the first draft passed while the code was broken, so both now assert the call site rather than the helper in isolation. A missing import in `runner.py` was caught this way and would have crashed every benchmark run.

Unrelated and pre-existing: `aggregate_token_usage` raises `Missing service owner code` for traces without a user id, which evaluator traces never have. That fires on the old API too and deserves its own issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added experiment context support for agent workflows, including experiment, dataset and item metadata.
  - Experiment details are now attached to workflow traces for improved observability and benchmark analysis.

- **Improvements**
  - Improved trace and observation retrieval with cursor-based pagination and reliable session matching.
  - Enhanced expired-trace discovery and clean-up using root workflow observations.
  - Added safeguards to detect incomplete observation results.

- **Tests**
  - Added coverage for experiment tagging, trace retrieval, pagination and clean-up scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->