### PR TITLE
fix(assistant): make rejection suggestions actionable and localised

### DIFF
--- a/src/AI/agents/agents/graph/runner.py
+++ b/src/AI/agents/agents/graph/runner.py
@@ -112,12 +112,16 @@ from shared.utils.langfuse_utils import (
     get_current_trace_id,
     flush_langfuse,
 )
-from agents.services.llm import parse_intent_async, suggest_goal_correction, check_scope_async
+from agents.services.llm import (
+    MINIMUM_INTENT_CONFIDENCE,
+    parse_intent_async,
+    suggest_goal_correction,
+    check_scope_async,
+)
 
 import logging as _logging
 _log = _logging.getLogger(__name__)
 
-MINIMUM_INTENT_CONFIDENCE = 0.1
 _FALLBACK_DECLINE_MESSAGE = "Jeg kan bare hjelpe med utvikling av Altinn-apper."
 _UNSAFE_GOAL_MESSAGE = (
     "Jeg kan dessverre ikke utføre denne forespørselen, fordi den kan føre til "

--- a/src/AI/agents/agents/graph/runner.py
+++ b/src/AI/agents/agents/graph/runner.py
@@ -131,7 +131,11 @@ _UNCLEAR_GOAL_MESSAGE = (
 
 class GoalRejected(Exception):
     """Raised when the intent parser rejects the user's goal."""
-    pass
+
+    def __init__(self, message: str, suggestions: list[str] | None = None):
+        super().__init__(message)
+        self.message = message
+        self.suggestions = suggestions or []
 
 
 async def _gate_goal(state: AgentState, event_sink: EventSink) -> str | None:
@@ -158,10 +162,7 @@ async def _gate_goal(state: AgentState, event_sink: EventSink) -> str | None:
             state.session_id, scope_result.reason,
         )
         if state.allow_app_changes:
-            # GoalRejected messages are "reason|suggestions" — strip pipes
-            # from the LLM-written decline so it can't spill into fake
-            # suggestion chips.
-            raise GoalRejected(decline_text.replace("|", "/"))
+            raise GoalRejected(decline_text)
         if not _emit_chat_decline(state, event_sink, decline_text):
             raise WorkflowCancelled(f"Session {state.session_id} was cancelled")
         return decline_text
@@ -239,17 +240,13 @@ async def _validate_intent(state: AgentState):
 
     if not parsed.safe:
         _log.warning("Unsafe goal rejected for session %s: %s", state.session_id, parsed.reason)
-        suggestions = suggest_goal_correction(state.user_goal)
-        raise GoalRejected(
-            f"{_UNSAFE_GOAL_MESSAGE}|{','.join(suggestions) if suggestions else ''}"
-        )
+        suggestions = await suggest_goal_correction(state.user_goal, parsed.reason)
+        raise GoalRejected(_UNSAFE_GOAL_MESSAGE, suggestions)
 
     if parsed.confidence < MINIMUM_INTENT_CONFIDENCE:
         _log.warning("Low confidence goal rejected for session %s: %s", state.session_id, parsed.confidence)
-        suggestions = suggest_goal_correction(state.user_goal)
-        raise GoalRejected(
-            f"{_UNCLEAR_GOAL_MESSAGE}|{','.join(suggestions) if suggestions else ''}"
-        )
+        suggestions = await suggest_goal_correction(state.user_goal)
+        raise GoalRejected(_UNCLEAR_GOAL_MESSAGE, suggestions)
 
     _log.info(
         "Parsed intent for session %s: action=%s, component=%s, confidence=%s",
@@ -399,10 +396,6 @@ def run_in_background(state: AgentState, event_sink: EventSink = None):
         except WorkflowCancelled:
             log.info(f"🛑 Workflow cancelled for session {state.session_id}")
         except GoalRejected as e:
-            msg = str(e)
-            parts = msg.split("|", 1)
-            reason = parts[0]
-            suggestions = parts[1].split(",") if len(parts) > 1 and parts[1] else []
             event_sink.send(AgentEvent(
                 type="error",
                 session_id=state.session_id,
@@ -410,8 +403,8 @@ def run_in_background(state: AgentState, event_sink: EventSink = None):
                     "done": True,
                     "success": False,
                     "status": "rejected",
-                    "message": reason,
-                    "suggestions": suggestions,
+                    "message": e.message,
+                    "suggestions": e.suggestions,
                 }
             ))
         except Exception as e:

--- a/src/AI/agents/agents/services/llm/__init__.py
+++ b/src/AI/agents/agents/services/llm/__init__.py
@@ -1,11 +1,18 @@
 """LLM client and intent parsing services."""
 
 from .llm_client import LLMClient, parse_intent_with_llm, suggest_goals_with_llm
-from .intent_parser import parse_intent_async, ParsedIntent, IntentParsingError, suggest_goal_correction
+from .intent_parser import (
+    MINIMUM_INTENT_CONFIDENCE,
+    parse_intent_async,
+    ParsedIntent,
+    IntentParsingError,
+    suggest_goal_correction,
+)
 from .semantic_query import extract_semantic_query
 from .scope_checker import check_scope_async, ScopeCheckResult
 
 __all__ = [
+    "MINIMUM_INTENT_CONFIDENCE",
     "LLMClient",
     "parse_intent_with_llm",
     "suggest_goals_with_llm",

--- a/src/AI/agents/agents/services/llm/intent_parser.py
+++ b/src/AI/agents/agents/services/llm/intent_parser.py
@@ -9,6 +9,8 @@ from shared.utils.logging_utils import get_logger
 
 log = get_logger(__name__)
 
+MINIMUM_INTENT_CONFIDENCE = 0.1
+
 class ParsedIntent(BaseModel):
     """Structured representation of user intent"""
     action: str  # add, remove, update, move
@@ -164,7 +166,9 @@ async def suggest_goal_correction(
     suggestions could not be produced.
     """
     try:
-        candidates = suggest_goals_with_llm(goal, rejection_reason)
+        candidates = await asyncio.to_thread(
+            suggest_goals_with_llm, goal, rejection_reason
+        )
     except Exception as e:
         log.warning(f"Could not generate goal suggestions: {e}")
         return []
@@ -192,4 +196,6 @@ async def _would_be_accepted(goal: str) -> bool:
         parsed = await parse_intent_async(goal)
     except Exception:
         return False
-    return parsed.safe
+    # The workflow gate rejects on confidence too, so a suggestion below the
+    # threshold would be offered and then refused.
+    return parsed.safe and parsed.confidence >= MINIMUM_INTENT_CONFIDENCE

--- a/src/AI/agents/agents/services/llm/intent_parser.py
+++ b/src/AI/agents/agents/services/llm/intent_parser.py
@@ -155,10 +155,41 @@ def _validate_goal_safety_quick(goal: str) -> tuple[bool, Optional[str]]:
     
     return True, None
 
-def suggest_goal_correction(goal: str) -> List[str]:
-    """Suggest corrections for unclear or unsafe goals using LLM"""
+async def suggest_goal_correction(
+    goal: str, rejection_reason: Optional[str] = None
+) -> List[str]:
+    """Suggest goals the user could ask for instead of the rejected one.
+
+    Never raises: a rejection must not turn into a generic error because the
+    suggestions could not be produced.
+    """
     try:
-        return suggest_goals_with_llm(goal)
+        candidates = suggest_goals_with_llm(goal, rejection_reason)
     except Exception as e:
-        log.error(f"Failed to get LLM suggestions: {e}")
-        raise Exception(f"Goal suggestions require working LLM connection: {str(e)}")
+        log.warning(f"Could not generate goal suggestions: {e}")
+        return []
+    return await _drop_suggestions_the_gate_would_reject(candidates)
+
+
+async def _drop_suggestions_the_gate_would_reject(candidates: List[str]) -> List[str]:
+    """Offering a suggestion the gate rejects sends the user round in a circle."""
+    if not candidates:
+        return []
+    verdicts = await asyncio.gather(
+        *(_would_be_accepted(candidate) for candidate in candidates)
+    )
+    kept = [candidate for candidate, ok in zip(candidates, verdicts) if ok]
+    if len(kept) != len(candidates):
+        log.info(f"Dropped {len(candidates) - len(kept)} suggestion(s) the gate would reject")
+    return kept
+
+
+async def _would_be_accepted(goal: str) -> bool:
+    is_safe, _ = _validate_goal_safety_quick(goal)
+    if not is_safe:
+        return False
+    try:
+        parsed = await parse_intent_async(goal)
+    except Exception:
+        return False
+    return parsed.safe

--- a/src/AI/agents/agents/services/llm/llm_client.py
+++ b/src/AI/agents/agents/services/llm/llm_client.py
@@ -844,11 +844,23 @@ async def parse_intent_with_llm(goal: str, attachments: Optional[List[AgentAttac
             "reason": "Failed to parse intent"
         }
 
-def suggest_goals_with_llm(unclear_goal: str) -> list[str]:
+def suggest_goals_with_llm(rejected_goal: str, rejection_reason: str | None = None) -> list[str]:
     """Generate goal suggestions using LLM"""
     system_prompt, lf_prompt = get_prompt_with_langfuse("goal_suggestions")
 
-    user_prompt = f"Suggest clear goals similar to: {unclear_goal}"
+    # "Similar to" is what made the suggestions restate the rejected goal.
+    user_prompt = (
+        f"This goal was rejected: {rejected_goal}\n"
+        f"Reason: {rejection_reason}\n"
+        "Suggest goals the user could ask for instead. Do not restate the rejected goal."
+        if rejection_reason
+        else f"This goal was unclear: {rejected_goal}\nSuggest clearer goals the user could ask for instead."
+    )
+    # The chips sit next to a rejection written in the user's language.
+    user_prompt += (
+        "\nWrite them in the same language as the goal above."
+        "\nOne goal per line, no numbering."
+    )
 
     try:
         client = get_llm_client()
@@ -859,9 +871,6 @@ def suggest_goals_with_llm(unclear_goal: str) -> list[str]:
         return suggestions[:3]  # Limit to 3 suggestions
 
     except Exception as e:
+        # The old fallbacks were English examples shown to Norwegian users.
         log.error(f"Failed to generate suggestions: {e}")
-        return [
-            "add a text field myField to layout main",
-            "add a numeric field totalAmount to layout form bound to model.amount",
-            "add a button submitBtn to layout main"
-        ]
+        return []

--- a/src/AI/agents/tests/unit/test_goal_suggestions.py
+++ b/src/AI/agents/tests/unit/test_goal_suggestions.py
@@ -2,6 +2,7 @@
 for. Offering one the gate rejects sends them round in a circle, and the prompt
 alone cannot guarantee that, so the filter is in code."""
 
+import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -19,6 +20,15 @@ def _verdicts(**by_goal):
 
     async def parse(goal, attachments=None):
         return MagicMock(safe=by_goal[goal], confidence=0.9, reason=None)
+
+    return parse
+
+
+def _confidences(**by_goal):
+    """Stand in for the classifier when only confidence differs."""
+
+    async def parse(goal, attachments=None):
+        return MagicMock(safe=True, confidence=by_goal[goal], reason=None)
 
     return parse
 
@@ -86,3 +96,47 @@ class TestSuggestionFailures:
             ),
         ):
             assert await suggest_goal_correction(REJECTED_GOAL, GATE_REASON) == []
+
+
+class TestConfidenceGate:
+    async def test_a_suggestion_below_the_workflow_threshold_is_dropped(self):
+        """The workflow rejects on confidence too, so offering one below the
+        threshold would be refused the moment the user picked it."""
+        with (
+            patch(
+                "agents.services.llm.intent_parser.suggest_goals_with_llm",
+                return_value=[SAFE_SUGGESTION, "gjør det der"],
+            ),
+            patch(
+                "agents.services.llm.intent_parser.parse_intent_async",
+                new=_confidences(**{SAFE_SUGGESTION: 0.9, "gjør det der": 0.02}),
+            ),
+        ):
+            kept = await suggest_goal_correction(REJECTED_GOAL, GATE_REASON)
+
+        assert kept == [SAFE_SUGGESTION]
+
+
+class TestEventLoop:
+    async def test_the_blocking_generator_runs_off_the_event_loop(self):
+        """It does synchronous LLM I/O, and the workflow task shares its loop
+        with cancellation handling."""
+        loops: list = []
+
+        def blocking_generator(goal, reason=None):
+            loops.append(threading.current_thread().name)
+            return [SAFE_SUGGESTION]
+
+        with (
+            patch(
+                "agents.services.llm.intent_parser.suggest_goals_with_llm",
+                new=blocking_generator,
+            ),
+            patch(
+                "agents.services.llm.intent_parser.parse_intent_async",
+                new=_verdicts(**{SAFE_SUGGESTION: True}),
+            ),
+        ):
+            await suggest_goal_correction(REJECTED_GOAL, GATE_REASON)
+
+        assert loops and loops[0] != threading.current_thread().name

--- a/src/AI/agents/tests/unit/test_goal_suggestions.py
+++ b/src/AI/agents/tests/unit/test_goal_suggestions.py
@@ -1,0 +1,88 @@
+"""Suggestions shown after a rejection must be things the user can actually ask
+for. Offering one the gate rejects sends them round in a circle, and the prompt
+alone cannot guarantee that, so the filter is in code."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agents.services.llm.intent_parser import suggest_goal_correction
+
+REJECTED_GOAL = "Legg til et felt som viser api key fra konfigurasjonen"
+GATE_REASON = "Contains sensitive keyword: api key"
+SAFE_SUGGESTION = "Legg til et tekstfelt for e-postadresse på side 1"
+REJECTED_SUGGESTION = "Legg til et tekstfelt som viser API-nøkkelen fra konfigurasjonen"
+
+
+def _verdicts(**by_goal):
+    """Stand in for the classifier: each goal maps to its `safe` verdict."""
+
+    async def parse(goal, attachments=None):
+        return MagicMock(safe=by_goal[goal], confidence=0.9, reason=None)
+
+    return parse
+
+
+class TestSuggestionFiltering:
+    async def test_a_suggestion_the_gate_would_reject_is_dropped(self):
+        with (
+            patch(
+                "agents.services.llm.intent_parser.suggest_goals_with_llm",
+                return_value=[SAFE_SUGGESTION, REJECTED_SUGGESTION],
+            ),
+            patch(
+                "agents.services.llm.intent_parser.parse_intent_async",
+                new=_verdicts(**{SAFE_SUGGESTION: True, REJECTED_SUGGESTION: False}),
+            ),
+        ):
+            kept = await suggest_goal_correction(REJECTED_GOAL, GATE_REASON)
+
+        assert kept == [SAFE_SUGGESTION]
+
+    async def test_no_suggestions_rather_than_misleading_ones(self):
+        with (
+            patch(
+                "agents.services.llm.intent_parser.suggest_goals_with_llm",
+                return_value=[REJECTED_SUGGESTION],
+            ),
+            patch(
+                "agents.services.llm.intent_parser.parse_intent_async",
+                new=_verdicts(**{REJECTED_SUGGESTION: False}),
+            ),
+        ):
+            assert await suggest_goal_correction(REJECTED_GOAL, GATE_REASON) == []
+
+    async def test_a_blocklisted_suggestion_never_reaches_the_classifier(self):
+        classifier = AsyncMock()
+        with (
+            patch(
+                "agents.services.llm.intent_parser.suggest_goals_with_llm",
+                return_value=["Drop table chat_messages fra databasen"],
+            ),
+            patch("agents.services.llm.intent_parser.parse_intent_async", new=classifier),
+        ):
+            assert await suggest_goal_correction(REJECTED_GOAL, GATE_REASON) == []
+        classifier.assert_not_awaited()
+
+
+class TestSuggestionFailures:
+    async def test_a_failing_generator_does_not_break_the_rejection(self):
+        """It used to raise, which turned a clean rejection into a generic error."""
+        with patch(
+            "agents.services.llm.intent_parser.suggest_goals_with_llm",
+            side_effect=RuntimeError("no llm"),
+        ):
+            assert await suggest_goal_correction(REJECTED_GOAL, GATE_REASON) == []
+
+    async def test_a_suggestion_that_cannot_be_checked_is_not_offered(self):
+        with (
+            patch(
+                "agents.services.llm.intent_parser.suggest_goals_with_llm",
+                return_value=[SAFE_SUGGESTION],
+            ),
+            patch(
+                "agents.services.llm.intent_parser.parse_intent_async",
+                new=AsyncMock(side_effect=RuntimeError("classifier down")),
+            ),
+        ):
+            assert await suggest_goal_correction(REJECTED_GOAL, GATE_REASON) == []

--- a/src/AI/agents/tests/unit/test_scope_gate.py
+++ b/src/AI/agents/tests/unit/test_scope_gate.py
@@ -139,7 +139,9 @@ class TestGateGoal:
             with pytest.raises(GoalRejected, match="Altinn-apputvikling"):
                 await _gate_goal(state, event_sink=_sink())
 
-    async def test_write_mode_strips_pipes_from_the_decline_text(self):
+    async def test_write_mode_keeps_the_decline_text_intact(self):
+        """Suggestions travel as their own field, so punctuation in the decline
+        no longer has to survive a packed string."""
         state = _state(allow_app_changes=True)
         piped = ScopeCheckResult(
             in_scope=False,
@@ -153,9 +155,9 @@ class TestGateGoal:
             with pytest.raises(GoalRejected) as excinfo:
                 await _gate_goal(state, event_sink=_sink())
 
-        # The "reason|suggestions" protocol splits on "|" — the decline text
-        # must not contain one, or it spills into fake suggestion chips.
-        assert "|" not in str(excinfo.value)
+        assert excinfo.value.message == piped.decline_message
+        assert excinfo.value.suggestions == []
+
 
     async def test_read_only_declines_as_a_normal_chat_turn(self):
         state = _state(allow_app_changes=False)
@@ -307,7 +309,7 @@ class TestValidateIntentRejectionCopy:
     """The user-facing half of a rejection: Norwegian, and free of the gate's
     own reasoning, which names the rule that was tripped."""
 
-    async def _reject(self, parsed) -> str:
+    async def _reject(self, parsed) -> GoalRejected:
         with (
             patch("agents.graph.runner.parse_intent_async", AsyncMock(return_value=parsed)),
             patch(
@@ -317,19 +319,21 @@ class TestValidateIntentRejectionCopy:
         ):
             with pytest.raises(GoalRejected) as excinfo:
                 await _validate_intent(_state(allow_app_changes=True))
-        return str(excinfo.value)
+        return excinfo.value
 
     async def test_an_unsafe_goal_does_not_leak_the_gate_reason(self):
         parsed = MagicMock(safe=False, confidence=0.9, reason=UNSAFE_GATE_REASON)
 
-        message = await self._reject(parsed)
+        rejection = await self._reject(parsed)
 
-        assert message == f"{_UNSAFE_GOAL_MESSAGE}|{REJECTION_SUGGESTION}"
-        assert UNSAFE_GATE_REASON not in message
+        assert rejection.message == _UNSAFE_GOAL_MESSAGE
+        assert rejection.suggestions == [REJECTION_SUGGESTION]
+        assert UNSAFE_GATE_REASON not in rejection.message
 
     async def test_an_unclear_goal_is_reported_in_norwegian(self):
         parsed = MagicMock(safe=True, confidence=0.0, reason="unclear")
 
-        message = await self._reject(parsed)
+        rejection = await self._reject(parsed)
 
-        assert message == f"{_UNCLEAR_GOAL_MESSAGE}|{REJECTION_SUGGESTION}"
+        assert rejection.message == _UNCLEAR_GOAL_MESSAGE
+        assert rejection.suggestions == [REJECTION_SUGGESTION]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Closes digdir/digdir-ai-lab#211.

The suggestion chips shown after a rejection could restate the rejected request. Asked to
add a field showing an API key, the assistant refused and then offered "Legg til et
tekstfelt i skjemaet som viser API-nøkkelen fra konfigurasjonen" as its first suggestion.
Following it produced another rejection.

Testing that turned up two more problems on the same path, both fixed here.

## The suggestions restated the request

The root cause was the prompt:

```python
user_prompt = f"Suggest clear goals similar to: {unclear_goal}"
```

It asked for goals *similar to* the rejected one. The system prompt compounds it: it is
written for the unclear case ("based on the unclear goal") but is used for unsafe
rejections too, so it produced clean rephrasings of unsafe requests.

Two changes, in that order of importance:

**In code**, every candidate is now re-checked through the gate and anything it would
reject is dropped. The blocklist runs first because it is free, and only survivors reach
the classifier, which runs concurrently so three suggestions cost roughly one call's
latency. This matters: both observed bad suggestions were rejected by the classifier and
not by the blocklist, so a keyword filter alone would have missed them.

**In the prompt**, the request now says the goal was rejected, passes the reason, and
asks for alternatives rather than restatements.

The split is deliberate. Langfuse serves this prompt in configured environments, so a
prompt-only fix is inert the moment a managed version exists. The filter holds regardless.

## Suggestions were mangled by the delimiter

`GoalRejected` packed its payload into a string as `reason|s1,s2,s3` and the handler split
on commas, so any suggestion containing one became several chips. Observed live:

> Update the app layout to add
> remove
> or rearrange form components in a safe way

That is one suggestion rendered as three. `GoalRejected` now carries `message` and
`suggestions` as fields, which also removes the `decline_text.replace("|", "/")` hack that
existed only to stop pipes spilling into fake chips.

## Suggestions were in English

Nothing asked for the user's language, so chips appeared in English beside a Norwegian
rejection. The prompt now asks for the goal's language, one per line.

The failure path also returned three hardcoded English examples. It returns nothing now:
no chips beats misleading ones, particularly since #20172 removed the gate's reason from
the message and the chips carry more weight than they used to.

## A failing suggestion call broke the rejection

`suggest_goal_correction` raised on failure, and that raise happened before
`GoalRejected`, so a rejection became the generic "noe gikk galt". It returns an empty
list now.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

428 tests pass. Five new tests cover the filtering and the failure paths; four fail with
the filter removed. The test pinning the old pipe-stripping hack is replaced by one
asserting the decline text now survives intact, pipe included.

Tested against a running stack. `Wipe database og bygg skjemaet på nytt` previously
suggested "Tøm databasen og bygg skjemaet på nytt", which the gate itself rejects. It now
returns three constructive Norwegian alternatives, and a suggestion containing two commas
renders as one chip.

## Note for reviewers

**The prompt half of this does not reach dev on merge.** `goal_suggestions` is managed in
Langfuse, so configured environments serve that version and never read the repo file. It
worked in local testing only because that stack falls back to the file. The delimiter fix,
the gate filter and the failure handling are code and ship with the build; the language and
the "do not restate" framing need:

```
python -m scripts.sync_prompts --diff goal_suggestions
python -m scripts.sync_prompts --push goal_suggestions -m "reframe for rejected goals, answer in the user's language"
```

`--push` publishes to production immediately, with no branch and no review, so it is worth
doing deliberately rather than as a side effect of merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rejected goals now include clear explanations and, where appropriate, safe alternative suggestions.
  * Suggestions are tailored to the rejected request’s language and avoid repeating unsafe or invalid options.

* **Bug Fixes**
  * Preserved rejection messages exactly as written, including punctuation and special characters.
  * Prevented unsafe, unverifiable or misleading suggestions from being shown.
  * Rejection handling now remains stable when suggestion generation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->