### PR TITLE
fix(resource-adm): fix resource admin Playwright test

### DIFF
--- a/.github/workflows/designer-frontend-resourceadm-run-playwright-on-pr.yml
+++ b/.github/workflows/designer-frontend-resourceadm-run-playwright-on-pr.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/Designer/frontend/resourceadm/**'
+      - 'src/Designer/frontend/packages/policy-editor/**'
       - '.github/workflows/designer-frontend-resourceadm-run-playwright-on-pr.yml'
       - '!**/AGENTS.md'
       - '!**/CLAUDE.md'

--- a/src/Designer/frontend/resourceadm/testing/playwright/pages/ResourcePage.ts
+++ b/src/Designer/frontend/resourceadm/testing/playwright/pages/ResourcePage.ts
@@ -201,15 +201,15 @@ export class ResourcePage extends ResourceEnvironment {
     const isPolicyRuleVisible = await this.ruleHeader.isVisible();
     if (!isPolicyRuleVisible) {
       await this.addPolicyRuleButton.click();
-      await this.setPolicyAction();
+      await this.setPolicyActionLes();
       await this.expandPolicySubjectAccordion();
       await this.setPolicySubject();
     }
   }
 
-  private async setPolicyAction(): Promise<void> {
+  private async setPolicyActionLes(): Promise<void> {
     await this.policyActionDropdown.click();
-    await this.policyActionDropdown.press('ArrowDown');
+    await this.policyActionDropdown.fill('Les');
     await this.policyActionDropdown.press('Enter');
   }
 

--- a/src/Designer/frontend/resourceadm/testing/playwright/pages/ResourcePage.ts
+++ b/src/Designer/frontend/resourceadm/testing/playwright/pages/ResourcePage.ts
@@ -101,9 +101,9 @@ export class ResourcePage extends ResourceEnvironment {
     this.addPolicyRuleButton = this.page.getByRole('button', {
       name: textMock('policy_editor.card_button_text'),
     });
-    this.policyActionDropdown = this.page.getByLabel(
-      textMock('policy_editor.rule_card_actions_title'),
-    );
+    this.policyActionDropdown = this.page.getByRole('combobox', {
+      name: textMock('policy_editor.rule_card_actions_title'),
+    });
     this.policySubjectAccordion = this.page
       .locator('summary')
       .filter({ hasText: textMock('policy_editor.org_subjects_header') });
@@ -209,7 +209,7 @@ export class ResourcePage extends ResourceEnvironment {
 
   private async setPolicyActionLes(): Promise<void> {
     await this.policyActionDropdown.click();
-    await this.policyActionDropdown.fill('Les');
+    await this.policyActionDropdown.fill(textMock('policy_editor.action_read'));
     await this.policyActionDropdown.press('Enter');
   }
 


### PR DESCRIPTION
## Description
- Fix failing resource admin Playwright test
- Change Github workflow file to run resource admin Playwright tests on changes in policy-editor

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Playwright coverage now runs when policy editor files are changed.
  - Updated automated resource policy tests to reliably select the localised “Read” action when adding a policy rule.
  - Improved test interactions by using accessible control labels and roles.

- **Bug Fixes**
  - Improved policy rule test reliability by selecting the read action explicitly rather than relying on keyboard navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->