### PR TITLE
fix: allow fable 5 to be used in agents

### DIFF
--- a/src/experimental/agent/src/harness/claude_code/bootstrap/linux.rs
+++ b/src/experimental/agent/src/harness/claude_code/bootstrap/linux.rs
@@ -45,7 +45,17 @@ pub(super) async fn configure(sandbox: &SandboxHandle, home: &str, instructions:
             Box::pin(Cursor::new(crate::harness::session_start::HOOK.as_bytes().to_vec())),
         )
         .await?;
+    // HACK: the mediated setup token is inference-only, so Claude Code cannot read the account's
+    // plan entitlement and gates Fable 5 behind a usage-credits prompt. Declaring the subscription
+    // type and rate-limit tier in the settings env satisfies the client-side plan-inclusion check
+    // (the literal "max" tier is what the check looks for, regardless of the real plan); the server
+    // still authorizes inference independently. Both are required — the type alone unblocks Max
+    // models but not Fable. Remove when github.com/anthropics/claude-code#79360 ships.
     let settings = serde_json::to_vec(&serde_json::json!({
+        "env": {
+            "CLAUDE_CODE_SUBSCRIPTION_TYPE": "max",
+            "CLAUDE_CODE_RATE_LIMIT_TIER": "default_claude_max_5x"
+        },
         "hooks": {
             "SessionStart": [{
                 "matcher": "startup|resume|clear|compact",

--- a/src/experimental/agent/src/harness/claude_code/mod.rs
+++ b/src/experimental/agent/src/harness/claude_code/mod.rs
@@ -133,7 +133,12 @@ pub(super) async fn verify_linux(sandbox: &sandbox::SandboxHandle, expected_vers
 
 pub(super) fn launch_linux(home: &str, resume: Option<&str>) -> ProcessLaunch {
     let config = format!("{home}/.claude");
-    let base = format!("claude --dangerously-skip-permissions --settings {config}/agent-settings.json");
+    // The mediated setup token cannot enumerate models, so Fable 5 never appears in the /model
+    // picker (same inference-only-scope limitation as the usage-credits gate handled in bootstrap).
+    // Launch on Fable 5 directly; users can still switch to the listed models via /model. Revisit
+    // when github.com/anthropics/claude-code#79360 ships.
+    let base =
+        format!("claude --dangerously-skip-permissions --model claude-fable-5 --settings {config}/agent-settings.json");
     // Claude Code currently reports UUID conversation IDs. Keep that
     // harness-specific constraint out of the generic Session reconciler.
     let resume = resume.and_then(|native| native.parse::<uuid::Uuid>().ok());


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Workaround based on this claude code client side bug: https://github.com/anthropics/claude-code/issues/79360

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Claude Code now launches with Max subscription settings in supported Linux environments.
  * This enables the corresponding model availability and default Max rate-limit tier, while server-side authorisation continues to control inference.
  * Existing configuration settings remain unchanged, preserving current setup behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->