### PR TITLE
ci: disable buildx provenance/sbom on image deploy builds

### DIFF
--- a/.github/workflows/deploy-github-runners.yaml
+++ b/.github/workflows/deploy-github-runners.yaml
@@ -123,6 +123,7 @@ jobs:
         run: |
           METADATA_FILE="${RUNNER_TEMP}/github-runner-build.json"
           docker buildx build \
+            --provenance=false --sbom=false \
             --build-arg "GO_VERSION=${GO_VERSION}" \
             --build-arg "RUST_VERSION=${RUST_VERSION}" \
             --build-arg "CYPRESS_VERSION=${CYPRESS_VERSION}" \
@@ -153,6 +154,7 @@ jobs:
         run: |
           METADATA_FILE="${RUNNER_TEMP}/github-runner-coordinator-build.json"
           docker buildx build \
+            --provenance=false --sbom=false \
             --cache-from "type=registry,ref=${COORDINATOR_REPOSITORY}:buildcache" \
             --cache-to "type=registry,ref=${COORDINATOR_REPOSITORY}:buildcache,mode=max,image-manifest=true" \
             --file src/ci/github-runner/Dockerfile.coordinator \
@@ -239,6 +241,7 @@ jobs:
         run: |
           METADATA_FILE="${RUNNER_TEMP}/github-runner-prepared-build.json"
           docker buildx build \
+            --provenance=false --sbom=false \
             --build-arg "COORDINATOR_IMAGE=${COORDINATOR_REPOSITORY}@${COORDINATOR_DIGEST}" \
             --file Dockerfile.prepared-image \
             --metadata-file "${METADATA_FILE}" \

--- a/.github/workflows/deploy-sandbox-node.yaml
+++ b/.github/workflows/deploy-sandbox-node.yaml
@@ -86,6 +86,7 @@ jobs:
         run: |
           METADATA_FILE="${RUNNER_TEMP}/sandbox-node-build.json"
           docker buildx build \
+            --provenance=false --sbom=false \
             --cache-from "type=registry,ref=${IMAGE_REPOSITORY}:buildcache" \
             --cache-to "type=registry,ref=${IMAGE_REPOSITORY}:buildcache,mode=max,image-manifest=true" \
             --file Dockerfile \
@@ -110,6 +111,7 @@ jobs:
         run: |
           METADATA_FILE="${RUNNER_TEMP}/sandbox-node-init-build.json"
           docker buildx build \
+            --provenance=false --sbom=false \
             --cache-from "type=registry,ref=${IMAGE_REPOSITORY}:buildcache" \
             --cache-to "type=registry,ref=${IMAGE_REPOSITORY}:buildcache,mode=max,image-manifest=true" \
             --file Dockerfile.init \


### PR DESCRIPTION
Fixes the `deploy-github-runners` failure on main ([run](https://github.com/Altinn/altinn-studio/actions/runs/32585524333/job/97062968363)): `config parse error: image reference digest … does not match manifest …` in the prepared-runner-image export.

Mechanism: with the classic image store, the docker driver could not produce attestations, so buildx's default provenance was silently inert and pushes were single-manifest images. The containerd image store (from #20121's workflow changes) made attestations possible, so pushes became OCI indexes — and the sandbox exporter verifies the runner image by the metadata-file digest, which now points at an index whose platform manifest hashes differently. `--provenance=false --sbom=false` pins the pre-existing pushed shape; studioctl's build wrapper already passes exactly these flags for the same reason. Applied to both `deploy-github-runners` and `deploy-sandbox-node` (same silent flip; its k8s consumers tolerate indexes, but the change was unintended).

After merge: re-run `deploy-github-runners` so the runner image rollout (baked Cypress etc.) completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image builds to omit provenance attestations and software bills of materials (SBOMs).
  * Applied this change across runner, coordinator, prepared runner, and sandbox node images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->