### PR TITLE
feat: Add help text support to components with title and description

### DIFF
--- a/src/App/frontend/src/layout/Group/GroupComponent.test.tsx
+++ b/src/App/frontend/src/layout/Group/GroupComponent.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+
+import { GroupComponent } from 'src/layout/Group/GroupComponent';
+import { renderGenericComponentTest } from 'src/test/renderWithProviders';
+import type { RenderGenericComponentTestProps } from 'src/test/renderWithProviders';
+
+const render = async ({
+  component,
+  isSummary,
+}: Partial<RenderGenericComponentTestProps<'Group'>> & { isSummary?: boolean } = {}) =>
+  await renderGenericComponentTest({
+    type: 'Group',
+    renderer: (props) => (
+      <GroupComponent
+        baseComponentId={props.baseComponentId}
+        isSummary={isSummary}
+        renderLayoutComponent={() => null}
+      />
+    ),
+    component: {
+      children: [],
+      ...component,
+    },
+  });
+
+describe('GroupComponent', () => {
+  it('should render the title and a help text button when a help text is set', async () => {
+    await render({
+      component: {
+        textResourceBindings: { title: 'The group title', help: 'this is the help text' },
+      },
+    });
+
+    expect(screen.getByText('The group title')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Hjelp/i })).toBeInTheDocument();
+  });
+
+  it('should not render the help text button when rendered as a summary', async () => {
+    await render({
+      component: {
+        textResourceBindings: { title: 'The group title', help: 'this is the help text' },
+      },
+      isSummary: true,
+    });
+
+    expect(screen.queryByRole('button', { name: /Hjelp/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/App/frontend/src/layout/Group/GroupComponent.tsx
+++ b/src/App/frontend/src/layout/Group/GroupComponent.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { JSX } from 'react';
 
-import { ConditionalWrapper, Fieldset, FullWidthWrapper, Panel } from '@app/form-component';
+import { ConditionalWrapper, Fieldset, FullWidthWrapper, HelpTextContainer, Panel } from '@app/form-component';
 import { Heading } from '@digdir/designsystemet-react';
 import cn from 'classnames';
 
@@ -38,7 +38,7 @@ export function GroupComponent({
   renderLayoutComponent,
 }: IGroupComponent) {
   const container = useItemWhenType(baseComponentId, 'Group');
-  const { title, summaryTitle, description } = container.textResourceBindings ?? {};
+  const { title, summaryTitle, description, help } = container.textResourceBindings ?? {};
   const isHidden = useIsHidden(baseComponentId);
 
   const indexedId = useIndexedId(baseComponentId);
@@ -84,6 +84,15 @@ export function GroupComponent({
               <span className={classes.description}>
                 <Lang id={description} />
               </span>
+            ) : undefined
+          }
+          help={
+            help && !isSummary ? (
+              <HelpTextContainer
+                id={indexedId}
+                title={legend}
+                helpText={<Lang id={help} />}
+              />
             ) : undefined
           }
         >

--- a/src/App/frontend/src/layout/Group/config.ts
+++ b/src/App/frontend/src/layout/Group/config.ts
@@ -31,6 +31,13 @@ export const Config = new CG.component({
       description: 'The description text shown underneath the title',
     }),
   )
+  .addTextResource(
+    new CG.trb({
+      name: 'help',
+      title: 'Help text',
+      description: 'Help text shown in a tooltip when clicking the help button',
+    }),
+  )
   .addProperty(
     new CG.prop(
       'groupingIndicator',

--- a/src/App/frontend/src/layout/Likert/LikertComponent.module.css
+++ b/src/App/frontend/src/layout/Likert/LikertComponent.module.css
@@ -66,3 +66,9 @@ Altinn, and making sure they are consistent. */
   border-inline-start: 1px solid #dde3e5;
   border-inline-end: 1px solid #dde3e5;
 }
+
+.likertTitleAndHelp {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-size-2);
+}

--- a/src/App/frontend/src/layout/Likert/LikertComponent.test.tsx
+++ b/src/App/frontend/src/layout/Likert/LikertComponent.test.tsx
@@ -99,6 +99,22 @@ describe('Likert', () => {
       expect(screen.getByText('Test left column header')).toBeInTheDocument();
     });
 
+    it('should render the help text button when a help text is set', async () => {
+      await render({
+        mockQuestions: defaultMockQuestions,
+        likertProps: {
+          textResourceBindings: {
+            title: 'Test title',
+            help: 'Test help text',
+          },
+        },
+      });
+
+      expect(screen.getByRole('button', { name: /Hjelp/i })).toBeInTheDocument();
+      // The help button lives in the caption, so the table must be named from the heading alone
+      expect(screen.getByRole('table')).toHaveAccessibleName('Test title');
+    });
+
     it('should render table with one selected row', async () => {
       const answer = defaultMockOptions[1];
       const mockQuestions = [
@@ -386,6 +402,23 @@ describe('Likert', () => {
       expect(screen.getByRole('group', { name: /Likert test title/i })).toHaveAccessibleDescription(
         'This is a test description',
       );
+    });
+
+    it('should render the help text button when a help text is set', async () => {
+      await render({
+        mockQuestions: defaultMockQuestions,
+        likertProps: {
+          textResourceBindings: {
+            title: 'Likert test title',
+            help: 'Test help text',
+          },
+        },
+        mobileView: true,
+      });
+
+      expect(screen.getByRole('button', { name: /Hjelp/i })).toBeInTheDocument();
+      // The help button sits next to the heading, so the group must be named from the heading alone
+      expect(screen.getByRole('group')).toHaveAccessibleName('Likert test title');
     });
 
     it('should prefix leftColumnHeader to each radio group legend', async () => {

--- a/src/App/frontend/src/layout/Likert/LikertComponent.tsx
+++ b/src/App/frontend/src/layout/Likert/LikertComponent.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Description, getDescriptionId, getLabelId, useIsMobileOrTablet } from '@app/form-component';
+import { Description, getDescriptionId, getLabelId, HelpTextContainer, useIsMobileOrTablet } from '@app/form-component';
 import { Heading, Table } from '@digdir/designsystemet-react';
 import cn from 'classnames';
 
@@ -19,6 +19,41 @@ import { DataModelLocationProvider, useIndexedId } from 'src/utils/layout/DataMo
 import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { IGenericComponentProps } from 'src/layout/GenericComponent';
 
+interface LikertTitleProps {
+  title: string;
+  description?: string;
+  help?: string;
+  componentId: string;
+  labelId: string;
+}
+
+function LikertTitle({ title, description, help, componentId, labelId }: LikertTitleProps) {
+  return (
+    <>
+      <div className={classes.likertTitleAndHelp}>
+        <Heading
+          id={labelId}
+          level={2}
+          data-size='sm'
+        >
+          <Lang id={title} />
+        </Heading>
+        {help && (
+          <HelpTextContainer
+            id={componentId}
+            title={title}
+            helpText={<Lang id={help} />}
+          />
+        )}
+      </div>
+      <Description
+        description={description && <Lang id={description} />}
+        componentId={componentId}
+      />
+    </>
+  );
+}
+
 export const LikertComponent = ({ baseComponentId }: PropsFromGenericComponent<'Likert'>) => {
   const { id, dataModelBindings, textResourceBindings, columns } = useItemWhenType(baseComponentId, 'Likert');
   const groupBinding = dataModelBindings.questions;
@@ -29,6 +64,8 @@ export const LikertComponent = ({ baseComponentId }: PropsFromGenericComponent<'
   const indexedId = useIndexedId(baseComponentId);
   const title = textResourceBindings?.title;
   const description = textResourceBindings?.description;
+  const help = textResourceBindings?.help;
+  const labelId = getLabelId(indexedId);
 
   if (mobileView) {
     return (
@@ -38,28 +75,20 @@ export const LikertComponent = ({ baseComponentId }: PropsFromGenericComponent<'
         data-componentbaseid={baseComponentId}
       >
         {title && (
-          <div
-            className={classes.likertHeading}
-            id={getLabelId(indexedId)}
-          >
-            <Heading
-              level={2}
-              data-size='sm'
-            >
-              <Lang id={title} />
-            </Heading>
-            {description && (
-              <Description
-                description={<Lang id={description} />}
-                componentId={indexedId}
-              />
-            )}
+          <div className={classes.likertHeading}>
+            <LikertTitle
+              title={title}
+              description={description}
+              help={help}
+              componentId={indexedId}
+              labelId={labelId}
+            />
           </div>
         )}
         <div
           role='group'
           className={classes.likertMobileGroup}
-          aria-labelledby={textResourceBindings?.title ? getLabelId(indexedId) : undefined}
+          aria-labelledby={textResourceBindings?.title ? labelId : undefined}
           aria-describedby={textResourceBindings?.description ? getDescriptionId(indexedId) : undefined}
         >
           {rows.map((row) =>
@@ -91,22 +120,17 @@ export const LikertComponent = ({ baseComponentId }: PropsFromGenericComponent<'
           id={id}
           border
           className={classes.likertTable}
-          aria-describedby={textResourceBindings?.description ? getDescriptionId(id) : undefined}
+          aria-labelledby={title ? labelId : undefined}
+          aria-describedby={textResourceBindings?.description ? getDescriptionId(indexedId) : undefined}
         >
           {title && (
-            <caption
-              id={getLabelId(indexedId)}
-              className={classes.likertHeading}
-            >
-              <Heading
-                level={2}
-                data-size='sm'
-              >
-                <Lang id={title} />
-              </Heading>
-              <Description
-                description={description && <Lang id={description} />}
+            <caption className={classes.likertHeading}>
+              <LikertTitle
+                title={title}
+                description={description}
+                help={help}
                 componentId={indexedId}
+                labelId={labelId}
               />
             </caption>
           )}

--- a/src/App/frontend/src/layout/Likert/config.ts
+++ b/src/App/frontend/src/layout/Likert/config.ts
@@ -41,6 +41,13 @@ export const Config = asOptionsComponent(
   )
   .addTextResource(
     new CG.trb({
+      name: 'help',
+      title: 'Help text',
+      description: 'Help text shown in a tooltip when clicking the help button',
+    }),
+  )
+  .addTextResource(
+    new CG.trb({
       name: 'leftColumnHeader',
       title: 'Left column header',
       description: 'The header text for the left column in the Likert table',

--- a/src/App/frontend/src/layout/Payment/PaymentComponent.test.tsx
+++ b/src/App/frontend/src/layout/Payment/PaymentComponent.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+
+import { PaymentContext } from 'src/features/payment/PaymentProvider';
+import { PaymentComponent } from 'src/layout/Payment/PaymentComponent';
+import { renderGenericComponentTest } from 'src/test/renderWithProviders';
+import type { RenderGenericComponentTestProps } from 'src/test/renderWithProviders';
+
+const render = async ({ component }: Partial<RenderGenericComponentTestProps<'Payment'>> = {}) =>
+  await renderGenericComponentTest({
+    type: 'Payment',
+    renderer: (props) => (
+      <PaymentContext.Provider value={{ performPayment: () => {}, paymentError: null }}>
+        <PaymentComponent {...props} />
+      </PaymentContext.Provider>
+    ),
+    component: {
+      textResourceBindings: { title: 'The payment title' },
+      ...component,
+    },
+  });
+
+describe('PaymentComponent', () => {
+  it('should render the title and a help text button when a help text is set', async () => {
+    await render({
+      component: {
+        textResourceBindings: { title: 'The payment title', help: 'this is the help text' },
+      },
+    });
+
+    expect(screen.getByText('The payment title')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Hjelp/i })).toBeInTheDocument();
+  });
+});

--- a/src/App/frontend/src/layout/Payment/PaymentComponent.tsx
+++ b/src/App/frontend/src/layout/Payment/PaymentComponent.tsx
@@ -29,7 +29,7 @@ export const PaymentComponent = ({ baseComponentId }: PropsFromGenericComponent<
   const isAnyProcessing = useIsAnyProcessing();
   const paymentInfo = usePaymentInformation();
   const { performPayment, paymentError } = usePayment();
-  const { title, description } = useItemWhenType(baseComponentId, 'Payment').textResourceBindings ?? {};
+  const { title, description, help } = useItemWhenType(baseComponentId, 'Payment').textResourceBindings ?? {};
   const { data: process, refetch: reFetchProcessData } = useProcessQuery();
   const navigateToTask = useNavigateToTask();
   const optimisticallyUpdateProcess = useOptimisticallyUpdateProcess();
@@ -97,6 +97,7 @@ export const PaymentComponent = ({ baseComponentId }: PropsFromGenericComponent<
           orderDetails={paymentInfo?.orderDetails}
           tableTitle={title}
           description={description}
+          help={help}
         />
         <div className={classes.alertContainer}>
           {(paymentInfo?.status === PaymentStatus.Failed || paymentError) && (

--- a/src/App/frontend/src/layout/Payment/config.ts
+++ b/src/App/frontend/src/layout/Payment/config.ts
@@ -32,4 +32,11 @@ export const Config = new CG.component({
       description: 'Description, optionally shown below the title',
     }),
   )
+  .addTextResource(
+    new CG.trb({
+      name: 'help',
+      title: 'Help text',
+      description: 'Help text shown in a tooltip when clicking the help button',
+    }),
+  )
   .addSummaryOverrides();

--- a/src/App/frontend/src/layout/PaymentDetails/PaymentDetailsComponent.test.tsx
+++ b/src/App/frontend/src/layout/PaymentDetails/PaymentDetailsComponent.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+
+import { PaymentDetailsComponent } from 'src/layout/PaymentDetails/PaymentDetailsComponent';
+import { renderGenericComponentTest } from 'src/test/renderWithProviders';
+import type { RenderGenericComponentTestProps } from 'src/test/renderWithProviders';
+
+const render = async ({ component }: Partial<RenderGenericComponentTestProps<'PaymentDetails'>> = {}) =>
+  await renderGenericComponentTest({
+    type: 'PaymentDetails',
+    renderer: (props) => <PaymentDetailsComponent {...props} />,
+    component: {
+      textResourceBindings: { title: 'The order details title' },
+      ...component,
+    },
+  });
+
+describe('PaymentDetailsComponent', () => {
+  it('should render the title and a help text button when a help text is set', async () => {
+    await render({
+      component: {
+        textResourceBindings: { title: 'The order details title', help: 'this is the help text' },
+      },
+    });
+
+    expect(screen.getByText('The order details title')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Hjelp/i })).toBeInTheDocument();
+  });
+});

--- a/src/App/frontend/src/layout/PaymentDetails/PaymentDetailsComponent.tsx
+++ b/src/App/frontend/src/layout/PaymentDetails/PaymentDetailsComponent.tsx
@@ -13,7 +13,7 @@ export function PaymentDetailsComponent({ baseComponentId }: PropsFromGenericCom
   const orderDetails = useOrderDetails();
   const refetchOrderDetails = useRefetchOrderDetails();
   const { mapping, textResourceBindings } = useItemWhenType(baseComponentId, 'PaymentDetails');
-  const { title, description } = textResourceBindings || {};
+  const { title, description, help } = textResourceBindings || {};
   const hasUnsavedChanges = FormStore.data.useHasUnsavedChanges();
 
   const mappedValues = FormStore.data.useMapping(mapping, FormStore.bootstrap.useDefaultDataType());
@@ -33,6 +33,7 @@ export function PaymentDetailsComponent({ baseComponentId }: PropsFromGenericCom
         orderDetails={orderDetails}
         tableTitle={title}
         description={description}
+        help={help}
       />
     </ComponentStructureWrapper>
   );

--- a/src/App/frontend/src/layout/PaymentDetails/PaymentDetailsTable.tsx
+++ b/src/App/frontend/src/layout/PaymentDetails/PaymentDetailsTable.tsx
@@ -12,9 +12,16 @@ type PaymentDetailsTableProps = {
   orderDetails?: OrderDetails;
   tableTitle?: string;
   description?: string;
+  help?: string;
 } & React.HTMLAttributes<HTMLTableElement>;
 
-export const PaymentDetailsTable = ({ orderDetails, tableTitle, description, ...rest }: PaymentDetailsTableProps) => (
+export const PaymentDetailsTable = ({
+  orderDetails,
+  tableTitle,
+  description,
+  help,
+  ...rest
+}: PaymentDetailsTableProps) => (
   <Table
     {...rest}
     className={cn(classes.orderDetailsTable, rest.className)}
@@ -23,6 +30,7 @@ export const PaymentDetailsTable = ({ orderDetails, tableTitle, description, ...
       <Caption
         title={<Lang id={tableTitle} />}
         description={description && <Lang id={description} />}
+        helpText={help ? { text: <Lang id={help} />, accessibleTitle: tableTitle } : undefined}
       />
     )}
 

--- a/src/App/frontend/src/layout/PaymentDetails/config.ts
+++ b/src/App/frontend/src/layout/PaymentDetails/config.ts
@@ -31,4 +31,11 @@ export const Config = new CG.component({
       description: 'Description, optionally shown below the title',
     }),
   )
+  .addTextResource(
+    new CG.trb({
+      name: 'help',
+      title: 'Help text',
+      description: 'Help text shown in a tooltip when clicking the help button',
+    }),
+  )
   .addProperty(new CG.prop('mapping', CG.common('IMapping').optional()));

--- a/src/App/frontend/src/layout/RepeatingGroup/Container/RepeatingGroupContainer.test.tsx
+++ b/src/App/frontend/src/layout/RepeatingGroup/Container/RepeatingGroupContainer.test.tsx
@@ -468,6 +468,35 @@ describe('RepeatingGroupContainer', () => {
     const saveButton = screen.getByText('New save text');
     expect(saveButton).toBeInTheDocument();
   });
+
+  describe('help text', () => {
+    it('should render the title and a help text button in showAll mode when a help text is set', async () => {
+      await render({
+        container: {
+          edit: { ...mockContainer.edit, mode: 'showAll' },
+          textResourceBindings: { title: 'Group title', help: 'Group help text' },
+        },
+        numRows: 1,
+      });
+
+      expect(screen.getByText('Group title')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Hjelp/i })).toBeInTheDocument();
+    });
+
+    it('should render the help text button when editing a row in hideTable mode', async () => {
+      await render({
+        container: {
+          edit: { ...mockContainer.edit, mode: 'hideTable' },
+          textResourceBindings: { title: 'Group title', help: 'Group help text' },
+        },
+        numRows: 1,
+      });
+
+      await userEvent.click(screen.getByRole('button', { name: /Rediger/i }));
+
+      expect(await screen.findByRole('button', { name: /Hjelp/i })).toBeInTheDocument();
+    });
+  });
 });
 
 function LeakEditIndex() {

--- a/src/App/frontend/src/layout/RepeatingGroup/Table/RepeatingGroupTable.test.tsx
+++ b/src/App/frontend/src/layout/RepeatingGroup/Table/RepeatingGroupTable.test.tsx
@@ -393,6 +393,19 @@ describe('RepeatingGroupTable', () => {
     });
   });
 
+  describe('help text', () => {
+    it('should render the title and a help text button in the table caption when a help text is set', async () => {
+      const groupWithHelpText = getFormLayoutRepeatingGroupMock({
+        id: 'mock-container-id',
+        textResourceBindings: { title: 'Group title', help: 'Group help text' },
+      });
+      await render(getLayout(groupWithHelpText, components));
+
+      expect(screen.getByText('Group title')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Hjelp/i })).toBeInTheDocument();
+    });
+  });
+
   const render = (
     layout = getLayout(group, components),
     formData: object = {

--- a/src/App/frontend/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
+++ b/src/App/frontend/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
@@ -123,6 +123,11 @@ export function RepeatingGroupTable(): React.JSX.Element | null {
             className={cn({ [classes.fullWidthCaption]: !isEmpty && !isNested })}
             title={<Lang id={textResourceBindings.title} />}
             description={textResourceBindings.description && <Lang id={textResourceBindings.description} />}
+            helpText={
+              textResourceBindings.help
+                ? { text: <Lang id={textResourceBindings.help} />, accessibleTitle: textResourceBindings.title }
+                : undefined
+            }
             labelSettings={labelSettings}
             required={required}
           />

--- a/src/App/frontend/src/layout/RepeatingGroup/config.ts
+++ b/src/App/frontend/src/layout/RepeatingGroup/config.ts
@@ -37,6 +37,13 @@ export const Config = new CG.component({
   )
   .addTextResource(
     new CG.trb({
+      name: 'help',
+      title: 'Help text',
+      description: 'Help text shown in a tooltip when clicking the help button',
+    }),
+  )
+  .addTextResource(
+    new CG.trb({
       name: 'addButtonFull',
       title: 'Add button (full) (for repeating groups)',
       description: 'The text for the "Add" button (overrides "addButton", and sets the full text for the button)',

--- a/src/App/frontend/src/layout/Subform/SubformComponent.test.tsx
+++ b/src/App/frontend/src/layout/Subform/SubformComponent.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+
+import { SubformComponent } from 'src/layout/Subform/SubformComponent';
+import { renderGenericComponentTest } from 'src/test/renderWithProviders';
+import type { RenderGenericComponentTestProps } from 'src/test/renderWithProviders';
+
+const render = async ({ component }: Partial<RenderGenericComponentTestProps<'Subform'>> = {}) =>
+  await renderGenericComponentTest({
+    type: 'Subform',
+    renderer: (props) => <SubformComponent {...props} />,
+    component: {
+      layoutSet: 'subform-layout',
+      tableColumns: [],
+      textResourceBindings: { title: 'The subform title' },
+      ...component,
+    },
+  });
+
+describe('SubformComponent', () => {
+  it('should render the title and a help text button when a help text is set', async () => {
+    await render({
+      component: {
+        textResourceBindings: { title: 'The subform title', help: 'this is the help text' },
+      },
+    });
+
+    expect(screen.getByText('The subform title')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Hjelp/i })).toBeInTheDocument();
+  });
+});

--- a/src/App/frontend/src/layout/Subform/SubformComponent.tsx
+++ b/src/App/frontend/src/layout/Subform/SubformComponent.tsx
@@ -98,11 +98,18 @@ export function SubformComponent({ baseComponentId }: PropsFromGenericComponent<
           id={`subform-${id}-table`}
           className={classes.subformTable}
         >
-          <Caption
-            id={`subform-${id}-caption`}
-            title={<Lang id={textResourceBindings?.title} />}
-            description={textResourceBindings?.description && <Lang id={textResourceBindings?.description} />}
-          />
+          {textResourceBindings?.title && (
+            <Caption
+              id={`subform-${id}-caption`}
+              title={<Lang id={textResourceBindings.title} />}
+              description={textResourceBindings.description && <Lang id={textResourceBindings.description} />}
+              helpText={
+                textResourceBindings.help
+                  ? { text: <Lang id={textResourceBindings.help} />, accessibleTitle: textResourceBindings.title }
+                  : undefined
+              }
+            />
+          )}
           {subformEntries.length > 0 && (
             <>
               <Table.Head id={`subform-${id}-table-body`}>

--- a/src/App/frontend/src/layout/Subform/Summary/SubformSummaryTable.tsx
+++ b/src/App/frontend/src/layout/Subform/Summary/SubformSummaryTable.tsx
@@ -169,11 +169,13 @@ export function SubformSummaryTable({
           id={`subform-${id}-table`}
           className={classes1.subformTable}
         >
-          <Caption
-            id={`subform-${id}-caption`}
-            title={<Lang id={textResourceBindings?.title} />}
-            description={textResourceBindings?.description && <Lang id={textResourceBindings?.description} />}
-          />
+          {textResourceBindings?.title && (
+            <Caption
+              id={`subform-${id}-caption`}
+              title={<Lang id={textResourceBindings.title} />}
+              description={textResourceBindings.description && <Lang id={textResourceBindings.description} />}
+            />
+          )}
           <Table.Head id={`subform-${id}-table-body`}>
             <Table.Row>
               {tableColumns.length ? (

--- a/src/App/frontend/src/layout/Subform/config.ts
+++ b/src/App/frontend/src/layout/Subform/config.ts
@@ -108,6 +108,13 @@ export const Config = new CG.component({
   )
   .addTextResource(
     new CG.trb({
+      name: 'help',
+      title: 'Help text',
+      description: 'Help text shown in a tooltip when clicking the help button',
+    }),
+  )
+  .addTextResource(
+    new CG.trb({
       name: 'addButton',
       title: 'Add button (suffix)',
       description: 'The text for the "Add" button (used as a suffix after the default button text)',


### PR DESCRIPTION
## Adds help text to components that only had title and description

Adds support for `textResourceBindings.help` in the six components that had `title` and
`description` but no help text:

| Component | Where the help button appears |
| --- | --- |
| `Group` | Next to the group heading |
| `Likert` | Next to the heading, in both the desktop table and the mobile view |
| `RepeatingGroup` | In the table caption, and in the group header in `showAll` / `hideTable` edit modes |
| `Payment` | In the order details table caption |
| `PaymentDetails` | In the order details table caption |
| `Subform` | In the table caption |

Two things to note about the behaviour:

- The help button is only shown when the component also has a title, since the button is
  named after the title. This is how the other components already work.
- The help button is not shown in summary views.

The new binding is included in the generated layout JSON schema, so it shows up for app
developers like any other text resource binding.

Closes #20159

## Clean up and fixes done along the way

**Likert – accessible name**
The heading is now the element that names the table and the mobile group. Previously the
name was built from the whole caption, which meant the description was read as part of the
name, and the new help button would have been too. The label id is also derived in one
place instead of three.

**Likert – wrong id in `aria-describedby`**
The desktop table pointed at the base component id instead of the indexed id, so the
reference was broken when a Likert is nested inside a repeating group.

**Likert – duplicated markup**
The heading and description markup was repeated in the desktop and mobile views. It is now
a small shared `LikertTitle` component.

**Subform – empty table caption**
The caption was rendered even when no title was set, producing an empty `<caption>` element
and some extra spacing above the table. It is now only rendered when there is a title,
which matches `Grid`, `SimpleTable`, `RepeatingGroup` and `PaymentDetails`. Applies to both
the form view and the summary table.

## Images
Made sample page locally to see how it looks with help text
<img width="1037" height="1000" alt="image" src="https://github.com/user-attachments/assets/8234c605-3cb4-4d2d-b71d-d067e3e67a5e" />

<img width="1009" height="919" alt="image" src="https://github.com/user-attachments/assets/556986a6-e215-444d-90f7-350083e8fd11" />
<img width="1002" height="835" alt="image" src="https://github.com/user-attachments/assets/f9fafac2-c22d-4cdf-be38-ed16387c4c64" />
<img width="1000" height="1005" alt="image" src="https://github.com/user-attachments/assets/69e0ca79-7162-4f95-994e-c644651216cc" />
<img width="1043" height="522" alt="image" src="https://github.com/user-attachments/assets/8aef82d2-3fae-4207-a38d-3cdc274a0fc6" />


## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional help-text buttons and tooltips to groups, Likert scales, payment sections, repeating groups and subforms.
  * Help text can now be configured alongside component titles and descriptions.
  * Help controls are displayed appropriately across desktop, mobile, summary and editing views.

* **Tests**
  * Added coverage verifying help-button visibility, labels, accessibility and contextual rendering across supported components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->