### PR TITLE
feat(experimental): port forwarding into agent sandboxes

### DIFF
--- a/src/experimental/agent/src/bin/agentctl/forward.rs
+++ b/src/experimental/agent/src/bin/agentctl/forward.rs
@@ -1,0 +1,217 @@
+//! Client-owned port forwards into Agent sandboxes.
+//!
+//! Forwards follow the k9s model: they live in this process, accept
+//! connections on a local listener, and dial the guest through the Sandbox
+//! agent relay. They end when the process exits or the forward is stopped.
+
+use std::{cell::RefCell, net::IpAddr, path::PathBuf, rc::Rc};
+
+use agent::{
+    Error,
+    sandbox::{Assignment, GuestDialer},
+};
+use tokio::net::TcpListener;
+
+/// One requested local-to-guest port mapping.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ForwardSpec {
+    /// Local interface address accepting connections.
+    pub(crate) address: IpAddr,
+    /// Local port to bind; zero selects an ephemeral port.
+    pub(crate) local_port: u16,
+    /// Guest port that receives forwarded connections.
+    pub(crate) guest_port: u16,
+}
+
+impl ForwardSpec {
+    /// Parses `GUEST`, `LOCAL:GUEST`, or `ADDRESS:LOCAL:GUEST`.
+    ///
+    /// An empty local port (`:GUEST`) selects an ephemeral local port.
+    pub(crate) fn parse(text: &str) -> Result<Self, String> {
+        let parts = text.split(':').collect::<Vec<_>>();
+        let (address, local, guest) = match parts.as_slice() {
+            [guest] => (None, *guest, *guest),
+            [local, guest] => (None, *local, *guest),
+            [address, local, guest] => (Some(*address), *local, *guest),
+            _ => return Err(format!("{text:?} is not GUEST, LOCAL:GUEST, or ADDRESS:LOCAL:GUEST")),
+        };
+        let address = match address {
+            None => IpAddr::from([127, 0, 0, 1]),
+            Some(text) => text
+                .parse::<IpAddr>()
+                .map_err(|_| format!("{text:?} is not a local IP address"))?,
+        };
+        let local_port = if local.is_empty() { 0 } else { parse_port(local)? };
+        let guest_port = parse_port(guest)?;
+        if guest_port == 0 {
+            return Err("guest port must not be zero".into());
+        }
+        Ok(Self {
+            address,
+            local_port,
+            guest_port,
+        })
+    }
+}
+
+fn parse_port(text: &str) -> Result<u16, String> {
+    text.parse::<u16>().map_err(|_| format!("{text:?} is not a port"))
+}
+
+/// One running forward with its local listener task.
+pub(crate) struct PortForward {
+    spec: ForwardSpec,
+    local: std::net::SocketAddr,
+    task: tokio::task::JoinHandle<()>,
+    status: Rc<RefCell<Option<String>>>,
+}
+
+impl PortForward {
+    /// Binds the local listener and serves connections until stopped.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the local address cannot be bound.
+    pub(crate) async fn start(home: PathBuf, assignment: Assignment, spec: ForwardSpec) -> Result<Self, Error> {
+        let listener = TcpListener::bind((spec.address, spec.local_port))
+            .await
+            .map_err(Error::from)?;
+        let local = listener.local_addr().map_err(Error::from)?;
+        let status = Rc::new(RefCell::new(None));
+        let task = tokio::task::spawn_local(accept_loop(
+            home,
+            assignment,
+            spec.guest_port,
+            listener,
+            Rc::clone(&status),
+        ));
+        Ok(Self {
+            spec,
+            local,
+            task,
+            status,
+        })
+    }
+
+    /// Returns the requested mapping.
+    pub(crate) const fn spec(&self) -> &ForwardSpec {
+        &self.spec
+    }
+
+    /// Returns the bound local address, with any ephemeral port resolved.
+    pub(crate) const fn local_address(&self) -> std::net::SocketAddr {
+        self.local
+    }
+
+    /// Returns the most recent connection failure, when one occurred.
+    pub(crate) fn status(&self) -> Option<String> {
+        self.status.borrow().clone()
+    }
+
+    /// Stops the listener and drops in-flight relays.
+    pub(crate) fn stop(&self) {
+        self.task.abort();
+    }
+}
+
+impl Drop for PortForward {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+async fn accept_loop(
+    home: PathBuf,
+    assignment: Assignment,
+    guest_port: u16,
+    listener: TcpListener,
+    status: Rc<RefCell<Option<String>>>,
+) {
+    // The dialer multiplexes streams over one agent connection; it is replaced
+    // when a connect fails, which re-reaches a Sandbox whose runtime restarted.
+    let mut dialer: Option<Rc<GuestDialer>> = None;
+    // Relays live in the accept task's JoinSet, so aborting the accept task
+    // drops the set and aborts every in-flight connection with it.
+    let mut relays = tokio::task::JoinSet::new();
+    loop {
+        while relays.try_join_next().is_some() {}
+        let stream = match listener.accept().await {
+            Ok((stream, _)) => stream,
+            Err(error) => {
+                *status.borrow_mut() = Some(format!("accept failed: {error}"));
+                return;
+            }
+        };
+        if dialer.is_none() {
+            match agent::sandbox::guest_tcp_dialer(&home, &assignment).await {
+                Ok(connected) => dialer = Some(Rc::new(connected)),
+                Err(error) => {
+                    *status.borrow_mut() = Some(error.to_string());
+                    continue;
+                }
+            }
+        }
+        let Some(connected) = &dialer else { continue };
+        match connected.connect("127.0.0.1", guest_port).await {
+            Ok(guest) => {
+                *status.borrow_mut() = None;
+                let status = Rc::clone(&status);
+                relays.spawn_local(async move {
+                    if let Err(error) = guest.relay(stream).await {
+                        *status.borrow_mut() = Some(error.to_string());
+                    }
+                });
+            }
+            Err(error) => {
+                *status.borrow_mut() = Some(error.to_string());
+                dialer = None;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used)]
+
+    use super::*;
+
+    #[test]
+    fn specs_follow_kubectl_shapes() {
+        assert_eq!(
+            ForwardSpec::parse("80").expect("guest-only spec"),
+            ForwardSpec {
+                address: IpAddr::from([127, 0, 0, 1]),
+                local_port: 80,
+                guest_port: 80,
+            }
+        );
+        assert_eq!(
+            ForwardSpec::parse("9090:80").expect("local and guest spec"),
+            ForwardSpec {
+                address: IpAddr::from([127, 0, 0, 1]),
+                local_port: 9090,
+                guest_port: 80,
+            }
+        );
+        assert_eq!(
+            ForwardSpec::parse("0.0.0.0:80:80").expect("address spec"),
+            ForwardSpec {
+                address: IpAddr::from([0, 0, 0, 0]),
+                local_port: 80,
+                guest_port: 80,
+            }
+        );
+        assert_eq!(
+            ForwardSpec::parse(":80").expect("ephemeral local port"),
+            ForwardSpec {
+                address: IpAddr::from([127, 0, 0, 1]),
+                local_port: 0,
+                guest_port: 80,
+            }
+        );
+        assert!(ForwardSpec::parse("web:80").is_err());
+        assert!(ForwardSpec::parse("1:2:3:4").is_err());
+        assert!(ForwardSpec::parse("8080:0").is_err());
+    }
+}

--- a/src/experimental/agent/src/bin/agentctl/forward.rs
+++ b/src/experimental/agent/src/bin/agentctl/forward.rs
@@ -108,6 +108,11 @@ impl PortForward {
         self.status.borrow().clone()
     }
 
+    /// Reports whether the listener task has ended and stopped serving.
+    pub(crate) fn finished(&self) -> bool {
+        self.task.is_finished()
+    }
+
     /// Stops the listener and drops in-flight relays.
     pub(crate) fn stop(&self) {
         self.task.abort();

--- a/src/experimental/agent/src/bin/agentctl/main.rs
+++ b/src/experimental/agent/src/bin/agentctl/main.rs
@@ -16,6 +16,7 @@ use agent::{
 use clap::{Parser, Subcommand};
 
 mod format;
+mod forward;
 mod tui;
 
 use format::{condition_status, format_age, format_harnesses, session_state};
@@ -118,6 +119,18 @@ enum Command {
         /// Command and arguments to execute after `--`.
         #[arg(last = true, required = true, num_args = 1..)]
         command: Vec<String>,
+    },
+    /// Forward local ports to a running Agent sandbox until interrupted.
+    PortForward {
+        /// Agent name, as an alternative to a leading Agent argument.
+        #[arg(long)]
+        agent: Option<String>,
+        /// Optional leading Agent resource or name, followed by port mappings
+        /// written as GUEST, LOCAL:GUEST, or ADDRESS:LOCAL:GUEST. An empty
+        /// local port (`:GUEST`) selects an ephemeral local port. The Agent is
+        /// inferred from the current directory when no leading Agent is given.
+        #[arg(required = true, num_args = 1..)]
+        arguments: Vec<String>,
     },
     /// Open the interactive terminal UI.
     Tui,
@@ -237,6 +250,9 @@ async fn execute(command: Command, home: &ControlPlaneHome, client: &Client) -> 
             agent,
             command,
         } => return exec_command(home, client, resource, agent, &command, stdin, tty).await,
+        Command::PortForward { agent, arguments } => {
+            return port_forward(home, client, agent, &arguments).await;
+        }
         Command::Tui => return tui::run(home, client).await,
         Command::Wait {
             condition,
@@ -351,6 +367,74 @@ async fn exec_command(
         stream_execution(execution).await?
     };
     Ok(exit_code(status.code))
+}
+
+/// Splits a leading Agent reference from the port mappings.
+///
+/// A first argument containing ':' or made only of digits is a port mapping;
+/// anything else names the Agent. Agent names cannot contain ':' and port
+/// mappings cannot contain letters, so the shapes never overlap.
+fn split_forward_arguments(arguments: &[String]) -> (Option<String>, &[String]) {
+    match arguments.split_first() {
+        Some((first, rest)) if !first.contains(':') && !first.bytes().all(|byte| byte.is_ascii_digit()) => {
+            (Some(first.clone()), rest)
+        }
+        _ => (None, arguments),
+    }
+}
+
+async fn port_forward(
+    home: &ControlPlaneHome,
+    client: &Client,
+    agent: Option<String>,
+    arguments: &[String],
+) -> CommandResult<ExitCode> {
+    let (resource, ports) = split_forward_arguments(arguments);
+    if agent.is_some() && resource.is_some() {
+        return Err(Error::Invalid("the Agent was supplied both as an argument and with --agent".into()).into());
+    }
+    if ports.is_empty() {
+        return Err(Error::Invalid("at least one port mapping is required".into()).into());
+    }
+    let specs = ports
+        .iter()
+        .map(|port| forward::ForwardSpec::parse(port))
+        .collect::<Result<Vec<_>, String>>()
+        .map_err(CommandError::Message)?;
+    let agent = resolve_execution_agent(client, resource, agent).await?;
+    eprintln!("Ensuring Agent {agent:?}; initial provisioning can take several minutes...");
+    let target = client.ensure_execution(&agent).await?;
+    let mut forwards = Vec::new();
+    for spec in specs {
+        let forward = forward::PortForward::start(home.path().to_path_buf(), target.sandbox.clone(), spec).await?;
+        println!(
+            "Forwarding from {} -> {} (agent {agent:?})",
+            forward.local_address(),
+            forward.spec().guest_port
+        );
+        forwards.push(forward);
+    }
+    let mut reported = vec![None; forwards.len()];
+    let mut poll = tokio::time::interval(Duration::from_secs(1));
+    loop {
+        tokio::select! {
+            result = tokio::signal::ctrl_c() => {
+                result.map_err(Error::from)?;
+                return Ok(ExitCode::SUCCESS);
+            }
+            _ = poll.tick() => {
+                for (forward, reported) in forwards.iter().zip(reported.iter_mut()) {
+                    let status = forward.status();
+                    if status != *reported {
+                        if let Some(message) = &status {
+                            eprintln!("{} -> {}: {message}", forward.local_address(), forward.spec().guest_port);
+                        }
+                        *reported = status;
+                    }
+                }
+            }
+        }
+    }
 }
 
 async fn resolve_execution_agent(
@@ -746,6 +830,35 @@ mod tests {
         };
         assert!(resource.is_none());
         assert_eq!(command, ["pwd"]);
+    }
+
+    #[test]
+    fn port_forward_accepts_kubectl_shapes_and_inference() {
+        let explicit = Arguments::try_parse_from(["agentctl", "port-forward", "agent/worker", "9090:80", ":5432"])
+            .expect("explicit port-forward arguments");
+        let Command::PortForward { agent, arguments } = explicit.command else {
+            panic!("expected port-forward command");
+        };
+        assert!(agent.is_none());
+        assert_eq!(
+            split_forward_arguments(&arguments),
+            (Some("agent/worker".into()), &arguments[1..])
+        );
+
+        let inferred =
+            Arguments::try_parse_from(["agentctl", "port-forward", "8080"]).expect("inferred port-forward arguments");
+        let Command::PortForward { arguments, .. } = inferred.command else {
+            panic!("expected port-forward command");
+        };
+        assert_eq!(split_forward_arguments(&arguments), (None, arguments.as_slice()));
+
+        let flagged = Arguments::try_parse_from(["agentctl", "port-forward", "--agent", "worker", "0.0.0.0:80:80"])
+            .expect("flagged port-forward arguments");
+        let Command::PortForward { agent, arguments } = flagged.command else {
+            panic!("expected port-forward command");
+        };
+        assert_eq!(agent.as_deref(), Some("worker"));
+        assert_eq!(split_forward_arguments(&arguments), (None, arguments.as_slice()));
     }
 
     #[test]

--- a/src/experimental/agent/src/bin/agentctl/main.rs
+++ b/src/experimental/agent/src/bin/agentctl/main.rs
@@ -432,6 +432,10 @@ async fn port_forward(
                         *reported = status;
                     }
                 }
+                if forwards.iter().all(forward::PortForward::finished) {
+                    eprintln!("every port forward has stopped");
+                    return Ok(ExitCode::FAILURE);
+                }
             }
         }
     }

--- a/src/experimental/agent/src/bin/agentctl/tui/app.rs
+++ b/src/experimental/agent/src/bin/agentctl/tui/app.rs
@@ -319,7 +319,9 @@ impl App {
             self.detail_key(key);
             return Action::None;
         }
-        if self.forwards_view {
+        // The error screen renders over the forwards view, so its keys must
+        // win over forwards_key while an error is shown.
+        if self.forwards_view && self.error.is_none() {
             return self.forwards_key(key);
         }
         self.main_key(key)
@@ -1125,6 +1127,19 @@ mod tests {
         assert_eq!(form.guest, "80");
         app.on_key(key(KeyCode::Esc));
         assert!(app.modal.is_none());
+        app.on_key(key(KeyCode::Char('q')));
+        assert!(!app.forwards_view);
+    }
+
+    #[test]
+    fn error_screen_keys_win_over_an_open_forwards_view() {
+        let mut app = populated();
+        app.on_key(key(KeyCode::Char('F')));
+        app.error = Some("control plane unreachable".into());
+        assert_eq!(app.on_key(key(KeyCode::Char('r'))), Action::Refresh);
+        assert_eq!(app.on_key(key(KeyCode::Char('q'))), Action::Quit);
+        assert!(app.forwards_view);
+        app.error = None;
         app.on_key(key(KeyCode::Char('q')));
         assert!(!app.forwards_view);
     }

--- a/src/experimental/agent/src/bin/agentctl/tui/app.rs
+++ b/src/experimental/agent/src/bin/agentctl/tui/app.rs
@@ -6,7 +6,7 @@ use agent::{
 };
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-use crate::format;
+use crate::{format, forward::ForwardSpec};
 
 pub(crate) struct App {
     pub(crate) agents: Vec<Agent>,
@@ -20,6 +20,27 @@ pub(crate) struct App {
     pub(crate) error: Option<String>,
     pub(crate) detail: Option<Detail>,
     pub(crate) modal: Option<Modal>,
+    pub(crate) forwards: Vec<ForwardEntry>,
+    pub(crate) forwards_view: bool,
+    pub(crate) forward_selected: usize,
+    pub(crate) creating: usize,
+}
+
+/// Display state of one process-owned port forward.
+pub(crate) struct ForwardEntry {
+    pub(crate) id: u64,
+    pub(crate) agent: String,
+    pub(crate) local: String,
+    pub(crate) guest_port: u16,
+    pub(crate) status: Option<String>,
+}
+
+impl ForwardEntry {
+    /// Renders the mapping as `LOCAL:GUEST`, keeping a non-loopback address.
+    fn mapping(&self) -> String {
+        let local = self.local.strip_prefix("127.0.0.1:").unwrap_or(&self.local);
+        format!("{local}:{}", self.guest_port)
+    }
 }
 
 pub(crate) struct Group {
@@ -51,6 +72,113 @@ pub(crate) enum Modal {
         harness: usize,
         error: Option<String>,
     },
+    PortForward(ForwardForm),
+}
+
+/// k9s-style port-forward form state.
+pub(crate) struct ForwardForm {
+    pub(crate) agent: String,
+    pub(crate) address: String,
+    pub(crate) local: String,
+    pub(crate) guest: String,
+    pub(crate) field: ForwardField,
+    pub(crate) error: Option<String>,
+    pub(crate) replace: Option<u64>,
+}
+
+impl ForwardForm {
+    /// Reopens the form for a mapping the runtime rejected, keeping its values.
+    pub(crate) fn rejected(agent: String, spec: &ForwardSpec, replace: Option<u64>, error: String) -> Self {
+        Self {
+            agent,
+            address: spec.address.to_string(),
+            local: if spec.local_port == 0 {
+                String::new()
+            } else {
+                spec.local_port.to_string()
+            },
+            guest: spec.guest_port.to_string(),
+            field: ForwardField::Address,
+            error: Some(bind_hint(spec, error)),
+            replace,
+        }
+    }
+
+    /// Applies one key press; a submitted or cancelled form returns its Action.
+    fn key(&mut self, key: KeyEvent) -> Option<Action> {
+        match key.code {
+            KeyCode::Esc => return Some(Action::None),
+            KeyCode::Enter => {
+                let local = if self.local.is_empty() {
+                    &self.guest
+                } else {
+                    &self.local
+                };
+                match ForwardSpec::parse(&format!("{}:{local}:{}", self.address, self.guest)) {
+                    Ok(spec) => {
+                        return Some(Action::CreateForward {
+                            agent: self.agent.clone(),
+                            spec,
+                            replace: self.replace,
+                        });
+                    }
+                    Err(invalid) => self.error = Some(invalid),
+                }
+            }
+            KeyCode::Tab | KeyCode::Down => self.field = self.field.next(),
+            KeyCode::BackTab | KeyCode::Up => self.field = self.field.previous(),
+            KeyCode::Backspace => {
+                self.field_text().pop();
+                self.error = None;
+            }
+            KeyCode::Char(character)
+                if key.modifiers.difference(KeyModifiers::SHIFT).is_empty()
+                    && forward_field_accepts(self.field, character) =>
+            {
+                let text = self.field_text();
+                if text.len() < 45 {
+                    text.push(character);
+                    self.error = None;
+                }
+            }
+            _ => {}
+        }
+        None
+    }
+
+    const fn field_text(&mut self) -> &mut String {
+        match self.field {
+            ForwardField::Address => &mut self.address,
+            ForwardField::LocalPort => &mut self.local,
+            ForwardField::GuestPort => &mut self.guest,
+        }
+    }
+}
+
+/// One editable field of the port-forward form.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ForwardField {
+    Address,
+    LocalPort,
+    GuestPort,
+}
+
+impl ForwardField {
+    const fn next(self) -> Self {
+        match self {
+            Self::Address => Self::LocalPort,
+            Self::LocalPort => Self::GuestPort,
+            Self::GuestPort => Self::Address,
+        }
+    }
+
+    const fn previous(self) -> Self {
+        match self {
+            Self::Address => Self::GuestPort,
+            Self::LocalPort => Self::Address,
+            Self::GuestPort => Self::LocalPort,
+        }
+    }
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -72,6 +200,14 @@ pub(crate) enum Action {
     },
     Delete {
         agent: String,
+    },
+    CreateForward {
+        agent: String,
+        spec: ForwardSpec,
+        replace: Option<u64>,
+    },
+    DeleteForward {
+        id: u64,
     },
 }
 
@@ -106,6 +242,10 @@ impl App {
             error: None,
             detail: None,
             modal: None,
+            forwards: Vec::new(),
+            forwards_view: false,
+            forward_selected: 0,
+            creating: 0,
         }
     }
 
@@ -179,6 +319,9 @@ impl App {
             self.detail_key(key);
             return Action::None;
         }
+        if self.forwards_view {
+            return self.forwards_key(key);
+        }
         self.main_key(key)
     }
 
@@ -189,6 +332,7 @@ impl App {
             KeyCode::Up | KeyCode::Char('k') => self.move_selection(-1),
             KeyCode::Char('r') => return Action::Refresh,
             KeyCode::Char('z') => self.toggle_all(),
+            KeyCode::Char('F') => self.forwards_view = true,
             _ => {
                 return match self.selected_row() {
                     Some(Row::Agent(group)) => self.agent_key(key, group),
@@ -196,6 +340,40 @@ impl App {
                     None => Action::None,
                 };
             }
+        }
+        Action::None
+    }
+
+    fn forwards_key(&mut self, key: KeyEvent) -> Action {
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q' | 'F') => self.forwards_view = false,
+            KeyCode::Down | KeyCode::Char('j') => self.move_forward_selection(1),
+            KeyCode::Up | KeyCode::Char('k') => self.move_forward_selection(-1),
+            KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                if let Some(entry) = self.forwards.get(self.forward_selected) {
+                    return Action::DeleteForward { id: entry.id };
+                }
+            }
+            KeyCode::Char('e') => {
+                if let Some(entry) = self.forwards.get(self.forward_selected) {
+                    let (address, local) = entry
+                        .local
+                        .rsplit_once(':')
+                        .map_or((String::new(), String::new()), |(address, local)| {
+                            (address.to_owned(), local.to_owned())
+                        });
+                    self.modal = Some(Modal::PortForward(ForwardForm {
+                        agent: entry.agent.clone(),
+                        address,
+                        local,
+                        guest: entry.guest_port.to_string(),
+                        field: ForwardField::LocalPort,
+                        error: None,
+                        replace: Some(entry.id),
+                    }));
+                }
+            }
+            _ => {}
         }
         Action::None
     }
@@ -237,6 +415,17 @@ impl App {
             }
             KeyCode::Char('n') => self.open_new_session(group),
             KeyCode::Char('e') => return Action::Exec { agent: name },
+            KeyCode::Char('f') => {
+                self.modal = Some(Modal::PortForward(ForwardForm {
+                    agent: name,
+                    address: "127.0.0.1".into(),
+                    local: String::new(),
+                    guest: String::new(),
+                    field: ForwardField::GuestPort,
+                    error: None,
+                    replace: None,
+                }));
+            }
             _ => {}
         }
         Action::None
@@ -351,6 +540,13 @@ impl App {
                 });
                 Action::None
             }
+            Some(Modal::PortForward(mut form)) => {
+                if let Some(action) = form.key(key) {
+                    return action;
+                }
+                self.modal = Some(Modal::PortForward(form));
+                Action::None
+            }
             None => Action::None,
         }
     }
@@ -391,6 +587,21 @@ impl App {
         self.rebuild();
     }
 
+    fn move_forward_selection(&mut self, delta: isize) {
+        if self.forwards.is_empty() {
+            return;
+        }
+        let length = isize::try_from(self.forwards.len()).unwrap_or(1);
+        let current = isize::try_from(self.forward_selected).unwrap_or_default();
+        self.forward_selected = usize::try_from((current + delta).rem_euclid(length)).unwrap_or_default();
+    }
+
+    /// Replaces the forward display list, keeping the selection in range.
+    pub(crate) fn set_forwards(&mut self, forwards: Vec<ForwardEntry>) {
+        self.forwards = forwards;
+        self.forward_selected = self.forward_selected.min(self.forwards.len().saturating_sub(1));
+    }
+
     fn move_selection(&mut self, delta: isize) {
         if self.rows.is_empty() {
             return;
@@ -427,11 +638,23 @@ impl App {
                         "▾ "
                     };
                     let (tone, status) = agent_tone(agent);
+                    let forwards = self
+                        .forwards
+                        .iter()
+                        .filter(|entry| entry.agent == agent.metadata.name)
+                        .map(ForwardEntry::mapping)
+                        .collect::<Vec<_>>();
+                    let forward_badge = if forwards.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" · ports: {}", forwards.join(" "))
+                    };
+                    let badge = format!("{running}/{} · {status}{forward_badge}", sessions.len());
                     Some(RowView {
                         marker,
                         dot: None,
                         label: agent.metadata.name.clone(),
-                        badge: format!("{running}/{} · {status}", sessions.len()),
+                        badge,
                         tone,
                         agent: true,
                     })
@@ -469,10 +692,14 @@ impl App {
             return match modal {
                 Modal::ConfirmDelete { .. } => vec![("y", "confirm"), ("n", "cancel")],
                 Modal::NewSession { .. } => vec![("enter", "create"), ("tab", "harness"), ("esc", "cancel")],
+                Modal::PortForward { .. } => vec![("enter", "forward"), ("tab", "field"), ("esc", "cancel")],
             };
         }
         if self.detail.is_some() {
             return vec![("j/k", "scroll"), ("q", "back")];
+        }
+        if self.forwards_view {
+            return vec![("e", "edit"), ("ctrl-d", "delete"), ("q", "back")];
         }
         match self.selected_row() {
             Some(Row::Agent(_)) => vec![
@@ -481,6 +708,7 @@ impl App {
                 ("y", "yaml"),
                 ("n", "new session"),
                 ("e", "exec"),
+                ("f", "forward"),
                 ("d", "delete"),
                 ("z", "all"),
             ],
@@ -528,6 +756,22 @@ const fn session_tone(state: State) -> Tone {
         State::Starting => Tone::Yellow,
         State::Idle => Tone::Gray,
         State::Failed => Tone::Red,
+    }
+}
+
+fn bind_hint(spec: &ForwardSpec, error: String) -> String {
+    let low_port_on_specific_address = spec.local_port != 0 && spec.local_port < 1024 && !spec.address.is_unspecified();
+    if cfg!(target_os = "macos") && low_port_on_specific_address && error.contains("Permission denied") {
+        format!("{error} — macOS allows ports below 1024 only on 0.0.0.0")
+    } else {
+        error
+    }
+}
+
+const fn forward_field_accepts(field: ForwardField, character: char) -> bool {
+    match field {
+        ForwardField::Address => character.is_ascii_digit() || character == '.',
+        ForwardField::LocalPort | ForwardField::GuestPort => character.is_ascii_digit(),
     }
 }
 
@@ -797,6 +1041,158 @@ mod tests {
         assert!(views[4].badge.contains("Pending"));
         assert_eq!(views[1].dot, Some("●"));
         assert!(views[1].badge.contains("Failed"));
+    }
+
+    #[test]
+    fn forward_form_mirrors_an_empty_local_port_and_creates_on_enter() {
+        let mut app = populated();
+        assert_eq!(app.on_key(key(KeyCode::Char('f'))), Action::None);
+        assert!(matches!(app.modal, Some(Modal::PortForward { .. })));
+        app.on_key(key(KeyCode::Char('8')));
+        app.on_key(key(KeyCode::Char('0')));
+        let action = app.on_key(key(KeyCode::Enter));
+        assert_eq!(
+            action,
+            Action::CreateForward {
+                agent: "builder".into(),
+                spec: ForwardSpec {
+                    address: std::net::IpAddr::from([127, 0, 0, 1]),
+                    local_port: 80,
+                    guest_port: 80,
+                },
+                replace: None,
+            }
+        );
+        assert!(app.modal.is_none());
+    }
+
+    #[test]
+    fn forward_form_cycles_fields_and_reports_invalid_input() {
+        let mut app = populated();
+        app.on_key(key(KeyCode::Char('f')));
+        app.on_key(key(KeyCode::Enter));
+        assert!(matches!(
+            app.modal,
+            Some(Modal::PortForward(ForwardForm { error: Some(_), .. }))
+        ));
+        app.on_key(key(KeyCode::Tab));
+        let Some(Modal::PortForward(form)) = &app.modal else {
+            panic!("expected the PortForward modal");
+        };
+        assert_eq!(form.field, ForwardField::Address);
+        app.on_key(key(KeyCode::Tab));
+        app.on_key(key(KeyCode::Char('9')));
+        app.on_key(key(KeyCode::Tab));
+        app.on_key(key(KeyCode::Char('8')));
+        app.on_key(key(KeyCode::Char('0')));
+        let action = app.on_key(key(KeyCode::Enter));
+        assert_eq!(
+            action,
+            Action::CreateForward {
+                agent: "builder".into(),
+                spec: ForwardSpec {
+                    address: std::net::IpAddr::from([127, 0, 0, 1]),
+                    local_port: 9,
+                    guest_port: 80,
+                },
+                replace: None,
+            }
+        );
+    }
+
+    #[test]
+    fn forwards_view_lists_deletes_and_edits_like_k9s() {
+        let mut app = populated();
+        app.set_forwards(vec![ForwardEntry {
+            id: 7,
+            agent: "worker".into(),
+            local: "127.0.0.1:9090".into(),
+            guest_port: 80,
+            status: None,
+        }]);
+        app.on_key(key(KeyCode::Char('F')));
+        assert!(app.forwards_view);
+        assert_eq!(
+            app.on_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL)),
+            Action::DeleteForward { id: 7 }
+        );
+        app.on_key(key(KeyCode::Char('e')));
+        let Some(Modal::PortForward(form)) = &app.modal else {
+            panic!("expected the PortForward modal");
+        };
+        assert_eq!(form.replace, Some(7));
+        assert_eq!(form.local, "9090");
+        assert_eq!(form.guest, "80");
+        app.on_key(key(KeyCode::Esc));
+        assert!(app.modal.is_none());
+        app.on_key(key(KeyCode::Char('q')));
+        assert!(!app.forwards_view);
+    }
+
+    #[test]
+    fn rejected_forwards_reopen_the_form_with_their_values() {
+        let spec = ForwardSpec {
+            address: std::net::IpAddr::from([127, 0, 0, 1]),
+            local_port: 0,
+            guest_port: 5432,
+        };
+        let form = ForwardForm::rejected("worker".into(), &spec, Some(3), "boom".into());
+        assert_eq!(form.agent, "worker");
+        assert_eq!(form.address, "127.0.0.1");
+        assert_eq!(form.local, "");
+        assert_eq!(form.guest, "5432");
+        assert_eq!(form.field, ForwardField::Address);
+        assert_eq!(form.error.as_deref(), Some("boom"));
+        assert_eq!(form.replace, Some(3));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn low_loopback_ports_get_the_wildcard_bind_hint() {
+        let spec = ForwardSpec {
+            address: std::net::IpAddr::from([127, 0, 0, 1]),
+            local_port: 80,
+            guest_port: 80,
+        };
+        let form = ForwardForm::rejected(
+            "worker".into(),
+            &spec,
+            None,
+            "bind: Permission denied (os error 13)".into(),
+        );
+        let error = form.error.expect("rejected form should keep its error");
+        assert!(error.contains("macOS allows ports below 1024 only on 0.0.0.0"));
+
+        let wildcard = ForwardSpec {
+            address: std::net::IpAddr::from([0, 0, 0, 0]),
+            ..spec
+        };
+        let form = ForwardForm::rejected("worker".into(), &wildcard, None, "Permission denied".into());
+        assert_eq!(form.error.as_deref(), Some("Permission denied"));
+    }
+
+    #[test]
+    fn agent_badges_list_forward_mappings() {
+        let mut app = populated();
+        app.set_forwards(vec![
+            ForwardEntry {
+                id: 1,
+                agent: "worker".into(),
+                local: "127.0.0.1:9090".into(),
+                guest_port: 80,
+                status: None,
+            },
+            ForwardEntry {
+                id: 2,
+                agent: "worker".into(),
+                local: "0.0.0.0:80".into(),
+                guest_port: 80,
+                status: None,
+            },
+        ]);
+        let views = app.render_rows();
+        assert!(!views[0].badge.contains("ports:"));
+        assert!(views[2].badge.contains("ports: 9090:80 0.0.0.0:80:80"));
     }
 
     #[test]

--- a/src/experimental/agent/src/bin/agentctl/tui/mod.rs
+++ b/src/experimental/agent/src/bin/agentctl/tui/mod.rs
@@ -12,7 +12,8 @@ use futures_util::StreamExt as _;
 use sandbox::terminal::TerminalAttachOutcome;
 
 use crate::CommandResult;
-use app::{Action, App};
+use crate::forward::{ForwardSpec, PortForward};
+use app::{Action, App, ForwardEntry, ForwardForm, Modal};
 use terminal::Tui;
 
 const REFRESH_INTERVAL: Duration = Duration::from_secs(2);
@@ -20,28 +21,50 @@ const REFRESH_INTERVAL: Duration = Duration::from_secs(2);
 enum Input {
     Event(Option<std::io::Result<Event>>),
     Tick,
+    ForwardCreated(CreateOutcome),
 }
+
+/// Completion of one background forward creation.
+type CreateOutcome = (String, ForwardSpec, Option<u64>, Result<PortForward, Error>);
 
 pub(crate) async fn run(home: &ControlPlaneHome, client: &Client) -> CommandResult<ExitCode> {
     if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
         return Err(Error::Invalid("tui requires an interactive local terminal".into()).into());
     }
     let mut app = App::new();
+    let mut forwards = ActiveForwards::default();
+    let (created_tx, mut created_rx) = tokio::sync::mpsc::unbounded_channel::<CreateOutcome>();
     let mut tui = Tui::enter()?;
     let mut events = EventStream::new();
     let mut tick = tokio::time::interval_at(tokio::time::Instant::now() + REFRESH_INTERVAL, REFRESH_INTERVAL);
     tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     refresh(&mut app, &mut tui, client).await?;
     loop {
+        app.set_forwards(forwards.entries());
         tui.draw(&app)?;
         let input = tokio::select! {
             event = events.next() => Input::Event(event),
             _ = tick.tick() => Input::Tick,
+            Some(outcome) = created_rx.recv() => Input::ForwardCreated(outcome),
         };
         match input {
             Input::Tick => {
                 if app.idle() {
                     refresh(&mut app, &mut tui, client).await?;
+                }
+            }
+            Input::ForwardCreated((agent, spec, replace, result)) => {
+                app.creating = app.creating.saturating_sub(1);
+                match result {
+                    Ok(forward) => forwards.push(agent, forward),
+                    Err(error) => {
+                        app.modal = Some(Modal::PortForward(ForwardForm::rejected(
+                            agent,
+                            &spec,
+                            replace,
+                            error.to_string(),
+                        )));
+                    }
                 }
             }
             Input::Event(None) => {
@@ -70,6 +93,14 @@ pub(crate) async fn run(home: &ControlPlaneHome, client: &Client) -> CommandResu
                         }
                         refresh(&mut app, &mut tui, client).await?;
                     }
+                    Action::CreateForward { agent, spec, replace } => {
+                        if let Some(id) = replace {
+                            forwards.remove(id);
+                        }
+                        app.creating += 1;
+                        spawn_create(home, created_tx.clone(), agent, spec, replace);
+                    }
+                    Action::DeleteForward { id } => forwards.remove(id),
                     action => {
                         drop(events);
                         suspended(&mut app, &mut tui, home, client, action).await?;
@@ -81,6 +112,59 @@ pub(crate) async fn run(home: &ControlPlaneHome, client: &Client) -> CommandResu
             Input::Event(Some(Ok(_))) => {}
         }
     }
+}
+
+/// Process-owned port forwards keyed by a stable per-run identity.
+#[derive(Default)]
+struct ActiveForwards {
+    next_id: u64,
+    active: Vec<(u64, String, PortForward)>,
+}
+
+impl ActiveForwards {
+    fn push(&mut self, agent: String, forward: PortForward) {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.active.push((id, agent, forward));
+    }
+
+    fn remove(&mut self, id: u64) {
+        self.active.retain(|(entry, _, _)| *entry != id);
+    }
+
+    fn entries(&self) -> Vec<ForwardEntry> {
+        self.active
+            .iter()
+            .map(|(id, agent, forward)| ForwardEntry {
+                id: *id,
+                agent: agent.clone(),
+                local: forward.local_address().to_string(),
+                guest_port: forward.spec().guest_port,
+                status: forward.status(),
+            })
+            .collect()
+    }
+}
+
+/// Creates a forward off the event loop so provisioning never freezes the UI.
+fn spawn_create(
+    home: &ControlPlaneHome,
+    outcomes: tokio::sync::mpsc::UnboundedSender<CreateOutcome>,
+    agent: String,
+    spec: ForwardSpec,
+    replace: Option<u64>,
+) {
+    let home_path = home.path().to_path_buf();
+    let socket_path = home.socket_path();
+    tokio::task::spawn_local(async move {
+        let client = Client::for_path(socket_path);
+        let result = async {
+            let target = client.ensure_execution(&agent).await?;
+            PortForward::start(home_path, target.sandbox, spec.clone()).await
+        }
+        .await;
+        let _ = outcomes.send((agent, spec, replace, result));
+    });
 }
 
 async fn refresh(app: &mut App, tui: &mut Tui, client: &Client) -> CommandResult<()> {

--- a/src/experimental/agent/src/bin/agentctl/tui/view.rs
+++ b/src/experimental/agent/src/bin/agentctl/tui/view.rs
@@ -6,7 +6,7 @@ use ratatui::{
     widgets::{Block, Clear, List, ListItem, ListState, Paragraph, Wrap},
 };
 
-use super::app::{App, Modal, Tone};
+use super::app::{App, ForwardField, Modal, Tone};
 
 pub(crate) fn render(frame: &mut Frame, app: &App) {
     let [header, body, footer] =
@@ -16,6 +16,8 @@ pub(crate) fn render(frame: &mut Frame, app: &App) {
         render_detail(frame, body, detail);
     } else if let Some(error) = &app.error {
         render_error(frame, body, error);
+    } else if app.forwards_view {
+        render_forwards(frame, body, app);
     } else {
         render_tree(frame, body, app);
     }
@@ -40,6 +42,9 @@ fn render_header(frame: &mut Frame, area: Rect, app: &App) {
     ];
     if app.loading {
         spans.push(Span::styled(" · ⟳", Style::new().fg(Color::Cyan)));
+    }
+    if app.creating > 0 {
+        spans.push(Span::styled(" · creating forward…", Style::new().fg(Color::Cyan)));
     }
     frame.render_widget(Line::from(spans), area);
 }
@@ -85,6 +90,40 @@ fn render_tree(frame: &mut Frame, area: Rect, app: &App) {
     frame.render_stateful_widget(list, area, &mut state);
 }
 
+fn render_forwards(frame: &mut Frame, area: Rect, app: &App) {
+    let block = Block::bordered().title(" port-forwards ");
+    if app.forwards.is_empty() {
+        frame.render_widget(
+            Paragraph::new("(no port forwards — press f on an agent to create one)")
+                .style(Style::new().fg(Color::DarkGray))
+                .block(block),
+            area,
+        );
+        return;
+    }
+    let items = app
+        .forwards
+        .iter()
+        .map(|entry| {
+            let mut spans = vec![
+                Span::styled("⇄ ", Style::new().fg(Color::Cyan)),
+                Span::raw(format!("{} → {}", entry.local, entry.guest_port)),
+                Span::styled(format!("  {}", entry.agent), Style::new().fg(Color::DarkGray)),
+            ];
+            match &entry.status {
+                Some(status) => spans.push(Span::styled(format!("  {status}"), Style::new().fg(Color::Red))),
+                None => spans.push(Span::styled("  active", Style::new().fg(Color::Green))),
+            }
+            ListItem::new(Line::from(spans))
+        })
+        .collect::<Vec<_>>();
+    let list = List::new(items)
+        .block(block)
+        .highlight_style(Style::new().add_modifier(Modifier::REVERSED));
+    let mut state = ListState::default().with_selected(Some(app.forward_selected));
+    frame.render_stateful_widget(list, area, &mut state);
+}
+
 fn render_detail(frame: &mut Frame, area: Rect, detail: &super::app::Detail) {
     let block = Block::bordered().title(format!(" {} — q back · ↑/↓ scroll ", detail.title));
     let scroll = u16::try_from(detail.scroll).unwrap_or(u16::MAX);
@@ -113,7 +152,7 @@ fn render_footer(frame: &mut Frame, area: Rect, app: &App) {
     frame.render_widget(Line::from(spans), contextual);
     frame.render_widget(
         Line::from(Span::styled(
-            "j/k move · r refresh · q quit",
+            "j/k move · r refresh · F forwards · q quit",
             Style::new().fg(Color::DarkGray),
         )),
         global,
@@ -168,7 +207,49 @@ fn render_modal(frame: &mut Frame, area: Rect, modal: &Modal) {
             lines.push(hint_line(&[("enter", "create"), ("tab", "harness"), ("esc", "cancel")]));
             popup(frame, area, " new session ", Color::Cyan, lines);
         }
+        Modal::PortForward(form) => {
+            let mut lines = vec![
+                Line::from(format!("Agent:         {}", form.agent)),
+                form_field("Local address", &form.address, form.field == ForwardField::Address),
+                form_field("Local port", &form.local, form.field == ForwardField::LocalPort),
+                form_field("Guest port", &form.guest, form.field == ForwardField::GuestPort),
+            ];
+            if form.local.is_empty() {
+                lines.push(Line::from(Span::styled(
+                    "An empty local port mirrors the guest port.",
+                    Style::new().fg(Color::DarkGray),
+                )));
+            }
+            if let Some(error) = &form.error {
+                lines.push(Line::from(Span::styled(error.clone(), Style::new().fg(Color::Red))));
+            }
+            lines.push(Line::default());
+            lines.push(hint_line(&[("enter", "forward"), ("tab", "field"), ("esc", "cancel")]));
+            let title = if form.replace.is_some() {
+                " edit forward "
+            } else {
+                " port forward "
+            };
+            popup(frame, area, title, Color::Cyan, lines);
+        }
     }
+}
+
+fn form_field(label: &str, value: &str, selected: bool) -> Line<'static> {
+    let mut spans = vec![Span::raw(format!(
+        "{label}:{}",
+        " ".repeat(14usize.saturating_sub(label.len()))
+    ))];
+    let style = if selected {
+        Style::new().fg(Color::Cyan)
+    } else {
+        Style::new()
+    };
+    spans.push(Span::styled(value.to_owned(), style));
+    if selected {
+        spans.push(Span::styled("▏", Style::new().fg(Color::Cyan)));
+    }
+    Line::from(spans)
 }
 
 fn hint_line(hints: &[(&'static str, &'static str)]) -> Line<'static> {
@@ -252,6 +333,6 @@ mod tests {
         assert!(text.contains("agentctl"));
         assert!(text.contains("0 agents · 0 sessions · 0 running"));
         assert!(text.contains("loading…"));
-        assert!(text.contains("j/k move · r refresh · q quit"));
+        assert!(text.contains("j/k move · r refresh · F forwards · q quit"));
     }
 }

--- a/src/experimental/agent/src/sandbox/microsandbox/forward.rs
+++ b/src/experimental/agent/src/sandbox/microsandbox/forward.rs
@@ -1,0 +1,57 @@
+//! Guest TCP dialing transport for the Microsandbox Backend.
+
+use sandbox_microsandbox::{GuestTcpDialer, GuestTcpStream, MicrosandboxProvider};
+
+use crate::{Error, sandbox::Assignment};
+
+/// Dials TCP connections from inside one Agent Sandbox.
+///
+/// The dialer multiplexes streams over a single Sandbox connection, so opening
+/// many concurrent connections through one dialer is cheap. It stops working
+/// when the Sandbox runtime restarts; create a replacement when a connect fails.
+pub struct GuestDialer(GuestTcpDialer);
+
+/// One open TCP stream dialed from inside an Agent Sandbox.
+pub struct GuestConnection(GuestTcpStream);
+
+impl GuestDialer {
+    /// Opens one TCP connection dialed from inside the guest.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the stream cannot be opened or the guest dial is
+    /// rejected.
+    pub async fn connect(&self, host: &str, port: u16) -> Result<GuestConnection, Error> {
+        Ok(GuestConnection(self.0.connect(host, port).await?))
+    }
+}
+
+impl GuestConnection {
+    /// Pipes bytes between a host socket and the guest connection until either
+    /// side closes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when either side of the relay fails.
+    pub async fn relay(self, stream: tokio::net::TcpStream) -> Result<(), Error> {
+        self.0.relay(stream).await.map_err(Error::from)
+    }
+}
+
+/// Connects a TCP dialer to an already-materialized Microsandbox.
+///
+/// # Errors
+///
+/// Returns an error when the assignment is not materialized or the exact
+/// Microsandbox is not running.
+pub(crate) async fn guest_tcp_dialer(home: &std::path::Path, assignment: &Assignment) -> Result<GuestDialer, Error> {
+    let provider = MicrosandboxProvider::open(home.join("microsandbox")).await?;
+    let Assignment::Materialized { id, .. } = assignment else {
+        return Err(Error::Invalid("forward target Sandbox is not materialized".into()));
+    };
+    provider
+        .guest_tcp_dialer(id)
+        .await
+        .map(GuestDialer)
+        .map_err(Error::from)
+}

--- a/src/experimental/agent/src/sandbox/microsandbox/mod.rs
+++ b/src/experimental/agent/src/sandbox/microsandbox/mod.rs
@@ -8,10 +8,13 @@ use sandbox_microsandbox::{MicrosandboxNetworkBackend, MicrosandboxProvider};
 use crate::{Error, authorization::AgentPolicyEngine, control_plane::AgentRecord, persistence};
 
 mod execution;
+mod forward;
 mod preparation;
 mod terminal;
 
 pub(super) use execution::start_execution;
+pub(super) use forward::guest_tcp_dialer;
+pub use forward::{GuestConnection, GuestDialer};
 pub use terminal::attach_terminal;
 
 use preparation::Preparation;

--- a/src/experimental/agent/src/sandbox/mod.rs
+++ b/src/experimental/agent/src/sandbox/mod.rs
@@ -12,6 +12,7 @@ pub mod microsandbox;
 pub mod platform;
 
 pub use execution::{ExecutionService, ExecutionTarget, start_execution};
+pub use microsandbox::{GuestConnection, GuestDialer};
 
 /// Stable identity of one configured Sandbox Provider.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -263,6 +264,21 @@ impl Service {
             .find(|provider| provider.id() == id)
             .map(Rc::as_ref)
             .ok_or_else(|| Error::Invalid(format!("assigned Sandbox Provider {id:?} is not configured")))
+    }
+}
+
+/// Connects a guest TCP dialer through the recorded Sandbox Provider.
+///
+/// # Errors
+///
+/// Returns an error when the Provider is unsupported by this client or the
+/// Sandbox is not running.
+pub async fn guest_tcp_dialer(home: &Path, assignment: &Assignment) -> Result<GuestDialer, Error> {
+    match assignment.provider().as_str() {
+        microsandbox::PROVIDER_ID => microsandbox::guest_tcp_dialer(home, assignment).await,
+        provider => Err(Error::Invalid(format!(
+            "guest TCP forwarding is not supported through Sandbox Provider {provider:?}"
+        ))),
     }
 }
 

--- a/src/experimental/sandbox-microsandbox/src/guest_tcp.rs
+++ b/src/experimental/sandbox-microsandbox/src/guest_tcp.rs
@@ -1,0 +1,190 @@
+//! Host-dialed TCP streams into a running Microsandbox guest.
+//!
+//! The Microsandbox agent relay multiplexes `TcpConnect` streams over the
+//! Sandbox's host socket, so a host process can open TCP connections that are
+//! dialed from inside the guest network namespace without any configuration
+//! on the Sandbox itself.
+
+use std::sync::Arc;
+
+use microsandbox::{
+    agent::AgentClient,
+    protocol::{
+        message::{Message, MessageType},
+        tcp::{TcpClose, TcpConnect, TcpConnected, TcpData, TcpEof, TcpFailed},
+    },
+};
+use sandbox::{Error, SandboxId};
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+use crate::{MicrosandboxProvider, error};
+
+const RELAY_READ_BUFFER_BYTES: usize = 32 * 1024;
+
+/// Dials TCP connections from inside one running Sandbox.
+///
+/// The dialer keeps a single multiplexed agent connection, so opening many
+/// concurrent streams through one dialer is cheap. It stops working when the
+/// Sandbox runtime restarts; create a replacement through
+/// [`MicrosandboxProvider::guest_tcp_dialer`] when a connect fails.
+pub struct GuestTcpDialer {
+    client: Arc<AgentClient>,
+    // Keeps the connected runtime handle (and its relay session) alive.
+    _sandbox: microsandbox::Sandbox,
+}
+
+/// One open TCP stream dialed from inside the guest.
+pub struct GuestTcpStream {
+    id: u32,
+    client: Arc<AgentClient>,
+    receiver: tokio::sync::mpsc::Receiver<Message>,
+}
+
+impl MicrosandboxProvider {
+    /// Connects a TCP dialer to one running Sandbox.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the Sandbox is unknown, not running, or its
+    /// runtime predates agent-relay TCP support.
+    pub async fn guest_tcp_dialer(&self, id: &SandboxId) -> Result<GuestTcpDialer, Error> {
+        let record = self.state.sandbox_by_id(id).await?;
+        let sandbox = self.connect_running(&record).await?;
+        let client = sandbox.client_arc();
+        if !client.supports(MessageType::TcpConnect) {
+            return Err(Error::Backend(
+                "Sandbox runtime does not support agent-relay TCP forwarding; restart the Sandbox".into(),
+            ));
+        }
+        Ok(GuestTcpDialer {
+            client,
+            _sandbox: sandbox,
+        })
+    }
+}
+
+impl GuestTcpDialer {
+    /// Opens one TCP connection dialed from inside the guest.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the relay stream cannot be opened or the guest
+    /// dial is rejected.
+    pub async fn connect(&self, host: &str, port: u16) -> Result<GuestTcpStream, Error> {
+        let request = TcpConnect {
+            host: host.to_owned(),
+            port,
+        };
+        let (id, mut receiver) = self
+            .client
+            .stream(MessageType::TcpConnect, &request)
+            .await
+            .map_err(error::backend)?;
+        let Some(first) = receiver.recv().await else {
+            return Err(Error::Backend(
+                "Sandbox agent closed the TCP stream before replying to connect".into(),
+            ));
+        };
+        match first.t {
+            MessageType::TcpConnected => {
+                let _: TcpConnected = first.payload().map_err(error::backend)?;
+                Ok(GuestTcpStream {
+                    id,
+                    client: Arc::clone(&self.client),
+                    receiver,
+                })
+            }
+            MessageType::TcpFailed => {
+                let failed: TcpFailed = first.payload().map_err(error::backend)?;
+                Err(Error::Backend(format!(
+                    "guest TCP connect to {host}:{port} failed: {}",
+                    failed.error
+                )))
+            }
+            other => Err(Error::Backend(format!(
+                "unexpected Sandbox agent reply {:?} to guest TCP connect",
+                other.as_str()
+            ))),
+        }
+    }
+}
+
+impl GuestTcpStream {
+    /// Pipes bytes between a host socket and the guest connection until either
+    /// side closes, then releases the relay stream.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a host socket read or write fails, or a relay
+    /// message cannot be sent or decoded.
+    pub async fn relay(mut self, stream: tokio::net::TcpStream) -> Result<(), Error> {
+        let (mut host_reader, mut host_writer) = stream.into_split();
+        let client = Arc::clone(&self.client);
+        let id = self.id;
+
+        let host_to_guest = async {
+            let mut buffer = vec![0u8; RELAY_READ_BUFFER_BYTES];
+            loop {
+                let read = host_reader
+                    .read(&mut buffer)
+                    .await
+                    .map_err(|source| error::io("read forwarded host connection", source))?;
+                if read == 0 {
+                    client
+                        .send(id, MessageType::TcpEof, &TcpEof {})
+                        .await
+                        .map_err(error::backend)?;
+                    return Ok::<(), Error>(());
+                }
+                let data = TcpData {
+                    data: buffer[..read].to_vec(),
+                };
+                client
+                    .send(id, MessageType::TcpData, &data)
+                    .await
+                    .map_err(error::backend)?;
+            }
+        };
+
+        let guest_to_host = async {
+            while let Some(message) = self.receiver.recv().await {
+                match message.t {
+                    MessageType::TcpData => {
+                        let data: TcpData = message.payload().map_err(error::backend)?;
+                        host_writer
+                            .write_all(&data.data)
+                            .await
+                            .map_err(|source| error::io("write forwarded host connection", source))?;
+                    }
+                    MessageType::TcpEof => {
+                        host_writer
+                            .shutdown()
+                            .await
+                            .map_err(|source| error::io("shut down forwarded host connection", source))?;
+                    }
+                    MessageType::TcpClosed => return Ok::<(), Error>(()),
+                    other => {
+                        return Err(Error::Backend(format!(
+                            "unexpected Sandbox agent message {:?} on a guest TCP stream",
+                            other.as_str()
+                        )));
+                    }
+                }
+            }
+            Ok(())
+        };
+
+        // A host-side EOF is a half-close: the guest may still be writing its
+        // response, so only a guest-side completion or an error ends the relay.
+        tokio::pin!(guest_to_host);
+        let result = tokio::select! {
+            result = &mut guest_to_host => result,
+            result = host_to_guest => match result {
+                Ok(()) => guest_to_host.await,
+                Err(error) => Err(error),
+            },
+        };
+        let _ = self.client.send(self.id, MessageType::TcpClose, &TcpClose {}).await;
+        result
+    }
+}

--- a/src/experimental/sandbox-microsandbox/src/guest_tcp.rs
+++ b/src/experimental/sandbox-microsandbox/src/guest_tcp.rs
@@ -109,9 +109,23 @@ impl GuestTcpDialer {
     }
 }
 
+impl Drop for GuestTcpStream {
+    /// Releases the guest socket and its agent session on every path — normal
+    /// completion, an error, and a cancelled relay task alike.
+    fn drop(&mut self) {
+        let client = Arc::clone(&self.client);
+        let id = self.id;
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                let _ = client.send(id, MessageType::TcpClose, &TcpClose {}).await;
+            });
+        }
+    }
+}
+
 impl GuestTcpStream {
     /// Pipes bytes between a host socket and the guest connection until either
-    /// side closes, then releases the relay stream.
+    /// side closes; dropping the stream releases the guest session.
     ///
     /// # Errors
     ///
@@ -177,14 +191,12 @@ impl GuestTcpStream {
         // A host-side EOF is a half-close: the guest may still be writing its
         // response, so only a guest-side completion or an error ends the relay.
         tokio::pin!(guest_to_host);
-        let result = tokio::select! {
+        tokio::select! {
             result = &mut guest_to_host => result,
             result = host_to_guest => match result {
                 Ok(()) => guest_to_host.await,
                 Err(error) => Err(error),
             },
-        };
-        let _ = self.client.send(self.id, MessageType::TcpClose, &TcpClose {}).await;
-        result
+        }
     }
 }

--- a/src/experimental/sandbox-microsandbox/src/lib.rs
+++ b/src/experimental/sandbox-microsandbox/src/lib.rs
@@ -11,6 +11,7 @@ mod encoding;
 mod error;
 mod execution;
 mod files;
+mod guest_tcp;
 mod image;
 mod network_backend;
 mod network_endpoint;
@@ -19,4 +20,5 @@ mod state;
 mod volumes;
 
 pub use backend::{MicrosandboxProvider, MicrosandboxProviderBuilder};
+pub use guest_tcp::{GuestTcpDialer, GuestTcpStream};
 pub use network_backend::{MicrosandboxNetworkBackend, SecretBinding};


### PR DESCRIPTION
Forward local TCP ports into running Agent sandboxes without any sandbox configuration, using the Microsandbox agent relay's TcpConnect streams. Forwards are client-owned like k9s: they live in the agentctl process and end with it.

- sandbox-microsandbox: GuestTcpDialer/GuestTcpStream open guest-dialed TCP connections over one multiplexed relay session, with half-close- correct bidirectional relaying.
- agent: adapter-contained GuestDialer/GuestConnection wrappers and an agent::sandbox::guest_tcp_dialer dispatcher.
- agentctl port-forward <agent> [ADDR:]LOCAL:GUEST... blocks until interrupted; :GUEST selects an ephemeral local port.
- agentctl tui: 'f' on an agent opens a forward form, 'F' lists forwards with edit (e) and delete (ctrl-d), and agent rows show active mappings.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TCP port forwarding between local ports and Agent sandboxes.
  * Added command-line support for creating and managing port forwards, including automatic local port assignment.
  * Added TUI controls for creating, editing, viewing, and deleting forwards, with live status indicators.
  * Added validation for addresses and port ranges, plus clear error handling and connection status reporting.
* **Tests**
  * Added coverage for port specifications, command-line options, form validation, and forward management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->