### PR TITLE
chore: add cargo deny for rust

### DIFF
--- a/.github/workflows/rust-dependency-checks.yaml
+++ b/.github/workflows/rust-dependency-checks.yaml
@@ -1,0 +1,37 @@
+name: Rust - dependency checks
+
+on:
+  pull_request:
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '**/Cargo.toml'
+      - 'deny.toml'
+      - '.github/workflows/rust-dependency-checks.yaml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Advisories and sources
+    runs-on: self-hosted-ubuntu
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Check dependency advisories and sources
+        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
+        with:
+          rust-version: '1.97.1'
+          arguments: '--locked'
+          command: check
+          command-arguments: 'advisories sources'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1823,9 +1823,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2788,7 +2788,7 @@ dependencies = [
 [[package]]
 name = "microsandbox"
 version = "0.6.9-digdir.2"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
+source = "git+https://github.com/martinothamar/microsandbox.git?rev=2e98dc56ceed8bc8b5bd1704f73267fdae5279d9#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -2843,7 +2843,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-agent-client"
 version = "0.6.9-digdir.2"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
+source = "git+https://github.com/martinothamar/microsandbox.git?rev=2e98dc56ceed8bc8b5bd1704f73267fdae5279d9#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
 dependencies = [
  "ciborium",
  "microsandbox-protocol",
@@ -2856,7 +2856,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-db"
 version = "0.6.9-digdir.2"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
+source = "git+https://github.com/martinothamar/microsandbox.git?rev=2e98dc56ceed8bc8b5bd1704f73267fdae5279d9#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2868,7 +2868,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-filesystem"
 version = "0.6.9-digdir.2"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
+source = "git+https://github.com/martinothamar/microsandbox.git?rev=2e98dc56ceed8bc8b5bd1704f73267fdae5279d9#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -2881,7 +2881,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-image"
 version = "0.6.9-digdir.2"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
+source = "git+https://github.com/martinothamar/microsandbox.git?rev=2e98dc56ceed8bc8b5bd1704f73267fdae5279d9#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -2909,7 +2909,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-metrics"
 version = "0.6.9-digdir.2"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
+source = "git+https://github.com/martinothamar/microsandbox.git?rev=2e98dc56ceed8bc8b5bd1704f73267fdae5279d9#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
 dependencies = [
  "chrono",
  "libc",
@@ -2921,7 +2921,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-migration"
 version = "0.6.9-digdir.2"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
+source = "git+https://github.com/martinothamar/microsandbox.git?rev=2e98dc56ceed8bc8b5bd1704f73267fdae5279d9#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
 dependencies = [
  "sea-orm-migration",
  "serde_json",
@@ -2930,7 +2930,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-network"
 version = "0.6.9-digdir.2"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
+source = "git+https://github.com/martinothamar/microsandbox.git?rev=2e98dc56ceed8bc8b5bd1704f73267fdae5279d9#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2975,7 +2975,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-protocol"
 version = "0.6.9-digdir.2"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
+source = "git+https://github.com/martinothamar/microsandbox.git?rev=2e98dc56ceed8bc8b5bd1704f73267fdae5279d9#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
 dependencies = [
  "chrono",
  "ciborium",
@@ -2990,7 +2990,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-runtime"
 version = "0.6.9-digdir.2"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
+source = "git+https://github.com/martinothamar/microsandbox.git?rev=2e98dc56ceed8bc8b5bd1704f73267fdae5279d9#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
 dependencies = [
  "bytes",
  "chrono",
@@ -3025,7 +3025,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-types"
 version = "0.6.9-digdir.2"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
+source = "git+https://github.com/martinothamar/microsandbox.git?rev=2e98dc56ceed8bc8b5bd1704f73267fdae5279d9#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
 dependencies = [
  "chrono",
  "ipnetwork",
@@ -3039,7 +3039,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-utils"
 version = "0.6.9-digdir.2"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
+source = "git+https://github.com/martinothamar/microsandbox.git?rev=2e98dc56ceed8bc8b5bd1704f73267fdae5279d9#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
 dependencies = [
  "dirs",
  "libc",
@@ -3052,7 +3052,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-vsock"
 version = "0.6.9-digdir.2"
-source = "git+https://github.com/martinothamar/microsandbox.git?branch=main-digdir#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
+source = "git+https://github.com/martinothamar/microsandbox.git?rev=2e98dc56ceed8bc8b5bd1704f73267fdae5279d9#2e98dc56ceed8bc8b5bd1704f73267fdae5279d9"
 dependencies = [
  "libc",
  "msb_krun",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,14 +25,15 @@ futures-core = "0.3.34"
 futures-util = "0.3.34"
 ignore = "0.4.33"
 jsonwebtoken = { version = "11.0.0", features = ["aws_lc_rs"] }
-microsandbox = { git = "https://github.com/martinothamar/microsandbox.git", branch = "main-digdir", default-features = false, features = ["net"] }
-microsandbox-image = { git = "https://github.com/martinothamar/microsandbox.git", branch = "main-digdir", package = "microsandbox-image" }
-microsandbox-network = { git = "https://github.com/martinothamar/microsandbox.git", branch = "main-digdir", package = "microsandbox-network" }
+# Microsandbox fork commit from `main-digdir`; update all four revisions together.
+microsandbox = { git = "https://github.com/martinothamar/microsandbox.git", rev = "2e98dc56ceed8bc8b5bd1704f73267fdae5279d9", default-features = false, features = ["net"] }
+microsandbox-image = { git = "https://github.com/martinothamar/microsandbox.git", rev = "2e98dc56ceed8bc8b5bd1704f73267fdae5279d9", package = "microsandbox-image" }
+microsandbox-network = { git = "https://github.com/martinothamar/microsandbox.git", rev = "2e98dc56ceed8bc8b5bd1704f73267fdae5279d9", package = "microsandbox-network" }
 # Microsandbox does not ship its embedded sandbox agent in the crate.
 # Enabling this transitive feature downloads only that build artifact into
 # Cargo's output directory; the host runtime is installed automatically on
 # first use into the control-plane home.
-microsandbox-filesystem = { git = "https://github.com/martinothamar/microsandbox.git", branch = "main-digdir", default-features = false, features = ["prebuilt"] }
+microsandbox-filesystem = { git = "https://github.com/martinothamar/microsandbox.git", rev = "2e98dc56ceed8bc8b5bd1704f73267fdae5279d9", default-features = false, features = ["prebuilt"] }
 reqwest = { version = "0.13.4", features = ["json"] }
 sandbox = { path = "src/experimental/sandbox" }
 sandbox-microsandbox = { path = "src/experimental/sandbox-microsandbox" }

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,21 @@
+# This policy intentionally contains no per-crate allowlist. New dependencies remain ordinary
+# Cargo.toml and Cargo.lock changes.
+
+[graph]
+all-features = true
+targets = [
+  "x86_64-unknown-linux-gnu",
+  "x86_64-pc-windows-gnu",
+  "aarch64-apple-darwin",
+  "x86_64-apple-darwin",
+]
+
+[advisories]
+yanked = "deny"
+
+[sources]
+# crates.io is allowed by default. Additional registries fail until deliberately configured.
+unknown-registry = "deny"
+# Do not maintain a git repository allowlist, but require an explicit revision specifier.
+unknown-git = "allow"
+required-git-spec = "rev"


### PR DESCRIPTION
## Description

To check advisories and whatnot

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated Rust dependency checks for security advisories and source-policy issues.
  * Checks cover Linux, Windows and macOS configurations and can run automatically on relevant changes or manually when required.
  * Dependencies are now pinned to specific revisions for more predictable builds.
  * Added policies to reject yanked crates and unapproved registries, while requiring explicit revisions for permitted Git sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->