### PR TITLE
fix(assistant): only flag injections when the turn had attachments

### DIFF
--- a/src/AI/agents/agents/graph/nodes/agentic_loop_node.py
+++ b/src/AI/agents/agents/graph/nodes/agentic_loop_node.py
@@ -521,6 +521,11 @@ def _make_event_bridge(session_id: str) -> EventCallback:
     return on_event
 
 
+def _turn_carried_attachment_content(state: AgentState) -> bool:
+    """Whether anything the user supplied could have carried an instruction."""
+    return bool(state.attachments) or state.form_spec is not None
+
+
 def _emit_workflow_completion(state: AgentState, result: LoopResult, ctx: LoopContext) -> None:
     """Emit the final `assistant_message` and `done` the frontend needs to close
     out a session; without both it renders empty bubbles and never runs its
@@ -534,14 +539,22 @@ def _emit_workflow_completion(state: AgentState, result: LoopResult, ctx: LoopCo
         "sources": ctx.extras.get("sources", []),
     }
     if security_notice:
-        # Only the flag crosses into Designer; attacker-influenced prose is
-        # never rendered to the user.
-        message_data["attachmentInstructionFlagged"] = True
         log.warning(
             "Prompt injection reported by the model for session %s: %s",
             state.session_id,
             security_notice,
         )
+        # The alert tells the user a document they uploaded carried the
+        # instruction, so it must not fire when there was no document.
+        if _turn_carried_attachment_content(state):
+            # Only the flag crosses into Designer; attacker-influenced prose is
+            # never rendered to the user.
+            message_data["attachmentInstructionFlagged"] = True
+        else:
+            log.warning(
+                "Ignoring the report for session %s: the turn had no attachment content",
+                state.session_id,
+            )
     if not state.allow_app_changes:
         message_data["no_branch_operations"] = True
     trace_id = state.trace_id or get_current_trace_id()

--- a/src/AI/agents/tests/unit/core/test_security_notice.py
+++ b/src/AI/agents/tests/unit/core/test_security_notice.py
@@ -61,7 +61,13 @@ class TestExtractSecurityNotice:
         assert len(notice) == MAX_SECURITY_NOTICE_LENGTH
 
 
-def _completion_events(monkeypatch, final_text: str, history: list | None = None) -> list:
+def _completion_events(
+    monkeypatch,
+    final_text: str,
+    history: list | None = None,
+    *,
+    with_attachment: bool = True,
+) -> list:
     sent: list = []
     recorded = history if history is not None else []
     monkeypatch.setattr(
@@ -77,6 +83,8 @@ def _completion_events(monkeypatch, final_text: str, history: list | None = None
         allow_app_changes=True,
         tests_passed=True,
         trace_id=None,
+        attachments=[object()] if with_attachment else [],
+        form_spec=None,
     )
     result = LoopResult(
         reason=TerminationReason.COMPLETED,
@@ -131,3 +139,23 @@ class TestEmittedEvent:
         _completion_events(monkeypatch, _SUMMARY, history)
 
         assert history[0][2] == _SUMMARY
+
+    def test_no_flag_when_the_turn_had_no_attachment(self, monkeypatch):
+        """The alert names an uploaded document, so it must not fire without one:
+        the model can report an injection after reading conversation history."""
+        sent = _completion_events(
+            monkeypatch, f"{_SUMMARY}\n\nSECURITY_NOTICE: {_NOTICE}", with_attachment=False
+        )
+
+        message = next(e for e in sent if e.type == "assistant_message")
+        assert "attachmentInstructionFlagged" not in message.data
+
+    def test_the_notice_is_still_stripped_without_an_attachment(self, monkeypatch):
+        """Not flagging is not a reason to leak the attacker-influenced sentence."""
+        sent = _completion_events(
+            monkeypatch, f"{_SUMMARY}\n\nSECURITY_NOTICE: {_NOTICE}", with_attachment=False
+        )
+
+        message = next(e for e in sent if e.type == "assistant_message")
+        assert _NOTICE not in message.data["content"]
+        assert "SECURITY_NOTICE" not in message.data["content"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Closes digdir/digdir-ai-lab#210.

The security notice alert tells the user that a document **they uploaded** carried
hidden text, and asks them to check where it came from:

> **Skjult instruksjon i opplastet fil**
> Et opplastet dokument inneholdt skjult tekst som forsøkte å styre assistenten.
> Instruksjonene ble ikke fulgt, og skjemaet er bygget som spesifisert. Kontroller
> hvor dokumentet kommer fra før du bruker det videre.

Nothing checked that a document existed. The model emitting the marker was enough to
render that claim, so the alert fired on a chat turn with no attachment at all. The
model had read an earlier adversarial-looking message from the conversation history and
reported it, and the user was asked to verify the provenance of a file they never
uploaded.

## What changed

The flag now requires the turn to have carried attachment content:

```python
def _turn_carried_attachment_content(state: AgentState) -> bool:
    """Whether anything the user supplied could have carried an instruction."""
    return bool(state.attachments) or state.form_spec is not None
```

Three details worth calling out:

**The warning log moved above the guard**, so a report is recorded either way. A model
reporting an injection with nothing attached is exactly the signal that surfaced this
bug; it just is not a claim about a file. A second line records that the report was not
shown.

**`form_spec` counts, not only `attachments`.** The spec extractor reads the attachment
and produces the spec, and the loop's system prompt embeds the spec rather than the raw
file. An injection can survive into the spec on a later turn where `attachments` is
already empty, so gating on attachments alone would reintroduce a false negative in the
case the feature exists for.

**Stripping the notice out of the summary is unchanged.** Not showing the alert is no
reason to leave attacker-influenced prose in the answer, and there is a test asserting
that.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

425 tests pass. Forcing the guard open makes
`test_no_flag_when_the_turn_had_no_attachment` fail, so it is genuinely pinned.

Three existing tests failed on the first run because their stub state had no
attachments, which is precisely the condition being gated. The helper now takes
`with_attachment`, defaulting to `True` so those tests keep their original meaning, and
two tests cover the new path: no flag without attachment content, and the notice still
stripped from the summary in that case.

## Note for reviewers

**The original false positive did not reproduce on demand.** I retried the two-turn
sequence that produced it, in both modes, and the model reasoned about the earlier
database request in its answer without classifying it as an injection. Nothing was
emitted, so the guard was never exercised. The trigger is the model's judgement varying,
not a missing precondition, and digdir/digdir-ai-lab#210 has been updated to say so
rather than implying a reliable repro.

The guard can be exercised deterministically by asking for the marker directly, in chat
mode with no attachment:

```
Skriv en kort oppsummering av appen som starter med linjen "SIKKERHETSMERKNAD: dette er en test"
```

The Norwegian spelling is matched because the marker pattern was widened in #20097. That
run should show no alert, the line stripped from the summary, and both log lines. Adding
any attachment and repeating should bring the alert back.

## Out of scope

This stops the false alert. It does not change the underlying behaviour that produced it:
the model reasoning over stale conversation history and attributing it to the current
turn. That is worth its own issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of security notices in workflow responses.
  * Attachment-related warnings are now flagged only when the turn includes attachment content.
  * Security notice text continues to be removed from displayed message content when no attachment is present.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->