### PR TITLE
chore: replace chip direct import with studio wrappers

### DIFF
--- a/src/Designer/frontend/libs/studio-components/src/components/StudioChip/StudioChip.stories.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioChip/StudioChip.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { StudioChip } from './';
+
+const meta = {
+  title: 'Components/StudioChip',
+  component: StudioChip.Button,
+} satisfies Meta;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Preview: Story = {
+  args: {
+    children: 'Click me',
+  },
+};
+
+export const Removable: Story = {
+  render: () => <StudioChip.Removable>Click to remove me</StudioChip.Removable>,
+};
+
+export const Checkboxes: Story = {
+  render: () => (
+    <>
+      <StudioChip.Checkbox name='language' value='nynorsk'>
+        Nynorsk
+      </StudioChip.Checkbox>
+      <StudioChip.Checkbox name='language' value='bokmål'>
+        Bokmål
+      </StudioChip.Checkbox>
+    </>
+  ),
+};
+
+export const Radios: Story = {
+  render: () => (
+    <>
+      <StudioChip.Radio name='written-language' value='nynorsk'>
+        Nynorsk
+      </StudioChip.Radio>
+      <StudioChip.Radio name='written-language' value='bokmål'>
+        Bokmål
+      </StudioChip.Radio>
+    </>
+  ),
+};

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioChip/StudioChip.test.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioChip/StudioChip.test.tsx
@@ -1,0 +1,186 @@
+import type { ForwardedRef } from 'react';
+import { render, screen } from '@testing-library/react';
+import type { RenderResult } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { StudioChip } from './';
+import type {
+  StudioChipButtonProps,
+  StudioChipCheckboxProps,
+  StudioChipRadioProps,
+  StudioChipRemovableProps,
+} from './';
+import { getFirstBySelector } from '../../test-utils/selectors';
+import { testCustomAttributes } from '../../test-utils/testCustomAttributes';
+import { testRefForwarding } from '../../test-utils/testRefForwarding';
+import { testRootClassNameAppending } from '../../test-utils/testRootClassNameAppending';
+
+const label: string = 'Norwegian';
+
+describe('StudioChip', () => {
+  describe('StudioChip.Button', () => {
+    it('Renders a button with the given label', () => {
+      renderButton();
+      expect(getButton()).toBeInTheDocument();
+    });
+
+    it('Calls the onClick callback when the user clicks the chip', async () => {
+      const user = userEvent.setup();
+      const onClick = jest.fn();
+      renderButton({ onClick });
+      await user.click(getButton());
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('Appends given classname to internal classname', () => {
+      testRootClassNameAppending((className) => renderButton({ className }));
+    });
+
+    it('Appends custom attributes to the button element', () => {
+      testCustomAttributes<HTMLButtonElement, StudioChipButtonProps>(renderButton);
+    });
+
+    it('Supports forwarding the ref', () => {
+      testRefForwarding<HTMLButtonElement>((ref) => renderButton({}, ref));
+    });
+  });
+
+  describe('StudioChip.Removable', () => {
+    it('Renders a removable button with the given label', () => {
+      renderRemovable();
+      expect(getButton()).toHaveAttribute('data-removable', 'true');
+    });
+
+    it('Calls the onClick callback when the user clicks the chip', async () => {
+      const user = userEvent.setup();
+      const onClick = jest.fn();
+      renderRemovable({ onClick });
+      await user.click(getButton());
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('Appends given classname to internal classname', () => {
+      testRootClassNameAppending((className) => renderRemovable({ className }));
+    });
+
+    it('Appends custom attributes to the button element', () => {
+      testCustomAttributes<HTMLButtonElement, StudioChipRemovableProps>(renderRemovable);
+    });
+
+    it('Supports forwarding the ref', () => {
+      testRefForwarding<HTMLButtonElement>((ref) => renderRemovable({}, ref));
+    });
+  });
+
+  describe('StudioChip.Checkbox', () => {
+    it('Renders a checkbox with the given label', () => {
+      renderCheckbox();
+      expect(getCheckbox()).toBeInTheDocument();
+    });
+
+    it('Reflects the checked state', () => {
+      renderCheckbox({ checked: true, onChange: jest.fn() });
+      expect(getCheckbox()).toBeChecked();
+    });
+
+    it('Calls the onChange callback when the user clicks the chip', async () => {
+      const user = userEvent.setup();
+      const onChange = jest.fn();
+      renderCheckbox({ onChange });
+      await user.click(getCheckbox());
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('Appends given classname to internal classname', () => {
+      testRootClassNameAppending((className) => renderCheckbox({ className }));
+    });
+
+    it('Appends custom attributes to the input element', () => {
+      testCustomAttributes<HTMLInputElement, StudioChipCheckboxProps>(renderCheckbox, getInput);
+    });
+
+    it('Supports forwarding the ref', () => {
+      testRefForwarding<HTMLLabelElement>((ref) => renderCheckbox({}, ref));
+    });
+  });
+
+  describe('StudioChip.Radio', () => {
+    it('Renders a radio button with the given label', () => {
+      renderRadio();
+      expect(getRadio()).toBeInTheDocument();
+    });
+
+    it('Reflects the checked state', () => {
+      renderRadio({ checked: true, onChange: jest.fn() });
+      expect(getRadio()).toBeChecked();
+    });
+
+    it('Calls the onChange callback when the user clicks the chip', async () => {
+      const user = userEvent.setup();
+      const onChange = jest.fn();
+      renderRadio({ onChange });
+      await user.click(getRadio());
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('Appends given classname to internal classname', () => {
+      testRootClassNameAppending((className) => renderRadio({ className }));
+    });
+
+    it('Appends custom attributes to the input element', () => {
+      testCustomAttributes<HTMLInputElement, StudioChipRadioProps>(renderRadio, getInput);
+    });
+
+    it('Supports forwarding the ref', () => {
+      testRefForwarding<HTMLLabelElement>((ref) => renderRadio({}, ref));
+    });
+  });
+});
+
+const renderButton = (
+  props: Partial<StudioChipButtonProps> = {},
+  ref?: ForwardedRef<HTMLButtonElement>,
+): RenderResult =>
+  render(
+    <StudioChip.Button {...props} ref={ref}>
+      {label}
+    </StudioChip.Button>,
+  );
+
+const renderRemovable = (
+  props: Partial<StudioChipRemovableProps> = {},
+  ref?: ForwardedRef<HTMLButtonElement>,
+): RenderResult =>
+  render(
+    <StudioChip.Removable {...props} ref={ref}>
+      {label}
+    </StudioChip.Removable>,
+  );
+
+const renderCheckbox = (
+  props: Partial<StudioChipCheckboxProps> = {},
+  ref?: ForwardedRef<HTMLLabelElement>,
+): RenderResult =>
+  render(
+    <StudioChip.Checkbox {...props} ref={ref}>
+      {label}
+    </StudioChip.Checkbox>,
+  );
+
+const renderRadio = (
+  props: Partial<StudioChipRadioProps> = {},
+  ref?: ForwardedRef<HTMLLabelElement>,
+): RenderResult =>
+  render(
+    <StudioChip.Radio {...props} ref={ref}>
+      {label}
+    </StudioChip.Radio>,
+  );
+
+const getButton = (): HTMLButtonElement => screen.getByRole('button', { name: label });
+
+const getCheckbox = (): HTMLInputElement => screen.getByRole('checkbox', { name: label });
+
+const getRadio = (): HTMLInputElement => screen.getByRole('radio', { name: label });
+
+const getInput = (container: RenderResult['container']): HTMLInputElement =>
+  getFirstBySelector<HTMLInputElement>(container, 'input');

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioChip/StudioChipButton.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioChip/StudioChipButton.tsx
@@ -1,0 +1,23 @@
+import { forwardRef } from 'react';
+import type { ReactElement, Ref } from 'react';
+import { Chip } from '@digdir/designsystemet-react';
+import type { ChipButtonProps } from '@digdir/designsystemet-react';
+import type { WithoutAsChild } from '../../types/WithoutAsChild';
+
+export type StudioChipButtonProps = WithoutAsChild<ChipButtonProps>;
+
+function StudioChipButton(
+  { children, ...rest }: StudioChipButtonProps,
+  ref: Ref<HTMLButtonElement>,
+): ReactElement {
+  return (
+    <Chip.Button ref={ref} {...rest}>
+      {children}
+    </Chip.Button>
+  );
+}
+
+const ForwardedStudioChipButton = forwardRef(StudioChipButton);
+ForwardedStudioChipButton.displayName = 'StudioChip.Button';
+
+export { ForwardedStudioChipButton as StudioChipButton };

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioChip/StudioChipCheckbox.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioChip/StudioChipCheckbox.tsx
@@ -1,0 +1,23 @@
+import { forwardRef } from 'react';
+import type { ReactElement, Ref } from 'react';
+import { Chip } from '@digdir/designsystemet-react';
+import type { ChipCheckboxProps } from '@digdir/designsystemet-react';
+import type { WithoutAsChild } from '../../types/WithoutAsChild';
+
+export type StudioChipCheckboxProps = WithoutAsChild<ChipCheckboxProps>;
+
+function StudioChipCheckbox(
+  { children, ...rest }: StudioChipCheckboxProps,
+  ref: Ref<HTMLLabelElement>,
+): ReactElement {
+  return (
+    <Chip.Checkbox ref={ref} {...rest}>
+      {children}
+    </Chip.Checkbox>
+  );
+}
+
+const ForwardedStudioChipCheckbox = forwardRef(StudioChipCheckbox);
+ForwardedStudioChipCheckbox.displayName = 'StudioChip.Checkbox';
+
+export { ForwardedStudioChipCheckbox as StudioChipCheckbox };

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioChip/StudioChipRadio.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioChip/StudioChipRadio.tsx
@@ -1,0 +1,23 @@
+import { forwardRef } from 'react';
+import type { ReactElement, Ref } from 'react';
+import { Chip } from '@digdir/designsystemet-react';
+import type { ChipRadioProps } from '@digdir/designsystemet-react';
+import type { WithoutAsChild } from '../../types/WithoutAsChild';
+
+export type StudioChipRadioProps = WithoutAsChild<ChipRadioProps>;
+
+function StudioChipRadio(
+  { children, ...rest }: StudioChipRadioProps,
+  ref: Ref<HTMLLabelElement>,
+): ReactElement {
+  return (
+    <Chip.Radio ref={ref} {...rest}>
+      {children}
+    </Chip.Radio>
+  );
+}
+
+const ForwardedStudioChipRadio = forwardRef(StudioChipRadio);
+ForwardedStudioChipRadio.displayName = 'StudioChip.Radio';
+
+export { ForwardedStudioChipRadio as StudioChipRadio };

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioChip/StudioChipRemovable.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioChip/StudioChipRemovable.tsx
@@ -1,0 +1,23 @@
+import { forwardRef } from 'react';
+import type { ReactElement, Ref } from 'react';
+import { Chip } from '@digdir/designsystemet-react';
+import type { ChipRemovableProps } from '@digdir/designsystemet-react';
+import type { WithoutAsChild } from '../../types/WithoutAsChild';
+
+export type StudioChipRemovableProps = WithoutAsChild<ChipRemovableProps>;
+
+function StudioChipRemovable(
+  { children, ...rest }: StudioChipRemovableProps,
+  ref: Ref<HTMLButtonElement>,
+): ReactElement {
+  return (
+    <Chip.Removable ref={ref} {...rest}>
+      {children}
+    </Chip.Removable>
+  );
+}
+
+const ForwardedStudioChipRemovable = forwardRef(StudioChipRemovable);
+ForwardedStudioChipRemovable.displayName = 'StudioChip.Removable';
+
+export { ForwardedStudioChipRemovable as StudioChipRemovable };

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioChip/index.ts
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioChip/index.ts
@@ -1,0 +1,23 @@
+import { StudioChipButton } from './StudioChipButton';
+import { StudioChipCheckbox } from './StudioChipCheckbox';
+import { StudioChipRadio } from './StudioChipRadio';
+import { StudioChipRemovable } from './StudioChipRemovable';
+
+type StudioChipComponent = {
+  Button: typeof StudioChipButton;
+  Checkbox: typeof StudioChipCheckbox;
+  Radio: typeof StudioChipRadio;
+  Removable: typeof StudioChipRemovable;
+};
+
+export const StudioChip: StudioChipComponent = {
+  Button: StudioChipButton,
+  Checkbox: StudioChipCheckbox,
+  Radio: StudioChipRadio,
+  Removable: StudioChipRemovable,
+};
+
+export type { StudioChipButtonProps } from './StudioChipButton';
+export type { StudioChipCheckboxProps } from './StudioChipCheckbox';
+export type { StudioChipRadioProps } from './StudioChipRadio';
+export type { StudioChipRemovableProps } from './StudioChipRemovable';

--- a/src/Designer/frontend/libs/studio-components/src/components/index.ts
+++ b/src/Designer/frontend/libs/studio-components/src/components/index.ts
@@ -19,6 +19,7 @@ export * from './StudioCenter';
 export * from './StudioCheckbox';
 export * from './StudioCheckboxGroup';
 export * from './StudioCheckboxTable';
+export * from './StudioChip';
 export * from './StudioCodeFragment';
 export * from './StudioCodeListEditor';
 export * from './StudioConfigCard';

--- a/src/Designer/frontend/packages/policy-editor/src/components/PolicyCardRules/PolicyRule/PolicyActions/PolicyActions.module.css
+++ b/src/Designer/frontend/packages/policy-editor/src/components/PolicyCardRules/PolicyRule/PolicyActions/PolicyActions.module.css
@@ -1,13 +1,4 @@
-.chipWrapper {
-  display: flex;
-  flex-wrap: wrap;
-}
-
 .dropdownWrapper {
   margin-top: var(--ds-size-8);
   margin-bottom: var(--ds-size-3);
-}
-
-.chip {
-  margin: var(--ds-size-1) var(--ds-size-1) 0 0;
 }

--- a/src/Designer/frontend/packages/policy-editor/src/components/PolicyCardRules/PolicyRule/PolicyActions/PolicyActions.test.tsx
+++ b/src/Designer/frontend/packages/policy-editor/src/components/PolicyCardRules/PolicyRule/PolicyActions/PolicyActions.test.tsx
@@ -1,5 +1,4 @@
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen, within } from '@testing-library/react';
 import { PolicyActions } from './PolicyActions';
 import { textMock } from '@studio/testing/mocks/i18nMock';
 import {
@@ -21,92 +20,67 @@ const mockActionOption4: string = mockActionId4;
 describe('PolicyActions', () => {
   afterEach(jest.clearAllMocks);
 
-  it('displays the selected actions as Chips', async () => {
-    const user = userEvent.setup();
+  it('renders the action field with its description', () => {
     renderPolicyActions();
 
-    const selectedAction1 = screen.getByLabelText(
-      `${textMock('general.delete')} ${mockActionOption1}`,
-    );
-    const selectedAction2 = screen.getByLabelText(
-      `${textMock('general.delete')} ${mockActionOption2}`,
-    );
-    const selectedAction3 = screen.queryByLabelText(
-      `${textMock('general.delete')} ${mockActionOption3}`,
-    );
-    const selectedAction4 = screen.getByLabelText(
-      `${textMock('general.delete')} ${mockActionOption4}`,
-    );
-    expect(selectedAction1).toBeInTheDocument();
-    expect(selectedAction2).toBeInTheDocument();
-    expect(selectedAction3).not.toBeInTheDocument();
-    expect(selectedAction4).toBeInTheDocument();
-
-    const [actionSelect] = screen.getAllByLabelText(
-      textMock('policy_editor.rule_card_actions_title'),
-    );
-    await user.click(actionSelect);
-
-    const optionAction1 = screen.queryByRole('option', { name: mockActionOption1 });
-    const optionAction2 = screen.queryByRole('option', { name: mockActionOption2 });
-    const optionAction3 = screen.getByRole('option', { name: mockActionOption3 });
-    const optionAction4 = screen.queryByRole('option', { name: mockActionOption4 });
-
-    expect(optionAction1).not.toBeInTheDocument();
-    expect(optionAction2).not.toBeInTheDocument();
-    expect(optionAction3).toBeInTheDocument();
-    expect(optionAction4).not.toBeInTheDocument();
-
-    await user.selectOptions(actionSelect, mockActionOption3);
-
-    expect(mockPolicyEditorContextValue.setPolicyRules).toHaveBeenCalledTimes(1);
     expect(
-      screen.queryByLabelText(`${textMock('general.delete')} ${mockActionOption3}`),
-    ).not.toBeInTheDocument();
-
-    const [inputAllSelected] = screen.getAllByText(
-      textMock('policy_editor.rule_card_actions_select_all_selected'),
-    );
-    expect(inputAllSelected).toBeInTheDocument();
+      screen.getByLabelText(textMock('policy_editor.rule_card_actions_title')),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(textMock('policy_editor.rule_card_actions_select_add')),
+    ).toBeInTheDocument();
   });
 
-  it('should append action to selectable actions options list when selected action is removed', async () => {
-    const user = userEvent.setup();
+  it('offers every available action as an option', () => {
     renderPolicyActions();
 
-    const [actionSelect] = screen.getAllByLabelText(
-      textMock('policy_editor.rule_card_actions_title'),
-    );
-    await user.click(actionSelect);
-
-    expect(screen.queryByRole('option', { name: mockActionOption1 })).toBeNull();
-
-    const selectedSubject = screen.getByLabelText(
-      `${textMock('general.delete')} ${mockActionOption1}`,
-    );
-    await user.click(selectedSubject);
-
-    await user.click(actionSelect);
-    expect(screen.getByRole('option', { name: mockActionOption1 })).toBeInTheDocument();
+    const options = within(getOptionList()).getAllByRole('option', { hidden: true });
+    expect(options.map((option) => option.textContent)).toEqual([
+      mockActionOption1,
+      mockActionOption2,
+      mockActionOption3,
+      mockActionOption4,
+    ]);
   });
 
-  it('calls the "setPolicyRules", "savePolicy", and "setPolicyError" function when the chip is clicked', async () => {
-    const user = userEvent.setup();
+  it('displays the actions of the rule as selected values, using their translated names', () => {
     renderPolicyActions();
 
-    const chipElement = screen.getByText(textMock('policy_editor.action_write'));
-    await user.click(chipElement);
+    // A selected action is rendered both as a selected value and as an option
+    expect(screen.getAllByText(mockActionOption1)).toHaveLength(2);
+    expect(screen.getAllByText(mockActionOption4)).toHaveLength(2);
+    expect(screen.getAllByText(mockActionOption3)).toHaveLength(1);
+  });
 
-    expect(mockPolicyEditorContextValue.setPolicyRules).toHaveBeenCalledTimes(1);
-    expect(mockPolicyEditorContextValue.savePolicy).toHaveBeenCalledTimes(1);
-    expect(mockPolicyRuleContextValue.setPolicyError).toHaveBeenCalledTimes(1);
+  it('displays the description for all actions being selected when none are left', () => {
+    renderPolicyActions({
+      policyRule: {
+        ...mockPolicyRuleContextValue.policyRule,
+        actions: [mockActionId1, mockActionId2, mockActionId3, mockActionId4],
+      },
+    });
+
+    expect(
+      screen.getByText(textMock('policy_editor.rule_card_actions_select_all_selected')),
+    ).toBeInTheDocument();
+  });
+
+  it('displays the error message when the rule has an action error and all errors are shown', () => {
+    renderPolicyActions({
+      showAllErrors: true,
+      policyError: { ...mockPolicyRuleContextValue.policyError, actionsError: true },
+    });
+
+    expect(screen.getByText(textMock('policy_editor.rule_card_actions_error'))).toBeInTheDocument();
   });
 });
 
-const renderPolicyActions = () => {
+const getOptionList = (): HTMLElement => screen.getByRole('listbox', { hidden: true });
+
+const renderPolicyActions = (ruleContextProps: Partial<typeof mockPolicyRuleContextValue> = {}) => {
   return render(
     <PolicyEditorContext.Provider value={mockPolicyEditorContextValue}>
-      <PolicyRuleContext.Provider value={mockPolicyRuleContextValue}>
+      <PolicyRuleContext.Provider value={{ ...mockPolicyRuleContextValue, ...ruleContextProps }}>
         <PolicyActions />
       </PolicyRuleContext.Provider>
     </PolicyEditorContext.Provider>,

--- a/src/Designer/frontend/packages/policy-editor/src/components/PolicyCardRules/PolicyRule/PolicyActions/PolicyActions.tsx
+++ b/src/Designer/frontend/packages/policy-editor/src/components/PolicyCardRules/PolicyRule/PolicyActions/PolicyActions.tsx
@@ -1,11 +1,12 @@
-import React, { useState } from 'react';
+import React from 'react';
 import classes from './PolicyActions.module.css';
 import { getActionOptions, getUpdatedRules } from '../../../../utils/PolicyRuleUtils';
 import { usePolicyEditorContext } from '../../../../contexts/PolicyEditorContext';
 import { usePolicyRuleContext } from '../../../../contexts/PolicyRuleContext';
 import { useTranslation } from 'react-i18next';
-import { Chip } from '@digdir/designsystemet-react';
-import { StudioSelect } from '@studio/components';
+import { StudioSuggestion } from '@studio/components';
+import type { StudioSuggestionItem } from '@studio/components';
+import type { PolicyAction } from '../../../../types';
 
 const wellKnownActionsIds: string[] = [
   'complete',
@@ -23,7 +24,7 @@ export const PolicyActions = (): React.ReactElement => {
   const { policyRule, uniqueId, showAllErrors, policyError, setPolicyError } =
     usePolicyRuleContext();
 
-  const [actionOptions, setActionOptions] = useState(getActionOptions(actions, policyRule));
+  const actionOptions = getActionOptions(actions, policyRule);
 
   const getTranslationByActionId = (actionId: string): string => {
     return wellKnownActionsIds.includes(actionId)
@@ -31,12 +32,7 @@ export const PolicyActions = (): React.ReactElement => {
       : actionId;
   };
 
-  const handleRemoveAction = (index: number, actionTitle: string) => {
-    const updatedActions = [...policyRule.actions];
-    updatedActions.splice(index, 1);
-
-    setActionOptions([...actionOptions, { value: actionTitle, label: actionTitle }]);
-
+  const saveActions = (updatedActions: string[]): void => {
     const updatedRules = getUpdatedRules(
       { ...policyRule, actions: updatedActions },
       policyRule.ruleId,
@@ -47,37 +43,15 @@ export const PolicyActions = (): React.ReactElement => {
     setPolicyError({ ...policyError, actionsError: updatedActions.length === 0 });
   };
 
-  const handleClickActionInList = (clickedOption: string) => {
-    if (!clickedOption) return;
-    const index = actionOptions.findIndex((o) => o.value === clickedOption);
-    const updatedOptions = [...actionOptions];
-    updatedOptions.splice(index, 1);
-    setActionOptions(updatedOptions);
-
-    const updatedActionTitles = [...policyRule.actions, clickedOption];
-    const updatedRules = getUpdatedRules(
-      { ...policyRule, actions: updatedActionTitles },
-      policyRule.ruleId,
-      rules,
-    );
-    setPolicyRules(updatedRules);
-    savePolicy(updatedRules);
-    setPolicyError({ ...policyError, actionsError: false });
+  const handleSelectedActionsChange = (items: StudioSuggestionItem[]): void => {
+    const updatedActions: string[] = items.map((item) => item.value);
+    saveActions(updatedActions);
   };
 
-  const displayActions = policyRule.actions.map((actionId, i) => {
-    return (
-      <Chip.Removable
-        className={classes.chip}
-        key={actionId}
-        aria-label={`${t('general.delete')} ${getTranslationByActionId(actionId)}`}
-        size='small'
-        onClick={() => handleRemoveAction(i, actionId)}
-      >
-        {getTranslationByActionId(actionId)}
-      </Chip.Removable>
-    );
-  });
+  const selectedActions: StudioSuggestionItem[] = policyRule.actions.map((actionId: string) => ({
+    value: actionId,
+    label: getTranslationByActionId(actionId),
+  }));
 
   const description =
     actionOptions.length === 0
@@ -88,25 +62,26 @@ export const PolicyActions = (): React.ReactElement => {
     showAllErrors && policyError.actionsError ? t('policy_editor.rule_card_actions_error') : false;
 
   return (
-    <>
-      <div className={classes.dropdownWrapper}>
-        <StudioSelect
-          label={t('policy_editor.rule_card_actions_title')}
-          description={description}
-          onChange={(event) => handleClickActionInList(event.target.value)}
-          disabled={actionOptions.length === 0}
-          error={error}
-          id={`selectAction-${uniqueId}`}
+    <StudioSuggestion
+      multiple
+      className={classes.dropdownWrapper}
+      label={t('policy_editor.rule_card_actions_title')}
+      description={description}
+      emptyText={t('general.no_options')}
+      error={error}
+      id={`suggestAction-${uniqueId}`}
+      selected={selectedActions}
+      onSelectedChange={handleSelectedActionsChange}
+    >
+      {actions.map((action: PolicyAction) => (
+        <StudioSuggestion.Option
+          key={action.actionId}
+          value={action.actionId}
+          label={getTranslationByActionId(action.actionId)}
         >
-          <StudioSelect.Option value='' hidden></StudioSelect.Option>
-          {actionOptions.map((option) => (
-            <StudioSelect.Option key={option.value} value={option.value}>
-              {getTranslationByActionId(option.label)}
-            </StudioSelect.Option>
-          ))}
-        </StudioSelect>
-      </div>
-      <div className={classes.chipWrapper}>{displayActions}</div>
-    </>
+          {getTranslationByActionId(action.actionId)}
+        </StudioSuggestion.Option>
+      ))}
+    </StudioSuggestion>
   );
 };

--- a/src/Designer/frontend/packages/policy-editor/src/components/PolicyCardRules/PolicyRule/PolicyRule.test.tsx
+++ b/src/Designer/frontend/packages/policy-editor/src/components/PolicyCardRules/PolicyRule/PolicyRule.test.tsx
@@ -2,7 +2,6 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { PolicyRule, type PolicyRuleProps } from './PolicyRule';
 import { textMock } from '@studio/testing/mocks/i18nMock';
-import { mockActionId3 } from '../../../../test/mocks/policyActionMocks';
 import { mockPolicyRuleCard1 } from '../../../../test/mocks/policyRuleMocks';
 import { mockSubject2, mockSubjectTitle2 } from '../../../../test/mocks/policySubjectMocks';
 import {
@@ -67,13 +66,6 @@ describe('PolicyRule', () => {
     await user.type(idInput, newWord);
     await user.tab();
 
-    const [actionSelect] = screen.getAllByLabelText(
-      textMock('policy_editor.rule_card_actions_title'),
-    );
-    const actionOption: string = textMock(`policy_editor.action_${mockActionId3}`);
-    await user.selectOptions(actionSelect, screen.getByRole('option', { name: actionOption }));
-    await user.tab();
-
     const altinnRoleTab = screen.getByText(
       textMock('policy_editor.rule_card_subjects_altinn_roles'),
     );
@@ -91,7 +83,7 @@ describe('PolicyRule', () => {
     await user.type(descriptionField, newWord);
     await user.tab();
 
-    const numFields = 5;
+    const numFields = 4;
     expect(mockSavePolicy).toHaveBeenCalledTimes(numFields + 1);
   });
 

--- a/src/Designer/frontend/packages/text-editor/src/TextEditor.module.css
+++ b/src/Designer/frontend/packages/text-editor/src/TextEditor.module.css
@@ -36,10 +36,18 @@
 }
 
 .sortAlphabetically {
-  gap: var(--fds-spacing-4);
+  gap: var(--ds-size-4);
   display: flex;
   align-items: center;
   white-space: nowrap;
+}
+
+.sortChip > input {
+  position: absolute;
+  height: 1px;
+  width: 1px;
+  opacity: 0;
+  pointer-events: none;
 }
 
 .textEditorBody {

--- a/src/Designer/frontend/packages/text-editor/src/TextEditor.test.tsx
+++ b/src/Designer/frontend/packages/text-editor/src/TextEditor.test.tsx
@@ -154,8 +154,10 @@ describe('TextEditor', () => {
     const textEntries = screen.getAllByRole('textbox');
     expect(textEntries[0]).toHaveValue(textValue1);
 
-    const sortAlphabeticallyButton = screen.getByText(textMock('text_editor.sort_alphabetically'));
-    await user.click(sortAlphabeticallyButton);
+    const sortAlphabeticallyChip = screen.getByRole('checkbox', {
+      name: textMock('text_editor.sort_alphabetically'),
+    });
+    await user.click(sortAlphabeticallyChip);
 
     const sortedTranslations = screen.getAllByRole('textbox');
     expect(sortedTranslations[0]).toHaveValue(textValue2);

--- a/src/Designer/frontend/packages/text-editor/src/TextEditor.tsx
+++ b/src/Designer/frontend/packages/text-editor/src/TextEditor.tsx
@@ -2,9 +2,8 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import classes from './TextEditor.module.css';
 import type { LangCode, TextResourceEntryDeletion, TextResourceIdMutation } from './types';
 import type { UpsertTextResourceMutation } from 'app-shared/hooks/mutations/useUpsertTextResourceMutation';
-import { Chip } from '@digdir/designsystemet-react';
 import { ArrowsUpDownIcon } from '@studio/icons';
-import { StudioButton, StudioSearch } from '@studio/components';
+import { StudioButton, StudioChip, StudioSearch } from '@studio/components';
 import { RightMenu } from './RightMenu';
 import { getRandNumber, mapResourceFilesToTableRows } from './utils';
 import { defaultLangCode } from './constants';
@@ -95,18 +94,17 @@ export const TextEditor = ({
             {t('text_editor.new_text')}
           </StudioButton>
           <div className={classes.filterAndSearch}>
-            <Chip.Toggle
-              size='small'
-              onClick={() => setSortTextsAlphabetically(!sortTextsAlphabetically)}
-              selected={sortTextsAlphabetically}
+            <StudioChip.Checkbox
+              className={classes.sortChip}
+              data-size='sm'
+              checked={sortTextsAlphabetically}
+              onChange={() => setSortTextsAlphabetically(!sortTextsAlphabetically)}
             >
-              {
-                <div className={classes.sortAlphabetically}>
-                  {t('text_editor.sort_alphabetically')}
-                  <ArrowsUpDownIcon />
-                </div>
-              }
-            </Chip.Toggle>
+              <div className={classes.sortAlphabetically}>
+                {t('text_editor.sort_alphabetically')}
+                <ArrowsUpDownIcon />
+              </div>
+            </StudioChip.Checkbox>
             <StudioSearch
               className={classes.search}
               label={t('text_editor.search_for_text')}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Since we now have `StudioSuggestion` it covers this case where we had two separate components (Selector and chip) to solve the same thing. 


Also created a StudioChip and replaced the chip in TextEditor with this new wrapper.

<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
