### PR TITLE
fix: gh runner deploy concurrency and rust install

### DIFF
--- a/.github/workflows/deploy-github-runners.yaml
+++ b/.github/workflows/deploy-github-runners.yaml
@@ -18,10 +18,6 @@ permissions:
   id-token: write
   contents: read
 
-concurrency:
-  group: deploy-github-runners
-  cancel-in-progress: false
-
 jobs:
   construct-environments-array:
     uses: ./.github/workflows/template-studio-construct-environments.yaml

--- a/src/ci/github-runner/Dockerfile
+++ b/src/ci/github-runner/Dockerfile
@@ -127,7 +127,7 @@ RUN apt-get update \
     && echo "${RUSTUP_INIT_SHA256}  /tmp/rustup-init" | sha256sum -c - \
     && chmod +x /tmp/rustup-init \
     && CARGO_HOME=/home/runner/.cargo RUSTUP_HOME=/home/runner/.rustup \
-      /tmp/rustup-init --yes --no-modify-path --profile minimal \
+      /tmp/rustup-init -y --no-modify-path --profile minimal \
         --default-toolchain "${RUST_VERSION}" --component clippy,rustfmt \
     && rm -f /tmp/rustup-init \
     && curl -fsSL "https://raw.githubusercontent.com/dotnet/install-scripts/${DOTNET_INSTALL_SCRIPT_COMMIT}/src/dotnet-install.sh" -o /tmp/dotnet-install.sh \


### PR DESCRIPTION
## Description

- concurrency config just blocked new deploys, this keeps to existing pattern
- bug int the parameter used for rust install

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
