### PR TITLE
perf: add pagination and debounce to text editor

### DIFF
--- a/src/Designer/frontend/app-development/features/textEditor/TextEditor.test.tsx
+++ b/src/Designer/frontend/app-development/features/textEditor/TextEditor.test.tsx
@@ -67,7 +67,7 @@ describe('TextEditor', () => {
     });
     await user.type(searchInput, search);
 
-    expect(mockSetSearchParams).toHaveBeenCalledWith({ search });
+    await waitFor(() => expect(mockSetSearchParams).toHaveBeenCalledWith({ search }));
   });
 
   it('adds new text resource when clicking add button', async () => {

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioTableRemotePagination/index.ts
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioTableRemotePagination/index.ts
@@ -5,3 +5,5 @@ export type {
   RemotePaginationProps,
   PaginationTexts,
 } from './StudioTableRemotePagination';
+export { StudioPagination } from './StudioPagination';
+export type { StudioPaginationProps } from './StudioPagination/StudioPagination';

--- a/src/Designer/frontend/packages/text-editor/src/TextEditor.test.tsx
+++ b/src/Designer/frontend/packages/text-editor/src/TextEditor.test.tsx
@@ -1,6 +1,6 @@
 import { TextEditor } from './TextEditor';
 import type { TextEditorProps } from './TextEditor';
-import { render as rtlRender, screen } from '@testing-library/react';
+import { act, render as rtlRender, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { textMock } from '@studio/testing/mocks/i18nMock';
 import type { ITextResource, ITextResources } from 'app-shared/types/global';
@@ -9,6 +9,7 @@ import { queriesMock } from 'app-shared/mocks/queriesMock';
 import { ServicesContextProvider } from 'app-shared/contexts/ServicesContext';
 import { QueryKey } from 'app-shared/types/QueryKey';
 import { queryClientMock } from 'app-shared/mocks/queryClientMock';
+import { searchDebounceTimeInMs } from './constants';
 
 const user = userEvent.setup();
 let mockScrollIntoView = jest.fn();
@@ -44,11 +45,15 @@ describe('TextEditor', () => {
       upsertTextResource: jest.fn(),
     };
     queryClientMock.setQueryData([QueryKey.LayoutNames, org, app], []);
-    return rtlRender(
-      <ServicesContextProvider {...queriesMock} client={queryClientMock}>
-        <TextEditor {...defaultProps} {...props} />
-      </ServicesContextProvider>,
-    );
+    const allProps: TextEditorProps = { ...defaultProps, ...props };
+    return {
+      allProps,
+      ...rtlRender(
+        <ServicesContextProvider {...queriesMock} client={queryClientMock}>
+          <TextEditor {...allProps} />
+        </ServicesContextProvider>,
+      ),
+    };
   };
   beforeEach(() => {
     // Need to mock the scrollIntoView function
@@ -270,6 +275,78 @@ describe('TextEditor', () => {
         name: textMock('schema_editor.delete'),
       });
       expect(resultAfter).toHaveLength(2);
+    });
+  });
+
+  describe('search', () => {
+    beforeEach(() => jest.useFakeTimers());
+
+    afterEach(() => {
+      jest.runOnlyPendingTimers();
+      jest.useRealTimers();
+    });
+
+    const getSearchInput = (): HTMLElement =>
+      screen.getByRole('searchbox', { name: textMock('text_editor.search_for_text') });
+
+    const setupSearch = () => {
+      const setSearchQuery = jest.fn();
+      const searchUser = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      renderTextEditor({ setSearchQuery });
+      return { setSearchQuery, searchUser };
+    };
+
+    it('applies the search query once the debounce time has passed', async () => {
+      const { setSearchQuery, searchUser } = setupSearch();
+
+      await searchUser.type(getSearchInput(), 'abc');
+      expect(setSearchQuery).not.toHaveBeenCalled();
+
+      act(() => jest.advanceTimersByTime(searchDebounceTimeInMs));
+
+      expect(setSearchQuery).toHaveBeenCalledTimes(1);
+      expect(setSearchQuery).toHaveBeenCalledWith('abc');
+    });
+
+    it('applies an empty search without waiting for the debounce time', async () => {
+      const { setSearchQuery, searchUser } = setupSearch();
+
+      await searchUser.type(getSearchInput(), 'abc');
+      act(() => jest.advanceTimersByTime(searchDebounceTimeInMs));
+      setSearchQuery.mockClear();
+
+      await searchUser.clear(getSearchInput());
+
+      expect(setSearchQuery).toHaveBeenCalledWith('');
+    });
+
+    it('does not apply a pending search after the search has been cleared', async () => {
+      const { setSearchQuery, searchUser } = setupSearch();
+
+      await searchUser.type(getSearchInput(), 'abc');
+      await searchUser.click(
+        screen.getByRole('button', { name: textMock('text_editor.new_text') }),
+      );
+      expect(setSearchQuery).toHaveBeenCalledWith('');
+      setSearchQuery.mockClear();
+
+      act(() => jest.advanceTimersByTime(searchDebounceTimeInMs * 2));
+
+      expect(setSearchQuery).not.toHaveBeenCalled();
+      expect(getSearchInput()).toHaveValue('');
+    });
+
+    it('updates the search field when the search query changes externally', () => {
+      const { rerender, allProps } = renderTextEditor({ searchQuery: 'first query' });
+      expect(getSearchInput()).toHaveValue('first query');
+
+      rerender(
+        <ServicesContextProvider {...queriesMock} client={queryClientMock}>
+          <TextEditor {...allProps} searchQuery='second query' />
+        </ServicesContextProvider>,
+      );
+
+      expect(getSearchInput()).toHaveValue('second query');
     });
   });
 });

--- a/src/Designer/frontend/packages/text-editor/src/TextEditor.tsx
+++ b/src/Designer/frontend/packages/text-editor/src/TextEditor.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import type { ChangeEvent } from 'react';
 import classes from './TextEditor.module.css';
 import type { LangCode, TextResourceEntryDeletion, TextResourceIdMutation } from './types';
 import type { UpsertTextResourceMutation } from 'app-shared/hooks/mutations/useUpsertTextResourceMutation';
@@ -6,7 +7,8 @@ import { ArrowsUpDownIcon } from '@studio/icons';
 import { StudioButton, StudioChip, StudioSearch } from '@studio/components';
 import { RightMenu } from './RightMenu';
 import { getRandNumber, mapResourceFilesToTableRows } from './utils';
-import { defaultLangCode } from './constants';
+import { defaultLangCode, searchDebounceTimeInMs } from './constants';
+import { useDebounce } from '@studio/hooks';
 import { TextList } from './TextList';
 import ISO6391 from 'iso-639-1';
 import type { ITextResources } from 'app-shared/types/global';
@@ -39,6 +41,11 @@ export const TextEditor = ({
 }: TextEditorProps) => {
   const { t } = useTranslation();
   const [sortTextsAlphabetically, setSortTextsAlphabetically] = useState<boolean>(false);
+  const [searchInputValue, setSearchInputValue] = useState<string>(searchQuery ?? '');
+  const { debounce } = useDebounce({ debounceTimeInMs: searchDebounceTimeInMs });
+  useEffect(() => {
+    setSearchInputValue(searchQuery ?? '');
+  }, [searchQuery]);
   const resourceRows = mapResourceFilesToTableRows(textResourceFiles, sortTextsAlphabetically);
   const previousSelectedLanguages = useRef<string[]>([]);
 
@@ -66,7 +73,8 @@ export const TextEditor = ({
     availableLangCodesFiltered.forEach((language) =>
       upsertTextResource({ language, textId, translation: '' }),
     );
-    setSearchQuery('');
+    setSearchInputValue('');
+    applySearchQuery('');
   };
 
   const removeEntry = ({ textId }: TextResourceEntryDeletion) => {
@@ -84,7 +92,13 @@ export const TextEditor = ({
       console.error('Renaming text-id failed:\n', e);
     }
   };
-  const handleSearchChange = (event: any) => setSearchQuery(event.target.value);
+  const applySearchQuery = (value: string): void =>
+    debounce(() => setSearchQuery(value), value ? {} : { debounceTimeInMs: 0 });
+
+  const handleSearchChange = (event: ChangeEvent<HTMLInputElement>): void => {
+    setSearchInputValue(event.target.value);
+    applySearchQuery(event.target.value);
+  };
 
   return (
     <div className={classes.textEditor}>
@@ -108,7 +122,7 @@ export const TextEditor = ({
             <StudioSearch
               className={classes.search}
               label={t('text_editor.search_for_text')}
-              value={searchQuery}
+              value={searchInputValue}
               onChange={handleSearchChange}
               clearButtonLabel={t('general.search_clear_button_title')}
             />

--- a/src/Designer/frontend/packages/text-editor/src/TextList.test.tsx
+++ b/src/Designer/frontend/packages/text-editor/src/TextList.test.tsx
@@ -9,6 +9,7 @@ import { queriesMock } from 'app-shared/mocks/queriesMock';
 import { QueryKey } from 'app-shared/types/QueryKey';
 import { queryClientMock } from 'app-shared/mocks/queryClientMock';
 import { app, org } from '@studio/testing/testids';
+import { textRowsPerPage } from './constants';
 
 const textKey1: string = 'a';
 
@@ -150,5 +151,50 @@ describe('TextList', () => {
 
     await user.keyboard('2{TAB}');
     expect(updateEntryId).toHaveBeenCalledWith({ oldId: 'a', newId: 'a2' });
+  });
+
+  describe('pagination', () => {
+    const renderManyRows = () => {
+      const resourceRows: TextTableRow[] = Array.from(
+        { length: textRowsPerPage * 2 },
+        (_, index) => ({
+          textKey: `key-${index}`,
+          translations: [{ lang: 'nb', translation: `value-${index}` }],
+        }),
+      );
+      queryClientMock.setQueryData([QueryKey.LayoutNames, org, app], []);
+      rtlRender(
+        <ServicesContextProvider {...queriesMock} client={queryClientMock}>
+          <TextList
+            resourceRows={resourceRows}
+            searchQuery={undefined}
+            updateEntryId={(_arg) => undefined}
+            removeEntry={(_arg) => undefined}
+            upsertTextResource={(_entry) => undefined}
+            selectedLanguages={['nb']}
+          />
+        </ServicesContextProvider>,
+      );
+    };
+
+    it('renders one page of rows at a time and moves to the page the user selects', async () => {
+      const user = userEvent.setup();
+      renderManyRows();
+
+      expect(screen.getAllByRole('row')).toHaveLength(textRowsPerPage + 1);
+      expect(screen.getByText('key-0')).toBeInTheDocument();
+      expect(screen.queryByText(`key-${textRowsPerPage}`)).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: `${textMock('general.page')} 2` }));
+
+      expect(screen.getByText(`key-${textRowsPerPage}`)).toBeInTheDocument();
+      expect(screen.queryByText('key-0')).not.toBeInTheDocument();
+    });
+
+    it('does not render pagination when all rows fit on one page', () => {
+      renderTextList();
+
+      expect(screen.queryByRole('navigation', { name: 'Pagination' })).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/Designer/frontend/packages/text-editor/src/TextList.test.tsx
+++ b/src/Designer/frontend/packages/text-editor/src/TextList.test.tsx
@@ -154,32 +154,17 @@ describe('TextList', () => {
   });
 
   describe('pagination', () => {
-    const renderManyRows = () => {
-      const resourceRows: TextTableRow[] = Array.from(
-        { length: textRowsPerPage * 2 },
-        (_, index) => ({
-          textKey: `key-${index}`,
-          translations: [{ lang: 'nb', translation: `value-${index}` }],
-        }),
-      );
-      queryClientMock.setQueryData([QueryKey.LayoutNames, org, app], []);
-      rtlRender(
-        <ServicesContextProvider {...queriesMock} client={queryClientMock}>
-          <TextList
-            resourceRows={resourceRows}
-            searchQuery={undefined}
-            updateEntryId={(_arg) => undefined}
-            removeEntry={(_arg) => undefined}
-            upsertTextResource={(_entry) => undefined}
-            selectedLanguages={['nb']}
-          />
-        </ServicesContextProvider>,
-      );
-    };
+    const manyResourceRows: TextTableRow[] = Array.from(
+      { length: textRowsPerPage * 2 },
+      (_, index) => ({
+        textKey: `key-${index}`,
+        translations: [{ lang: 'nb', translation: `value-${index}` }],
+      }),
+    );
 
     it('renders one page of rows at a time and moves to the page the user selects', async () => {
       const user = userEvent.setup();
-      renderManyRows();
+      renderTextList({ resourceRows: manyResourceRows, selectedLanguages: ['nb'] });
 
       expect(screen.getAllByRole('row')).toHaveLength(textRowsPerPage + 1);
       expect(screen.getByText('key-0')).toBeInTheDocument();

--- a/src/Designer/frontend/packages/text-editor/src/TextList.tsx
+++ b/src/Designer/frontend/packages/text-editor/src/TextList.tsx
@@ -2,13 +2,15 @@ import { useMemo } from 'react';
 import { TextRow } from './TextRow';
 import type { TextResourceEntryDeletion, TextResourceIdMutation, TextTableRow } from './types';
 import type { UpsertTextResourceMutation } from 'app-shared/hooks/mutations/useUpsertTextResourceMutation';
-import { filterFunction, getLangName } from './utils';
+import { filterRows, getLangName } from './utils';
 import { useTranslation } from 'react-i18next';
 import { APP_NAME } from 'app-shared/constants';
 import { useLayoutNamesQuery } from './hooks/useLayoutNamesQuery';
+import { usePaginatedRows } from './hooks/usePaginatedRows';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
-import { StudioTable } from '@studio/components';
+import { StudioPagination, StudioTable } from '@studio/components';
 import { StringUtils } from '@studio/pure-functions';
+import { textRowsPerPage } from './constants';
 
 export type TextListProps = {
   resourceRows: TextTableRow[];
@@ -35,32 +37,37 @@ export const TextList = ({
       .filter((textId: string) => textId.toLowerCase() !== oldTextId.toLowerCase())
       .some((textId: string) => StringUtils.areCaseInsensitiveEqual(textId, newTextId));
 
+  const matchingRows = filterRows(resourceRows, searchQuery);
+  const { currentPage, pageCount, rowsOnPage, goToPage } = usePaginatedRows(
+    matchingRows,
+    textRowsPerPage,
+    searchQuery,
+  );
+
   return (
-    <StudioTable>
-      <StudioTable.Head>
-        <StudioTable.Row>
-          <StudioTable.HeaderCell />
-          {selectedLanguages.map((language) => (
-            <StudioTable.HeaderCell
-              id={getTableHeaderCellId(language)}
-              key={getTableHeaderCellId(language)}
-            >
-              {getLangName({ code: language })}
+    <>
+      <StudioTable>
+        <StudioTable.Head>
+          <StudioTable.Row>
+            <StudioTable.HeaderCell />
+            {selectedLanguages.map((language) => (
+              <StudioTable.HeaderCell
+                id={getTableHeaderCellId(language)}
+                key={getTableHeaderCellId(language)}
+              >
+                {getLangName({ code: language })}
+              </StudioTable.HeaderCell>
+            ))}
+            <StudioTable.HeaderCell>
+              {t('text_editor.table_header_text_key')}
             </StudioTable.HeaderCell>
-          ))}
-          <StudioTable.HeaderCell>{t('text_editor.table_header_text_key')}</StudioTable.HeaderCell>
-          <StudioTable.HeaderCell>{t('text_editor.table_header_variables')}</StudioTable.HeaderCell>
-        </StudioTable.Row>
-      </StudioTable.Head>
-      <StudioTable.Body>
-        {resourceRows
-          .filter((row) =>
-            filterFunction({
-              entry: { id: row.textKey, translations: row.translations },
-              searchString: searchQuery,
-            }),
-          )
-          .map((row) => {
+            <StudioTable.HeaderCell>
+              {t('text_editor.table_header_variables')}
+            </StudioTable.HeaderCell>
+          </StudioTable.Row>
+        </StudioTable.Head>
+        <StudioTable.Body>
+          {rowsOnPage.map((row) => {
             const keyIsAppName = row.textKey === APP_NAME;
             const keyIsLayoutName = !layoutNamesPending && layoutNames.includes(row.textKey);
             return (
@@ -77,7 +84,18 @@ export const TextList = ({
               />
             );
           })}
-      </StudioTable.Body>
-    </StudioTable>
+        </StudioTable.Body>
+      </StudioTable>
+      {pageCount > 1 && (
+        <StudioPagination
+          currentPage={currentPage}
+          totalPages={pageCount}
+          onChange={goToPage}
+          previousButtonAriaLabel={t('general.previous')}
+          nextButtonAriaLabel={t('general.next')}
+          numberButtonAriaLabel={(number: number) => `${t('general.page')} ${number}`}
+        />
+      )}
+    </>
   );
 };

--- a/src/Designer/frontend/packages/text-editor/src/constants.ts
+++ b/src/Designer/frontend/packages/text-editor/src/constants.ts
@@ -1,1 +1,3 @@
 export const defaultLangCode = 'nb';
+export const textRowsPerPage = 25;
+export const searchDebounceTimeInMs = 300;

--- a/src/Designer/frontend/packages/text-editor/src/hooks/usePaginatedRows.test.ts
+++ b/src/Designer/frontend/packages/text-editor/src/hooks/usePaginatedRows.test.ts
@@ -1,0 +1,66 @@
+import { act, renderHook } from '@testing-library/react';
+import { usePaginatedRows } from './usePaginatedRows';
+
+describe('usePaginatedRows', () => {
+  const rows = Array.from({ length: 7 }, (_, index) => `row-${index}`);
+  const pageSize = 3;
+
+  it('returns the first page and the number of pages', () => {
+    const { result } = renderHook(() => usePaginatedRows(rows, pageSize, 'key'));
+
+    expect(result.current.currentPage).toBe(1);
+    expect(result.current.pageCount).toBe(3);
+    expect(result.current.rowsOnPage).toEqual(['row-0', 'row-1', 'row-2']);
+  });
+
+  it('returns the rows of the selected page', () => {
+    const { result } = renderHook(() => usePaginatedRows(rows, pageSize, 'key'));
+
+    act(() => {
+      result.current.goToPage(3);
+    });
+
+    expect(result.current.currentPage).toBe(3);
+    expect(result.current.rowsOnPage).toEqual(['row-6']);
+  });
+
+  it('reports a single page when there are no rows', () => {
+    const { result } = renderHook(() => usePaginatedRows([], pageSize, 'key'));
+
+    expect(result.current.pageCount).toBe(1);
+    expect(result.current.rowsOnPage).toEqual([]);
+  });
+
+  it('returns to the first page when the reset key changes', () => {
+    const { result, rerender } = renderHook(
+      ({ resetKey }) => usePaginatedRows(rows, pageSize, resetKey),
+      { initialProps: { resetKey: 'a' } },
+    );
+
+    act(() => {
+      result.current.goToPage(3);
+    });
+    expect(result.current.currentPage).toBe(3);
+
+    rerender({ resetKey: 'b' });
+
+    expect(result.current.currentPage).toBe(1);
+    expect(result.current.rowsOnPage).toEqual(['row-0', 'row-1', 'row-2']);
+  });
+
+  it('falls back to the last page when the rows no longer reach the selected page', () => {
+    const { result, rerender } = renderHook(
+      ({ items }) => usePaginatedRows(items, pageSize, 'key'),
+      { initialProps: { items: rows } },
+    );
+
+    act(() => {
+      result.current.goToPage(3);
+    });
+
+    rerender({ items: rows.slice(0, 4) });
+
+    expect(result.current.currentPage).toBe(2);
+    expect(result.current.rowsOnPage).toEqual(['row-3']);
+  });
+});

--- a/src/Designer/frontend/packages/text-editor/src/hooks/usePaginatedRows.ts
+++ b/src/Designer/frontend/packages/text-editor/src/hooks/usePaginatedRows.ts
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+
+export type PaginatedRows<T> = {
+  currentPage: number;
+  pageCount: number;
+  rowsOnPage: T[];
+  goToPage: (page: number) => void;
+};
+
+export const usePaginatedRows = <T>(
+  rows: T[],
+  pageSize: number,
+  resetKey: unknown,
+): PaginatedRows<T> => {
+  const [selectedPage, setSelectedPage] = useState<number>(1);
+  const [previousResetKey, setPreviousResetKey] = useState<unknown>(resetKey);
+
+  if (previousResetKey !== resetKey) {
+    setPreviousResetKey(resetKey);
+    setSelectedPage(1);
+  }
+
+  const pageCount = Math.max(1, Math.ceil(rows.length / pageSize));
+  const currentPage = Math.min(selectedPage, pageCount);
+
+  return {
+    currentPage,
+    pageCount,
+    rowsOnPage: rows.slice((currentPage - 1) * pageSize, currentPage * pageSize),
+    goToPage: setSelectedPage,
+  };
+};

--- a/src/Designer/frontend/packages/text-editor/src/utils.test.ts
+++ b/src/Designer/frontend/packages/text-editor/src/utils.test.ts
@@ -1,4 +1,11 @@
-import { filterFunction, getLangName, getRandNumber, mapResourceFilesToTableRows } from './utils';
+import {
+  filterFunction,
+  filterRows,
+  getLangName,
+  getRandNumber,
+  mapResourceFilesToTableRows,
+} from './utils';
+import type { TextTableRow } from './types';
 import type { ITextResources } from 'app-shared/types/global';
 
 describe('getLangName', () => {
@@ -160,5 +167,21 @@ describe('mapResourceFilesToTableRows', () => {
     const rows = mapResourceFilesToTableRows(textResources, true);
     expect(rows).toHaveLength(2);
     expect(rows[1].variables).toHaveLength(1);
+  });
+});
+
+describe('filterRows', () => {
+  const rows: TextTableRow[] = [
+    { textKey: 'first', translations: [{ lang: 'nb', translation: 'Norsk tekst' }] },
+    { textKey: 'second', translations: [{ lang: 'nb', translation: 'Annen tekst' }] },
+  ];
+
+  it('returns the rows whose key or translation matches the search', () => {
+    expect(filterRows(rows, 'first')).toEqual([rows[0]]);
+    expect(filterRows(rows, 'annen')).toEqual([rows[1]]);
+  });
+
+  it('returns every row when the search is empty', () => {
+    expect(filterRows(rows, '')).toEqual(rows);
   });
 });

--- a/src/Designer/frontend/packages/text-editor/src/utils.ts
+++ b/src/Designer/frontend/packages/text-editor/src/utils.ts
@@ -112,3 +112,11 @@ export const validateTextId = (textIdToValidate: string): string | null => {
 
   return null;
 };
+
+export const filterRows = (rows: TextTableRow[], searchString: string): TextTableRow[] =>
+  rows.filter((row) =>
+    filterFunction({
+      entry: { id: row.textKey, translations: row.translations },
+      searchString,
+    }),
+  );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Users experience problems working in text editor when they have a larger textfile, https://digdir.slack.com/archives/C09BLD1CRK8/p1787231379057949. 
Even when it is 100 rows (texts) it is pretty laggy to work in text editor such as using search, sort or add/remove languages. 

To solve this I added a debounce on the search field in a previous PR, https://github.com/Altinn/altinn-studio/pull/20094.
That solved some of the problem, but it keeps freezing when rendering the full list when search is cleared. 

But with debounce and pagination together it solved the problem. We don't render the full textfile, but 25 rows for each pagination. 
I experience this to be much more user friendly. I have understood we are going to do a revamp of text editor4, so i have kept it simpel. 

Below I have tested with a app that contains 100 ish texts.

<details><summary>Video before fix</summary>

https://github.com/user-attachments/assets/337bb550-b6ba-42d6-9660-521082177323

</details>

<details><summary>Video after fix</summary>

https://github.com/user-attachments/assets/d0b2e07f-f3c1-4bd3-9c36-9b8d4c68c9b9

</details>

<!--- Describe your changes in detail -->

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added pagination to text lists, displaying up to 25 rows per page with navigation controls when needed.
  - Added text filtering across keys and translations.
  - Added debounced search, applying queries after a short delay while clearing search results immediately.
  - Search input now stays synchronised when its value is changed externally.
- **Bug Fixes**
  - Clearing the search no longer allows a previously pending query to be applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->