### PR TITLE
fix: restore defaultDataType binding when a v9 datamodel is recreated

### DIFF
--- a/src/Designer/backend/src/Designer/Services/Implementation/SchemaModelService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/SchemaModelService.cs
@@ -23,6 +23,7 @@ using Altinn.Studio.Designer.Infrastructure.GitRepository;
 using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Models.App;
 using Altinn.Studio.Designer.Services.Interfaces;
+using Altinn.Studio.Designer.TypedHttpClients.Exceptions;
 using Json.Schema;
 using Microsoft.Extensions.Logging;
 
@@ -596,9 +597,26 @@ public class SchemaModelService : ISchemaModelService
         string id
     )
     {
+        HashSet<string> processTaskIds;
+        try
+        {
+            processTaskIds =
+                altinnAppGitRepository.GetProcessDefinitions()?.Process?.Tasks?.Select(task => task.Id).ToHashSet()
+                ?? [];
+        }
+        catch (NotFoundHttpRequestException)
+        {
+            return null;
+        }
+
         IEnumerable<string> uiFolders = await altinnAppGitRepository.GetUiFolders();
         foreach (string layoutSetName in uiFolders)
         {
+            if (!processTaskIds.Contains(layoutSetName))
+            {
+                continue;
+            }
+
             LayoutSettings layoutSettings;
             try
             {

--- a/src/Designer/backend/src/Designer/Services/Implementation/SchemaModelService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/SchemaModelService.cs
@@ -168,7 +168,12 @@ public class SchemaModelService : ISchemaModelService
         ModelMetadata modelMetadata = GetModelMetadataForCsharpGeneration(serializedJsonContent, jsonSchema);
         string csharpModelName = modelMetadata.GetRootElement().TypeName;
         await UpdateCSharpClasses(altinnAppGitRepository, modelMetadata, schemaFileName);
-        await UpdateApplicationMetadata(altinnAppGitRepository, schemaFileName, csharpModelName);
+        await UpdateApplicationMetadata(
+            altinnRepoEditingContext,
+            altinnAppGitRepository,
+            schemaFileName,
+            csharpModelName
+        );
         await UpdateXsdFromJsonSchema(altinnAppGitRepository, jsonSchema, schemaFileName);
     }
 
@@ -253,7 +258,12 @@ public class SchemaModelService : ISchemaModelService
         ModelMetadata modelMetadata = GetModelMetadataForCsharpGeneration(serializedJsonContent, jsonSchema);
         string csharpModelName = modelMetadata.GetRootElement().TypeName;
         await UpdateCSharpClasses(altinnAppGitRepository, modelMetadata, schemaFileName);
-        await UpdateApplicationMetadata(altinnAppGitRepository, schemaFileName, csharpModelName);
+        await UpdateApplicationMetadata(
+            altinnRepoEditingContext,
+            altinnAppGitRepository,
+            schemaFileName,
+            csharpModelName
+        );
 
         return serializedJsonContent;
     }
@@ -336,7 +346,12 @@ public class SchemaModelService : ISchemaModelService
 
             var relativePath = await altinnAppGitRepository.SaveJsonSchema(jsonSchema, schemaAndModelName);
 
-            await UpdateApplicationMetadata(altinnAppGitRepository, schemaAndModelName, schemaAndModelName);
+            await UpdateApplicationMetadata(
+                altinnRepoEditingContext,
+                altinnAppGitRepository,
+                schemaAndModelName,
+                schemaAndModelName
+            );
 
             return (relativePath, jsonSchema);
         }
@@ -445,6 +460,7 @@ public class SchemaModelService : ISchemaModelService
     }
 
     private async Task UpdateApplicationMetadata(
+        AltinnRepoEditingContext altinnRepoEditingContext,
         AltinnAppGitRepository altinnAppGitRepository,
         string schemaFileName,
         string csharpModelName
@@ -452,8 +468,18 @@ public class SchemaModelService : ISchemaModelService
     {
         ApplicationMetadata application = await altinnAppGitRepository.GetApplicationMetadata();
 
+        bool isNewDataType = application.DataTypes?.Any(d => d.Id == schemaFileName) != true;
+        string restoredTaskId = null;
+        if (isNewDataType && _appVersionService.IsV9App(altinnRepoEditingContext))
+        {
+            // The datamodel may have previously been deleted and is now being recreated with the same
+            // id. Its old task binding still lives in that task's Settings.json (defaultDataType is no
+            // longer cleared on delete), so restore it here instead of leaving TaskId unset.
+            restoredTaskId = await FindTaskIdWithDefaultDataType(altinnAppGitRepository, schemaFileName);
+        }
+
         string fullTypeName = GetFullTypeName(application, csharpModelName);
-        UpdateApplicationWithAppLogicModel(application, schemaFileName, fullTypeName);
+        UpdateApplicationWithAppLogicModel(application, schemaFileName, fullTypeName, restoredTaskId);
 
         await altinnAppGitRepository.SaveApplicationMetadata(application);
     }
@@ -465,10 +491,14 @@ public class SchemaModelService : ISchemaModelService
     /// <param name="application">The <see cref="Application"/> object to be updated.</param>
     /// <param name="dataTypeId">The id of the datatype to bed added.</param>
     /// <param name="classRef">The C# class reference of the data type.</param>
+    /// <param name="taskId">
+    /// The task id to bind a newly created data type to, if a previous binding for this id was found.
+    /// </param>
     private static void UpdateApplicationWithAppLogicModel(
         ApplicationMetadata application,
         string dataTypeId,
-        string classRef
+        string classRef,
+        string taskId = null
     )
     {
         if (application.DataTypes == null)
@@ -483,7 +513,7 @@ public class SchemaModelService : ISchemaModelService
             logicElement = new DataType
             {
                 Id = dataTypeId,
-                TaskId = null,
+                TaskId = taskId,
                 AllowedContentTypes = new List<string>() { "application/xml" },
                 MaxCount = 1,
                 MinCount = 1,
@@ -548,11 +578,12 @@ public class SchemaModelService : ISchemaModelService
         if (applicationMetadata.DataTypes != null)
         {
             DataType dataTypeToDelete = applicationMetadata.DataTypes.Find(m => m.Id == id);
-            if (isV9OrNewer)
-            {
-                await ClearDefaultDataTypeFromLayoutSettings(altinnAppGitRepository, id);
-            }
-            else if (altinnAppGitRepository.AppUsesLayoutSets())
+
+            // v9 apps: deliberately leave defaultDataType in the task's Settings.json untouched. It
+            // becomes a dangling reference until either the datamodel is recreated with the same id
+            // (UpdateApplicationMetadata restores the TaskId binding from it) or the user reconnects the
+            // task to a different datamodel in the process editor.
+            if (!isV9OrNewer && altinnAppGitRepository.AppUsesLayoutSets())
             {
                 await ClearDataTypeFromLayoutSets(altinnAppGitRepository, id);
             }
@@ -568,7 +599,7 @@ public class SchemaModelService : ISchemaModelService
         await altinnAppGitRepository.SaveLayoutSets(layoutSets);
     }
 
-    private static async Task ClearDefaultDataTypeFromLayoutSettings(
+    private static async Task<string> FindTaskIdWithDefaultDataType(
         AltinnAppGitRepository altinnAppGitRepository,
         string id
     )
@@ -586,14 +617,13 @@ public class SchemaModelService : ISchemaModelService
                 continue;
             }
 
-            if (layoutSettings.DefaultDataType != id)
+            if (layoutSettings.DefaultDataType == id)
             {
-                continue;
+                return layoutSetName;
             }
-
-            layoutSettings.DefaultDataType = null;
-            await altinnAppGitRepository.SaveLayoutSettings(layoutSetName, layoutSettings);
         }
+
+        return null;
     }
 
     private string GetFullTypeName(ApplicationMetadata application, string csharpModelName)

--- a/src/Designer/backend/src/Designer/Services/Implementation/SchemaModelService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/SchemaModelService.cs
@@ -472,9 +472,6 @@ public class SchemaModelService : ISchemaModelService
         string restoredTaskId = null;
         if (isNewDataType && _appVersionService.IsV9App(altinnRepoEditingContext))
         {
-            // The datamodel may have previously been deleted and is now being recreated with the same
-            // id. Its old task binding still lives in that task's Settings.json (defaultDataType is no
-            // longer cleared on delete), so restore it here instead of leaving TaskId unset.
             restoredTaskId = await FindTaskIdWithDefaultDataType(altinnAppGitRepository, schemaFileName);
         }
 
@@ -491,9 +488,7 @@ public class SchemaModelService : ISchemaModelService
     /// <param name="application">The <see cref="Application"/> object to be updated.</param>
     /// <param name="dataTypeId">The id of the datatype to bed added.</param>
     /// <param name="classRef">The C# class reference of the data type.</param>
-    /// <param name="taskId">
-    /// The task id to bind a newly created data type to, if a previous binding for this id was found.
-    /// </param>
+    /// <param name="taskId">The task id to bind a newly created data type to, if a previous binding for this id was found.</param>
     private static void UpdateApplicationWithAppLogicModel(
         ApplicationMetadata application,
         string dataTypeId,
@@ -579,10 +574,7 @@ public class SchemaModelService : ISchemaModelService
         {
             DataType dataTypeToDelete = applicationMetadata.DataTypes.Find(m => m.Id == id);
 
-            // v9 apps: deliberately leave defaultDataType in the task's Settings.json untouched. It
-            // becomes a dangling reference until either the datamodel is recreated with the same id
-            // (UpdateApplicationMetadata restores the TaskId binding from it) or the user reconnects the
-            // task to a different datamodel in the process editor.
+            // v9: keep defaultDataType so recreate can restore TaskId.
             if (!isV9OrNewer && altinnAppGitRepository.AppUsesLayoutSets())
             {
                 await ClearDataTypeFromLayoutSets(altinnAppGitRepository, id);

--- a/src/Designer/backend/src/Designer/Services/Implementation/SchemaModelService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/SchemaModelService.cs
@@ -597,30 +597,23 @@ public class SchemaModelService : ISchemaModelService
         string id
     )
     {
-        HashSet<string> processTaskIds;
+        IEnumerable<string> processTaskIds;
         try
         {
             processTaskIds =
-                altinnAppGitRepository.GetProcessDefinitions()?.Process?.Tasks?.Select(task => task.Id).ToHashSet()
-                ?? [];
+                altinnAppGitRepository.GetProcessDefinitions()?.Process?.Tasks?.Select(task => task.Id) ?? [];
         }
         catch (NotFoundHttpRequestException)
         {
             return null;
         }
 
-        IEnumerable<string> uiFolders = await altinnAppGitRepository.GetUiFolders();
-        foreach (string layoutSetName in uiFolders)
+        foreach (string taskId in processTaskIds)
         {
-            if (!processTaskIds.Contains(layoutSetName))
-            {
-                continue;
-            }
-
             LayoutSettings layoutSettings;
             try
             {
-                layoutSettings = await altinnAppGitRepository.GetLayoutSettings(layoutSetName);
+                layoutSettings = await altinnAppGitRepository.GetLayoutSettings(taskId);
             }
             catch (Exception e) when (e is FileNotFoundException or JsonException)
             {
@@ -629,7 +622,7 @@ public class SchemaModelService : ISchemaModelService
 
             if (layoutSettings.DefaultDataType == id)
             {
-                return layoutSetName;
+                return taskId;
             }
         }
 


### PR DESCRIPTION




## Description


Deleting a datamodel used to clear `defaultDataType` from every task's `Settings.json` (v9 apps). Recreating a datamodel with the same id never wrote it back, so the task/datamodel binding was silently severed.

Delete now leaves the `defaultDataType` reference in `Settings.json` untouched, and create/recreate looks for a task still referencing the id to restore applicationmetadata.json's DataType.TaskId.





<details><summary>Before fix</summary>


https://github.com/user-attachments/assets/121920a7-c1c6-4d6a-a58f-a62cd8c17165



</details>



<details><summary>After fix</summary>


https://github.com/user-attachments/assets/53ee22ac-de1a-4f2d-a62b-132349c943ab



</details>

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New data types in version 9 and later applications are automatically associated with the relevant layout task.
* **Bug Fixes**
  * Schema imports, updates and template creation now preserve the correct layout and data-type associations.
  * Deleting a schema no longer removes the default data type configured in layout settings, allowing it to be reused when the schema is recreated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->