### PR TITLE
refactor: move `CustomButton` layout tp lib

### DIFF
--- a/src/App/frontend/src/layout/CustomButton/CustomButtonComponent.tsx
+++ b/src/App/frontend/src/layout/CustomButton/CustomButtonComponent.tsx
@@ -2,10 +2,10 @@ import React, { useEffect } from 'react';
 import { useParams } from 'react-router';
 import { toast } from 'react-toastify';
 
-import { Button } from '@app/form-component';
+import { CustomButton } from '@app/form-component';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
-import type { ButtonColor, ButtonVariant } from '@app/form-component';
 
 import { useAppMutations } from 'src/core/contexts/AppQueriesProvider';
 import { useResetScrollPosition } from 'src/core/ui/useResetScrollPosition';
@@ -13,14 +13,12 @@ import { FormStore } from 'src/features/form/FormContext';
 import { useIsAuthorized } from 'src/features/instance/useProcessQuery';
 import { Lang } from 'src/features/language/Lang';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
-import { useLanguage } from 'src/features/language/useLanguage';
 import { useGetNavigationIsPrevented } from 'src/features/navigation/utils';
 import { useOnPageNavigationValidation } from 'src/features/validation/callbacks/onPageNavigationValidation';
 import { useIsSubformPage, useNavigationParam } from 'src/hooks/navigation';
 import { useNavigatePage } from 'src/hooks/useNavigatePage';
 import { usePageValidation } from 'src/hooks/usePageValidation';
 import { useIsAnyProcessing, useIsThisProcessing, useProcessingMutation } from 'src/hooks/useProcessingMutation';
-import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import { isSpecificClientAction } from 'src/layout/CustomButton/typeHelpers';
 import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { BackendValidationIssueGroups } from 'src/features/validation';
@@ -175,30 +173,7 @@ function useHandleServerActionMutationFn(acquireLock: FormDataLocking) {
   };
 }
 
-export const buttonStyles: { [style in CBTypes.ButtonStyle]: { color: ButtonColor; variant: ButtonVariant } } = {
-  primary: { variant: 'primary', color: 'success' },
-  secondary: { variant: 'secondary', color: 'first' },
-  tertiary: { variant: 'tertiary', color: 'second' },
-};
-
-function toShorthandSize(size?: CBTypes.CustomButtonSize): 'sm' | 'md' | 'lg' {
-  switch (size) {
-    case 'sm':
-    case 'small':
-      return 'sm';
-    case 'md':
-    case 'medium':
-      return 'md';
-    case 'lg':
-    case 'large':
-      return 'lg';
-    default:
-      return 'md';
-  }
-}
-
 export const CustomButtonComponent = ({ baseComponentId }: PropsFromGenericComponent<'CustomButton'>) => {
-  const { langAsString } = useLanguage();
   const { textResourceBindings, actions, id, buttonColor, buttonSize, buttonStyle } = useItemWhenType(
     baseComponentId,
     'CustomButton',
@@ -291,22 +266,16 @@ export const CustomButtonComponent = ({ baseComponentId }: PropsFromGenericCompo
       }
     });
 
-  const style = buttonStyles[interceptedButtonStyle];
-
   return (
-    <ComponentStructureWrapper baseComponentId={baseComponentId}>
-      <Button
-        id={`custom-button-${id}`}
-        disabled={disabled}
-        onClick={onClick}
-        size={toShorthandSize(buttonSize)}
-        color={buttonColor ?? style.color}
-        variant={style.variant}
-        isLoading={isThisProcessing}
-        loadingLabel={langAsString('general.loading')}
-      >
-        <Lang id={buttonText} />
-      </Button>
-    </ComponentStructureWrapper>
+    <CustomButton
+      componentId={id}
+      title={buttonText}
+      buttonStyle={interceptedButtonStyle}
+      buttonColor={buttonColor}
+      buttonSize={buttonSize}
+      disabled={disabled}
+      isLoading={isThisProcessing}
+      onClick={onClick}
+    />
   );
 };

--- a/src/common/ts/form-component/src/layout-components/CustomButton/CustomButton.mdx
+++ b/src/common/ts/form-component/src/layout-components/CustomButton/CustomButton.mdx
@@ -1,0 +1,9 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+import { LayoutComponentDocs } from '../common/storybook';
+import * as CustomButtonStories from './CustomButton.stories';
+import { CUSTOM_BUTTON_PROP_CATEGORIES } from './CustomButton.stories';
+
+<Meta of={CustomButtonStories} />
+
+<LayoutComponentDocs categories={CUSTOM_BUTTON_PROP_CATEGORIES} />

--- a/src/common/ts/form-component/src/layout-components/CustomButton/CustomButton.stories.tsx
+++ b/src/common/ts/form-component/src/layout-components/CustomButton/CustomButton.stories.tsx
@@ -1,0 +1,67 @@
+import { fn } from 'storybook/test';
+import type { PropCategories } from '@app/form-component/layout-components/common/storybook';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { CustomButton } from './CustomButton';
+import type { CustomButtonProps } from './CustomButton';
+
+export const CUSTOM_BUTTON_PROP_CATEGORIES = {
+  title: 'text',
+  componentId: 'content',
+  buttonStyle: 'content',
+  buttonColor: 'content',
+  buttonSize: 'content',
+  disabled: 'runtime',
+  isLoading: 'runtime',
+  onClick: 'runtime',
+} satisfies PropCategories<CustomButtonProps>;
+
+const meta = {
+  title: 'LayoutComponents/CustomButton',
+  component: CustomButton,
+  excludeStories: ['CUSTOM_BUTTON_PROP_CATEGORIES'],
+  parameters: {
+    layout: 'padded',
+  },
+  args: {
+    componentId: 'custom-button-preview',
+    title: 'Velg neste steg',
+    onClick: fn(),
+  },
+} satisfies Meta<typeof CustomButton>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Preview: Story = {};
+
+export const Primary: Story = {
+  args: {
+    componentId: 'custom-button-primary',
+    buttonStyle: 'primary',
+    title: 'Fullfør',
+  },
+};
+
+export const Tertiary: Story = {
+  args: {
+    componentId: 'custom-button-tertiary',
+    buttonStyle: 'tertiary',
+    title: 'Avbryt',
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    componentId: 'custom-button-loading',
+    isLoading: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    componentId: 'custom-button-disabled',
+    disabled: true,
+  },
+};

--- a/src/common/ts/form-component/src/layout-components/CustomButton/CustomButton.test.tsx
+++ b/src/common/ts/form-component/src/layout-components/CustomButton/CustomButton.test.tsx
@@ -1,0 +1,47 @@
+import type { ComponentProps } from 'react';
+
+import {
+  renderWithTranslations,
+  type RenderWithTranslationsOptions,
+} from '@app/form-component/test/renderWithTranslations';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { CustomButton } from './CustomButton';
+
+const render = (
+  props?: Partial<ComponentProps<typeof CustomButton>>,
+  options?: RenderWithTranslationsOptions,
+) =>
+  renderWithTranslations(
+    <CustomButton componentId='cb-1' title='custom.button' onClick={() => undefined} {...props} />,
+    {
+      overrides: { 'custom.button': 'Velg neste steg' },
+      ...options,
+    },
+  );
+
+describe('CustomButton', () => {
+  it('shows the button label', () => {
+    render();
+    expect(screen.getByRole('button', { name: 'Velg neste steg' })).toBeInTheDocument();
+  });
+
+  it('calls onClick when the button is pressed', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render({ onClick });
+    await user.click(screen.getByRole('button'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the button when disabled is set', () => {
+    render({ disabled: true });
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('renders the form-content wrapper for the given componentId', () => {
+    render({ componentId: 'custom-1' });
+    expect(document.getElementById('form-content-custom-1')).toBeInTheDocument();
+  });
+});

--- a/src/common/ts/form-component/src/layout-components/CustomButton/CustomButton.tsx
+++ b/src/common/ts/form-component/src/layout-components/CustomButton/CustomButton.tsx
@@ -1,0 +1,73 @@
+import { Button } from '@app/form-component/app-components/Button';
+import { useTranslation } from '@app/form-component/LanguageTranslatorProvider';
+import { ComponentStructure } from '@app/form-component/layout-components/common/ComponentStructure';
+import type { ButtonColor, ButtonVariant } from '@app/form-component/app-components/Button';
+
+export type CustomButtonStyle = 'primary' | 'secondary' | 'tertiary';
+export type CustomButtonSize = 'sm' | 'md' | 'lg' | 'small' | 'medium' | 'large';
+
+const buttonStyles: {
+  [style in CustomButtonStyle]: { color: ButtonColor; variant: ButtonVariant };
+} = {
+  primary: { variant: 'primary', color: 'success' },
+  secondary: { variant: 'secondary', color: 'first' },
+  tertiary: { variant: 'tertiary', color: 'second' },
+};
+
+function toShorthandSize(size?: CustomButtonSize): 'sm' | 'md' | 'lg' {
+  switch (size) {
+    case 'sm':
+    case 'small':
+      return 'sm';
+    case 'md':
+    case 'medium':
+      return 'md';
+    case 'lg':
+    case 'large':
+      return 'lg';
+    default:
+      return 'md';
+  }
+}
+
+export interface CustomButtonProps {
+  componentId: string;
+  title?: string;
+  buttonStyle?: CustomButtonStyle;
+  buttonColor?: ButtonColor;
+  buttonSize?: CustomButtonSize;
+  disabled?: boolean;
+  isLoading?: boolean;
+  onClick: () => void;
+}
+
+export function CustomButton({
+  componentId,
+  title,
+  buttonStyle = 'secondary',
+  buttonColor,
+  buttonSize,
+  disabled = false,
+  isLoading = false,
+  onClick,
+}: CustomButtonProps) {
+  const { lang, langAsString } = useTranslation();
+  const style = buttonStyles[buttonStyle];
+
+  return (
+    <ComponentStructure componentId={componentId}>
+      <Button
+        id={`custom-button-${componentId}`}
+        disabled={disabled}
+        onClick={onClick}
+        size={toShorthandSize(buttonSize)}
+        color={buttonColor ?? style.color}
+        variant={style.variant}
+        isLoading={isLoading}
+        loadingLabel={langAsString('general.loading')}
+      >
+        {lang(title)}
+      </Button>
+    </ComponentStructure>
+  );
+}

--- a/src/common/ts/form-component/src/layout-components/CustomButton/index.ts
+++ b/src/common/ts/form-component/src/layout-components/CustomButton/index.ts
@@ -1,0 +1,2 @@
+export { CustomButton } from './CustomButton';
+export type { CustomButtonProps, CustomButtonSize, CustomButtonStyle } from './CustomButton';

--- a/src/common/ts/form-component/src/layout-components/index.ts
+++ b/src/common/ts/form-component/src/layout-components/index.ts
@@ -6,6 +6,7 @@ export * from './AttachmentList';
 export * from './Audio';
 export * from './Button';
 export * from './ButtonGroup';
+export * from './CustomButton';
 export * from './Date';
 export * from './Datepicker';
 export * from './Divider';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Moves the **CustomButton** layout component's presentational logic from app-frontend (`src/layout/CustomButton`) into `@app/form-component` (`layout-components/CustomButton`).
- **Lib** owns presentation: shared `Button`, style/size/color mapping (`buttonStyle` / `buttonSize` / `buttonColor`), title via `useTranslation`, loading/disabled UI, and `ComponentStructure` for the `form-content` wrapper. 
- **Wrapper** (`CustomButtonComponent.tsx`) only resolves runtime data and passes props into the lib component. 
- Adds Storybook stories + docs and lib unit tests.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
