### PR TITLE
ci: caching overhaul

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -35,7 +35,7 @@ Couplings to keep in sync:
 
 | When changing… | Also update… |
 | --- | --- |
-| Go modules (add/remove) | The `go-modules` matrix in cache-warm **and** the workflow's `setup-go-cached` step — the matrix must cover every (module, runner OS) pair the PR workflows use. |
+| Go modules (add/remove) | The `go-modules` matrix in cache-warm **and** the workflow's `setup-go-cached` step — the matrix must cover every (module, runner environment) combination the PR workflows use — keys are scoped per runner environment and image. |
 | Yarn caching | Single scheme: `setup-node` with `cache: 'yarn'` + `cache-dependency-path: yarn.lock` (the root lockfile), seeded by cache-warm's `yarn` job. |
 | ghcr `localtest-*-cache` refs | Hardcoded in [`core.go`](../src/cli/internal/cmd/env/localtest/components/core.go) and [`pdf.go`](../src/cli/internal/cmd/env/localtest/components/pdf.go); written only by cache-warm. |
 | Cypress (`src/App/frontend/package.json`) or Rust (root `Cargo.toml`) versions | Nothing by hand — `deploy-github-runners.yaml` bakes them into the runner image; workflows fall back (`npx cypress install` / rustup) on drift until it rebuilds. |

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,47 @@
+# AGENTS.md — GitHub CI (`.github`)
+
+GitHub Actions workflows (`workflows/`) and composite actions (`actions/`).
+Guidance is organized by topic.
+
+## Caching
+
+Three mechanisms, by content type:
+
+1. **GitHub Actions cache** (10GB/repo, LRU-evicted). Shared entries are seeded
+   on main by [`workflows/cache-warm.yml`](workflows/cache-warm.yml) (daily
+   06:00 UTC + dispatch) and restored-only by PR jobs — PR-ref saves are
+   invisible to other PRs and evict the shared entries (letting PR jobs save
+   freely is what blew the quota; see #20121). Two bounded exceptions save
+   wherever they run:
+   - *Run-handoff caches* (LocalTest image tar, focused node_modules, studioctl
+     dev-home): content-addressed archives one job builds and sibling jobs in
+     the same run require; the nightly cypress cron seeds them on main.
+   - *setup-node's built-in yarn cache* saves only on a primary-key miss, i.e.
+     one entry per lockfile-changing PR. Go outgrew that same behavior
+     (Renovate churn) and uses
+     [`actions/setup-go-cached`](actions/setup-go-cached/action.yaml) instead.
+2. **BuildKit registry cache** (ghcr/ACR `:buildcache` refs, no quota) for
+   docker image layers. Every build reads via `--cache-from` (public refs need
+   no auth). Writes happen only from trusted main contexts: `cache-warm.yml`
+   for the LocalTest images, each `deploy-*` workflow for its own images (ACR
+   refs need `image-manifest=true`). Never grant `packages: write` to a
+   PR-triggered job.
+3. **The runner image**
+   ([`src/ci/github-runner`](../src/ci/github-runner/Dockerfile)): anything
+   identical on every run (Go/Node/Rust/.NET toolchains, Chrome, Cypress,
+   cargo-machete) is baked in, not downloaded or cached per job.
+
+Couplings to keep in sync:
+
+| When changing… | Also update… |
+| --- | --- |
+| Go modules (add/remove) | The `go-modules` matrix in cache-warm **and** the workflow's `setup-go-cached` step — the matrix must cover every (module, runner OS) pair the PR workflows use. |
+| Yarn caching | Single scheme: `setup-node` with `cache: 'yarn'` + `cache-dependency-path: yarn.lock` (the root lockfile), seeded by cache-warm's `yarn` job. |
+| ghcr `localtest-*-cache` refs | Hardcoded in [`core.go`](../src/cli/internal/cmd/env/localtest/components/core.go) and [`pdf.go`](../src/cli/internal/cmd/env/localtest/components/pdf.go); written only by cache-warm. |
+| Cypress (`src/App/frontend/package.json`) or Rust (root `Cargo.toml`) versions | Nothing by hand — `deploy-github-runners.yaml` bakes them into the runner image; workflows fall back (`npx cypress install` / rustup) on drift until it rebuilds. |
+| rust-cache | One `shared-key: rust`; cache-warm is the only saver (`save-if: false` in the PR workflows). |
+
+Prefer `restore-keys` prefixes on hash-keyed caches (dependency-bump PRs get
+partial hits from the latest main entry) but never on content-addressed ones (a
+partial restore is silently stale). A new heavy per-run download belongs in the
+runner image, not in a workflow step.

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/.github/actions/app-frontend-test-dependencies/action.yaml
+++ b/.github/actions/app-frontend-test-dependencies/action.yaml
@@ -25,9 +25,9 @@ runs:
       shell: bash
       env:
         PROVIDED_CACHE_KEY: ${{ inputs.cache-key }}
-        SOURCE_HASH: ${{ hashFiles('yarn.lock', '.yarnrc.yml', 'package.json', 'src/App/frontend/package.json', 'app-libs/**/package.json') }}
+        SOURCE_HASH: ${{ hashFiles('yarn.lock', '.yarnrc.yml', 'package.json', 'src/App/frontend/package.json', 'src/common/ts/package.json', 'src/common/ts/*/package.json') }}
       run: |
-        cache_key="${PROVIDED_CACHE_KEY:-app-frontend-focused-dependencies-v2-${{ runner.os }}-${{ runner.arch }}-node22-yarn4.18-${SOURCE_HASH}}"
+        cache_key="${PROVIDED_CACHE_KEY:-app-frontend-focused-dependencies-v3-${{ runner.os }}-${{ runner.arch }}-node22-yarn4.18-${SOURCE_HASH}}"
         echo "cache-key=${cache_key}" >> "$GITHUB_OUTPUT"
 
     - name: Restore focused App Frontend dependencies
@@ -37,7 +37,8 @@ runs:
         path: |
           node_modules
           src/App/frontend/node_modules
-          app-libs/**/node_modules
+          src/common/ts/node_modules
+          src/common/ts/*/node_modules
           .yarn/install-state.gz
         key: ${{ steps.resolve-cache-key.outputs.cache-key }}
         lookup-only: ${{ inputs.populate-cache }}
@@ -95,7 +96,8 @@ runs:
         path: |
           node_modules
           src/App/frontend/node_modules
-          app-libs/**/node_modules
+          src/common/ts/node_modules
+          src/common/ts/*/node_modules
           .yarn/install-state.gz
         key: ${{ steps.resolve-cache-key.outputs.cache-key }}
 
@@ -106,7 +108,8 @@ runs:
         path: |
           node_modules
           src/App/frontend/node_modules
-          app-libs/**/node_modules
+          src/common/ts/node_modules
+          src/common/ts/*/node_modules
           .yarn/install-state.gz
         key: ${{ steps.resolve-cache-key.outputs.cache-key }}
         lookup-only: true

--- a/.github/actions/setup-go-cached/action.yaml
+++ b/.github/actions/setup-go-cached/action.yaml
@@ -1,0 +1,65 @@
+name: "Set up Go with shared caches"
+description: "setup-go plus restore-only Go module/build caches seeded from main by cache-warm.yml"
+inputs:
+  module:
+    description: "Path to the Go module directory (contains go.mod)"
+    required: true
+  populate-cache:
+    description: "Build the module and save the cache on a primary-key miss (cache-warm.yml only)"
+    required: false
+    default: "false"
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Go
+      id: setup
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      with:
+        go-version-file: ${{ inputs.module }}/go.mod
+        cache: false
+
+    - name: Resolve Go cache locations and key
+      id: config
+      shell: bash
+      env:
+        # go.sum is hashed together with go.mod; a module without external
+        # dependencies has no go.sum, and a hashFiles pattern that matches
+        # nothing simply contributes nothing to the hash.
+        CACHE_KEY: go-cache-v1-${{ runner.os }}-${{ runner.arch }}-go${{ steps.setup.outputs.go-version }}-${{ inputs.module }}-${{ hashFiles(format('{0}/go.sum', inputs.module), format('{0}/go.mod', inputs.module)) }}
+      run: |
+        echo "gomodcache=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+        echo "gocache=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+        echo "key=${CACHE_KEY}" >> "$GITHUB_OUTPUT"
+
+    # Restore only: the shared entries are saved from main by cache-warm.yml.
+    # PR-ref saves cannot be restored by other PRs or main and just evict the
+    # shared entries, so PR jobs never save. The restore-keys prefix gives
+    # dependency-update PRs a partial hit on the latest main entry, so only
+    # the changed modules are downloaded.
+    - name: Restore Go caches
+      id: restore
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: |
+          ${{ steps.config.outputs.gomodcache }}
+          ${{ steps.config.outputs.gocache }}
+        key: ${{ steps.config.outputs.key }}
+        restore-keys: |
+          go-cache-v1-${{ runner.os }}-${{ runner.arch }}-go${{ steps.setup.outputs.go-version }}-${{ inputs.module }}-
+
+    - name: Warm Go module and build caches
+      if: ${{ inputs.populate-cache == 'true' && steps.restore.outputs.cache-hit != 'true' }}
+      shell: bash
+      working-directory: ${{ inputs.module }}
+      run: |
+        go mod download
+        go build ./...
+
+    - name: Save Go caches
+      if: ${{ inputs.populate-cache == 'true' && steps.restore.outputs.cache-hit != 'true' }}
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: |
+          ${{ steps.config.outputs.gomodcache }}
+          ${{ steps.config.outputs.gocache }}
+        key: ${{ steps.config.outputs.key }}

--- a/.github/actions/setup-go-cached/action.yaml
+++ b/.github/actions/setup-go-cached/action.yaml
@@ -22,14 +22,21 @@ runs:
       id: config
       shell: bash
       env:
-        # go.sum is hashed together with go.mod; a module without external
-        # dependencies has no go.sum, and a hashFiles pattern that matches
-        # nothing simply contributes nothing to the hash.
-        CACHE_KEY: go-cache-v1-${{ runner.os }}-${{ runner.arch }}-go${{ steps.setup.outputs.go-version }}-${{ inputs.module }}-${{ hashFiles(format('{0}/go.sum', inputs.module), format('{0}/go.mod', inputs.module)) }}
+        # runner.environment + ImageOS separate the independently maintained
+        # runner images (self-hosted vs GitHub-hosted, and image versions
+        # within each lineage): Go build-cache entries hash the C toolchain
+        # for cgo packages, so entries built on one image can silently never
+        # hit on another. go.sum is hashed together with go.mod; a module
+        # without external dependencies has no go.sum, and a hashFiles
+        # pattern that matches nothing simply contributes nothing.
+        KEY_PREFIX: go-cache-v1-${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}
+        KEY_SUFFIX: go${{ steps.setup.outputs.go-version }}-${{ inputs.module }}
+        SOURCE_HASH: ${{ hashFiles(format('{0}/go.sum', inputs.module), format('{0}/go.mod', inputs.module)) }}
       run: |
         echo "gomodcache=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
         echo "gocache=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
-        echo "key=${CACHE_KEY}" >> "$GITHUB_OUTPUT"
+        echo "restore-prefix=${KEY_PREFIX}-${ImageOS:-none}-${KEY_SUFFIX}-" >> "$GITHUB_OUTPUT"
+        echo "key=${KEY_PREFIX}-${ImageOS:-none}-${KEY_SUFFIX}-${SOURCE_HASH}" >> "$GITHUB_OUTPUT"
 
     # Restore only: the shared entries are saved from main by cache-warm.yml.
     # PR-ref saves cannot be restored by other PRs or main and just evict the
@@ -45,7 +52,7 @@ runs:
           ${{ steps.config.outputs.gocache }}
         key: ${{ steps.config.outputs.key }}
         restore-keys: |
-          go-cache-v1-${{ runner.os }}-${{ runner.arch }}-go${{ steps.setup.outputs.go-version }}-${{ inputs.module }}-
+          ${{ steps.config.outputs.restore-prefix }}
 
     - name: Warm Go module and build caches
       if: ${{ inputs.populate-cache == 'true' && steps.restore.outputs.cache-hit != 'true' }}

--- a/.github/actions/setup-studioctl/action.yaml
+++ b/.github/actions/setup-studioctl/action.yaml
@@ -17,9 +17,9 @@ runs:
 
     - name: Set up Go
       if: ${{ steps.cache-studioctl.outputs.cache-hit != 'true' }}
-      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      uses: ./.github/actions/setup-go-cached
       with:
-        go-version-file: src/cli/go.mod
+        module: src/cli
 
     - name: Set up .NET
       uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0

--- a/.github/actions/yarn-install/action.yaml
+++ b/.github/actions/yarn-install/action.yaml
@@ -15,20 +15,6 @@ runs:
         cache-dependency-path: ${{ inputs.working-directory }}/yarn.lock
         node-version: '22'
 
-    - name: "Getting yarn cache directory path"
-      id: yarn-cache-dir-path
-      run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      shell: bash
-      working-directory: ${{ inputs.working-directory }}
-
-    - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      id: yarn-cache
-      with:
-        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-yarn-${{ hashFiles(format('{0}/yarn.lock', inputs.working-directory)) }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
-
     - name: 'Installing Dependencies'
       run: yarn install --immutable --inline-builds
       shell: bash

--- a/.github/workflows/app-frontend-cypress.yml
+++ b/.github/workflows/app-frontend-cypress.yml
@@ -259,16 +259,15 @@ jobs:
             echo "ENABLE_PERCY=true" >> "$GITHUB_ENV"
           fi
 
+      # The runner image bakes the Cypress binary at CYPRESS_CACHE_FOLDER;
+      # this is a no-op on version match and a fallback download on drift.
       - name: Install Cypress binary
         shell: bash
-        env:
-          CYPRESS_CACHE_FOLDER: ${{ github.workspace }}/.cache/Cypress
         run: npx cypress install
 
       - name: Cypress run
         shell: bash
         env:
-          CYPRESS_CACHE_FOLDER: ${{ github.workspace }}/.cache/Cypress
           CYPRESS_PROJECT_ID: o7mikf
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }} # CYPRESS_RECORD_KEY comes from "org secrets"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -356,14 +355,10 @@ jobs:
 
       - name: Install Cypress binary
         shell: bash
-        env:
-          CYPRESS_CACHE_FOLDER: ${{ github.workspace }}/.cache/Cypress
         run: npx cypress install
 
       - name: Cypress run
         shell: bash
-        env:
-          CYPRESS_CACHE_FOLDER: ${{ github.workspace }}/.cache/Cypress
         run: npx cypress run --browser "${CHROME_PATH:-chrome}" --spec test/e2e/integration --env environment=localtest
 
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/.github/workflows/app-frontend-unit-tests.yml
+++ b/.github/workflows/app-frontend-unit-tests.yml
@@ -40,18 +40,8 @@ jobs:
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '22'
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
-
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache: 'yarn'
+          cache-dependency-path: yarn.lock
 
       - name: install dependencies
         run: yarn --immutable

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -77,6 +77,9 @@ jobs:
         # warmed where its consumers run (releaser runs in both).
         include:
           - { module: src/cli, runner: self-hosted-ubuntu }
+          # Fork PRs fall back to ubuntu-latest (e.g. cypress build-studioctl)
+          # and can restore main-scoped caches.
+          - { module: src/cli, runner: ubuntu-latest }
           - { module: src/cli, runner: macos-latest }
           - { module: src/cli, runner: windows-latest }
           - { module: src/tools/releaser, runner: self-hosted-ubuntu }

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -71,17 +71,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Mirror the (module, runner, dependency-path) combinations the PR
-        # workflows' setup-go steps use, so the warm entries land on the
-        # exact keys those workflows compute. cli-build-test also runs on
-        # macOS and Windows, whose OS-scoped keys need warming from matching
-        # GitHub-hosted runners. releaser has no external dependencies and
-        # thus no go.sum; it and its consumer workflows key on go.mod.
+        # Mirror the (module, runner) combinations the PR workflows'
+        # setup-go-cached steps use, so the warm entries land on the exact
+        # keys those workflows compute. cli-build-test also runs on macOS
+        # and Windows, whose OS-scoped keys need warming from matching
+        # GitHub-hosted runners.
         include:
           - { module: src/cli, runner: self-hosted-ubuntu }
           - { module: src/cli, runner: macos-latest }
           - { module: src/cli, runner: windows-latest }
-          - { module: src/tools/releaser, runner: self-hosted-ubuntu, dep: src/tools/releaser/go.mod }
+          - { module: src/tools/releaser, runner: self-hosted-ubuntu }
           - { module: src/tools/health, runner: self-hosted-ubuntu }
           - { module: src/Runtime/devenv, runner: self-hosted-ubuntu }
           - { module: src/Runtime/gateway, runner: self-hosted-ubuntu }
@@ -98,18 +97,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      - name: Warm Go caches
+        uses: ./.github/actions/setup-go-cached
         with:
-          go-version-file: ${{ matrix.module }}/go.mod
-          cache-dependency-path: ${{ matrix.dep || format('{0}/go.sum', matrix.module) }}
-
-      - name: Download modules and warm build cache
-        working-directory: ${{ matrix.module }}
-        shell: bash
-        run: |
-          go mod download
-          go build ./...
+          module: ${{ matrix.module }}
+          populate-cache: 'true'
 
   rust:
     name: Warm Rust cache

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -146,3 +146,37 @@ jobs:
         run: |
           make -C src/experimental build
           make -C src/ci/github-runner/coordinator build
+
+  localtest-image-registry-cache:
+    name: Warm LocalTest image registry cache
+    runs-on: self-hosted-ubuntu
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    env:
+      # studioctl reads BuildKit layer cache from the ghcr localtest-*-cache
+      # refs on every CI build; this job is the only writer, so the refs
+      # always reflect main and PR jobs never need a packages:write token.
+      STUDIOCTL_REGISTRY_CACHE_WRITE: 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Set up studioctl dev install
+        uses: ./.github/actions/setup-studioctl
+
+      # Build unconditionally (no image-tar short-circuit) so the layer
+      # cache refreshes even when the GH-cache image tar is warm; with warm
+      # layers a no-change rebuild is cheap.
+      - name: Build LocalTest images and push registry cache
+        run: studioctl env up --detach
+
+      - name: Stop environment
+        if: always()
+        run: studioctl env down || true

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -1,0 +1,148 @@
+name: Cache warm
+
+# Seeds the shared GitHub Actions caches from main. Caches saved on PR merge
+# refs are only restorable by re-runs of the same PR, so PR runs cannot seed
+# anything for each other — only entries created on main (schedule or
+# dispatch runs on the default branch) are visible to every PR. This
+# workflow keeps those main-scoped entries warm so PR jobs restore instead
+# of rebuilding and re-saving.
+#
+# Runs once a day: dependency bumps merged during the day stay cold until
+# the next morning run (or a manual dispatch). Every job is idempotent and
+# cheap when the caches are already warm: exact cache hits skip both the
+# install/build work and the save.
+
+on:
+  schedule:
+    # 08:00 Oslo in summer / 07:00 in winter (GitHub cron is UTC-only).
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: cache-warm-main
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  yarn:
+    name: Warm yarn cache
+    runs-on: self-hosted-ubuntu
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js with yarn cache
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: '22'
+          cache: 'yarn'
+          cache-dependency-path: yarn.lock
+
+      - name: Install dependencies
+        run: yarn install --immutable --inline-builds
+        env:
+          HUSKY: '0'
+          YARN_NM_MODE: 'hardlinks-local'
+
+  app-frontend-dependencies:
+    name: Warm App Frontend test dependency cache
+    runs-on: self-hosted-ubuntu
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Populate App Frontend test dependency cache
+        uses: ./.github/actions/app-frontend-test-dependencies
+        with:
+          populate-cache: true
+
+  go-modules:
+    name: Warm Go caches (${{ matrix.module }}, ${{ matrix.runner }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        # Mirror the (module, runner, dependency-path) combinations the PR
+        # workflows' setup-go steps use, so the warm entries land on the
+        # exact keys those workflows compute. cli-build-test also runs on
+        # macOS and Windows, whose OS-scoped keys need warming from matching
+        # GitHub-hosted runners. releaser has no external dependencies and
+        # thus no go.sum; it and its consumer workflows key on go.mod.
+        include:
+          - { module: src/cli, runner: self-hosted-ubuntu }
+          - { module: src/cli, runner: macos-latest }
+          - { module: src/cli, runner: windows-latest }
+          - { module: src/tools/releaser, runner: self-hosted-ubuntu, dep: src/tools/releaser/go.mod }
+          - { module: src/tools/health, runner: self-hosted-ubuntu }
+          - { module: src/Runtime/devenv, runner: self-hosted-ubuntu }
+          - { module: src/Runtime/gateway, runner: self-hosted-ubuntu }
+          - { module: src/Runtime/operator, runner: self-hosted-ubuntu }
+          - { module: src/Runtime/pdf3, runner: self-hosted-ubuntu }
+          - { module: src/ci/sandbox-node, runner: self-hosted-ubuntu }
+    steps:
+      - name: Enable long paths for git on Windows
+        if: matrix.runner == 'windows-latest'
+        run: git config --system core.longpaths true
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: ${{ matrix.module }}/go.mod
+          cache-dependency-path: ${{ matrix.dep || format('{0}/go.sum', matrix.module) }}
+
+      - name: Download modules and warm build cache
+        working-directory: ${{ matrix.module }}
+        shell: bash
+        run: |
+          go mod download
+          go build ./...
+
+  rust:
+    name: Warm Rust cache
+    runs-on: self-hosted-ubuntu
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install native build dependencies
+        run: |
+          if ! pkg-config --exists libcap-ng; then
+            sudo apt-get update
+            sudo apt-get install --yes --no-install-recommends libcap-ng-dev
+          fi
+
+      - name: Verify Rust toolchain
+        run: |
+          RUST_VERSION="$(sed -n 's/^rust-version = "\([^"]*\)"$/\1/p' "${GITHUB_WORKSPACE}/Cargo.toml")"
+          test -n "${RUST_VERSION}"
+          if [ "$(rustc --version | awk '{ print $2 }')" != "${RUST_VERSION}" ]; then
+            rustup toolchain install "${RUST_VERSION}" --profile minimal --component rustfmt,clippy
+            rustup default "${RUST_VERSION}"
+          fi
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          shared-key: rust
+
+      - name: Build workspace
+        run: |
+          make -C src/experimental build
+          make -C src/ci/github-runner/coordinator build

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -71,22 +71,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Mirror the (module, runner) combinations the PR workflows'
-        # setup-go-cached steps use, so the warm entries land on the exact
-        # keys those workflows compute. cli-build-test also runs on macOS
-        # and Windows, whose OS-scoped keys need warming from matching
-        # GitHub-hosted runners.
+        # Mirror the (module, runner environment) combinations the PR
+        # workflows' setup-go-cached steps actually run on — cache keys are
+        # scoped per runner environment and image, so each module must be
+        # warmed where its consumers run (releaser runs in both).
         include:
           - { module: src/cli, runner: self-hosted-ubuntu }
           - { module: src/cli, runner: macos-latest }
           - { module: src/cli, runner: windows-latest }
           - { module: src/tools/releaser, runner: self-hosted-ubuntu }
+          - { module: src/tools/releaser, runner: ubuntu-latest }
           - { module: src/tools/health, runner: self-hosted-ubuntu }
           - { module: src/Runtime/devenv, runner: self-hosted-ubuntu }
-          - { module: src/Runtime/gateway, runner: self-hosted-ubuntu }
-          - { module: src/Runtime/operator, runner: self-hosted-ubuntu }
-          - { module: src/Runtime/pdf3, runner: self-hosted-ubuntu }
-          - { module: src/ci/sandbox-node, runner: self-hosted-ubuntu }
+          - { module: src/Runtime/gateway, runner: ubuntu-latest }
+          - { module: src/Runtime/operator, runner: ubuntu-latest }
+          - { module: src/Runtime/pdf3, runner: ubuntu-latest }
+          - { module: src/ci/sandbox-node, runner: ubuntu-latest }
     steps:
       - name: Enable long paths for git on Windows
         if: matrix.runner == 'windows-latest'
@@ -124,7 +124,9 @@ jobs:
         run: |
           RUST_VERSION="$(sed -n 's/^rust-version = "\([^"]*\)"$/\1/p' "${GITHUB_WORKSPACE}/Cargo.toml")"
           test -n "${RUST_VERSION}"
-          if [ "$(rustc --version | awk '{ print $2 }')" != "${RUST_VERSION}" ]; then
+          if [ "$(rustc --version | awk '{ print $2 }')" != "${RUST_VERSION}" ] \
+            || ! rustfmt --version >/dev/null 2>&1 \
+            || ! cargo clippy --version >/dev/null 2>&1; then
             rustup toolchain install "${RUST_VERSION}" --profile minimal --component rustfmt,clippy
             rustup default "${RUST_VERSION}"
           fi

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: 'src/tools/releaser/go.mod'
-          cache-dependency-path: src/tools/releaser/go.sum
+          cache-dependency-path: src/tools/releaser/go.mod
 
       # On a pull request, validate only the changelogs changed in the PR.
       # On workflow_dispatch the SHAs are empty, so the command falls back to

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -37,10 +37,9 @@ jobs:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        uses: ./.github/actions/setup-go-cached
         with:
-          go-version-file: 'src/tools/releaser/go.mod'
-          cache-dependency-path: src/tools/releaser/go.mod
+          module: src/tools/releaser
 
       # On a pull request, validate only the changelogs changed in the PR.
       # On workflow_dispatch the SHAs are empty, so the command falls back to

--- a/.github/workflows/cli-build-test.yaml
+++ b/.github/workflows/cli-build-test.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: src/tools/releaser/go.mod
-          cache-dependency-path: src/tools/releaser/go.sum
+          cache-dependency-path: src/tools/releaser/go.mod
 
       - name: Build release artifacts via releaser dry-run
         working-directory: src/tools/releaser

--- a/.github/workflows/cli-build-test.yaml
+++ b/.github/workflows/cli-build-test.yaml
@@ -34,10 +34,9 @@ jobs:
           global-json-file: src/cli/global.json
 
       - name: Setup Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        uses: ./.github/actions/setup-go-cached
         with:
-          go-version-file: src/tools/releaser/go.mod
-          cache-dependency-path: src/tools/releaser/go.mod
+          module: src/tools/releaser
 
       - name: Build release artifacts via releaser dry-run
         working-directory: src/tools/releaser
@@ -84,10 +83,9 @@ jobs:
           global-json-file: src/cli/global.json
 
       - name: Setup Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        uses: ./.github/actions/setup-go-cached
         with:
-          go-version-file: 'src/cli/go.mod'
-          cache-dependency-path: src/cli/go.sum
+          module: src/cli
 
       - name: Build
         working-directory: src/cli

--- a/.github/workflows/cli-changelog.yaml
+++ b/.github/workflows/cli-changelog.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: 'src/tools/releaser/go.mod'
-          cache-dependency-path: src/tools/releaser/go.sum
+          cache-dependency-path: src/tools/releaser/go.mod
 
       - name: Validate studioctl changelog entry
         working-directory: src/tools/releaser

--- a/.github/workflows/cli-changelog.yaml
+++ b/.github/workflows/cli-changelog.yaml
@@ -36,10 +36,9 @@ jobs:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        uses: ./.github/actions/setup-go-cached
         with:
-          go-version-file: 'src/tools/releaser/go.mod'
-          cache-dependency-path: src/tools/releaser/go.mod
+          module: src/tools/releaser
 
       - name: Validate studioctl changelog entry
         working-directory: src/tools/releaser

--- a/.github/workflows/common-typescript-unit-test.yml
+++ b/.github/workflows/common-typescript-unit-test.yml
@@ -35,18 +35,8 @@ jobs:
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '22'
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
-
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache: 'yarn'
+          cache-dependency-path: yarn.lock
 
       - name: install dependencies
         run: yarn --immutable

--- a/.github/workflows/deploy-github-runners.yaml
+++ b/.github/workflows/deploy-github-runners.yaml
@@ -93,6 +93,12 @@ jobs:
           test -n "${RUST_VERSION}"
           echo "version=${RUST_VERSION}" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve Cypress version
+        id: cypress-version
+        run: |
+          CYPRESS_VERSION="$(jq -er '.devDependencies.cypress' "${GITHUB_WORKSPACE}/src/App/frontend/package.json")"
+          echo "version=${CYPRESS_VERSION}" >> "$GITHUB_OUTPUT"
+
       - name: Build and publish runner image
         id: runner-image
         env:
@@ -100,11 +106,13 @@ jobs:
           LATEST: ${{ steps.vars.outputs.runner-latest }}
           GO_VERSION: ${{ steps.go-version.outputs.version }}
           RUST_VERSION: ${{ steps.rust-version.outputs.version }}
+          CYPRESS_VERSION: ${{ steps.cypress-version.outputs.version }}
         run: |
           METADATA_FILE="${RUNNER_TEMP}/github-runner-build.json"
           docker buildx build \
             --build-arg "GO_VERSION=${GO_VERSION}" \
             --build-arg "RUST_VERSION=${RUST_VERSION}" \
+            --build-arg "CYPRESS_VERSION=${CYPRESS_VERSION}" \
             --file Dockerfile \
             --metadata-file "${METADATA_FILE}" \
             --platform linux/amd64 \

--- a/.github/workflows/deploy-github-runners.yaml
+++ b/.github/workflows/deploy-github-runners.yaml
@@ -51,6 +51,18 @@ jobs:
         with:
           persist-credentials: false
 
+      # The containerd image store lets the default builder export registry
+      # cache (--cache-to type=registry), matching the runtime deploys.
+      - name: Set up Docker
+        uses: docker/setup-docker-action@e43656e248c0bd0647d3f5c195d116aacf6fcaf4 # v4.7.0
+        with:
+          daemon-config: |
+            {
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
+
       - name: Set vars
         id: vars
         run: |
@@ -104,6 +116,7 @@ jobs:
         env:
           IMAGE: ${{ steps.vars.outputs.runner-image }}
           LATEST: ${{ steps.vars.outputs.runner-latest }}
+          RUNNER_REPOSITORY: ${{ steps.vars.outputs.runner-repository }}
           GO_VERSION: ${{ steps.go-version.outputs.version }}
           RUST_VERSION: ${{ steps.rust-version.outputs.version }}
           CYPRESS_VERSION: ${{ steps.cypress-version.outputs.version }}
@@ -113,6 +126,8 @@ jobs:
             --build-arg "GO_VERSION=${GO_VERSION}" \
             --build-arg "RUST_VERSION=${RUST_VERSION}" \
             --build-arg "CYPRESS_VERSION=${CYPRESS_VERSION}" \
+            --cache-from "type=registry,ref=${RUNNER_REPOSITORY}:buildcache" \
+            --cache-to "type=registry,ref=${RUNNER_REPOSITORY}:buildcache,mode=max,image-manifest=true" \
             --file Dockerfile \
             --metadata-file "${METADATA_FILE}" \
             --platform linux/amd64 \
@@ -134,9 +149,12 @@ jobs:
         env:
           IMAGE: ${{ steps.vars.outputs.coordinator-image }}
           LATEST: ${{ steps.vars.outputs.coordinator-latest }}
+          COORDINATOR_REPOSITORY: ${{ steps.vars.outputs.coordinator-repository }}
         run: |
           METADATA_FILE="${RUNNER_TEMP}/github-runner-coordinator-build.json"
           docker buildx build \
+            --cache-from "type=registry,ref=${COORDINATOR_REPOSITORY}:buildcache" \
+            --cache-to "type=registry,ref=${COORDINATOR_REPOSITORY}:buildcache,mode=max,image-manifest=true" \
             --file src/ci/github-runner/Dockerfile.coordinator \
             --metadata-file "${METADATA_FILE}" \
             --platform linux/amd64 \

--- a/.github/workflows/deploy-runtime-kubernetes-wrapper.yaml
+++ b/.github/workflows/deploy-runtime-kubernetes-wrapper.yaml
@@ -56,6 +56,8 @@ jobs:
           SHA="${GITHUB_SHA::10}"
           IMAGE_BASE="ghcr.io/altinn/altinn-studio/kubernetes-wrapper"
           docker build --platform linux/amd64,linux/arm64 src \
+            --cache-from "type=registry,ref=${IMAGE_BASE}:buildcache" \
+            --cache-to "type=registry,ref=${IMAGE_BASE}:buildcache,mode=max" \
             -f src/Runtime/kubernetes-wrapper/src/Dockerfile \
             -t "${IMAGE_BASE}:${SHA}"
 

--- a/.github/workflows/deploy-runtime-localtest.yaml
+++ b/.github/workflows/deploy-runtime-localtest.yaml
@@ -51,7 +51,11 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Build image
-        run: docker build --platform linux/amd64,linux/arm64 -t ${{ steps.vars.outputs.image }} -f Runtime/localtest/Dockerfile .
+        run: |
+          docker build --platform linux/amd64,linux/arm64 \
+            --cache-from type=registry,ref=ghcr.io/altinn/altinn-studio/runtime-localtest:buildcache \
+            --cache-to type=registry,ref=ghcr.io/altinn/altinn-studio/runtime-localtest:buildcache,mode=max \
+            -t ${{ steps.vars.outputs.image }} -f Runtime/localtest/Dockerfile .
 
       - name: Push image
         run: docker push ${{ steps.vars.outputs.image }}

--- a/.github/workflows/deploy-runtime-operator.yaml
+++ b/.github/workflows/deploy-runtime-operator.yaml
@@ -86,7 +86,11 @@ jobs:
         uses: fluxcd/flux2/action@889be9d6cc8afa8ed639e1e1ba4ab678e3b38d8c # v2.9.4
 
       - name: docker build
-        run: docker build --platform linux/amd64,linux/arm64 -t ${{ steps.vars.outputs.ghcr-image-repo }} -f Dockerfile .
+        run: |
+          docker build --platform linux/amd64,linux/arm64 \
+            --cache-from type=registry,ref=ghcr.io/altinn/altinn-studio/runtime-operator:buildcache \
+            --cache-to type=registry,ref=ghcr.io/altinn/altinn-studio/runtime-operator:buildcache,mode=max \
+            -t ${{ steps.vars.outputs.ghcr-image-repo }} -f Dockerfile .
 
       - name: push images
         run: docker push ${{ steps.vars.outputs.ghcr-image-repo }}

--- a/.github/workflows/deploy-runtime-pdf3.yaml
+++ b/.github/workflows/deploy-runtime-pdf3.yaml
@@ -90,9 +90,15 @@ jobs:
       - name: docker build
         run: |
           set -e
-          docker build --platform linux/amd64,linux/arm64 -t ${{ steps.vars.outputs.ghcr-image-proxy-repo }} -f Dockerfile.proxy . &
+          docker build --platform linux/amd64,linux/arm64 \
+            --cache-from type=registry,ref=ghcr.io/altinn/altinn-studio/runtime-pdf3-proxy:buildcache \
+            --cache-to type=registry,ref=ghcr.io/altinn/altinn-studio/runtime-pdf3-proxy:buildcache,mode=max \
+            -t ${{ steps.vars.outputs.ghcr-image-proxy-repo }} -f Dockerfile.proxy . &
           PROXY_PID=$!
-          docker build --platform linux/amd64,linux/arm64 -t ${{ steps.vars.outputs.ghcr-image-worker-repo }} -f Dockerfile.worker . &
+          docker build --platform linux/amd64,linux/arm64 \
+            --cache-from type=registry,ref=ghcr.io/altinn/altinn-studio/runtime-pdf3-worker:buildcache \
+            --cache-to type=registry,ref=ghcr.io/altinn/altinn-studio/runtime-pdf3-worker:buildcache,mode=max \
+            -t ${{ steps.vars.outputs.ghcr-image-worker-repo }} -f Dockerfile.worker . &
           WORKER_PID=$!
           wait $PROXY_PID
           wait $WORKER_PID

--- a/.github/workflows/deploy-runtime-workflow-engine-app.yaml
+++ b/.github/workflows/deploy-runtime-workflow-engine-app.yaml
@@ -101,7 +101,10 @@ jobs:
           if [ "${{ inputs.tag-latest }}" = "true" ]; then
             TAGS="$TAGS -t ghcr.io/altinn/altinn-studio/runtime-workflow-engine-app:latest"
           fi
-          docker build --platform linux/amd64,linux/arm64 --build-arg BUILD_VERSION=${{ steps.vars.outputs.short-sha }} $TAGS -f Runtime/workflow-engine-app/Dockerfile .
+          docker build --platform linux/amd64,linux/arm64 \
+            --cache-from type=registry,ref=ghcr.io/altinn/altinn-studio/runtime-workflow-engine-app:buildcache \
+            --cache-to type=registry,ref=ghcr.io/altinn/altinn-studio/runtime-workflow-engine-app:buildcache,mode=max \
+            --build-arg BUILD_VERSION=${{ steps.vars.outputs.short-sha }} $TAGS -f Runtime/workflow-engine-app/Dockerfile .
 
       - name: push image
         run: docker push ${{ steps.vars.outputs.image-repo }}

--- a/.github/workflows/deploy-sandbox-node.yaml
+++ b/.github/workflows/deploy-sandbox-node.yaml
@@ -40,6 +40,18 @@ jobs:
         with:
           persist-credentials: false
 
+      # The containerd image store lets the default builder export registry
+      # cache (--cache-to type=registry), matching the runtime deploys.
+      - name: Set up Docker
+        uses: docker/setup-docker-action@e43656e248c0bd0647d3f5c195d116aacf6fcaf4 # v4.7.0
+        with:
+          daemon-config: |
+            {
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
+
       - name: Set vars
         id: vars
         run: |
@@ -70,9 +82,12 @@ jobs:
         id: image
         env:
           IMAGE_TAG: ${{ steps.vars.outputs.image-tag }}
+          IMAGE_REPOSITORY: ${{ steps.vars.outputs.image-repository }}
         run: |
           METADATA_FILE="${RUNNER_TEMP}/sandbox-node-build.json"
           docker buildx build \
+            --cache-from "type=registry,ref=${IMAGE_REPOSITORY}:buildcache" \
+            --cache-to "type=registry,ref=${IMAGE_REPOSITORY}:buildcache,mode=max,image-manifest=true" \
             --file Dockerfile \
             --metadata-file "${METADATA_FILE}" \
             --platform linux/amd64 \
@@ -91,9 +106,12 @@ jobs:
         id: init-image
         env:
           IMAGE_TAG: ${{ steps.vars.outputs.init-image-tag }}
+          IMAGE_REPOSITORY: ${{ steps.vars.outputs.init-image-repository }}
         run: |
           METADATA_FILE="${RUNNER_TEMP}/sandbox-node-init-build.json"
           docker buildx build \
+            --cache-from "type=registry,ref=${IMAGE_REPOSITORY}:buildcache" \
+            --cache-to "type=registry,ref=${IMAGE_REPOSITORY}:buildcache,mode=max,image-manifest=true" \
             --file Dockerfile.init \
             --metadata-file "${METADATA_FILE}" \
             --platform linux/amd64 \

--- a/.github/workflows/designer-frontend-playwright-staging.yml
+++ b/.github/workflows/designer-frontend-playwright-staging.yml
@@ -22,19 +22,7 @@ jobs:
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           cache: 'yarn'
-
-      - name: Get yarn cache directory path
-        working-directory: src/Designer/frontend
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache-dependency-path: yarn.lock
 
       - name: Attempt to wait for deploy to environment (15 minutes sleep)
         run: |

--- a/.github/workflows/designer-frontend-resourceadm-playwright-staging.yml
+++ b/.github/workflows/designer-frontend-resourceadm-playwright-staging.yml
@@ -22,19 +22,7 @@ jobs:
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           cache: 'yarn'
-
-      - name: Get yarn cache directory path
-        working-directory: src/Designer/frontend
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache-dependency-path: yarn.lock
 
       - name: Attempt to wait for deploy to environment (15 minutes sleep)
         run: |

--- a/.github/workflows/experimental-build.yaml
+++ b/.github/workflows/experimental-build.yaml
@@ -49,7 +49,9 @@ jobs:
         run: |
           RUST_VERSION="$(sed -n 's/^rust-version = "\([^"]*\)"$/\1/p' "${GITHUB_WORKSPACE}/Cargo.toml")"
           test -n "${RUST_VERSION}"
-          if [ "$(rustc --version | awk '{ print $2 }')" != "${RUST_VERSION}" ]; then
+          if [ "$(rustc --version | awk '{ print $2 }')" != "${RUST_VERSION}" ] \
+            || ! rustfmt --version >/dev/null 2>&1 \
+            || ! cargo clippy --version >/dev/null 2>&1; then
             rustup toolchain install "${RUST_VERSION}" --profile minimal --component rustfmt,clippy
             rustup default "${RUST_VERSION}"
           fi

--- a/.github/workflows/experimental-build.yaml
+++ b/.github/workflows/experimental-build.yaml
@@ -42,13 +42,17 @@ jobs:
             sudo apt-get install --yes --no-install-recommends libcap-ng-dev
           fi
 
-      - name: Install Rust toolchain
+      # The runner image bakes the toolchain pinned by Cargo.toml; only
+      # install through rustup when the two have drifted (e.g. a PR bumping
+      # rust-version before the image has been rebuilt).
+      - name: Verify Rust toolchain
         run: |
           RUST_VERSION="$(sed -n 's/^rust-version = "\([^"]*\)"$/\1/p' "${GITHUB_WORKSPACE}/Cargo.toml")"
           test -n "${RUST_VERSION}"
-          curl --proto '=https' --tlsv1.2 --fail --silent --show-error https://sh.rustup.rs \
-            | sh -s -- -y --profile minimal --default-toolchain "${RUST_VERSION}" --component rustfmt,clippy
-          echo "${HOME}/.cargo/bin" >> "${GITHUB_PATH}"
+          if [ "$(rustc --version | awk '{ print $2 }')" != "${RUST_VERSION}" ]; then
+            rustup toolchain install "${RUST_VERSION}" --profile minimal --component rustfmt,clippy
+            rustup default "${RUST_VERSION}"
+          fi
 
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2

--- a/.github/workflows/experimental-build.yaml
+++ b/.github/workflows/experimental-build.yaml
@@ -53,8 +53,12 @@ jobs:
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
-          shared-key: experimental
-          key: cargo-machete-0.9.2
+          # One shared cache for the whole root Cargo workspace, seeded by
+          # cache-warm.yml. Restore only: this workflow never runs on main,
+          # and saves from PR merge refs cannot be shared with other PRs and
+          # evict main-scoped caches.
+          shared-key: rust
+          save-if: false
 
       - name: Install cargo-machete
         run: |

--- a/.github/workflows/github-runner-build.yaml
+++ b/.github/workflows/github-runner-build.yaml
@@ -57,8 +57,12 @@ jobs:
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
-          shared-key: github-runner
-          key: cargo-machete-0.9.2
+          # One shared cache for the whole root Cargo workspace, seeded by
+          # cache-warm.yml. Restore only: this workflow never runs on main,
+          # and saves from PR merge refs cannot be shared with other PRs and
+          # evict main-scoped caches.
+          shared-key: rust
+          save-if: false
 
       - name: Install cargo-machete
         run: |

--- a/.github/workflows/github-runner-build.yaml
+++ b/.github/workflows/github-runner-build.yaml
@@ -46,13 +46,17 @@ jobs:
             sudo apt-get install --yes --no-install-recommends libcap-ng-dev
           fi
 
-      - name: Install Rust toolchain
+      # The runner image bakes the toolchain pinned by Cargo.toml; only
+      # install through rustup when the two have drifted (e.g. a PR bumping
+      # rust-version before the image has been rebuilt).
+      - name: Verify Rust toolchain
         run: |
           RUST_VERSION="$(sed -n 's/^rust-version = "\([^"]*\)"$/\1/p' "${GITHUB_WORKSPACE}/Cargo.toml")"
           test -n "${RUST_VERSION}"
-          curl --proto '=https' --tlsv1.2 --fail --silent --show-error https://sh.rustup.rs \
-            | sh -s -- -y --profile minimal --default-toolchain "${RUST_VERSION}" --component rustfmt,clippy
-          echo "${HOME}/.cargo/bin" >> "${GITHUB_PATH}"
+          if [ "$(rustc --version | awk '{ print $2 }')" != "${RUST_VERSION}" ]; then
+            rustup toolchain install "${RUST_VERSION}" --profile minimal --component rustfmt,clippy
+            rustup default "${RUST_VERSION}"
+          fi
 
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2

--- a/.github/workflows/github-runner-build.yaml
+++ b/.github/workflows/github-runner-build.yaml
@@ -53,7 +53,9 @@ jobs:
         run: |
           RUST_VERSION="$(sed -n 's/^rust-version = "\([^"]*\)"$/\1/p' "${GITHUB_WORKSPACE}/Cargo.toml")"
           test -n "${RUST_VERSION}"
-          if [ "$(rustc --version | awk '{ print $2 }')" != "${RUST_VERSION}" ]; then
+          if [ "$(rustc --version | awk '{ print $2 }')" != "${RUST_VERSION}" ] \
+            || ! rustfmt --version >/dev/null 2>&1 \
+            || ! cargo clippy --version >/dev/null 2>&1; then
             rustup toolchain install "${RUST_VERSION}" --profile minimal --component rustfmt,clippy
             rustup default "${RUST_VERSION}"
           fi

--- a/.github/workflows/release-app.yaml
+++ b/.github/workflows/release-app.yaml
@@ -44,10 +44,9 @@ jobs:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        uses: ./.github/actions/setup-go-cached
         with:
-          go-version-file: 'src/tools/releaser/go.mod'
-          cache-dependency-path: src/tools/releaser/go.mod
+          module: src/tools/releaser
 
       - name: Resolve environment
         id: context
@@ -111,10 +110,9 @@ jobs:
           cache-dependency-path: yarn.lock
 
       - name: Setup Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        uses: ./.github/actions/setup-go-cached
         with:
-          go-version-file: 'src/tools/releaser/go.mod'
-          cache-dependency-path: src/tools/releaser/go.mod
+          module: src/tools/releaser
 
       - name: Configure git
         run: |

--- a/.github/workflows/release-app.yaml
+++ b/.github/workflows/release-app.yaml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: 'src/tools/releaser/go.mod'
-          cache-dependency-path: src/tools/releaser/go.sum
+          cache-dependency-path: src/tools/releaser/go.mod
 
       - name: Resolve environment
         id: context
@@ -114,7 +114,7 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: 'src/tools/releaser/go.mod'
-          cache-dependency-path: src/tools/releaser/go.sum
+          cache-dependency-path: src/tools/releaser/go.mod
 
       - name: Configure git
         run: |

--- a/.github/workflows/release-studioctl.yaml
+++ b/.github/workflows/release-studioctl.yaml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: 'src/tools/releaser/go.mod'
-          cache-dependency-path: src/tools/releaser/go.sum
+          cache-dependency-path: src/tools/releaser/go.mod
 
       - name: Configure git
         run: |

--- a/.github/workflows/release-studioctl.yaml
+++ b/.github/workflows/release-studioctl.yaml
@@ -62,10 +62,9 @@ jobs:
           global-json-file: src/cli/global.json
 
       - name: Setup Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        uses: ./.github/actions/setup-go-cached
         with:
-          go-version-file: 'src/tools/releaser/go.mod'
-          cache-dependency-path: src/tools/releaser/go.mod
+          module: src/tools/releaser
 
       - name: Configure git
         run: |

--- a/.github/workflows/releaser-build-test.yml
+++ b/.github/workflows/releaser-build-test.yml
@@ -29,10 +29,9 @@ jobs:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        uses: ./.github/actions/setup-go-cached
         with:
-          go-version-file: src/tools/releaser/go.mod
-          cache-dependency-path: src/tools/releaser/go.mod
+          module: src/tools/releaser
 
       - name: Build
         run: make build

--- a/.github/workflows/releaser-build-test.yml
+++ b/.github/workflows/releaser-build-test.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: src/tools/releaser/go.mod
-          cache-dependency-path: src/tools/releaser/go.sum
+          cache-dependency-path: src/tools/releaser/go.mod
 
       - name: Build
         run: make build

--- a/.github/workflows/runtime-devenv-build.yml
+++ b/.github/workflows/runtime-devenv-build.yml
@@ -28,10 +28,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      - name: Set up Go
+        uses: ./.github/actions/setup-go-cached
         with:
-          go-version-file: src/Runtime/devenv/go.mod
-          cache-dependency-path: src/Runtime/devenv/go.sum
+          module: src/Runtime/devenv
 
       - name: Check formatting
         run: |

--- a/.github/workflows/runtime-gateway-tests.yaml
+++ b/.github/workflows/runtime-gateway-tests.yaml
@@ -38,10 +38,9 @@ jobs:
             10.0.x
 
       - name: Setup Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        uses: ./.github/actions/setup-go-cached
         with:
-          go-version-file: src/Runtime/gateway/go.mod
-          cache-dependency-path: src/Runtime/gateway/go.sum
+          module: src/Runtime/gateway
 
       - name: Restore
         run: make restore

--- a/.github/workflows/runtime-health-build.yml
+++ b/.github/workflows/runtime-health-build.yml
@@ -28,10 +28,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      - name: Set up Go
+        uses: ./.github/actions/setup-go-cached
         with:
-          go-version-file: src/tools/health/go.mod
-          cache-dependency-path: src/tools/health/go.sum
+          module: src/tools/health
 
       - name: Check formatting
         run: |

--- a/.github/workflows/runtime-operator-build.yml
+++ b/.github/workflows/runtime-operator-build.yml
@@ -33,10 +33,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      - name: Set up Go
+        uses: ./.github/actions/setup-go-cached
         with:
-          go-version-file: src/Runtime/operator/go.mod
-          cache-dependency-path: src/Runtime/operator/go.sum
+          module: src/Runtime/operator
 
       - name: Check formatting
         run: |
@@ -68,10 +68,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      - name: Set up Go
+        uses: ./.github/actions/setup-go-cached
         with:
-          go-version-file: src/Runtime/operator/go.mod
-          cache-dependency-path: src/Runtime/operator/go.sum
+          module: src/Runtime/operator
 
       - name: Run fixture
         run: make start

--- a/.github/workflows/runtime-pdf3-build.yml
+++ b/.github/workflows/runtime-pdf3-build.yml
@@ -32,10 +32,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      - name: Set up Go
+        uses: ./.github/actions/setup-go-cached
         with:
-          go-version-file: src/Runtime/pdf3/go.mod
-          cache-dependency-path: src/Runtime/pdf3/go.sum
+          module: src/Runtime/pdf3
 
       - name: Check formatting
         run: |

--- a/.github/workflows/runtime-workflow-engine-docker-build.yaml
+++ b/.github/workflows/runtime-workflow-engine-docker-build.yaml
@@ -40,10 +40,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # No cache ref for the standalone workflow-engine image: nothing
+          # publishes a cache for it (only this workflow builds it).
           - name: workflow-engine
             dockerfile: Runtime/workflow-engine/Dockerfile
+            cache-from: ''
           - name: workflow-engine-app
             dockerfile: Runtime/workflow-engine-app/Dockerfile
+            # Written by deploy-runtime-workflow-engine-app.yaml on main;
+            # public package, so the read needs no auth.
+            cache-from: type=registry,ref=ghcr.io/altinn/altinn-studio/runtime-workflow-engine-app:buildcache
     defaults:
       run:
         working-directory: src
@@ -54,4 +60,9 @@ jobs:
           persist-credentials: false
 
       - name: Build image
-        run: docker build -f ${{ matrix.dockerfile }} .
+        run: |
+          if [ -n "${{ matrix.cache-from }}" ]; then
+            docker build --cache-from "${{ matrix.cache-from }}" -f ${{ matrix.dockerfile }} .
+          else
+            docker build -f ${{ matrix.dockerfile }} .
+          fi

--- a/.github/workflows/sandbox-node-build.yml
+++ b/.github/workflows/sandbox-node-build.yml
@@ -35,10 +35,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      - name: Set up Go
+        uses: ./.github/actions/setup-go-cached
         with:
-          go-version-file: src/ci/sandbox-node/go.mod
-          cache-dependency-path: src/ci/sandbox-node/go.sum
+          module: src/ci/sandbox-node
 
       - name: Check formatting
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,9 @@ Small build/ops images and configs, documented here rather than individually:
 - `load-balancer` — nginx edge proxy (with OpenTelemetry) fronting Studio services; local + k8s configs.
 
 Other top-level dirs: `charts/` (Helm), `infra/` (deployment infra), `docs/` (ADRs, diagrams),
-`scripts/`, and root Docker/compose files for the Designer dev stack (see `README.md`).
+`scripts/`, [`.github/`](.github/AGENTS.md) (workflows + composite actions, incl. the CI caching
+architecture and its cross-repo couplings), and root Docker/compose files for the Designer dev
+stack (see `README.md`).
 
 ## Conventions across the repo
 

--- a/src/ci/github-runner/Dockerfile
+++ b/src/ci/github-runner/Dockerfile
@@ -10,6 +10,10 @@ ARG DOTNET_CHANNEL=10.0
 ARG CHROME_FOR_TESTING_CHANNEL=Stable
 ARG DOTNET_INSTALL_SCRIPT_COMMIT=6f559c420847ded38591392dafe785ad511f39f5
 ARG DOTNET_INSTALL_SCRIPT_SHA256=082f7685e156738a1b2e2ed8381a621870d4ce8e8c59278034556f05c186eb2e
+# Kept in sync with src/App/frontend/package.json by deploy-github-runners.yaml;
+# jobs fall back to `npx cypress install` when the versions drift.
+ARG CYPRESS_VERSION=15.20.0
+ARG CARGO_MACHETE_VERSION=0.9.2
 
 USER root
 
@@ -137,6 +141,14 @@ RUN apt-get update \
     && rm -f /tmp/dotnet-install.sh \
     && PATH="/opt/tools/node/current/bin:${PATH}" COREPACK_HOME=/opt/corepack corepack enable \
     && PATH="/opt/tools/node/current/bin:${PATH}" COREPACK_HOME=/opt/corepack corepack prepare "yarn@${YARN_CHANNEL}" --activate \
+    && PATH="/opt/tools/node/current/bin:${PATH}" npm_config_cache=/tmp/npm-cache \
+      CYPRESS_CACHE_FOLDER=/home/runner/.cache/Cypress \
+      npx --yes "cypress@${CYPRESS_VERSION}" install \
+    && rm -rf /tmp/npm-cache \
+    && CARGO_HOME=/home/runner/.cargo RUSTUP_HOME=/home/runner/.rustup \
+      PATH="/home/runner/.cargo/bin:${PATH}" \
+      cargo install cargo-machete --version "${CARGO_MACHETE_VERSION}" --locked \
+    && rm -rf /home/runner/.cargo/registry /home/runner/.cargo/git \
     && git config --system checkout.workers 4 \
     && git config --system checkout.thresholdForParallelism 100 \
     && usermod -aG docker runner \
@@ -161,6 +173,7 @@ ENV COREPACK_HOME=/opt/corepack
 ENV RUNNER_TOOL_CACHE=/opt/tools
 ENV CHROME_PATH=/opt/chrome-for-testing/chrome-linux64/chrome
 ENV PUPPETEER_EXECUTABLE_PATH=/opt/chrome-for-testing/chrome-linux64/chrome
+ENV CYPRESS_CACHE_FOLDER=/home/runner/.cache/Cypress
 ENV TMPDIR=/tmp
 ENV TMP=/tmp
 ENV TEMP=/tmp

--- a/src/cli/internal/cmd/env/localtest/components/core.go
+++ b/src/cli/internal/cmd/env/localtest/components/core.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	devImageTagLocaltest   = "localtest:dev"
-	buildCacheRefLocaltest = "ghcr.io/altinn/altinn-studio/localtest-main-cache:latest"
+	buildCacheRefLocaltest = "ghcr.io/altinn/altinn-studio/localtest-dev-cache:buildcache"
 
 	// LocaltestServicePort is the HTTP port used by the localtest container.
 	LocaltestServicePort = "5101"

--- a/src/cli/internal/cmd/env/localtest/components/pdf.go
+++ b/src/cli/internal/cmd/env/localtest/components/pdf.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	devImageTagPDF3   = "localtest-pdf3:dev"
-	buildCacheRefPDF3 = "ghcr.io/altinn/altinn-studio/localtest-pdf3-cache:latest"
+	buildCacheRefPDF3 = "ghcr.io/altinn/altinn-studio/localtest-pdf3-dev-cache:buildcache"
 )
 
 func registerPDFComponents(manifest *Manifest, opts *Options) {


### PR DESCRIPTION
The repo's 10GB Actions cache quota was blown (10.65GB active, ~70% on PR merge refs that no other PR or main can restore), so main-scoped entries were continuously evicted and most jobs cold-started; the studioctl BuildKit registry cache had been stale since #19222 removed its GHCR write path; and no docker build used layer caching. This PR overhauls caching holistically — GHA caches become main-seeded and restore-only in PRs, docker builds get registry layer caching with a single trusted writer, per-run downloads move into the runner image, and the architecture and its couplings are documented. One commit per concern; smoke-tested pre-merge via a temporary `pull_request` trigger on the warm workflow.

- **`cache-warm.yml`** seeds shared caches daily on main (06:00 UTC + dispatch): yarn, focused node_modules, per-module Go (incl. macOS/Windows legs for `src/cli`), Rust (`save-if: false` + one `shared-key` in the PR workflows). Also fixes releaser Go caching, silently disabled forever (stdlib-only module, no `go.sum` — now keyed on `go.mod`).
- **ghcr registry cache for studioctl image builds revived**: reads were already active; writes now happen only from the cache-warm job (`packages: write` never reaches PR jobs; no tag races). Enabled by the containerd image store from #20122.
- **Runner image bakes** the Cypress binary (~130MB × 6 shard VMs downloaded per run today) and `cargo-machete`; the rustup reinstall becomes a drift-only fallback.
- **Docker layer caching** (`--cache-from/to type=registry`, `:buildcache` tags) on the runtime deploys (QEMU multi-arch gains most), runner-image and sandbox-node deploys (ACR, `image-manifest=true`); read-only in the PR-side workflow-engine build.
- **Yarn dedup**: three competing key schemes (incl. a double save per `yarn-install` job) unified on setup-node keyed on the root lockfile; fixes dead `app-libs/**` globs (moved to `src/common/ts` in #19840).
- **`setup-go-cached` composite action**: restore-only in PRs with `restore-keys` (Renovate PRs get partial hits instead of full cold starts), saved only by cache-warm; key `go-cache-v1-{os}-{arch}-{runner-environment}-{ImageOS}-go{version}-{module}-{hash(go.mod, go.sum)}` (environment + image discriminators keep self-hosted and GitHub-hosted caches separate; the warm matrix mirrors the consumers' actual environments). Conversion caught a third silently-broken cache site (`setup-studioctl` hashed a nonexistent root `go.sum`).
- **`.github/AGENTS.md`** documents the three-mechanism model and the sync table for the deliberate couplings; studioctl cache refs renamed to the `:buildcache` convention (`localtest-dev-cache`, `localtest-pdf3-dev-cache`).

Deliberate omissions: NuGet caching (measured previously — no faster than nuget.org); the run-handoff tar caches keep their in-run PR saves (sibling shards require them; nightly cron seeds main); no restore-keys on content-addressed caches (partial restore = silently stale). Follow-ups: drop the localtest image tarball once registry hit rates are proven; Designer compose builds (~7 cold images per playwright PR run); default `GITHUB_TOKEN` permission → read.

Verification: actionlint zero new findings; `docs:validate` green; pre-merge smoke test ran the full warm matrix twice — all 14 jobs green (incl. Windows after a `core.longpaths` fix), the ghcr `buildcache` manifests confirmed written from a real microVM (containerd-store daemon → `--cache-to` → registry), and all `go-cache-v1` keys landed with the expected shapes across the three OSes. Remaining unverified: nothing — post-merge, dispatch `cache-warm.yml` once to seed main-scoped entries and let the merge-triggered `deploy-github-runners` roll out the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added scheduled and manually triggered cache-warming runs to speed up builds and tests.
  - Improved reuse of dependency, build, and toolchain caches across development and release workflows.
  - Added consistent registry-backed caching for container image builds.

- **Bug Fixes**
  - Improved cache handling for frontend, Go, Rust, Cypress, and local development builds.
  - Ensured configured Rust and Cypress versions are used consistently in build environments.

- **Documentation**
  - Added guidance for maintaining workflow caching and runner configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
