### PR TITLE
ci: tune gh runner resource alloc

### DIFF
--- a/src/ci/github-runner/infra/kustomize/base/scaledjob.yaml
+++ b/src/ci/github-runner/infra/kustomize/base/scaledjob.yaml
@@ -68,7 +68,6 @@ spec:
                 cpu: "4"
                 memory: 2Gi
               limits:
-                cpu: "4"
                 memory: 2Gi
             volumeMounts:
               - name: provider-cache
@@ -104,7 +103,7 @@ spec:
               - name: SANDBOX_CPUS
                 value: "4"
               - name: SANDBOX_MEMORY
-                value: 12Gi
+                value: 16Gi
               - name: SANDBOX_ROOT_FILESYSTEM
                 value: 100Gi
               - name: GITHUB_API_URL
@@ -143,11 +142,11 @@ spec:
             resources:
               requests:
                 cpu: "5"
-                memory: 14Gi
+                memory: 17Gi
                 ephemeral-storage: 2Gi
                 devices.altinn.studio/kvm: "1"
               limits:
-                memory: 14Gi
+                memory: 18Gi
                 ephemeral-storage: 4Gi
                 devices.altinn.studio/kvm: "1"
             volumeMounts:


### PR DESCRIPTION
## Description

- no cpu limit on init container
- increase memory available to sandbox since we do slightly less packing now, should still be abou 20GiB headroom afterwards on a full node

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Increased available memory and resources for coordinator workloads, supporting more demanding processing.
  - Expanded sandbox memory capacity from 12 GiB to 16 GiB.
  - Increased coordinator resource capacity to improve workload stability.
  - Removed an unnecessary CPU reservation during image preparation, allowing more flexible resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->