### PR TITLE
feat: Give user feedback that party is selected before redirect happens

### DIFF
--- a/src/App/frontend/src/components/altinnParty.module.css
+++ b/src/App/frontend/src/components/altinnParty.module.css
@@ -11,20 +11,12 @@
   gap: 0.75rem;
 }
 
-/* Only a selectable row advertises that it can be clicked. Blocked rows
-   (another party's selection is in flight) carry no class of their own:
-   without the selectable class they simply have no hover affordance. */
 .partyWrapperSelectable:hover {
   background-color: var(--colors-primary-blueLight);
   cursor: pointer;
 }
 
 .partyWrapperSelected {
-  /* Pressed-button look while the selection request is in flight: one step
-     darker than :hover. Applied to the clickable row rather than the paper,
-     so an expanded sub-unit list does not look selected along with it.
-     The progress cursor marks temporary busy — distinct from the permanent
-     not-allowed on no-access parties. */
   background-color: var(--colors-primary-blueLighterActive);
   cursor: progress;
 }
@@ -76,15 +68,12 @@
   padding: 0 1.25rem;
 }
 
-/* See .partyWrapperSelectable: only selectable rows get the hover affordance */
 .subUnitSelectable:hover {
   background: var(--colors-primary-blueLight);
   cursor: pointer;
 }
 
 .subUnitSelected {
-  /* Pressed-button look while the selection request is in flight: one step
-     darker than :hover (which is active at the moment of clicking). */
   background: var(--colors-primary-blueLighterActive);
   cursor: progress;
 }

--- a/src/App/frontend/src/components/altinnParty.module.css
+++ b/src/App/frontend/src/components/altinnParty.module.css
@@ -21,6 +21,10 @@
   cursor: progress;
 }
 
+.partyBlocked {
+  cursor: not-allowed;
+}
+
 .partyWrapperDisabled:hover {
   cursor: not-allowed;
 }

--- a/src/App/frontend/src/components/altinnParty.module.css
+++ b/src/App/frontend/src/components/altinnParty.module.css
@@ -11,13 +11,11 @@
   gap: 0.75rem;
 }
 
-/* Shared by parties and sub-units: a row the user can select. */
 .partySelectable:hover {
   background-color: var(--colors-primary-blueLight);
   cursor: pointer;
 }
 
-/* Shared by parties and sub-units: the row whose selection is in flight. */
 .partySubmitting {
   background-color: var(--colors-primary-blueLighterActive);
   cursor: progress;

--- a/src/App/frontend/src/components/altinnParty.module.css
+++ b/src/App/frontend/src/components/altinnParty.module.css
@@ -11,12 +11,14 @@
   gap: 0.75rem;
 }
 
-.partyWrapperSelectable:hover {
+/* Shared by parties and sub-units: a row the user can select. */
+.partySelectable:hover {
   background-color: var(--colors-primary-blueLight);
   cursor: pointer;
 }
 
-.partyWrapperSelected {
+/* Shared by parties and sub-units: the row whose selection is in flight. */
+.partySubmitting {
   background-color: var(--colors-primary-blueLighterActive);
   cursor: progress;
 }
@@ -66,16 +68,6 @@
 .subUnit {
   width: 100%;
   padding: 0 1.25rem;
-}
-
-.subUnitSelectable:hover {
-  background: var(--colors-primary-blueLight);
-  cursor: pointer;
-}
-
-.subUnitSelected {
-  background: var(--colors-primary-blueLighterActive);
-  cursor: progress;
 }
 
 .subUnitListHeader {

--- a/src/App/frontend/src/components/altinnParty.module.css
+++ b/src/App/frontend/src/components/altinnParty.module.css
@@ -11,24 +11,25 @@
   gap: 0.75rem;
 }
 
-.partyWrapper:hover {
+/* Only a selectable row advertises that it can be clicked. Blocked rows
+   (another party's selection is in flight) carry no class of their own:
+   without the selectable class they simply have no hover affordance. */
+.partyWrapperSelectable:hover {
   background-color: var(--colors-primary-blueLight);
   cursor: pointer;
 }
 
-.partyWrapperSelected,
-.partyWrapperSelected:hover {
+.partyWrapperSelected {
   /* Pressed-button look while the selection request is in flight: one step
      darker than :hover. Applied to the clickable row rather than the paper,
-     so an expanded sub-unit list does not look selected along with it. */
+     so an expanded sub-unit list does not look selected along with it.
+     The progress cursor marks temporary busy — distinct from the permanent
+     not-allowed on no-access parties. */
   background-color: var(--colors-primary-blueLighterActive);
-  /* Temporary busy — distinct from the permanent not-allowed on no-access parties */
   cursor: progress;
 }
 
 .partyWrapperDisabled:hover {
-  /* No-access rows are not clickable: keep the paper's resting background */
-  background-color: var(--colors-primary-blueLighter);
   cursor: not-allowed;
 }
 
@@ -75,13 +76,13 @@
   padding: 0 1.25rem;
 }
 
-.subUnit:hover {
+/* See .partyWrapperSelectable: only selectable rows get the hover affordance */
+.subUnitSelectable:hover {
   background: var(--colors-primary-blueLight);
   cursor: pointer;
 }
 
-.subUnitSelected,
-.subUnitSelected:hover {
+.subUnitSelected {
   /* Pressed-button look while the selection request is in flight: one step
      darker than :hover (which is active at the moment of clicking). */
   background: var(--colors-primary-blueLighterActive);

--- a/src/App/frontend/src/components/altinnParty.module.css
+++ b/src/App/frontend/src/components/altinnParty.module.css
@@ -12,10 +12,23 @@
 }
 
 .partyWrapper:hover {
+  background-color: var(--colors-primary-blueLight);
   cursor: pointer;
 }
 
+.partyWrapperSelected,
+.partyWrapperSelected:hover {
+  /* Pressed-button look while the selection request is in flight: one step
+     darker than :hover. Applied to the clickable row rather than the paper,
+     so an expanded sub-unit list does not look selected along with it. */
+  background-color: var(--colors-primary-blueLighterActive);
+  /* Temporary busy — distinct from the permanent not-allowed on no-access parties */
+  cursor: progress;
+}
+
 .partyWrapperDisabled:hover {
+  /* No-access rows are not clickable: keep the paper's resting background */
+  background-color: var(--colors-primary-blueLighter);
   cursor: not-allowed;
 }
 
@@ -65,6 +78,14 @@
 .subUnit:hover {
   background: var(--colors-primary-blueLight);
   cursor: pointer;
+}
+
+.subUnitSelected,
+.subUnitSelected:hover {
+  /* Pressed-button look while the selection request is in flight: one step
+     darker than :hover (which is active at the moment of clicking). */
+  background: var(--colors-primary-blueLighterActive);
+  cursor: progress;
 }
 
 .subUnitListHeader {

--- a/src/App/frontend/src/components/altinnParty.test.tsx
+++ b/src/App/frontend/src/components/altinnParty.test.tsx
@@ -80,7 +80,7 @@ describe('altinnParty', () => {
     await render({
       showSubUnits: true,
       party: partyWithChildParties,
-      selectedPartyId: partyWithChildParties.partyId,
+      pendingPartyId: partyWithChildParties.partyId,
     });
 
     const wrapper = screen.getByTestId('AltinnParty-PartyWrapper');

--- a/src/App/frontend/src/components/altinnParty.test.tsx
+++ b/src/App/frontend/src/components/altinnParty.test.tsx
@@ -83,11 +83,11 @@ describe('altinnParty', () => {
       pendingPartyId: partyWithChildParties.partyId,
     });
 
-    const wrapper = screen.getByTestId('AltinnParty-PartyWrapper');
+    const wrapper = screen.getByRole('button', { name: /ola privatperson/i });
     expect(wrapper).toHaveAttribute('aria-busy', 'true');
     expect(wrapper).toHaveAttribute('aria-disabled', 'false');
 
-    const subUnit = screen.getByText(/child party 1/i).closest('[role="button"]');
+    const subUnit = screen.getByRole('button', { name: /child party 1/i });
     expect(subUnit).toHaveAttribute('aria-busy', 'false');
     expect(subUnit).toHaveAttribute('aria-disabled', 'true');
   });

--- a/src/App/frontend/src/components/altinnParty.test.tsx
+++ b/src/App/frontend/src/components/altinnParty.test.tsx
@@ -76,65 +76,20 @@ describe('altinnParty', () => {
     });
   });
 
-  describe('selected state', () => {
-    it('should mark the party as selected when selectedPartyId matches', async () => {
-      await render({ selectedPartyId: getPartyMock().partyId });
-
-      const wrapper = screen.getByTestId('AltinnParty-PartyWrapper');
-      expect(wrapper).toHaveAttribute('aria-busy', 'true');
-      expect(wrapper).toHaveAttribute('aria-disabled', 'false');
-      expect(wrapper).toHaveClass('partyWrapperSelected');
+  it('should mark the selected party as busy and block the others', async () => {
+    await render({
+      showSubUnits: true,
+      party: partyWithChildParties,
+      selectedPartyId: partyWithChildParties.partyId,
     });
 
-    it('should mark the party as blocked when another party is selected', async () => {
-      await render({ selectedPartyId: getPartyMock().partyId + 1 });
+    const wrapper = screen.getByTestId('AltinnParty-PartyWrapper');
+    expect(wrapper).toHaveAttribute('aria-busy', 'true');
+    expect(wrapper).toHaveAttribute('aria-disabled', 'false');
 
-      const wrapper = screen.getByTestId('AltinnParty-PartyWrapper');
-      expect(wrapper).toHaveAttribute('aria-busy', 'false');
-      expect(wrapper).toHaveAttribute('aria-disabled', 'true');
-      expect(wrapper).not.toHaveClass('partyWrapperSelected');
-      expect(wrapper).not.toHaveClass('partyWrapperSelectable');
-    });
-
-    it('should be selectable when no selection is in flight', async () => {
-      await render();
-
-      const wrapper = screen.getByTestId('AltinnParty-PartyWrapper');
-      expect(wrapper).toHaveAttribute('aria-busy', 'false');
-      expect(wrapper).toHaveAttribute('aria-disabled', 'false');
-      expect(wrapper).not.toHaveClass('partyWrapperSelected');
-      expect(wrapper).toHaveClass('partyWrapperSelectable');
-    });
-
-    it('should mark the sub-unit as selected when selectedPartyId matches a child party', async () => {
-      await render({
-        showSubUnits: true,
-        party: partyWithChildParties,
-        selectedPartyId: 1,
-      });
-
-      const subUnit = screen.getByText(/child party 1/i).closest('[role="button"]');
-      expect(subUnit).toHaveAttribute('aria-busy', 'true');
-      expect(subUnit).toHaveAttribute('aria-disabled', 'false');
-      expect(subUnit).toHaveClass('subUnitSelected');
-
-      const otherSubUnit = screen.getByText(/child party 2/i).closest('[role="button"]');
-      expect(otherSubUnit).toHaveAttribute('aria-busy', 'false');
-      expect(otherSubUnit).toHaveAttribute('aria-disabled', 'true');
-      expect(otherSubUnit).not.toHaveClass('subUnitSelected');
-      expect(otherSubUnit).not.toHaveClass('subUnitSelectable');
-    });
-
-    it('should never mark a party without access as selected', async () => {
-      const party = { ...getPartyMock(), onlyHierarchyElementWithNoAccess: true };
-      await render({ party, selectedPartyId: party.partyId });
-
-      const wrapper = screen.getByTestId('AltinnParty-PartyWrapper');
-      expect(wrapper).toHaveAttribute('aria-busy', 'false');
-      expect(wrapper).toHaveAttribute('aria-disabled', 'true');
-      expect(wrapper.parentElement).toHaveClass('partyPaperDisabled');
-      expect(wrapper).not.toHaveClass('partyWrapperSelected');
-    });
+    const subUnit = screen.getByText(/child party 1/i).closest('[role="button"]');
+    expect(subUnit).toHaveAttribute('aria-busy', 'false');
+    expect(subUnit).toHaveAttribute('aria-disabled', 'true');
   });
 
   describe('should render with correct icon based on what kind of party it is', () => {

--- a/src/App/frontend/src/components/altinnParty.test.tsx
+++ b/src/App/frontend/src/components/altinnParty.test.tsx
@@ -76,6 +76,50 @@ describe('altinnParty', () => {
     });
   });
 
+  describe('selected state', () => {
+    it('should mark the party as selected when selectedPartyId matches', async () => {
+      await render({ selectedPartyId: getPartyMock().partyId });
+
+      const wrapper = screen.getByTestId('AltinnParty-PartyWrapper');
+      expect(wrapper).toHaveAttribute('aria-busy', 'true');
+      expect(wrapper).toHaveClass('partyWrapperSelected');
+    });
+
+    it('should not mark the party as selected when selectedPartyId does not match', async () => {
+      await render({ selectedPartyId: getPartyMock().partyId + 1 });
+
+      const wrapper = screen.getByTestId('AltinnParty-PartyWrapper');
+      expect(wrapper).toHaveAttribute('aria-busy', 'false');
+      expect(wrapper).not.toHaveClass('partyWrapperSelected');
+    });
+
+    it('should mark the sub-unit as selected when selectedPartyId matches a child party', async () => {
+      await render({
+        showSubUnits: true,
+        party: partyWithChildParties,
+        selectedPartyId: 1,
+      });
+
+      const subUnit = screen.getByText(/child party 1/i).closest('[role="button"]');
+      expect(subUnit).toHaveAttribute('aria-busy', 'true');
+      expect(subUnit).toHaveClass('subUnitSelected');
+
+      const otherSubUnit = screen.getByText(/child party 2/i).closest('[role="button"]');
+      expect(otherSubUnit).toHaveAttribute('aria-busy', 'false');
+      expect(otherSubUnit).not.toHaveClass('subUnitSelected');
+    });
+
+    it('should never mark a party without access as selected', async () => {
+      const party = { ...getPartyMock(), onlyHierarchyElementWithNoAccess: true };
+      await render({ party, selectedPartyId: party.partyId });
+
+      const wrapper = screen.getByTestId('AltinnParty-PartyWrapper');
+      expect(wrapper).toHaveAttribute('aria-busy', 'false');
+      expect(wrapper.parentElement).toHaveClass('partyPaperDisabled');
+      expect(wrapper).not.toHaveClass('partyWrapperSelected');
+    });
+  });
+
   describe('should render with correct icon based on what kind of party it is', () => {
     it('should render with person icon if party is a person', async () => {
       await render();

--- a/src/App/frontend/src/components/altinnParty.test.tsx
+++ b/src/App/frontend/src/components/altinnParty.test.tsx
@@ -82,15 +82,28 @@ describe('altinnParty', () => {
 
       const wrapper = screen.getByTestId('AltinnParty-PartyWrapper');
       expect(wrapper).toHaveAttribute('aria-busy', 'true');
+      expect(wrapper).toHaveAttribute('aria-disabled', 'false');
       expect(wrapper).toHaveClass('partyWrapperSelected');
     });
 
-    it('should not mark the party as selected when selectedPartyId does not match', async () => {
+    it('should mark the party as blocked when another party is selected', async () => {
       await render({ selectedPartyId: getPartyMock().partyId + 1 });
 
       const wrapper = screen.getByTestId('AltinnParty-PartyWrapper');
       expect(wrapper).toHaveAttribute('aria-busy', 'false');
+      expect(wrapper).toHaveAttribute('aria-disabled', 'true');
       expect(wrapper).not.toHaveClass('partyWrapperSelected');
+      expect(wrapper).not.toHaveClass('partyWrapperSelectable');
+    });
+
+    it('should be selectable when no selection is in flight', async () => {
+      await render();
+
+      const wrapper = screen.getByTestId('AltinnParty-PartyWrapper');
+      expect(wrapper).toHaveAttribute('aria-busy', 'false');
+      expect(wrapper).toHaveAttribute('aria-disabled', 'false');
+      expect(wrapper).not.toHaveClass('partyWrapperSelected');
+      expect(wrapper).toHaveClass('partyWrapperSelectable');
     });
 
     it('should mark the sub-unit as selected when selectedPartyId matches a child party', async () => {
@@ -102,11 +115,14 @@ describe('altinnParty', () => {
 
       const subUnit = screen.getByText(/child party 1/i).closest('[role="button"]');
       expect(subUnit).toHaveAttribute('aria-busy', 'true');
+      expect(subUnit).toHaveAttribute('aria-disabled', 'false');
       expect(subUnit).toHaveClass('subUnitSelected');
 
       const otherSubUnit = screen.getByText(/child party 2/i).closest('[role="button"]');
       expect(otherSubUnit).toHaveAttribute('aria-busy', 'false');
+      expect(otherSubUnit).toHaveAttribute('aria-disabled', 'true');
       expect(otherSubUnit).not.toHaveClass('subUnitSelected');
+      expect(otherSubUnit).not.toHaveClass('subUnitSelectable');
     });
 
     it('should never mark a party without access as selected', async () => {
@@ -115,6 +131,7 @@ describe('altinnParty', () => {
 
       const wrapper = screen.getByTestId('AltinnParty-PartyWrapper');
       expect(wrapper).toHaveAttribute('aria-busy', 'false');
+      expect(wrapper).toHaveAttribute('aria-disabled', 'true');
       expect(wrapper.parentElement).toHaveClass('partyPaperDisabled');
       expect(wrapper).not.toHaveClass('partyWrapperSelected');
     });

--- a/src/App/frontend/src/components/altinnParty.tsx
+++ b/src/App/frontend/src/components/altinnParty.tsx
@@ -17,31 +17,27 @@ export interface IAltinnPartyProps {
   party: IParty;
   onSelectParty: (party: IParty) => Promise<void> | void;
   showSubUnits: boolean;
-  selectedPartyId?: number;
+  /** The party selected by user and is currently in flight*/
+  pendingPartyId?: number;
 }
 
-/** State of a party element. 'selectable' means it can be selected, 'noAccess' means the user has no access, 'selected' means it is currently selected, and 'blocked' means another party is selected. */
-export type AltinnPartyState = 'selectable' | 'noAccess' | 'selected' | 'blocked';
+/** Selection state of a party. 'selectable' means it can be selected, 'submitting' means its selection is in flight, and 'blocked' means another party's selection is in flight. */
+type SelectionState = 'selectable' | 'submitting' | 'blocked';
 
-function getPartyState(party: IParty, selectedPartyId: number | undefined): AltinnPartyState {
-  if (party.onlyHierarchyElementWithNoAccess) {
-    return 'noAccess';
-  }
-  if (party.partyId === selectedPartyId) {
-    return 'selected';
-  }
-  if (selectedPartyId !== undefined) {
-    return 'blocked';
+function getSelectionState(party: IParty, pendingPartyId: number | undefined): SelectionState {
+  if (pendingPartyId !== undefined) {
+    return pendingPartyId === party.partyId ? 'submitting' : 'blocked';
   }
   return 'selectable';
 }
 
-export function AltinnParty({ party, onSelectParty, showSubUnits, selectedPartyId }: IAltinnPartyProps) {
+export function AltinnParty({ party, onSelectParty, showSubUnits, pendingPartyId }: IAltinnPartyProps) {
   const { langAsString } = useLanguage();
 
   const [subUnitsExpanded, setSubUnitsExpanded] = React.useState<boolean>(false);
   const isOrg = party.partyTypeName === PartyType.Organization;
-  const partyState = getPartyState(party, selectedPartyId);
+  const noAccess = party.onlyHierarchyElementWithNoAccess;
+  const selectionState = getSelectionState(party, pendingPartyId);
 
   function onClickParty(selectedParty: IParty, event: React.MouseEvent<HTMLDivElement, MouseEvent>) {
     event.stopPropagation();
@@ -113,7 +109,7 @@ export function AltinnParty({ party, onSelectParty, showSubUnits, selectedPartyI
           <SubUnit
             key={childParty.partyId}
             party={childParty}
-            selectedPartyId={selectedPartyId}
+            pendingPartyId={pendingPartyId}
             tabbable={subUnitsExpanded}
             onClick={(event) => onClickParty(childParty, event)}
             onKeyPress={(event) => onKeyPressParty(childParty, event)}
@@ -124,24 +120,24 @@ export function AltinnParty({ party, onSelectParty, showSubUnits, selectedPartyI
   }
 
   return (
-    <div className={partyState === 'noAccess' ? classes.partyPaperDisabled : classes.partyPaper}>
+    <div className={noAccess ? classes.partyPaperDisabled : classes.partyPaper}>
       <Flex
         id={`party-${party.partyId}`}
-        role='button'
+        role={party.onlyHierarchyElementWithNoAccess ? undefined : 'button'}
         data-testid='AltinnParty-PartyWrapper'
         container
         direction='row'
         alignItems='center'
         className={cn(classes.partyWrapper, {
-          [classes.partyWrapperSelectable]: partyState === 'selectable',
-          [classes.partyWrapperDisabled]: partyState === 'noAccess',
-          [classes.partyWrapperSelected]: partyState === 'selected',
+          [classes.partySelectable]: !noAccess && selectionState === 'selectable',
+          [classes.partyWrapperDisabled]: noAccess,
+          [classes.partySubmitting]: selectionState === 'submitting',
         })}
-        onClick={partyState !== 'noAccess' ? (event) => onClickParty(party, event) : undefined}
-        onKeyPress={partyState !== 'noAccess' ? (event) => onKeyPressParty(party, event) : undefined}
-        tabIndex={partyState !== 'noAccess' ? 0 : undefined}
-        aria-busy={partyState === 'selected'}
-        aria-disabled={partyState === 'noAccess' || partyState === 'blocked'}
+        onClick={!party.onlyHierarchyElementWithNoAccess ? (event) => onClickParty(party, event) : undefined}
+        onKeyPress={!party.onlyHierarchyElementWithNoAccess ? (event) => onKeyPressParty(party, event) : undefined}
+        tabIndex={!party.onlyHierarchyElementWithNoAccess ? 0 : undefined}
+        aria-busy={selectionState === 'submitting'}
+        aria-disabled={selectionState === 'blocked'}
       >
         {isOrg ? (
           <Buildings3Icon
@@ -172,14 +168,14 @@ export function AltinnParty({ party, onSelectParty, showSubUnits, selectedPartyI
 
 interface ISubUnitProps {
   party: IParty;
-  selectedPartyId: number | undefined;
+  pendingPartyId: number | undefined;
   tabbable: boolean;
   onClick: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
   onKeyPress: (event: React.KeyboardEvent) => void;
 }
 
-function SubUnit({ party, selectedPartyId, tabbable, onClick, onKeyPress }: ISubUnitProps) {
-  const partyState = getPartyState(party, selectedPartyId);
+function SubUnit({ party, pendingPartyId, tabbable, onClick, onKeyPress }: ISubUnitProps) {
+  const selectionState = getSelectionState(party, pendingPartyId);
 
   return (
     <Flex
@@ -191,16 +187,16 @@ function SubUnit({ party, selectedPartyId, tabbable, onClick, onKeyPress }: ISub
       <Flex
         role='button'
         className={cn(classes.subUnit, {
-          [classes.subUnitSelectable]: partyState === 'selectable',
-          [classes.subUnitSelected]: partyState === 'selected',
+          [classes.partySelectable]: selectionState === 'selectable',
+          [classes.partySubmitting]: selectionState === 'submitting',
         })}
         container
         direction='column'
         onClick={onClick}
         onKeyPress={onKeyPress}
         tabIndex={tabbable ? 0 : undefined}
-        aria-busy={partyState === 'selected'}
-        aria-disabled={partyState === 'noAccess' || partyState === 'blocked'}
+        aria-busy={selectionState === 'submitting'}
+        aria-disabled={selectionState === 'blocked'}
       >
         <Flex
           container

--- a/src/App/frontend/src/components/altinnParty.tsx
+++ b/src/App/frontend/src/components/altinnParty.tsx
@@ -36,7 +36,6 @@ export function AltinnParty({ party, onSelectParty, showSubUnits, pendingPartyId
 
   const [subUnitsExpanded, setSubUnitsExpanded] = React.useState<boolean>(false);
   const isOrg = party.partyTypeName === PartyType.Organization;
-  const noAccess = party.onlyHierarchyElementWithNoAccess;
   const selectionState = getSelectionState(party, pendingPartyId);
 
   function onClickParty(selectedParty: IParty, event: React.MouseEvent<HTMLDivElement, MouseEvent>) {
@@ -120,7 +119,7 @@ export function AltinnParty({ party, onSelectParty, showSubUnits, pendingPartyId
   }
 
   return (
-    <div className={noAccess ? classes.partyPaperDisabled : classes.partyPaper}>
+    <div className={party.onlyHierarchyElementWithNoAccess ? classes.partyPaperDisabled : classes.partyPaper}>
       <Flex
         id={`party-${party.partyId}`}
         role={party.onlyHierarchyElementWithNoAccess ? undefined : 'button'}
@@ -129,8 +128,8 @@ export function AltinnParty({ party, onSelectParty, showSubUnits, pendingPartyId
         direction='row'
         alignItems='center'
         className={cn(classes.partyWrapper, {
-          [classes.partySelectable]: !noAccess && selectionState === 'selectable',
-          [classes.partyWrapperDisabled]: noAccess,
+          [classes.partySelectable]: !party.onlyHierarchyElementWithNoAccess && selectionState === 'selectable',
+          [classes.partyWrapperDisabled]: party.onlyHierarchyElementWithNoAccess,
           [classes.partySubmitting]: selectionState === 'submitting',
         })}
         onClick={!party.onlyHierarchyElementWithNoAccess ? (event) => onClickParty(party, event) : undefined}

--- a/src/App/frontend/src/components/altinnParty.tsx
+++ b/src/App/frontend/src/components/altinnParty.tsx
@@ -20,18 +20,17 @@ export interface IAltinnPartyProps {
   selectedPartyId?: number;
 }
 
+/** State of a party element. 'selectable' means it can be selected, 'noAccess' means the user has no access, 'selected' means it is currently selected, and 'blocked' means another party is selected. */
 export type AltinnPartyState = 'selectable' | 'noAccess' | 'selected' | 'blocked';
 
 function getPartyState(party: IParty, selectedPartyId: number | undefined): AltinnPartyState {
   if (party.onlyHierarchyElementWithNoAccess) {
-    // Takes precedence — a party without access can never be the chosen one
     return 'noAccess';
   }
   if (party.partyId === selectedPartyId) {
     return 'selected';
   }
   if (selectedPartyId !== undefined) {
-    // Another party's selection is in flight — this one cannot be selected right now
     return 'blocked';
   }
   return 'selectable';

--- a/src/App/frontend/src/components/altinnParty.tsx
+++ b/src/App/frontend/src/components/altinnParty.tsx
@@ -49,7 +49,7 @@ export function AltinnParty({ party, onSelectParty, showSubUnits, selectedPartyI
     onSelectParty(selectedParty);
   }
 
-  function onKeyPress(selectedParty: IParty, event: React.KeyboardEvent) {
+  function onKeyPressParty(selectedParty: IParty, event: React.KeyboardEvent) {
     event.stopPropagation();
     if (event.key === 'Enter' || event.key === ' ') {
       onSelectParty(selectedParty);
@@ -110,48 +110,16 @@ export function AltinnParty({ party, onSelectParty, showSubUnits, selectedPartyI
           </Flex>
         }
       >
-        {party.childParties.map((childParty: IParty, index: number) => {
-          const childPartyState = getPartyState(childParty, selectedPartyId);
-          return (
-            <Flex
-              data-testid='AltinnParty-SubUnitWrapper'
-              key={index}
-              container
-              direction='column'
-              className={classes.subUnitWrapper}
-            >
-              <Flex
-                key={index}
-                role='button'
-                className={cn(classes.subUnit, {
-                  [classes.subUnitSelectable]: childPartyState === 'selectable',
-                  [classes.subUnitSelected]: childPartyState === 'selected',
-                })}
-                container
-                direction='column'
-                onClick={onClickParty.bind(null, childParty)}
-                onKeyPress={onKeyPress.bind(null, childParty)}
-                tabIndex={subUnitsExpanded ? 0 : undefined}
-                aria-busy={childPartyState === 'selected'}
-                aria-disabled={childPartyState === 'noAccess' || childPartyState === 'blocked'}
-              >
-                <Flex
-                  container
-                  direction='row'
-                  alignItems='center'
-                  className={classes.subUnitTextWrapper}
-                >
-                  <Paragraph className={classes.partyName}>{childParty.name}</Paragraph>
-                  <Paragraph className={classes.partyInfo}>
-                    &nbsp;
-                    <Lang id='party_selection.unit_org_number' />
-                    &nbsp;{childParty.orgNumber}
-                  </Paragraph>
-                </Flex>
-              </Flex>
-            </Flex>
-          );
-        })}
+        {party.childParties.map((childParty: IParty) => (
+          <SubUnit
+            key={childParty.partyId}
+            party={childParty}
+            selectedPartyId={selectedPartyId}
+            tabbable={subUnitsExpanded}
+            onClick={(event) => onClickParty(childParty, event)}
+            onKeyPress={(event) => onKeyPressParty(childParty, event)}
+          />
+        ))}
       </AltinnCollapsibleList>
     );
   }
@@ -170,8 +138,8 @@ export function AltinnParty({ party, onSelectParty, showSubUnits, selectedPartyI
           [classes.partyWrapperDisabled]: partyState === 'noAccess',
           [classes.partyWrapperSelected]: partyState === 'selected',
         })}
-        onClick={partyState !== 'noAccess' ? onClickParty.bind(null, party) : undefined}
-        onKeyPress={partyState !== 'noAccess' ? onKeyPress.bind(null, party) : undefined}
+        onClick={partyState !== 'noAccess' ? (event) => onClickParty(party, event) : undefined}
+        onKeyPress={partyState !== 'noAccess' ? (event) => onKeyPressParty(party, event) : undefined}
         tabIndex={partyState !== 'noAccess' ? 0 : undefined}
         aria-busy={partyState === 'selected'}
         aria-disabled={partyState === 'noAccess' || partyState === 'blocked'}
@@ -200,5 +168,55 @@ export function AltinnParty({ party, onSelectParty, showSubUnits, selectedPartyI
       </Flex>
       {renderSubunits()}
     </div>
+  );
+}
+
+interface ISubUnitProps {
+  party: IParty;
+  selectedPartyId: number | undefined;
+  tabbable: boolean;
+  onClick: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+  onKeyPress: (event: React.KeyboardEvent) => void;
+}
+
+function SubUnit({ party, selectedPartyId, tabbable, onClick, onKeyPress }: ISubUnitProps) {
+  const partyState = getPartyState(party, selectedPartyId);
+
+  return (
+    <Flex
+      data-testid='AltinnParty-SubUnitWrapper'
+      container
+      direction='column'
+      className={classes.subUnitWrapper}
+    >
+      <Flex
+        role='button'
+        className={cn(classes.subUnit, {
+          [classes.subUnitSelectable]: partyState === 'selectable',
+          [classes.subUnitSelected]: partyState === 'selected',
+        })}
+        container
+        direction='column'
+        onClick={onClick}
+        onKeyPress={onKeyPress}
+        tabIndex={tabbable ? 0 : undefined}
+        aria-busy={partyState === 'selected'}
+        aria-disabled={partyState === 'noAccess' || partyState === 'blocked'}
+      >
+        <Flex
+          container
+          direction='row'
+          alignItems='center'
+          className={classes.subUnitTextWrapper}
+        >
+          <Paragraph className={classes.partyName}>{party.name}</Paragraph>
+          <Paragraph className={classes.partyInfo}>
+            &nbsp;
+            <Lang id='party_selection.unit_org_number' />
+            &nbsp;{party.orgNumber}
+          </Paragraph>
+        </Flex>
+      </Flex>
+    </Flex>
   );
 }

--- a/src/App/frontend/src/components/altinnParty.tsx
+++ b/src/App/frontend/src/components/altinnParty.tsx
@@ -131,6 +131,7 @@ export function AltinnParty({ party, onSelectParty, showSubUnits, pendingPartyId
           [classes.partySelectable]: !party.onlyHierarchyElementWithNoAccess && selectionState === 'selectable',
           [classes.partyWrapperDisabled]: party.onlyHierarchyElementWithNoAccess,
           [classes.partySubmitting]: selectionState === 'submitting',
+          [classes.partyBlocked]: selectionState === 'blocked',
         })}
         onClick={!party.onlyHierarchyElementWithNoAccess ? (event) => onClickParty(party, event) : undefined}
         onKeyPress={!party.onlyHierarchyElementWithNoAccess ? (event) => onKeyPressParty(party, event) : undefined}
@@ -188,6 +189,7 @@ function SubUnit({ party, pendingPartyId, tabbable, onClick, onKeyPress }: ISubU
         className={cn(classes.subUnit, {
           [classes.partySelectable]: selectionState === 'selectable',
           [classes.partySubmitting]: selectionState === 'submitting',
+          [classes.partyBlocked]: selectionState === 'blocked',
         })}
         container
         direction='column'

--- a/src/App/frontend/src/components/altinnParty.tsx
+++ b/src/App/frontend/src/components/altinnParty.tsx
@@ -15,15 +15,27 @@ import type { IParty } from 'src/types/shared';
 
 export interface IAltinnPartyProps {
   party: IParty;
-  onSelectParty: (party: IParty) => void;
+  onSelectParty: (party: IParty) => Promise<void> | void;
   showSubUnits: boolean;
+  selectedPartyId?: number;
 }
 
-export function AltinnParty({ party, onSelectParty, showSubUnits }: IAltinnPartyProps) {
+export type AltinnPartyState = 'selectable' | 'noAccess' | 'selected';
+
+function getPartyState(party: IParty, selectedPartyId: number | undefined): AltinnPartyState {
+  if (party.onlyHierarchyElementWithNoAccess) {
+    // Takes precedence — a party without access can never be the chosen one
+    return 'noAccess';
+  }
+  return party.partyId === selectedPartyId ? 'selected' : 'selectable';
+}
+
+export function AltinnParty({ party, onSelectParty, showSubUnits, selectedPartyId }: IAltinnPartyProps) {
   const { langAsString } = useLanguage();
 
   const [subUnitsExpanded, setSubUnitsExpanded] = React.useState<boolean>(false);
   const isOrg = party.partyTypeName === PartyType.Organization;
+  const partyState = getPartyState(party, selectedPartyId);
 
   function onClickParty(selectedParty: IParty, event: React.MouseEvent<HTMLDivElement, MouseEvent>) {
     event.stopPropagation();
@@ -102,12 +114,15 @@ export function AltinnParty({ party, onSelectParty, showSubUnits }: IAltinnParty
             <Flex
               key={index}
               role='button'
-              className={classes.subUnit}
+              className={cn(classes.subUnit, {
+                [classes.subUnitSelected]: getPartyState(childParty, selectedPartyId) === 'selected',
+              })}
               container
               direction='column'
               onClick={onClickParty.bind(null, childParty)}
               onKeyPress={onKeyPress.bind(null, childParty)}
               tabIndex={subUnitsExpanded ? 0 : undefined}
+              aria-busy={getPartyState(childParty, selectedPartyId) === 'selected'}
             >
               <Flex
                 container
@@ -130,7 +145,7 @@ export function AltinnParty({ party, onSelectParty, showSubUnits }: IAltinnParty
   }
 
   return (
-    <div className={party.onlyHierarchyElementWithNoAccess ? classes.partyPaperDisabled : classes.partyPaper}>
+    <div className={partyState === 'noAccess' ? classes.partyPaperDisabled : classes.partyPaper}>
       <Flex
         id={`party-${party.partyId}`}
         role='button'
@@ -138,10 +153,14 @@ export function AltinnParty({ party, onSelectParty, showSubUnits }: IAltinnParty
         container
         direction='row'
         alignItems='center'
-        className={cn(classes.partyWrapper, { [classes.partyWrapperDisabled]: party.onlyHierarchyElementWithNoAccess })}
-        onClick={!party.onlyHierarchyElementWithNoAccess ? onClickParty.bind(null, party) : undefined}
-        onKeyPress={!party.onlyHierarchyElementWithNoAccess ? onKeyPress.bind(null, party) : undefined}
-        tabIndex={!party.onlyHierarchyElementWithNoAccess ? 0 : undefined}
+        className={cn(classes.partyWrapper, {
+          [classes.partyWrapperDisabled]: partyState === 'noAccess',
+          [classes.partyWrapperSelected]: partyState === 'selected',
+        })}
+        onClick={partyState !== 'noAccess' ? onClickParty.bind(null, party) : undefined}
+        onKeyPress={partyState !== 'noAccess' ? onKeyPress.bind(null, party) : undefined}
+        tabIndex={partyState !== 'noAccess' ? 0 : undefined}
+        aria-busy={partyState === 'selected'}
       >
         {isOrg ? (
           <Buildings3Icon

--- a/src/App/frontend/src/components/altinnParty.tsx
+++ b/src/App/frontend/src/components/altinnParty.tsx
@@ -20,14 +20,21 @@ export interface IAltinnPartyProps {
   selectedPartyId?: number;
 }
 
-export type AltinnPartyState = 'selectable' | 'noAccess' | 'selected';
+export type AltinnPartyState = 'selectable' | 'noAccess' | 'selected' | 'blocked';
 
 function getPartyState(party: IParty, selectedPartyId: number | undefined): AltinnPartyState {
   if (party.onlyHierarchyElementWithNoAccess) {
     // Takes precedence — a party without access can never be the chosen one
     return 'noAccess';
   }
-  return party.partyId === selectedPartyId ? 'selected' : 'selectable';
+  if (party.partyId === selectedPartyId) {
+    return 'selected';
+  }
+  if (selectedPartyId !== undefined) {
+    // Another party's selection is in flight — this one cannot be selected right now
+    return 'blocked';
+  }
+  return 'selectable';
 }
 
 export function AltinnParty({ party, onSelectParty, showSubUnits, selectedPartyId }: IAltinnPartyProps) {
@@ -103,43 +110,48 @@ export function AltinnParty({ party, onSelectParty, showSubUnits, selectedPartyI
           </Flex>
         }
       >
-        {party.childParties.map((childParty: IParty, index: number) => (
-          <Flex
-            data-testid='AltinnParty-SubUnitWrapper'
-            key={index}
-            container
-            direction='column'
-            className={classes.subUnitWrapper}
-          >
+        {party.childParties.map((childParty: IParty, index: number) => {
+          const childPartyState = getPartyState(childParty, selectedPartyId);
+          return (
             <Flex
+              data-testid='AltinnParty-SubUnitWrapper'
               key={index}
-              role='button'
-              className={cn(classes.subUnit, {
-                [classes.subUnitSelected]: getPartyState(childParty, selectedPartyId) === 'selected',
-              })}
               container
               direction='column'
-              onClick={onClickParty.bind(null, childParty)}
-              onKeyPress={onKeyPress.bind(null, childParty)}
-              tabIndex={subUnitsExpanded ? 0 : undefined}
-              aria-busy={getPartyState(childParty, selectedPartyId) === 'selected'}
+              className={classes.subUnitWrapper}
             >
               <Flex
+                key={index}
+                role='button'
+                className={cn(classes.subUnit, {
+                  [classes.subUnitSelectable]: childPartyState === 'selectable',
+                  [classes.subUnitSelected]: childPartyState === 'selected',
+                })}
                 container
-                direction='row'
-                alignItems='center'
-                className={classes.subUnitTextWrapper}
+                direction='column'
+                onClick={onClickParty.bind(null, childParty)}
+                onKeyPress={onKeyPress.bind(null, childParty)}
+                tabIndex={subUnitsExpanded ? 0 : undefined}
+                aria-busy={childPartyState === 'selected'}
+                aria-disabled={childPartyState === 'noAccess' || childPartyState === 'blocked'}
               >
-                <Paragraph className={classes.partyName}>{childParty.name}</Paragraph>
-                <Paragraph className={classes.partyInfo}>
-                  &nbsp;
-                  <Lang id='party_selection.unit_org_number' />
-                  &nbsp;{childParty.orgNumber}
-                </Paragraph>
+                <Flex
+                  container
+                  direction='row'
+                  alignItems='center'
+                  className={classes.subUnitTextWrapper}
+                >
+                  <Paragraph className={classes.partyName}>{childParty.name}</Paragraph>
+                  <Paragraph className={classes.partyInfo}>
+                    &nbsp;
+                    <Lang id='party_selection.unit_org_number' />
+                    &nbsp;{childParty.orgNumber}
+                  </Paragraph>
+                </Flex>
               </Flex>
             </Flex>
-          </Flex>
-        ))}
+          );
+        })}
       </AltinnCollapsibleList>
     );
   }
@@ -154,6 +166,7 @@ export function AltinnParty({ party, onSelectParty, showSubUnits, selectedPartyI
         direction='row'
         alignItems='center'
         className={cn(classes.partyWrapper, {
+          [classes.partyWrapperSelectable]: partyState === 'selectable',
           [classes.partyWrapperDisabled]: partyState === 'noAccess',
           [classes.partyWrapperSelected]: partyState === 'selected',
         })}
@@ -161,6 +174,7 @@ export function AltinnParty({ party, onSelectParty, showSubUnits, selectedPartyI
         onKeyPress={partyState !== 'noAccess' ? onKeyPress.bind(null, party) : undefined}
         tabIndex={partyState !== 'noAccess' ? 0 : undefined}
         aria-busy={partyState === 'selected'}
+        aria-disabled={partyState === 'noAccess' || partyState === 'blocked'}
       >
         {isOrg ? (
           <Buildings3Icon

--- a/src/App/frontend/src/features/instantiate/containers/PartySelection.test.tsx
+++ b/src/App/frontend/src/features/instantiate/containers/PartySelection.test.tsx
@@ -196,47 +196,21 @@ describe('PartySelection', () => {
     );
 
     it('should ignore further clicks while a selection is in flight', async () => {
-      let resolveMutation: (value: 'Party successfully updated') => void = () => {};
-      const setSelectedPartyMock = vi.fn(
-        () =>
-          new Promise<'Party successfully updated'>((resolve) => {
-            resolveMutation = resolve;
-          }),
-      );
-      const twoParties = [
-        getPartyMock({ ssn: '010175*****', partyId: 12346, name: 'Kari Nordmann' }),
-        getPartyMock({ ssn: '030375*****', partyId: 12348, name: 'Per Nordmann' }),
-      ];
+      const setSelectedPartyMock = vi.fn<PartyApi['setSelectedParty']>(() => new Promise(() => {}));
       const user = userEvent.setup({ delay: null });
-      await render(twoParties, setSelectedPartyMock);
+      await render(
+        [
+          getPartyMock({ ssn: '010175*****', partyId: 12346, name: 'Kari Nordmann' }),
+          getPartyMock({ ssn: '030375*****', partyId: 12348, name: 'Per Nordmann' }),
+        ],
+        setSelectedPartyMock,
+      );
 
-      await user.click(screen.getByRole('button', { name: /^Kari Nordmann/ }));
       await user.click(screen.getByRole('button', { name: /^Kari Nordmann/ }));
       await user.click(screen.getByRole('button', { name: /^Per Nordmann/ }));
 
       expect(setSelectedPartyMock).toHaveBeenCalledTimes(1);
       expect(setSelectedPartyMock).toHaveBeenCalledWith({ partyId: 12346 });
-
-      resolveMutation('Party successfully updated');
-      await waitFor(() => expect(screen.getByTestId('current-party')).toHaveTextContent('12346'));
-    });
-
-    it('should allow selecting again when the backend rejects the selection', async () => {
-      const setSelectedPartyMock = vi
-        .fn<PartyApi['setSelectedParty']>()
-        .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce('Party successfully updated');
-      const user = userEvent.setup({ delay: null });
-      await render([getPartyMock({ ssn: '010175*****', partyId: 12346, name: 'Kari Nordmann' })], setSelectedPartyMock);
-
-      await user.click(screen.getByRole('button', { name: /^Kari Nordmann/ }));
-      await waitFor(() => expect(setSelectedPartyMock).toHaveBeenCalledTimes(1));
-      expect(screen.getByTestId('valid-party')).toHaveTextContent('false');
-
-      await user.click(screen.getByRole('button', { name: /^Kari Nordmann/ }));
-      await waitFor(() => expect(setSelectedPartyMock).toHaveBeenCalledTimes(2));
-      await waitFor(() => expect(screen.getByTestId('current-party')).toHaveTextContent('12346'));
-      await waitFor(() => expect(screen.getByTestId('valid-party')).toHaveTextContent('true'));
     });
   });
 });

--- a/src/App/frontend/src/features/instantiate/containers/PartySelection.test.tsx
+++ b/src/App/frontend/src/features/instantiate/containers/PartySelection.test.tsx
@@ -194,5 +194,49 @@ describe('PartySelection', () => {
         await waitFor(() => expect(screen.getByTestId('valid-party')).toHaveTextContent('true'));
       },
     );
+
+    it('should ignore further clicks while a selection is in flight', async () => {
+      let resolveMutation: (value: 'Party successfully updated') => void = () => {};
+      const setSelectedPartyMock = vi.fn(
+        () =>
+          new Promise<'Party successfully updated'>((resolve) => {
+            resolveMutation = resolve;
+          }),
+      );
+      const twoParties = [
+        getPartyMock({ ssn: '010175*****', partyId: 12346, name: 'Kari Nordmann' }),
+        getPartyMock({ ssn: '030375*****', partyId: 12348, name: 'Per Nordmann' }),
+      ];
+      const user = userEvent.setup({ delay: null });
+      await render(twoParties, setSelectedPartyMock);
+
+      await user.click(screen.getByRole('button', { name: /^Kari Nordmann/ }));
+      await user.click(screen.getByRole('button', { name: /^Kari Nordmann/ }));
+      await user.click(screen.getByRole('button', { name: /^Per Nordmann/ }));
+
+      expect(setSelectedPartyMock).toHaveBeenCalledTimes(1);
+      expect(setSelectedPartyMock).toHaveBeenCalledWith({ partyId: 12346 });
+
+      resolveMutation('Party successfully updated');
+      await waitFor(() => expect(screen.getByTestId('current-party')).toHaveTextContent('12346'));
+    });
+
+    it('should allow selecting again when the backend rejects the selection', async () => {
+      const setSelectedPartyMock = vi
+        .fn<PartyApi['setSelectedParty']>()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce('Party successfully updated');
+      const user = userEvent.setup({ delay: null });
+      await render([getPartyMock({ ssn: '010175*****', partyId: 12346, name: 'Kari Nordmann' })], setSelectedPartyMock);
+
+      await user.click(screen.getByRole('button', { name: /^Kari Nordmann/ }));
+      await waitFor(() => expect(setSelectedPartyMock).toHaveBeenCalledTimes(1));
+      expect(screen.getByTestId('valid-party')).toHaveTextContent('false');
+
+      await user.click(screen.getByRole('button', { name: /^Kari Nordmann/ }));
+      await waitFor(() => expect(setSelectedPartyMock).toHaveBeenCalledTimes(2));
+      await waitFor(() => expect(screen.getByTestId('current-party')).toHaveTextContent('12346'));
+      await waitFor(() => expect(screen.getByTestId('valid-party')).toHaveTextContent('true'));
+    });
   });
 });

--- a/src/App/frontend/src/features/instantiate/containers/PartySelection.tsx
+++ b/src/App/frontend/src/features/instantiate/containers/PartySelection.tsx
@@ -63,10 +63,7 @@ export const PartySelection = () => {
 
   const onSelectParty = (party: IParty) =>
     performProcess(party.partyId, async () => {
-      const result = await selectParty(party);
-      if (!result) {
-        return;
-      }
+      await selectParty(party);
       setUserHasSelectedParty(true);
       // await navigation, including running loaders, keeping the pressed state and the click guard active until the page swaps.
       await navigate('/');

--- a/src/App/frontend/src/features/instantiate/containers/PartySelection.tsx
+++ b/src/App/frontend/src/features/instantiate/containers/PartySelection.tsx
@@ -58,8 +58,6 @@ export const PartySelection = () => {
   const appOwner = useAppOwner();
 
   // The processing mutation guards against a second selection while one is in flight
-  // (clicks on any party are ignored until it settles), and its process key drives the
-  // pressed state on the clicked party.
   const performProcess = useProcessingMutationWithKey<string>('select-party');
   const processingPartyId = useCurrentProcessKey('select-party');
   const selectedPartyId = processingPartyId !== null ? Number(processingPartyId) : undefined;
@@ -68,14 +66,10 @@ export const PartySelection = () => {
     performProcess(String(party.partyId), async () => {
       const result = await selectParty(party);
       if (!result) {
-        // selectParty resolves to undefined when the backend did not accept the change
-        // (real errors unmount this page via DisplayError in the provider). Returning
-        // settles the mutation, clearing the pressed state and re-enabling selection.
         return;
       }
       setUserHasSelectedParty(true);
-      // In the data router this resolves when the "/" route has finished loading,
-      // keeping the pressed state and the click guard active until the page swaps.
+      // await navigation, including running loaders, keeping the pressed state and the click guard active until the page swaps.
       await navigate('/');
     });
 

--- a/src/App/frontend/src/features/instantiate/containers/PartySelection.tsx
+++ b/src/App/frontend/src/features/instantiate/containers/PartySelection.tsx
@@ -58,12 +58,11 @@ export const PartySelection = () => {
   const appOwner = useAppOwner();
 
   // The processing mutation guards against a second selection while one is in flight
-  const performProcess = useProcessingMutationWithKey<string>('select-party');
-  const processingPartyId = useCurrentProcessKey('select-party');
-  const selectedPartyId = processingPartyId !== null ? Number(processingPartyId) : undefined;
+  const performProcess = useProcessingMutationWithKey<number>('select-party');
+  const pendingPartyId = useCurrentProcessKey<number>('select-party') ?? undefined;
 
   const onSelectParty = (party: IParty) =>
-    performProcess(String(party.partyId), async () => {
+    performProcess(party.partyId, async () => {
       const result = await selectParty(party);
       if (!result) {
         return;
@@ -95,7 +94,7 @@ export const PartySelection = () => {
             party={party}
             onSelectParty={onSelectParty}
             showSubUnits={showSubUnits}
-            selectedPartyId={selectedPartyId}
+            pendingPartyId={pendingPartyId}
           />
         ))}
         {hasMoreParties ? (

--- a/src/App/frontend/src/features/instantiate/containers/PartySelection.tsx
+++ b/src/App/frontend/src/features/instantiate/containers/PartySelection.tsx
@@ -51,13 +51,25 @@ export const PartySelection = () => {
   const [numberOfPartiesShown, setNumberOfPartiesShown] = React.useState(4);
   const [showSubUnits, setShowSubUnits] = React.useState(true);
   const [showDeleted, setShowDeleted] = React.useState(defaultShowDeleted);
+  const [selectedPartyId, setSelectedPartyId] = React.useState<number | undefined>(undefined);
   const navigate = useNavigate();
 
   const appName = useAppName();
   const appOwner = useAppOwner();
 
   const onSelectParty = async (party: IParty) => {
-    await selectParty(party);
+    if (selectedPartyId !== undefined) {
+      // A selection is already in flight — ignore clicks on any party until it completes
+      return;
+    }
+    setSelectedPartyId(party.partyId);
+    const result = await selectParty(party);
+    if (!result) {
+      // selectParty resolves to undefined when the backend did not accept the change
+      // (real errors unmount this page via DisplayError in the provider)
+      setSelectedPartyId(undefined);
+      return;
+    }
     setUserHasSelectedParty(true);
     navigate('/');
   };
@@ -84,6 +96,7 @@ export const PartySelection = () => {
             party={party}
             onSelectParty={onSelectParty}
             showSubUnits={showSubUnits}
+            selectedPartyId={selectedPartyId}
           />
         ))}
         {hasMoreParties ? (

--- a/src/App/frontend/src/features/instantiate/containers/PartySelection.tsx
+++ b/src/App/frontend/src/features/instantiate/containers/PartySelection.tsx
@@ -19,6 +19,7 @@ import {
   useSetHasSelectedParty,
   useSetSelectedParty,
 } from 'src/features/party/PartiesProvider';
+import { useCurrentProcessKey, useProcessingMutationWithKey } from 'src/hooks/useProcessingMutation';
 import { AltinnPalette } from 'src/theme/altinnAppTheme';
 import { changeBodyBackground } from 'src/utils/bodyStyling';
 import { getPageTitle } from 'src/utils/getPageTitle';
@@ -51,28 +52,32 @@ export const PartySelection = () => {
   const [numberOfPartiesShown, setNumberOfPartiesShown] = React.useState(4);
   const [showSubUnits, setShowSubUnits] = React.useState(true);
   const [showDeleted, setShowDeleted] = React.useState(defaultShowDeleted);
-  const [selectedPartyId, setSelectedPartyId] = React.useState<number | undefined>(undefined);
   const navigate = useNavigate();
 
   const appName = useAppName();
   const appOwner = useAppOwner();
 
-  const onSelectParty = async (party: IParty) => {
-    if (selectedPartyId !== undefined) {
-      // A selection is already in flight — ignore clicks on any party until it completes
-      return;
-    }
-    setSelectedPartyId(party.partyId);
-    const result = await selectParty(party);
-    if (!result) {
-      // selectParty resolves to undefined when the backend did not accept the change
-      // (real errors unmount this page via DisplayError in the provider)
-      setSelectedPartyId(undefined);
-      return;
-    }
-    setUserHasSelectedParty(true);
-    navigate('/');
-  };
+  // The processing mutation guards against a second selection while one is in flight
+  // (clicks on any party are ignored until it settles), and its process key drives the
+  // pressed state on the clicked party.
+  const performProcess = useProcessingMutationWithKey<string>('select-party');
+  const processingPartyId = useCurrentProcessKey('select-party');
+  const selectedPartyId = processingPartyId !== null ? Number(processingPartyId) : undefined;
+
+  const onSelectParty = (party: IParty) =>
+    performProcess(String(party.partyId), async () => {
+      const result = await selectParty(party);
+      if (!result) {
+        // selectParty resolves to undefined when the backend did not accept the change
+        // (real errors unmount this page via DisplayError in the provider). Returning
+        // settles the mutation, clearing the pressed state and re-enabling selection.
+        return;
+      }
+      setUserHasSelectedParty(true);
+      // In the data router this resolves when the "/" route has finished loading,
+      // keeping the pressed state and the click guard active until the page swaps.
+      await navigate('/');
+    });
 
   const numberFilterString = filterString.replace(/\s+/g, '');
   const hasNumberFilter = numberFilterString.length > 0 && numberFilterString.match(/^\d+$/);

--- a/src/App/frontend/src/features/instantiate/selection/InstanceSelection.tsx
+++ b/src/App/frontend/src/features/instantiate/selection/InstanceSelection.tsx
@@ -264,7 +264,7 @@ function InstanceSelection({ instances: _instances }: { instances: ISimpleInstan
                     if (data) {
                       const { instanceOwnerPartyId, instanceGuid } = parseInstanceId(data.id);
                       const url = buildInstanceUrl(instanceOwnerPartyId, instanceGuid);
-                      navigate(url);
+                      await navigate(url);
                     }
                   }
                 })

--- a/src/App/frontend/src/hooks/useProcessingMutation.ts
+++ b/src/App/frontend/src/hooks/useProcessingMutation.ts
@@ -18,13 +18,18 @@ export type MutationKey =
   'instantiation' | 'exit-subform' | 'add-subform' | 'custom-action' | 'navigate-page' | 'select-party';
 
 /**
+ * Identifies which specific action within a mutation key is running.
+ */
+type ProcessKey = string | number;
+
+/**
  * Process keys for 'navigate-page' mutations.
  * Can be a specific action or a dynamic page ID string.
  */
 export type NavigatePageProcessKey = 'next' | 'previous' | 'backToSummary' | 'backToPage' | string;
 
 type PerformProcessFn = (callback: () => Promise<unknown>) => Promise<void>;
-type PerformProcessWithKeyFn<T extends string> = (processKey: T, callback: () => Promise<unknown>) => Promise<void>;
+type PerformProcessWithKeyFn<T extends ProcessKey> = (processKey: T, callback: () => Promise<unknown>) => Promise<void>;
 
 function getFullMutationKey(mutationKey: MutationKey) {
   return [...PROCESSING_MUTATION_KEY, mutationKey] as const;
@@ -36,7 +41,7 @@ function getFullMutationKey(mutationKey: MutationKey) {
  *
  * @param mutationKey - Groups related mutations together for `useIsThisProcessing` checks.
  */
-export function useProcessingMutationWithKey<TProcessKey extends string>(
+export function useProcessingMutationWithKey<TProcessKey extends ProcessKey>(
   mutationKey: MutationKey,
 ): PerformProcessWithKeyFn<TProcessKey> {
   const queryClient = useQueryClient();
@@ -68,7 +73,7 @@ export function useProcessingMutationWithKey<TProcessKey extends string>(
  * @param mutationKey - Groups related mutations together for `useIsThisProcessing` checks.
  */
 export function useProcessingMutation(mutationKey: MutationKey): PerformProcessFn {
-  const performProcess = useProcessingMutationWithKey(mutationKey);
+  const performProcess = useProcessingMutationWithKey<string>(mutationKey);
   return useCallback((callback: () => Promise<unknown>) => performProcess('', callback), [performProcess]);
 }
 
@@ -101,7 +106,7 @@ export function useIsAnyProcessing(): boolean {
  * Returns the process key of the currently running mutation with the given mutation key.
  * Useful for showing a spinner on the specific button that triggered the action.
  */
-export function useCurrentProcessKey<TProcessKey extends string = string>(
+export function useCurrentProcessKey<TProcessKey extends ProcessKey = string>(
   mutationKey: MutationKey,
 ): TProcessKey | null {
   const variables = useMutationState({

--- a/src/App/frontend/src/hooks/useProcessingMutation.ts
+++ b/src/App/frontend/src/hooks/useProcessingMutation.ts
@@ -12,9 +12,7 @@ const PROCESSING_MUTATION_KEY = ['processing'] as const;
  * - 'subform': Adding subform entries
  * - 'custom-action': Custom button actions
  * - 'navigate-page': All page navigation (NavigationBar, NavigationButtons, Page, PageGroup)
- * - 'select-party': Selecting the party to represent (PartySelection). Spans the whole gesture:
- *   the selection request plus the awaited navigation to "/", whose loader may create an instance
- *   directly (never via the 'instantiation' key, which is only used by click handlers on later pages).
+ * - 'select-party': Selecting the party, including the automatic creation of an instance if needed.
  */
 export type MutationKey =
   'instantiation' | 'exit-subform' | 'add-subform' | 'custom-action' | 'navigate-page' | 'select-party';

--- a/src/App/frontend/src/hooks/useProcessingMutation.ts
+++ b/src/App/frontend/src/hooks/useProcessingMutation.ts
@@ -12,8 +12,12 @@ const PROCESSING_MUTATION_KEY = ['processing'] as const;
  * - 'subform': Adding subform entries
  * - 'custom-action': Custom button actions
  * - 'navigate-page': All page navigation (NavigationBar, NavigationButtons, Page, PageGroup)
+ * - 'select-party': Selecting the party to represent (PartySelection). Spans the whole gesture:
+ *   the selection request plus the awaited navigation to "/", whose loader may create an instance
+ *   directly (never via the 'instantiation' key, which is only used by click handlers on later pages).
  */
-export type MutationKey = 'instantiation' | 'exit-subform' | 'add-subform' | 'custom-action' | 'navigate-page';
+export type MutationKey =
+  'instantiation' | 'exit-subform' | 'add-subform' | 'custom-action' | 'navigate-page' | 'select-party';
 
 /**
  * Process keys for 'navigate-page' mutations.

--- a/src/App/frontend/src/layout/InstantiationButton/InstantiationButton.tsx
+++ b/src/App/frontend/src/layout/InstantiationButton/InstantiationButton.tsx
@@ -58,7 +58,7 @@ export const InstantiationButton = ({
             if (data) {
               const { instanceOwnerPartyId, instanceGuid } = parseInstanceId(data.id);
               const url = buildInstanceUrl(instanceOwnerPartyId, instanceGuid);
-              navigate(url);
+              await navigate(url);
             }
           })
         }

--- a/src/App/frontend/src/theme/altinnAppTheme.tsx
+++ b/src/App/frontend/src/theme/altinnAppTheme.tsx
@@ -8,6 +8,7 @@ export const AltinnPalette = {
   blueHover: '#37b7f8',
   blueLight: '#CFF0FF',
   blueLighter: '#E3F7FF',
+  blueLighterActive: '#ACE3FD',
   green: '#12AA64',
   greenHover: '#45D489',
   greenLight: '#D4F9E4',

--- a/src/common/ts/form-component/src/styles/global.css
+++ b/src/common/ts/form-component/src/styles/global.css
@@ -18,6 +18,7 @@
   --colors-primary-blueHover: #37b7f8;
   --colors-primary-blueLight: #cff0ff;
   --colors-primary-blueLighter: #e3f7ff;
+  --colors-primary-blueLighterActive: #ace3fd;
   --colors-primary-green: #12aa64;
   --colors-primary-greenHover: #45d489;
   --colors-primary-greenLight: #d4f9e4;


### PR DESCRIPTION
Give selected party a active styling color, and prohibit other parties to be selected while request is in progress.

Before : 

https://github.com/user-attachments/assets/32505ac4-7790-429a-862f-9a1cccc0ba6b

After : 

https://github.com/user-attachments/assets/88127d3d-adeb-4d9e-bb4d-035fb9144764

## Description

Picking a party creates an instance before the page can change. On a slow backend that took several
seconds with nothing happening on screen, so users clicked again, on the same party or another one,
and started a second instantiation.

### Fixing the issue 

**Only one selection at a time.** A selection now takes a lock while it runs. Further clicks, on any
party or sub-unit, are ignored until it finishes and the page has changed. No more duplicate instances.

**The selected party shows that it is working.** It gets a darker background and a `progress` cursor,
while the other parties get a `not-allowed` cursor. Screen readers get the same information through
`aria-busy` on the pending party and `aria-disabled` on the rest.
We did not have a color in the pallette that was darker than the hover state, so I introduced a new color  --colors-primary-blueLighterActive. It follows similar naming convention such as --colors-primary-greenHover. Alternatives to new color was a dark transparent overlay or using color-mix do darken colors-primary-blueLighter

Navigation after a successful selection is awaited, including its loaders, so the pressed state and
the lock stay active until the new page is rendered.

### Also fixed

**Consistent hover styling.** Sub-units had a background highlight on hover, top-level parties only a
pointer cursor. Both now use the same style. Parties the user has no access to no longer get a button
role or hover cursor, since they cannot be clicked.

Sub-unit markup was extracted into a `SubUnit` component, keyed by party id instead of array index.

### Why `useProcessingMutation` instead of `useState`
To block the user from selecting a new party (or the same again) while the app is working,  we use : 
```tsx
const performProcess = useProcessingMutationWithKey<number>('select-party');
const pendingPartyId = useCurrentProcessKey<number>('select-party') ?? undefined;
```

This could be solved by a simple react useState. I can revert to a solution like that if the reviewer thinks the current solution is overkill. I think it would give use the same benefits, but if we later allow the user to select party from the header, it can be good to have this in a state that is available fro the rest of the application.
We already use this mechanism for instantiation, page navigation, custom actions and sub-forms.
Anything using useIsAnyProcessing, such as navigation, custom and instantiation buttons, knows a party selection is running, and vice versa.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
