### PR TITLE
fix: exclude nested dist folders from tsconfig

### DIFF
--- a/src/Designer/frontend/tsconfig.json
+++ b/src/Designer/frontend/tsconfig.json
@@ -44,7 +44,7 @@
     "tmp",
     "./testing/cypress/**",
     "./testing/playwright/**",
-    "dist",
+    "**/dist",
     "**/prettier.config.js",
     "./scripts/**"
   ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

exclude: "dist" only matched frontend/dist, not admin/dist, app-development/dist and the other per-app build folders, so a local yarn build yesterday evening pulled 15 MB of minified bundles into the TypeScript program, which broke Find All References. **/dist fixes it.

<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved TypeScript project configuration to exclude generated distribution files across all nested directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->