### PR TITLE
ci: try to minimize runner allocation during non-work hours

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -8,7 +8,7 @@ Guidance is organized by topic.
 Three mechanisms, by content type:
 
 1. **GitHub Actions cache** (10GB/repo, LRU-evicted). Shared entries are seeded
-   on main by [`workflows/cache-warm.yml`](workflows/cache-warm.yml) (daily
+   on main by [`workflows/cache-warm.yml`](workflows/cache-warm.yml) (weekdays
    06:00 UTC + dispatch) and restored-only by PR jobs — PR-ref saves are
    invisible to other PRs and evict the shared entries (letting PR jobs save
    freely is what blew the quota; see #20121). Two bounded exceptions save

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -7,15 +7,18 @@ name: Cache warm
 # workflow keeps those main-scoped entries warm so PR jobs restore instead
 # of rebuilding and re-saving.
 #
-# Runs once a day: dependency bumps merged during the day stay cold until
-# the next morning run (or a manual dispatch). Every job is idempotent and
-# cheap when the caches are already warm: exact cache hits skip both the
+# Runs each weekday morning: dependency bumps merged during the day stay
+# cold until the next morning run (or a manual dispatch). Weekends are
+# skipped so the self-hosted runners' AKS nodes can stay scaled down — no
+# PRs consume the caches then, and GH cache entries live 7 days so the
+# Friday entries survive to Monday. Every job is idempotent and cheap when
+# the caches are already warm: exact cache hits skip both the
 # install/build work and the save.
 
 on:
   schedule:
-    # 08:00 Oslo in summer / 07:00 in winter (GitHub cron is UTC-only).
-    - cron: '0 6 * * *'
+    # Weekdays 08:00 Oslo in summer / 07:00 in winter (GitHub cron is UTC-only).
+    - cron: '0 6 * * 1-5'
   workflow_dispatch:
 
 concurrency:

--- a/renovate.json
+++ b/renovate.json
@@ -212,5 +212,6 @@
   ],
   "schedule": ["* 7-15 * * 1-5"],
   "updateNotScheduled": false,
-  "automergeSchedule": ["* 7-15 * * 1-5"]
+  "automergeSchedule": ["* 7-15 * * 1-5"],
+  "platformAutomerge": false
 }

--- a/renovate.json
+++ b/renovate.json
@@ -210,5 +210,7 @@
       "enabled": false
     }
   ],
-  "schedule": []
+  "schedule": ["* 7-15 * * 1-5"],
+  "updateNotScheduled": false,
+  "automergeSchedule": ["* 7-15 * * 1-5"]
 }


### PR DESCRIPTION
## Description

- dont do the cache-warming thing during weekends (happens every morning weekdays)
- keep renovate schedule also to weekdays during workhours

Both to try to only trigger CI time when there is likely to already be runners needed due to us working.
When nodes are scaled up in the underlying cluster by the cluster autoscaler, it takes some minutes before nodes
are scaled down again, so its more expensive if we do that at a time where runners are unlikely to be needed  

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Cache warming now runs at 06:00 UTC on weekdays only, with weekend cache retention and runner scaling documented.
  * Dependency update checks and automatic merges are scheduled for weekdays between 07:00 and 15:00.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->