### PR TITLE
fix(ci): use valid XFS label for sandbox storage

### DIFF
--- a/src/ci/sandbox-node/init-storage.sh
+++ b/src/ci/sandbox-node/init-storage.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 readonly ARRAY_DEVICE=/dev/md/altinn-sandbox
 readonly ARRAY_NAME=altinn-sandbox
-readonly FILESYSTEM_LABEL=altinn-sandbox
+readonly FILESYSTEM_LABEL=altinn-sbx
 readonly MOUNT_POINT=/var/lib/altinn/sandbox
 LOCAL_NVME_DEVICES=()
 


### PR DESCRIPTION
## Summary

- shorten the sandbox storage filesystem label to fit XFS's 12-character limit
- preserve the existing md array name and mount path

## Verification

- reproduced during the production D32ds_v6 cutover: four raw NVMe disks were discovered and RAID0 created, but mkfs.xfs rejected the 14-character label
- Bash syntax and ShellCheck pass
- the replacement label is 10 characters


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the sandbox storage filesystem label to ensure RAID array formatting uses the correct identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->