### PR TITLE
feat(layout-contract): add the shared contract package foundation

### DIFF
--- a/.github/workflows/common-typescript-unit-test.yml
+++ b/.github/workflows/common-typescript-unit-test.yml
@@ -47,6 +47,9 @@ jobs:
       - name: run eslint
         run: yarn lint
 
+      - name: check formatting
+        run: yarn format:check
+
       - name: run tests
         run: yarn test:ci
         # TODO : Run with coverage (yarn test:ci --coverage ?)

--- a/src/Designer/Dockerfile
+++ b/src/Designer/Dockerfile
@@ -45,6 +45,7 @@ COPY src/common/ts/package.json ./src/common/ts/
 COPY src/common/ts/form-component/package.json ./src/common/ts/form-component/
 COPY src/common/ts/form-engine/package.json ./src/common/ts/form-engine/
 COPY src/common/ts/language/package.json ./src/common/ts/language/
+COPY src/common/ts/layout-contract/package.json ./src/common/ts/layout-contract/
 
 ARG CYPRESS_INSTALL_BINARY=0
 ARG PUPPETEER_SKIP_DOWNLOAD=true

--- a/src/common/ts/AGENTS.md
+++ b/src/common/ts/AGENTS.md
@@ -10,11 +10,15 @@ for the wider repository picture.
 
 ## Packages
 
-| Folder           | Package               | What it is                                           |
-| ---------------- | --------------------- | ---------------------------------------------------- |
-| `form-component` | `@app/form-component` | React UI and layout components used to render forms. |
-| `form-engine`    | `@app/form-engine`    | Form logic that does not depend on React.            |
-| `language`       | `@app/language`       | Language resources and text helpers.                 |
+| Folder            | Package                | What it is                                           |
+| ----------------- | ---------------------- | ---------------------------------------------------- |
+| `form-component`  | `@app/form-component`  | React UI and layout components used to render forms. |
+| `form-engine`     | `@app/form-engine`     | Form logic that does not depend on React.            |
+| `language`        | `@app/language`        | Language resources and text helpers.                 |
+| `layout-contract` | `@app/layout-contract` | Shared layout component and property contracts.      |
+
+Most of `layout-contract` is generated from definitions and generator sources in `src/App/frontend`.
+Do not edit generated files by hand; run `yarn gen` from `src/App/frontend` after changing generator inputs.
 
 ## Build & test
 

--- a/src/common/ts/layout-contract/eslint.config.mjs
+++ b/src/common/ts/layout-contract/eslint.config.mjs
@@ -1,0 +1,25 @@
+import js from '@eslint/js';
+import tsPlugin from '@typescript-eslint/eslint-plugin';
+import tsParser from '@typescript-eslint/parser';
+
+export default [
+  js.configs.recommended,
+  {
+    files: ['src/**/*.ts'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 2022,
+        sourceType: 'module',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+    },
+    rules: {
+      ...tsPlugin.configs.recommended.rules,
+      'no-unused-vars': 'off',
+      '@typescript-eslint/no-unused-vars': 'error',
+    },
+  },
+];

--- a/src/common/ts/layout-contract/package.json
+++ b/src/common/ts/layout-contract/package.json
@@ -9,8 +9,8 @@
     "./schemas/*": "./schemas/*"
   },
   "scripts": {
-    "format": "prettier --write \"src/**/*.ts\" package.json tsconfig.json",
-    "format:check": "prettier --check \"src/**/*.ts\" package.json tsconfig.json",
+    "format": "prettier --write \"src/**/*.ts\" eslint.config.mjs vitest.config.ts package.json tsconfig.json",
+    "format:check": "prettier --check \"src/**/*.ts\" eslint.config.mjs vitest.config.ts package.json tsconfig.json",
     "lint": "eslint .",
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit"

--- a/src/common/ts/layout-contract/package.json
+++ b/src/common/ts/layout-contract/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@app/layout-contract",
+  "version": "0.1.0",
+  "private": true,
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./generated/*": "./src/generated/*.ts",
+    "./schemas/*": "./schemas/*"
+  },
+  "scripts": {
+    "format": "prettier --write \"src/**/*.ts\" package.json tsconfig.json",
+    "format:check": "prettier --check \"src/**/*.ts\" package.json tsconfig.json",
+    "lint": "eslint .",
+    "test": "vitest run --passWithNoTests",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@eslint/js": "^10.0.1",
+    "@typescript-eslint/eslint-plugin": "8.66.0",
+    "@typescript-eslint/parser": "8.66.0",
+    "@typescript/native": "npm:typescript@7.0.2",
+    "eslint": "10.8.1",
+    "globals": "17.9.0",
+    "prettier": "3.9.6",
+    "typescript": "npm:@typescript/typescript6@6.0.2",
+    "vitest": "4.1.10"
+  }
+}

--- a/src/common/ts/layout-contract/src/index.ts
+++ b/src/common/ts/layout-contract/src/index.ts
@@ -1,0 +1,12 @@
+export type {
+  ComponentCatalog,
+  ComponentDefinition,
+  ComponentLifecycle,
+  ComponentMetadata,
+  LocalizedText,
+  PropertyDefinition,
+  PropertyMetadata,
+  PropertyValueDefinition,
+} from './types';
+export { CompCategory } from './types';
+export type { ComponentAvailability, ComponentBehaviors, ComponentCapabilities } from './types';

--- a/src/common/ts/layout-contract/src/types.ts
+++ b/src/common/ts/layout-contract/src/types.ts
@@ -1,0 +1,104 @@
+export type LocalizedText = Readonly<{
+  nb: string;
+  en: string;
+}>;
+
+/** Broad component categories shared by layout tooling and the App renderer. */
+export enum CompCategory {
+  Presentation = 'Presentation',
+  Form = 'Form',
+  Action = 'Action',
+  Container = 'Container',
+}
+
+export type ComponentCapabilities = {
+  renderInTable: boolean;
+  renderInButtonGroup: boolean;
+  renderInAccordion: boolean;
+  renderInAccordionGroup: boolean;
+  renderInTabs: boolean;
+  renderInCards: boolean;
+  renderInCardsMedia: boolean;
+};
+
+export type ComponentBehaviors = {
+  isSummarizable: boolean;
+  canHaveLabel: boolean;
+  canHaveOptions: boolean;
+  canHaveAttachments: boolean;
+};
+
+export type ComponentAvailability = 'configurable' | 'internal';
+
+export type ComponentLifecycle = Readonly<{
+  status: 'stable' | 'beta' | 'deprecated';
+  replacedBy?: string;
+}>;
+
+export type ComponentMetadata = Readonly<{
+  name: LocalizedText;
+  description?: LocalizedText;
+  lifecycle?: ComponentLifecycle;
+}>;
+
+export type PropertyMetadata = Readonly<{
+  title?: LocalizedText;
+  description?: LocalizedText;
+  default?: unknown;
+  examples?: readonly unknown[];
+  deprecated?: boolean;
+}>;
+
+export type PropertyValueDefinition =
+  | Readonly<{
+      type: 'string';
+      expression?: true;
+      allowedValues?: readonly string[];
+      pattern?: string;
+    }>
+  | Readonly<{ type: 'date'; expression?: true }>
+  | Readonly<{
+      type: 'number';
+      expression?: true;
+      allowedValues?: readonly number[];
+      minimum?: number;
+      maximum?: number;
+    }>
+  | Readonly<{
+      type: 'integer';
+      expression?: true;
+      allowedValues?: readonly number[];
+      minimum?: number;
+      maximum?: number;
+    }>
+  | Readonly<{ type: 'boolean'; expression?: true }>
+  | Readonly<{ type: 'null' }>
+  | Readonly<{ type: 'any'; expression?: true }>
+  | Readonly<{ type: 'constant'; value: string | number | boolean | null }>
+  | Readonly<{ type: 'array'; expression?: true; items: PropertyValueDefinition }>
+  | Readonly<{
+      type: 'object';
+      expression?: true;
+      properties: Readonly<Record<string, PropertyDefinition>>;
+      additionalProperties?: false | PropertyValueDefinition;
+    }>
+  | Readonly<{ type: 'union'; variants: readonly PropertyValueDefinition[] }>
+  | Readonly<{ type: 'intersection'; parts: readonly PropertyValueDefinition[] }>;
+
+export type PropertyDefinition = Readonly<
+  PropertyMetadata &
+    PropertyValueDefinition & {
+      required: boolean;
+    }
+>;
+
+export type ComponentDefinition = Readonly<{
+  kind: 'component' | 'container';
+  category: `${CompCategory}`;
+  capabilities: Readonly<ComponentCapabilities>;
+  behaviors: Readonly<ComponentBehaviors>;
+  metadata: ComponentMetadata;
+  properties: Readonly<Record<string, PropertyDefinition>>;
+}>;
+
+export type ComponentCatalog = Readonly<Record<string, ComponentDefinition>>;

--- a/src/common/ts/layout-contract/tsconfig.json
+++ b/src/common/ts/layout-contract/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "module": "preserve",
+    "target": "es2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/src/common/ts/layout-contract/vitest.config.ts
+++ b/src/common/ts/layout-contract/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.{test,spec}.ts'],
+  },
+});

--- a/src/common/ts/package.json
+++ b/src/common/ts/package.json
@@ -7,7 +7,8 @@
     "test": "vitest",
     "test:ci": "vitest run",
     "typecheck": "yarn workspaces foreach -A --include '@app/*' run typecheck",
-    "lint": "yarn workspaces foreach -A --include '@app/*' run lint"
+    "lint": "yarn workspaces foreach -A --include '@app/*' run lint",
+    "format:check": "yarn workspaces foreach -A --include '@app/*' --if-present run format:check"
   },
   "devDependencies": {
     "@typescript/native": "npm:typescript@7.0.2",

--- a/src/common/ts/package.json
+++ b/src/common/ts/package.json
@@ -8,7 +8,7 @@
     "test:ci": "vitest run",
     "typecheck": "yarn workspaces foreach -A --include '@app/*' run typecheck",
     "lint": "yarn workspaces foreach -A --include '@app/*' run lint",
-    "format:check": "yarn workspaces foreach -A --include '@app/*' --if-present run format:check"
+    "format:check": "yarn workspaces foreach -A --include '@app/*' run format:check"
   },
   "devDependencies": {
     "@typescript/native": "npm:typescript@7.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -232,7 +232,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@app/layout-contract@workspace:*, @app/layout-contract@workspace:src/common/ts/layout-contract":
+"@app/layout-contract@workspace:src/common/ts/layout-contract":
   version: 0.0.0-use.local
   resolution: "@app/layout-contract@workspace:src/common/ts/layout-contract"
   dependencies:
@@ -7504,7 +7504,6 @@ __metadata:
     "@app/form-component": "workspace:*"
     "@app/form-engine": "workspace:*"
     "@app/language": "workspace:*"
-    "@app/layout-contract": "workspace:*"
     "@babel/core": "npm:7.29.7"
     "@babel/plugin-transform-runtime": "npm:7.29.7"
     "@babel/preset-env": "npm:7.29.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -232,6 +232,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@app/layout-contract@workspace:*, @app/layout-contract@workspace:src/common/ts/layout-contract":
+  version: 0.0.0-use.local
+  resolution: "@app/layout-contract@workspace:src/common/ts/layout-contract"
+  dependencies:
+    "@eslint/js": "npm:^10.0.1"
+    "@typescript-eslint/eslint-plugin": "npm:8.66.0"
+    "@typescript-eslint/parser": "npm:8.66.0"
+    "@typescript/native": "npm:typescript@7.0.2"
+    eslint: "npm:10.8.1"
+    globals: "npm:17.9.0"
+    prettier: "npm:3.9.6"
+    typescript: "npm:@typescript/typescript6@6.0.2"
+    vitest: "npm:4.1.10"
+  languageName: unknown
+  linkType: soft
+
 "@asamuzakjp/css-color@npm:^3.2.0":
   version: 3.2.0
   resolution: "@asamuzakjp/css-color@npm:3.2.0"
@@ -7488,6 +7504,7 @@ __metadata:
     "@app/form-component": "workspace:*"
     "@app/form-engine": "workspace:*"
     "@app/language": "workspace:*"
+    "@app/layout-contract": "workspace:*"
     "@babel/core": "npm:7.29.7"
     "@babel/plugin-transform-runtime": "npm:7.29.7"
     "@babel/preset-env": "npm:7.29.7"


### PR DESCRIPTION
## Description

Introduces `@app/layout-contract` as a dependency-light shared package for concepts that describe layouts without depending on either the App renderer or Studio Designer.

The package defines:

- the recursive property model used by generated consumers, including objects, arrays, unions, intersections, constraints, defaults and expression support;
- component metadata such as localized names, category, availability, lifecycle, capabilities and behaviors;
- the public TypeScript boundary that later generated catalogs and serialized layout types will implement.

Keeping these structural types separate from generated output gives the generator a stable target and lets App, Designer and documentation tooling consume the same vocabulary. The package has its own TypeScript, ESLint, Prettier and test configuration and is included in the shared TypeScript CI workflow.

Stack: 1 of 4. Base: `main`. Related to #20108.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared layout component contracts covering metadata, capabilities, behaviours, availability, lifecycle, and property definitions.
  * Introduced a typed catalog interface for defining and describing layout components.
  * Added the layout contracts package with integrated linting, type-checking, formatting, and test configuration.

* **Quality Improvements**
  * Added automated formatting checks to the unit-test workflow.
  * Extended workspace tooling to support formatting validation across shared packages.

* **Documentation**
  * Documented the layout contracts package and its generated-file workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->