### PR TITLE
chore: enforce the studio-components facade and scope Designsystemet deps

### DIFF
--- a/src/Designer/frontend/eslint.config.mjs
+++ b/src/Designer/frontend/eslint.config.mjs
@@ -17,12 +17,21 @@ const compat = new FlatCompat({
   resolvePluginsRelativeTo: __dirname,
 });
 
-const restrictedImports = (patterns) => [
+const designsystemetRestriction = {
+  group: ['@digdir/designsystemet-react', '@digdir/designsystemet-react/*'],
+  message:
+    'Do not import components directly from Designsystemet. Import them from @studio/components instead, and add a wrapper there if the component is missing.',
+};
+
+const restrictedImportsAllowingDesignsystemet = (patterns) => [
   'error',
   {
     patterns,
   },
 ];
+
+const restrictedImports = (patterns) =>
+  restrictedImportsAllowingDesignsystemet([...patterns, designsystemetRestriction]);
 
 const strictLibraryRules = {
   '@typescript-eslint/explicit-function-return-type': 'error',
@@ -215,7 +224,7 @@ export default [
     },
     rules: {
       ...strictLibraryRules,
-      'no-restricted-imports': restrictedImports([
+      'no-restricted-imports': restrictedImportsAllowingDesignsystemet([
         {
           group: ['@tanstack/react-query'],
           message:
@@ -252,7 +261,7 @@ export default [
       'testing-library/custom-renders': ['rowsToRender'],
     },
     rules: {
-      'no-restricted-imports': restrictedImports([
+      'no-restricted-imports': restrictedImportsAllowingDesignsystemet([
         {
           group: ['@tanstack/react-query'],
           message:

--- a/src/Designer/frontend/libs/studio-components-legacy/package.json
+++ b/src/Designer/frontend/libs/studio-components-legacy/package.json
@@ -10,6 +10,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@digdir/designsystemet-react": "0.63.1",
     "@studio/icons": "workspace:^",
     "@studio/pure-functions": "workspace:^",
     "ajv": "8.20.0",
@@ -21,6 +22,8 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^5.0.1",
+    "@digdir/design-system-tokens": "0.13.0",
+    "@digdir/designsystemet-css": "0.10.0",
     "@storybook/addon-docs": "10.5.7",
     "@storybook/addon-links": "10.5.7",
     "@storybook/builder-vite": "10.5.7",

--- a/src/Designer/frontend/package.json
+++ b/src/Designer/frontend/package.json
@@ -1,10 +1,6 @@
 {
   "name": "studio-designer-frontend",
   "dependencies": {
-    "@digdir/design-system-tokens": "0.13.0",
-    "@digdir/designsystemet-css": "0.10.0",
-    "@digdir/designsystemet-react": "0.63.1",
-    "@digdir/designsystemet-theme": "0.15.3",
     "@microsoft/applicationinsights-react-js": "17.3.6",
     "@microsoft/applicationinsights-web": "3.4.3",
     "@microsoft/signalr": "8.0.29",

--- a/src/Designer/frontend/packages/shared/package.json
+++ b/src/Designer/frontend/packages/shared/package.json
@@ -3,6 +3,8 @@
   "version": "0.1.0",
   "author": "Altinn",
   "dependencies": {
+    "@digdir/designsystemet-css": "0.10.0",
+    "@digdir/designsystemet-theme": "0.15.3",
     "bpmn-moddle": "9.0.4",
     "classnames": "2.5.1",
     "qs": "6.15.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5496,6 +5496,9 @@ __metadata:
   resolution: "@studio/components-legacy@workspace:src/Designer/frontend/libs/studio-components-legacy"
   dependencies:
     "@chromatic-com/storybook": "npm:^5.0.1"
+    "@digdir/design-system-tokens": "npm:0.13.0"
+    "@digdir/designsystemet-css": "npm:0.10.0"
+    "@digdir/designsystemet-react": "npm:0.63.1"
     "@storybook/addon-docs": "npm:10.5.7"
     "@storybook/addon-links": "npm:10.5.7"
     "@storybook/builder-vite": "npm:10.5.7"
@@ -7603,6 +7606,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "app-shared@workspace:src/Designer/frontend/packages/shared"
   dependencies:
+    "@digdir/designsystemet-css": "npm:0.10.0"
+    "@digdir/designsystemet-theme": "npm:0.15.3"
     "@studio/ui-test": "workspace:^"
     "@types/bpmn-moddle": "npm:9.0.1"
     "@types/react": "npm:19.2.18"
@@ -18729,10 +18734,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "studio-designer-frontend@workspace:src/Designer/frontend"
   dependencies:
-    "@digdir/design-system-tokens": "npm:0.13.0"
-    "@digdir/designsystemet-css": "npm:0.10.0"
-    "@digdir/designsystemet-react": "npm:0.63.1"
-    "@digdir/designsystemet-theme": "npm:0.15.3"
     "@eslint/compat": "npm:2.1.0"
     "@eslint/eslintrc": "npm:3.3.6"
     "@microsoft/applicationinsights-react-js": "npm:17.3.6"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
No code outside studio-components imports Designsystemet directly any more (124 files did before this series of cleanup). This locks it in from two sides:

- An ESLint no-restricted-imports rule on `@digdir/designsystemet-react`, added in the shared helper because no-restricted-imports is redefined in twelve scopes. The two component libs opt out.

- The four designsystemet dependencies move from the frontend root into the workspaces that import them: designsystemet-react (+ Storybook's design-system-tokens and designsystemet-css) into studio-components-legacy, and designsystemet-css + designsystemet-theme into app-shared. No versions change.


When the legacy components are gone, 0.63.1 and its opt-out are deleted along with studio-components-legacy/package.json, nothing left behind in the root for someone to find later and not dare to remove. app-shared keeps theme + css regardless; they supply the `--fds-*` tokens still used by 298 files.


## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved consistency in how design system components are sourced across the application.
  * Updated component libraries to use the appropriate design system packages.
  * Consolidated shared design system styling and theme dependencies.
  * Removed redundant package references from the main frontend setup.
  * Added safeguards to help prevent inconsistent component imports and support a more reliable development experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->