### PR TITLE
chore: move designsystemet css to legacy

### DIFF
--- a/src/Designer/frontend/admin/index.tsx
+++ b/src/Designer/frontend/admin/index.tsx
@@ -7,7 +7,6 @@ import { initReactI18next } from 'react-i18next';
 import { ServicesContextProvider } from 'app-shared/contexts/ServicesContext';
 import * as queries from 'app-shared/api/queries';
 import * as mutations from 'app-shared/api/mutations';
-import 'app-shared/design-tokens';
 import type { LoggerConfig } from 'app-shared/contexts/LoggerContext';
 import { LoggerContextProvider } from 'app-shared/contexts/LoggerContext';
 import { EnvironmentConfigProvider } from 'app-shared/contexts/EnvironmentConfigContext';

--- a/src/Designer/frontend/app-development/index.tsx
+++ b/src/Designer/frontend/app-development/index.tsx
@@ -3,7 +3,6 @@ import { ServicesContextProvider } from 'app-shared/contexts/ServicesContext';
 import * as queries from 'app-shared/api/queries';
 import * as mutations from 'app-shared/api/mutations';
 import { PreviewConnectionContextProvider } from 'app-shared/providers/PreviewConnectionContext';
-import 'app-shared/design-tokens';
 import type { LoggerConfig } from 'app-shared/contexts/LoggerContext';
 import { LoggerContextProvider } from 'app-shared/contexts/LoggerContext';
 import { EnvironmentConfigProvider } from 'app-shared/contexts/EnvironmentConfigContext';

--- a/src/Designer/frontend/app-preview/index.tsx
+++ b/src/Designer/frontend/app-preview/index.tsx
@@ -7,7 +7,6 @@ import { PreviewConnectionContextProvider } from 'app-shared/providers/PreviewCo
 import { ServicesContextProvider } from 'app-shared/contexts/ServicesContext';
 import * as queries from 'app-shared/api/queries';
 import * as mutations from 'app-shared/api/mutations';
-import 'app-shared/design-tokens';
 import { EnvironmentConfigProvider } from 'app-shared/contexts/EnvironmentConfigContext/EnvironmentConfigContext';
 import { FeatureFlagsProvider } from '@studio/feature-flags';
 

--- a/src/Designer/frontend/dashboard/index.tsx
+++ b/src/Designer/frontend/dashboard/index.tsx
@@ -11,7 +11,6 @@ import type { QueryClientConfig } from '@tanstack/react-query';
 import { ServicesContextProvider } from 'app-shared/contexts/ServicesContext';
 import * as queries from 'app-shared/api/queries';
 import * as mutations from 'app-shared/api/mutations';
-import 'app-shared/design-tokens';
 import { EnvironmentConfigProvider } from 'app-shared/contexts/EnvironmentConfigContext';
 
 i18next.use(initReactI18next).init({

--- a/src/Designer/frontend/eslint.config.mjs
+++ b/src/Designer/frontend/eslint.config.mjs
@@ -18,9 +18,16 @@ const compat = new FlatCompat({
 });
 
 const designsystemetRestriction = {
-  group: ['@digdir/designsystemet-react', '@digdir/designsystemet-react/*'],
+  group: [
+    '@digdir/designsystemet-react',
+    '@digdir/designsystemet-react/*',
+    '@digdir/designsystemet-css',
+    '@digdir/designsystemet-css/**',
+    '@digdir/designsystemet-theme',
+    '@digdir/designsystemet-theme/**',
+  ],
   message:
-    'Do not import components directly from Designsystemet. Import them from @studio/components instead, and add a wrapper there if the component is missing.',
+    'Do not import from Designsystemet directly. Import components from @studio/components instead, and add a wrapper there if the component is missing. The Designsystemet stylesheets are loaded by @studio/components and @studio/components-legacy.',
 };
 
 const restrictedImportsAllowingDesignsystemet = (patterns) => [

--- a/src/Designer/frontend/libs/studio-assistant/package.json
+++ b/src/Designer/frontend/libs/studio-assistant/package.json
@@ -4,7 +4,6 @@
   "version": "0.1.0",
   "main": "./src/index.ts",
   "dependencies": {
-    "@digdir/designsystemet-theme": "^1.0.8",
     "@studio/components": "workspace:^",
     "dompurify": "^3.2.6",
     "marked": "^17.0.6"

--- a/src/Designer/frontend/libs/studio-components-legacy/package.json
+++ b/src/Designer/frontend/libs/studio-components-legacy/package.json
@@ -10,7 +10,9 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@digdir/designsystemet-css": "0.10.0",
     "@digdir/designsystemet-react": "0.63.1",
+    "@digdir/designsystemet-theme": "0.15.3",
     "@studio/icons": "workspace:^",
     "@studio/pure-functions": "workspace:^",
     "ajv": "8.20.0",
@@ -22,8 +24,6 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^5.0.1",
-    "@digdir/design-system-tokens": "0.13.0",
-    "@digdir/designsystemet-css": "0.10.0",
     "@storybook/addon-docs": "10.5.7",
     "@storybook/addon-links": "10.5.7",
     "@storybook/builder-vite": "10.5.7",

--- a/src/Designer/frontend/libs/studio-components-legacy/src/index.ts
+++ b/src/Designer/frontend/libs/studio-components-legacy/src/index.ts
@@ -1,3 +1,6 @@
+// These imports are here to make sure that the CSS of the components are rendered correctly
+import '@digdir/designsystemet-css/dist/index.css';
+import '@digdir/designsystemet-theme/brand/altinn/tokens.css';
 import classes from './style/studioBetaTag.module.css';
 
 export * from './components';

--- a/src/Designer/frontend/libs/studio-content-library/package.json
+++ b/src/Designer/frontend/libs/studio-content-library/package.json
@@ -4,7 +4,6 @@
   "version": "0.1.0",
   "main": "./src/index.ts",
   "dependencies": {
-    "@digdir/designsystemet-theme": "^1.0.8",
     "@studio/components": "workspace:^",
     "@studio/components-legacy": "workspace:^"
   },

--- a/src/Designer/frontend/packages/shared/package.json
+++ b/src/Designer/frontend/packages/shared/package.json
@@ -3,8 +3,6 @@
   "version": "0.1.0",
   "author": "Altinn",
   "dependencies": {
-    "@digdir/designsystemet-css": "0.10.0",
-    "@digdir/designsystemet-theme": "0.15.3",
     "bpmn-moddle": "9.0.4",
     "classnames": "2.5.1",
     "qs": "6.15.3",

--- a/src/Designer/frontend/packages/shared/src/design-tokens.js
+++ b/src/Designer/frontend/packages/shared/src/design-tokens.js
@@ -1,2 +1,0 @@
-import '@digdir/designsystemet-theme/brand/altinn/tokens.css';
-import '@digdir/designsystemet-css';

--- a/src/Designer/frontend/resourceadm/index.tsx
+++ b/src/Designer/frontend/resourceadm/index.tsx
@@ -13,7 +13,6 @@ import type { QueryClientConfig } from '@tanstack/react-query';
 import { ServicesContextProvider } from 'app-shared/contexts/ServicesContext';
 import * as queries from 'app-shared/api/queries';
 import * as mutations from 'app-shared/api/mutations';
-import 'app-shared/design-tokens';
 import { EnvironmentConfigProvider } from 'app-shared/contexts/EnvironmentConfigContext';
 
 i18next.use(initReactI18next).init({

--- a/src/Designer/frontend/settings/index.tsx
+++ b/src/Designer/frontend/settings/index.tsx
@@ -8,7 +8,6 @@ import type { QueryClientConfig } from '@tanstack/react-query';
 import { ServicesContextProvider } from 'app-shared/contexts/ServicesContext';
 import * as queries from 'app-shared/api/queries';
 import * as mutations from 'app-shared/api/mutations';
-import 'app-shared/design-tokens';
 import type { LoggerConfig } from 'app-shared/contexts/LoggerContext';
 import { LoggerContextProvider } from 'app-shared/contexts/LoggerContext';
 import { PageRoutes } from './routes/PageRoutes';

--- a/src/Designer/frontend/studio-root/index.tsx
+++ b/src/Designer/frontend/studio-root/index.tsx
@@ -12,7 +12,6 @@ import { ServicesContextProvider } from 'app-shared/contexts/ServicesContext';
 import * as queries from 'app-shared/api/queries';
 import * as mutations from 'app-shared/api/mutations';
 import { EnvironmentConfigProvider } from 'app-shared/contexts/EnvironmentConfigContext';
-import 'app-shared/design-tokens';
 
 i18next.use(initReactI18next).init({
   lng: DEFAULT_LANGUAGE,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1967,13 +1967,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@digdir/design-system-tokens@npm:0.13.0":
-  version: 0.13.0
-  resolution: "@digdir/design-system-tokens@npm:0.13.0"
-  checksum: 10/1564c638807b6bb4706ae893ecc6142f0aa8816f9915a0d43aa08c121a6a8810501b3d7857067df4151c67d372c9443123924351efcc8f490aecf65bc135d7d3
-  languageName: node
-  linkType: hard
-
 "@digdir/designsystemet-css@npm:0.10.0":
   version: 0.10.0
   resolution: "@digdir/designsystemet-css@npm:0.10.0"
@@ -2061,7 +2054,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@digdir/designsystemet-theme@npm:1.11.0, @digdir/designsystemet-theme@npm:^1.0.8":
+"@digdir/designsystemet-theme@npm:1.11.0":
   version: 1.11.0
   resolution: "@digdir/designsystemet-theme@npm:1.11.0"
   dependencies:
@@ -5461,7 +5454,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@studio/assistant@workspace:src/Designer/frontend/libs/studio-assistant"
   dependencies:
-    "@digdir/designsystemet-theme": "npm:^1.0.8"
     "@studio/components": "workspace:^"
     dompurify: "npm:^3.2.6"
     marked: "npm:^17.0.6"
@@ -5496,9 +5488,9 @@ __metadata:
   resolution: "@studio/components-legacy@workspace:src/Designer/frontend/libs/studio-components-legacy"
   dependencies:
     "@chromatic-com/storybook": "npm:^5.0.1"
-    "@digdir/design-system-tokens": "npm:0.13.0"
     "@digdir/designsystemet-css": "npm:0.10.0"
     "@digdir/designsystemet-react": "npm:0.63.1"
+    "@digdir/designsystemet-theme": "npm:0.15.3"
     "@storybook/addon-docs": "npm:10.5.7"
     "@storybook/addon-links": "npm:10.5.7"
     "@storybook/builder-vite": "npm:10.5.7"
@@ -5563,7 +5555,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@studio/content-library@workspace:src/Designer/frontend/libs/studio-content-library"
   dependencies:
-    "@digdir/designsystemet-theme": "npm:^1.0.8"
     "@studio/components": "workspace:^"
     "@studio/components-legacy": "workspace:^"
     "@testing-library/jest-dom": "npm:6.9.1"
@@ -7606,8 +7597,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "app-shared@workspace:src/Designer/frontend/packages/shared"
   dependencies:
-    "@digdir/designsystemet-css": "npm:0.10.0"
-    "@digdir/designsystemet-theme": "npm:0.15.3"
     "@studio/ui-test": "workspace:^"
     "@types/bpmn-moddle": "npm:9.0.1"
     "@types/react": "npm:19.2.18"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Follow-up to #20109. That PR scoped the Designsystemet dependencies down from the frontend root to the packages that use them. The v0 stylesheets stayed in `app-shared` because `app-shared/design-tokens` loaded them globally for all seven entry points:

```js
import '@digdir/designsystemet-theme/brand/altinn/tokens.css';  // --fds-* tokens
import '@digdir/designsystemet-css';                            // .fds-* classes
```

Now that the --fds-* tokens are gone from the rest of the Designer frontend, the only remaining consumer of those sheets is studio-components-legacy. So the library loads them itself, in its own index.ts, the same pattern @studio/components already uses for the v1 sheets.

- app-shared: dropped designsystemet-css@0.10.0 and designsystemet-theme@0.15.3, deleted design-tokens.js and its import from all seven entry points.
- studio-components-legacy: both promoted to real dependencies (css was devDep-only), imported at the top of the barrel so the base CSS still precedes the library's own CSS modules. The explicit dist/index.css path is deliberate — jest's moduleNameMapper only stubs \.(css|less)$, so a bare specifier would make jest parse the stylesheet as JS.
- Removed three dependencies with no imports anywhere: @digdir/design-system-tokens in studio-components-legacy, and @digdir/designsystemet-theme in studio-content-library and studio-assistant.
- Extended the no-restricted-imports boundary from #20109 to cover -css and -theme, so the two libraries stay the only places that may import Designsystemet directly.


Why this is better: the dependency now lives where it is actually used, the legacy components are self-contained instead of relying on a global stylesheet loaded elsewhere, and studio-root, admin and settings — none of which use legacy components — stop
shipping ~96 KB of stylesheet they never referenced. When the legacy library is eventually emptied, the whole v0 Designsystemet goes away in one deletion.



<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of component styling across the Designer’s admin, development, preview, dashboard, resource management, settings and studio areas.
  * Ensured shared component styles and brand theme styling are loaded through the component library, reducing the risk of missing or duplicated styles.
  * Updated development guidance to help prevent unsupported direct stylesheet imports and promote consistent component usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->