### PR TITLE
chore(ci): tighten checkout credential and fetch-depth usage

### DIFF
--- a/.github/workflows/agents-docs-validate.yaml
+++ b/.github/workflows/agents-docs-validate.yaml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0

--- a/.github/workflows/app-backend-codeql.yml
+++ b/.github/workflows/app-backend-codeql.yml
@@ -46,6 +46,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0

--- a/.github/workflows/app-backend-formatting.yml
+++ b/.github/workflows/app-backend-formatting.yml
@@ -25,6 +25,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:

--- a/.github/workflows/app-backend-tests.yml
+++ b/.github/workflows/app-backend-tests.yml
@@ -25,6 +25,8 @@ jobs:
     runs-on: self-hosted-ubuntu
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/app-build-frontend
   analyze:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
@@ -52,7 +54,7 @@ jobs:
         run: git config --system core.longpaths true
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+          persist-credentials: false
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:

--- a/.github/workflows/app-codelists-codeql.yml
+++ b/.github/workflows/app-codelists-codeql.yml
@@ -47,6 +47,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Generate CodeQL config
       id: codeql-config

--- a/.github/workflows/app-codelists-tests.yml
+++ b/.github/workflows/app-codelists-tests.yml
@@ -42,7 +42,8 @@ jobs:
             10.0.x
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0  # MinVer needs full history/tags to compute the package version
+          persist-credentials: false
       - name: Build
         working-directory: ${{ matrix.os.workingDir }}
         run: |

--- a/.github/workflows/app-fileanalyzers-codeql.yml
+++ b/.github/workflows/app-fileanalyzers-codeql.yml
@@ -47,6 +47,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Generate CodeQL config
       id: codeql-config

--- a/.github/workflows/app-fileanalyzers-tests.yml
+++ b/.github/workflows/app-fileanalyzers-tests.yml
@@ -42,7 +42,8 @@ jobs:
             10.0.x
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0  # MinVer needs full history/tags to compute the package version
+          persist-credentials: false
       - name: Build
         working-directory: ${{ matrix.os.workingDir }}
         run: |

--- a/.github/workflows/app-frontend-codeql.yml
+++ b/.github/workflows/app-frontend-codeql.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
       - name: Generate CodeQL config
         id: codeql-config

--- a/.github/workflows/app-frontend-cypress.yml
+++ b/.github/workflows/app-frontend-cypress.yml
@@ -47,6 +47,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Build frontend
         uses: ./.github/actions/app-build-frontend
 
@@ -61,6 +63,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Build frontend
         uses: ./.github/actions/app-build-frontend
 
@@ -76,6 +80,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Resolve app run targets
         id: app-run-targets
@@ -219,6 +225,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Download app process outputs
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -319,6 +327,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Download app process outputs
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/app-frontend-k6-browser.yml
+++ b/.github/workflows/app-frontend-k6-browser.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Build frontend
         uses: ./.github/actions/app-build-frontend
 
@@ -49,6 +51,8 @@ jobs:
     needs: [build-frontend]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Run Local Environment
         uses: ./.github/actions/app-run-local-env

--- a/.github/workflows/app-frontend-lighthouse-ci.yml
+++ b/.github/workflows/app-frontend-lighthouse-ci.yml
@@ -48,6 +48,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Build frontend
         uses: ./.github/actions/app-build-frontend
 
@@ -60,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up App Frontend test dependencies
         uses: ./.github/actions/app-frontend-test-dependencies

--- a/.github/workflows/app-frontend-unit-tests.yml
+++ b/.github/workflows/app-frontend-unit-tests.yml
@@ -26,7 +26,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     runs-on: self-hosted-ubuntu
     timeout-minutes: 30
-    name: Type-checks, eslint, unit tests and SonarCloud
+    name: Type-checks, eslint and unit tests
     defaults:
       run:
         working-directory: src/App/frontend/
@@ -34,7 +34,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+          persist-credentials: false
 
       - name: install node
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
@@ -76,16 +76,3 @@ jobs:
         run: yarn test --coverage --maxWorkers=4
         env:
           NODE_OPTIONS: --max-old-space-size=4096
-
-      # TODO: consider for removal?
-      # - name: SonarCloud Scan
-      #   if: |
-      #     github.repository_owner == 'Altinn' &&
-      #     (github.event_name != 'pull_request' && github.event.repository.fork == false) ||
-      #     (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
-      #   with:
-      #     projectBaseDir: src/App/frontend/
-      #   uses: SonarSource/sonarqube-scan-action@1a6d90ebcb0e6a6b1d87e37ba693fe453195ae25 # v5.3.1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/app-template-build-on-pr.yaml
+++ b/.github/workflows/app-template-build-on-pr.yaml
@@ -29,6 +29,8 @@ jobs:
       DOTNET_HOSTBUILDER__RELOADCONFIGONCHANGE: false
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Make template release
         run: |

--- a/.github/workflows/app-template-test.yml
+++ b/.github/workflows/app-template-test.yml
@@ -40,7 +40,7 @@ jobs:
             10.0.x
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          persist-credentials: false
       - name: Build
         run: |
            dotnet build src/App.sln -v m

--- a/.github/workflows/cli-build-test.yaml
+++ b/.github/workflows/cli-build-test.yaml
@@ -25,8 +25,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
@@ -76,7 +76,7 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0

--- a/.github/workflows/codeowners-validate.yaml
+++ b/.github/workflows/codeowners-validate.yaml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0

--- a/.github/workflows/common-typescript-unit-test.yml
+++ b/.github/workflows/common-typescript-unit-test.yml
@@ -29,7 +29,6 @@ jobs:
       - name: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
           persist-credentials: false
 
       - name: install node

--- a/.github/workflows/construct-environments-script-test.yaml
+++ b/.github/workflows/construct-environments-script-test.yaml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
+          persist-credentials: false
           sparse-checkout: |
             .github/scripts
 

--- a/.github/workflows/deploy-admin-syncroot.yaml
+++ b/.github/workflows/deploy-admin-syncroot.yaml
@@ -27,7 +27,6 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
           persist-credentials: false
 
       - name: Set vars
@@ -73,7 +72,6 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
           persist-credentials: false
 
       - name: az login

--- a/.github/workflows/deploy-admin-workflow-engine-db.yaml
+++ b/.github/workflows/deploy-admin-workflow-engine-db.yaml
@@ -27,7 +27,6 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
           persist-credentials: false
 
       - name: Set vars
@@ -73,7 +72,6 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
           persist-credentials: false
 
       - name: az login

--- a/.github/workflows/deploy-admin-workflow-engine-tenant-db-template.yaml
+++ b/.github/workflows/deploy-admin-workflow-engine-tenant-db-template.yaml
@@ -27,7 +27,6 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
           persist-credentials: false
 
       - name: Set vars
@@ -73,7 +72,6 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
           persist-credentials: false
 
       - name: az login

--- a/.github/workflows/deploy-github-runners.yaml
+++ b/.github/workflows/deploy-github-runners.yaml
@@ -52,6 +52,8 @@ jobs:
         working-directory: src/ci/github-runner
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set vars
         id: vars
@@ -154,6 +156,8 @@ jobs:
         working-directory: src/ci/github-runner
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: az login
         uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1
@@ -234,6 +238,8 @@ jobs:
       CONFIG_REPO: ${{ needs.build-images.outputs.config_repo }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: az login
         uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1

--- a/.github/workflows/deploy-lhci-server.yaml
+++ b/.github/workflows/deploy-lhci-server.yaml
@@ -35,6 +35,8 @@ jobs:
         working-directory: src/lhci-server
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set vars
         id: vars

--- a/.github/workflows/deploy-runner-org-sync.yaml
+++ b/.github/workflows/deploy-runner-org-sync.yaml
@@ -35,6 +35,8 @@ jobs:
         working-directory: src/ci/runner-org-sync
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set vars
         id: vars

--- a/.github/workflows/deploy-runtime-apps-config.yaml
+++ b/.github/workflows/deploy-runtime-apps-config.yaml
@@ -37,6 +37,8 @@ jobs:
         working-directory: infra/runtime/apps-config
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set vars
         id: vars

--- a/.github/workflows/deploy-runtime-flux-config.yaml
+++ b/.github/workflows/deploy-runtime-flux-config.yaml
@@ -37,6 +37,8 @@ jobs:
         working-directory: infra/runtime/flux-config
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set vars
         id: vars

--- a/.github/workflows/deploy-runtime-gateway.yaml
+++ b/.github/workflows/deploy-runtime-gateway.yaml
@@ -40,6 +40,8 @@ jobs:
         working-directory: src/Runtime/gateway
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set vars
         id: vars

--- a/.github/workflows/deploy-runtime-grafana-manifests.yaml
+++ b/.github/workflows/deploy-runtime-grafana-manifests.yaml
@@ -38,6 +38,8 @@ jobs:
         working-directory: infra/runtime/grafana-manifests
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set vars
         id: vars

--- a/.github/workflows/deploy-runtime-kubernetes-wrapper.yaml
+++ b/.github/workflows/deploy-runtime-kubernetes-wrapper.yaml
@@ -32,6 +32,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Docker
         uses: docker/setup-docker-action@e43656e248c0bd0647d3f5c195d116aacf6fcaf4 # v4.7.0
@@ -76,6 +78,8 @@ jobs:
       config-repo: ${{ steps.vars.outputs.config-repo }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set vars
         id: vars

--- a/.github/workflows/deploy-runtime-localtest.yaml
+++ b/.github/workflows/deploy-runtime-localtest.yaml
@@ -24,6 +24,8 @@ jobs:
         working-directory: src
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Docker
         uses: docker/setup-docker-action@e43656e248c0bd0647d3f5c195d116aacf6fcaf4 # v4.7.0

--- a/.github/workflows/deploy-runtime-observability.yaml
+++ b/.github/workflows/deploy-runtime-observability.yaml
@@ -38,6 +38,8 @@ jobs:
         working-directory: infra/observability
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set vars
         id: vars

--- a/.github/workflows/deploy-runtime-operator.yaml
+++ b/.github/workflows/deploy-runtime-operator.yaml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0 # Shallow clone
+          persist-credentials: false
 
       - name: Set up Docker
         uses: docker/setup-docker-action@e43656e248c0bd0647d3f5c195d116aacf6fcaf4 # v4.7.0
@@ -122,7 +122,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0 # Shallow clone
+          persist-credentials: false
 
       - name: az login
         uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1

--- a/.github/workflows/deploy-runtime-pdf3.yaml
+++ b/.github/workflows/deploy-runtime-pdf3.yaml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0 # Shallow clone
+          persist-credentials: false
 
       - name: Set up Docker
         uses: docker/setup-docker-action@e43656e248c0bd0647d3f5c195d116aacf6fcaf4 # v4.7.0
@@ -141,7 +141,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0 # Shallow clone
+          persist-credentials: false
 
       - name: az login
         uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1

--- a/.github/workflows/deploy-runtime-syncroot.yaml
+++ b/.github/workflows/deploy-runtime-syncroot.yaml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0 # Shallow clone
+          persist-credentials: false
 
       - name: Set vars
         id: vars
@@ -81,7 +81,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0 # Shallow clone
+          persist-credentials: false
 
       - name: az login
         uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1

--- a/.github/workflows/deploy-runtime-workflow-engine-app.yaml
+++ b/.github/workflows/deploy-runtime-workflow-engine-app.yaml
@@ -53,6 +53,8 @@ jobs:
         working-directory: src/Runtime/workflow-engine-app
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set vars
         id: vars

--- a/.github/workflows/deploy-sandbox-node.yaml
+++ b/.github/workflows/deploy-sandbox-node.yaml
@@ -37,6 +37,8 @@ jobs:
         working-directory: src/ci/sandbox-node
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set vars
         id: vars

--- a/.github/workflows/deploy-studio-ai-agents.yaml
+++ b/.github/workflows/deploy-studio-ai-agents.yaml
@@ -38,6 +38,8 @@ jobs:
         working-directory: src/AI/agents
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set vars
         id: vars

--- a/.github/workflows/deploy-studio-external-secrets-operator.yaml
+++ b/.github/workflows/deploy-studio-external-secrets-operator.yaml
@@ -36,6 +36,8 @@ jobs:
         working-directory: infra/studio/external-secrets-operator
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set vars
         id: vars

--- a/.github/workflows/deploy-studio-keyvault-secret-store.yaml
+++ b/.github/workflows/deploy-studio-keyvault-secret-store.yaml
@@ -32,6 +32,8 @@ jobs:
       CONFIG_REPO: ${{ steps.vars.outputs.config-repo }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set vars
         id: vars

--- a/.github/workflows/deploy-studio-observability.yaml
+++ b/.github/workflows/deploy-studio-observability.yaml
@@ -38,6 +38,8 @@ jobs:
         working-directory: infra/observability
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set vars
         id: vars

--- a/.github/workflows/deploy-studio-otel-operator.yaml
+++ b/.github/workflows/deploy-studio-otel-operator.yaml
@@ -36,6 +36,8 @@ jobs:
         working-directory: infra/studio/otel-operator
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set vars
         id: vars

--- a/.github/workflows/deploy-studio-ssl-cert.yaml
+++ b/.github/workflows/deploy-studio-ssl-cert.yaml
@@ -32,6 +32,8 @@ jobs:
       CONFIG_REPO: ${{ steps.vars.outputs.config-repo }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set vars
         id: vars

--- a/.github/workflows/deploy-studio-syncroot.yaml
+++ b/.github/workflows/deploy-studio-syncroot.yaml
@@ -38,6 +38,8 @@ jobs:
         working-directory: ./infra/studio
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set vars
         id: vars

--- a/.github/workflows/deployer-check.yaml
+++ b/.github/workflows/deployer-check.yaml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0

--- a/.github/workflows/designer-backend-check-quartz-update.yml
+++ b/.github/workflows/designer-backend-check-quartz-update.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check if quartz library is updated
         id: check-quartz-update

--- a/.github/workflows/designer-backend-codeql.yml
+++ b/.github/workflows/designer-backend-codeql.yml
@@ -44,6 +44,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0

--- a/.github/workflows/designer-backend-dotnet-format.yaml
+++ b/.github/workflows/designer-backend-dotnet-format.yaml
@@ -25,6 +25,8 @@ jobs:
         working-directory: src/Designer/backend
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:

--- a/.github/workflows/designer-backend-dotnet-migrations-ensure-compatibility.yaml
+++ b/.github/workflows/designer-backend-dotnet-migrations-ensure-compatibility.yaml
@@ -26,6 +26,8 @@ jobs:
       OidcLoginSettings__ClientSecret: 'dummyRequired'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0

--- a/.github/workflows/designer-backend-dotnet-test.yaml
+++ b/.github/workflows/designer-backend-dotnet-test.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          persist-credentials: false
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:

--- a/.github/workflows/designer-backend-gitea-and-db-integration-tests.yaml
+++ b/.github/workflows/designer-backend-gitea-and-db-integration-tests.yaml
@@ -27,6 +27,8 @@ jobs:
       DOTNET_HOSTBUILDER__RELOADCONFIGONCHANGE: false
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0

--- a/.github/workflows/designer-frontend-codeql.yml
+++ b/.github/workflows/designer-frontend-codeql.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
       - name: Generate CodeQL config
         id: codeql-config

--- a/.github/workflows/designer-frontend-playwright-staging.yml
+++ b/.github/workflows/designer-frontend-playwright-staging.yml
@@ -17,7 +17,7 @@ jobs:
       - name: 'Checking Out Code'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:

--- a/.github/workflows/designer-frontend-resourceadm-playwright-staging.yml
+++ b/.github/workflows/designer-frontend-resourceadm-playwright-staging.yml
@@ -17,7 +17,7 @@ jobs:
       - name: 'Checking Out Code'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:

--- a/.github/workflows/designer-frontend-resourceadm-run-playwright-on-pr.yml
+++ b/.github/workflows/designer-frontend-resourceadm-run-playwright-on-pr.yml
@@ -25,7 +25,7 @@ jobs:
       - name: 'Checking Out Code'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
       - name: Generate .env file
         run: |

--- a/.github/workflows/designer-frontend-run-playwright-on-pr.yaml
+++ b/.github/workflows/designer-frontend-run-playwright-on-pr.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: 'Checking Out Code'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
       - name: Generate .env file
         run: |

--- a/.github/workflows/designer-frontend-unit-tests.yml
+++ b/.github/workflows/designer-frontend-unit-tests.yml
@@ -36,7 +36,7 @@ jobs:
       - name: 'Checking Out Code'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
       - name: 'Installing Dependencies'
         uses: ./.github/actions/yarn-install
@@ -66,7 +66,7 @@ jobs:
       - name: 'Checking Out Code'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
       - name: 'Installing Dependencies'
         uses: ./.github/actions/yarn-install

--- a/.github/workflows/designer-scan.yml
+++ b/.github/workflows/designer-scan.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - name: Build the Docker image
       run: docker build --file ./src/Designer/Dockerfile --tag altinn-designer:${{github.sha}} .
 

--- a/.github/workflows/gitea-check-texts-file.yml
+++ b/.github/workflows/gitea-check-texts-file.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
       - name: Get the new gitea version
         id: get-gitea-version

--- a/.github/workflows/gitea-proxy-test.yml
+++ b/.github/workflows/gitea-proxy-test.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install hurl
         run: |

--- a/.github/workflows/gitea-runner-test.yml
+++ b/.github/workflows/gitea-runner-test.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Build Docker image
         run: docker build -t gitea-runner-test .

--- a/.github/workflows/release-studioctl.yaml
+++ b/.github/workflows/release-studioctl.yaml
@@ -41,6 +41,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.merge_commit_sha || github.sha }}
+          persist-credentials: false
 
       - name: Checkout base branch
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,8 +21,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: altinn-studio
-          fetch-tags: true
-          fetch-depth: 0
+          persist-credentials: false
 
       - name: Run release script
         working-directory: altinn-studio

--- a/.github/workflows/releaser-build-test.yml
+++ b/.github/workflows/releaser-build-test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0

--- a/.github/workflows/repositories-scan.yml
+++ b/.github/workflows/repositories-scan.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - name: Build the Docker image
       run: docker build ./gitea --tag altinn-repos:${{github.sha}}
 

--- a/.github/workflows/runtime-devenv-build.yml
+++ b/.github/workflows/runtime-devenv-build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:

--- a/.github/workflows/runtime-gateway-tests.yaml
+++ b/.github/workflows/runtime-gateway-tests.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0

--- a/.github/workflows/runtime-health-build.yml
+++ b/.github/workflows/runtime-health-build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:

--- a/.github/workflows/runtime-kubernetes-wrapper-build.yaml
+++ b/.github/workflows/runtime-kubernetes-wrapper-build.yaml
@@ -31,6 +31,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Setup .NET
       uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0

--- a/.github/workflows/runtime-localtest-build.yml
+++ b/.github/workflows/runtime-localtest-build.yml
@@ -22,6 +22,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:

--- a/.github/workflows/runtime-operator-build.yml
+++ b/.github/workflows/runtime-operator-build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
@@ -66,7 +66,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:

--- a/.github/workflows/runtime-pdf3-build.yml
+++ b/.github/workflows/runtime-pdf3-build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:

--- a/.github/workflows/runtime-workflow-engine-app-tests.yaml
+++ b/.github/workflows/runtime-workflow-engine-app-tests.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
       - name: Spell check
         uses: crate-ci/typos@8a48f81b6c64dcfea44b3633223084c4be58ac5f # v1.49.0

--- a/.github/workflows/runtime-workflow-engine-tests.yaml
+++ b/.github/workflows/runtime-workflow-engine-tests.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
       - name: Spell check
         uses: crate-ci/typos@8a48f81b6c64dcfea44b3633223084c4be58ac5f # v1.49.0

--- a/.github/workflows/sandbox-node-build.yml
+++ b/.github/workflows/sandbox-node-build.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:

--- a/.github/workflows/storybook-to-github-pages.yaml
+++ b/.github/workflows/storybook-to-github-pages.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Use node LTS and yarn cache
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0

--- a/.github/workflows/studio-components-deploy.yaml
+++ b/.github/workflows/studio-components-deploy.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Use node LTS and yarn cache
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0

--- a/.github/workflows/studio-components-legacy-deploy.yaml
+++ b/.github/workflows/studio-components-legacy-deploy.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Use node LTS and yarn cache
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0

--- a/.github/workflows/template-docker-push.yaml
+++ b/.github/workflows/template-docker-push.yaml
@@ -48,6 +48,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ inputs.checkout-repository }}
+          persist-credentials: false
 
       - name: 'Azure login'
         uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1

--- a/.github/workflows/template-flux-config-push.yaml
+++ b/.github/workflows/template-flux-config-push.yaml
@@ -53,6 +53,8 @@ jobs:
     environment: ${{ inputs.environment }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: 'Azure login'
         uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1

--- a/.github/workflows/template-helm-push.yaml
+++ b/.github/workflows/template-helm-push.yaml
@@ -32,6 +32,8 @@ jobs:
     environment: ${{ inputs.environment }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: 'Azure login'
         uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1

--- a/.github/workflows/template-runtime-construct-environments.yaml
+++ b/.github/workflows/template-runtime-construct-environments.yaml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
+          persist-credentials: false
           sparse-checkout: |
             .github/scripts
 

--- a/.github/workflows/template-studio-construct-environments.yaml
+++ b/.github/workflows/template-studio-construct-environments.yaml
@@ -33,6 +33,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
+          persist-credentials: false
           sparse-checkout: |
             .github/scripts
 

--- a/.github/workflows/validate-renovate.yaml
+++ b/.github/workflows/validate-renovate.yaml
@@ -21,6 +21,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 22


### PR DESCRIPTION
## Summary

CI hygiene pass over all `actions/checkout` usages (117 occurrences across 95 workflow files):

- **`persist-credentials: false`** added to every checkout step that does not push via git afterwards. The one intentional exception is `rotate-grafana-gateway-token-expiry.yaml`, which does `git commit` + `git push --force-with-lease` and therefore needs persisted credentials.
- **`fetch-depth: 0` removed** where full history is not actually used — mostly copy-pasted "better relevancy of analysis" Sonar boilerplate with no active Sonar step in the workflow.
- **Removed the commented-out SonarCloud scan step** from `app-frontend-unit-tests.yml` (tagged `TODO: consider for removal?`), along with the `fetch-depth: 0` and the job-name mention that only existed for it.

## Where `fetch-depth: 0` was kept (verified necessary)

- `app-codelists-tests.yml`, `app-fileanalyzers-tests.yml` — MinVer computes package versions from tag history (comment updated to say so).
- `changelog.yml`, `cli-changelog.yaml`, `release-app.yaml`, `release-studioctl.yaml` — the releaser's changelog validation uses `git merge-base` between PR base and head.
- `designer-backend-check-quartz-update.yml` — diffs `origin/$BASE_REF...origin/$HEAD_REF`, which needs all refs fetched.

## Verification

- All workflow files parse as valid YAML.
- Riskier removals were checked against the code they invoke: `release.sh` resolves versions via the GitHub releases API (no local git), the releaser dry-run in `cli-build-test.yaml` only uses `git rev-parse`/`git ls-remote`, Lighthouse CI receives its ancestor hash via `LHCI_BUILD_CONTEXT__ANCESTOR_HASH`, and the SonarAnalyzer hits in `Directory.Build.props` files are the compile-time Roslyn analyzer, which needs no history.
- No branch protection/ruleset required status checks reference the renamed unit-test job.

## Follow-up (not in this PR)

- `src/cli/Directory.Packages.props` declares MinVer 6.1.0 but no project references it; `cli-build-test.yaml` also retains a likely-unneeded `fetch-tags: true`. Both can go in a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Improved CI/CD security by preventing Git credentials from being persisted after repository checkout.
  - Reduced unnecessary full-history and tag downloads across automated workflows.

- **Maintenance**
  - Updated checkout configuration consistently across build, test, analysis, deployment and release processes.
  - Preserved full repository history only where required for version calculation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->