### PR TITLE
ci: switch runner docker daemon to containerd image store

### DIFF
--- a/src/ci/github-runner/run.sh
+++ b/src/ci/github-runner/run.sh
@@ -170,7 +170,7 @@ fi
 dockerd_args=(
   --host="${DOCKER_HOST}"
   --ip6tables=false
-  --storage-driver=overlay2
+  --feature containerd-snapshotter=true
 )
 if [[ -n "${DOCKER_REGISTRY_MIRROR}" ]]; then
   dockerd_args+=(--registry-mirror="${DOCKER_REGISTRY_MIRROR}")
@@ -180,12 +180,14 @@ dockerd "${dockerd_args[@]}" &
 dockerd_pid="$!"
 wait_for_docker
 
+# With the containerd-snapshotter feature enabled, `docker info` reports the
+# snapshotter name (overlayfs) rather than the classic overlay2 graph driver.
 docker_driver="$(docker info --format '{{.Driver}}')"
-if [[ "${docker_driver}" != "overlay2" ]]; then
-  log "Docker storage driver is ${docker_driver}, expected overlay2"
+if [[ "${docker_driver}" != "overlayfs" ]]; then
+  log "Docker storage driver is ${docker_driver}, expected overlayfs"
   exit 1
 fi
-log "Docker is ready with overlay2"
+log "Docker is ready with overlayfs (containerd snapshotter)"
 
 export ACTIONS_RUNNER_INPUT_TOKEN="${RUNNER_REGISTRATION_TOKEN}"
 unset RUNNER_REGISTRATION_TOKEN


### PR DESCRIPTION
## Motivation

The per-job self-hosted runner (`src/ci/github-runner/run.sh`) starts dockerd with
`--storage-driver=overlay2` (the classic image store). With that store, the
daemon-embedded BuildKit builder (the default `docker` buildx driver) cannot:

- export build cache to a registry (`--cache-to type=registry`) — [Docker's own docs](https://docs.docker.com/build/cache/backends/registry/)
  state this backend "works with the default `docker` driver only when the
  containerd image store is enabled"
- build multi-platform images

This is also the reason draft PR #20121 adds a `docker buildx create --driver
docker-container` step in `.github/workflows/app-frontend-cypress.yml` as a
bridge/workaround. Once this change is merged and rolled out, that step can
be dropped in favor of the now-capable default builder.

This also brings the self-hosted runner in line with the GitHub-hosted
runners, which already enable this via `docker/setup-docker-action`'s
`daemon-config: {"features":{"containerd-snapshotter":true}}` in the
`deploy-runtime-*` workflows.

## Change

`dockerd_args` now passes `--feature containerd-snapshotter=true` instead of
`--storage-driver=overlay2`. The driver assertion that follows dockerd
startup is updated to match: with the containerd snapshotter enabled,
`docker info --format '{{.Driver}}'` reports `overlayfs` (the snapshotter
name), not `overlay2` (the classic graph driver name). The log messages are
updated to match.

`require_filesystem /var/lib/docker ext4` is left as-is — the overlayfs
containerd snapshotter still needs a real filesystem under it for its
upper/work/lower dirs, same as the classic overlay2 driver did.

## What changes for CI jobs using Docker

All docker-using CI jobs on this runner move from the classic overlay2
store to the containerd image store. I verified empirically (Ubuntu 24.04
container, `docker.io` package 29.1.3, `dockerd --feature
containerd-snapshotter=true`) that the following keep working unchanged
under the containerd store:

- `docker build` / `docker run` (legacy builder and BuildKit via `docker
  compose build`)
- `docker save` / `docker load` of image tars
- `docker compose build` / `docker compose run`

`docker info --format '{{.Driver}}'` reported exactly `overlayfs` in this
test, confirming the assertion value chosen above.

Because `/var/lib/docker` is a fresh, empty ext4 directory on every job (no
persistent volume, no prior image-store state), there is no image-store
migration path to worry about — each job's dockerd simply starts cold with
the new store from the first invocation.

## Rollout

Merging this triggers `deploy-github-runners`, which rebuilds and deploys
the runner image; no other coordination needed.

## Verification

Executed (not just researched):
- Built a throwaway privileged Ubuntu 24.04 container, installed the same
  `docker.io` package the runner Dockerfile installs (candidate version
  29.1.3 as of this writing), and ran `dockerd --feature
  containerd-snapshotter=true` directly (matching the flag form added to
  `dockerd_args`, which keeps the change local to that array rather than
  introducing `/etc/docker/daemon.json`).
- Confirmed `docker info` reports `Storage Driver: overlayfs` /
  `driver-type: io.containerd.snapshotter.v1`, and that
  `docker info --format '{{.Driver}}'` returns exactly `overlayfs`.
- Confirmed `docker build`, `docker save`/`docker load`, `docker run`, and
  `docker compose build`/`run` all succeed under the containerd store.
- Note: on this package version (29.1.3), the daemon log states
  `"containerd-snapshotter" is now the default and no longer needed to be
  set` — Docker Engine 29+ defaults to the containerd store already. The
  explicit flag is kept anyway for clarity of intent and so the behavior
  doesn't depend on which Docker Engine version Ubuntu's `docker.io`
  package happens to resolve to at build time (the Dockerfile does not pin
  a version).

Not verified by execution:
- `--cache-to type=registry` against a real registry, and multi-platform
  builds, from inside the actual runner image/microVM environment (nested
  virtualization/overlay constraints in my sandbox prevented a fully
  faithful end-to-end repro of the microVM; the registry-cache capability
  itself is directly documented by Docker as gated on the containerd image
  store, cited above).
- Behavior on the exact base image (`ghcr.io/actions/actions-runner:2.335.1`,
  Ubuntu 24.04) rather than a same-OS proxy container — the `docker.io`
  package version and dockerd behavior should be identical, but this wasn't
  built end-to-end through the real `Dockerfile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Docker storage configuration for improved container image handling.
  * Enhanced readiness checks to validate the expected Docker storage driver.
  * Added clearer logging for Docker configuration status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->