### PR TITLE
fix: workflow engine cold-start latency and readiness gating

### DIFF
--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/WorkflowEngineService.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/WorkflowEngineService.cs
@@ -18,10 +18,17 @@ namespace Altinn.App.Core.Internal.WorkflowEngine;
 
 internal sealed class WorkflowEngineService : IWorkflowEngineService
 {
-    // A transition is only observed at a rung of this ladder, so the cap bounds how long the wait
-    // adds to a settled transition. Do not raise it without measuring.
-    private const int InitialWorkflowPollingDelayMs = 25;
-    private const int MaxWorkflowPollingDelayMs = 100;
+    // A transition is only observed at a rung of this ladder, so the ladder decides both how long the
+    // wait adds to a settled transition and how many collection reads a slow one costs. Poll tightly
+    // for as long as a synchronous completion is still plausible - the same window as the parked
+    // release grace below - then slope off to the 2s cap, which bounds what a genuinely slow
+    // transition costs. Doubling from 100ms was the old shape, and its rungs (100/300/700/1500)
+    // overshot a ~115ms transition by ~190ms; a permanently tight ladder is the opposite mistake,
+    // turning a slow transition into a thousand reads. Change none of these without measuring both.
+    private const int InitialWorkflowPollingDelayMs = 50;
+    private const int WorkflowPollingTightWindowMs = 2_000;
+    private const int WorkflowPollingBackoffPercent = 50;
+    private const int MaxWorkflowPollingDelayMs = 2_000;
     private const int AcceptanceProbeAttempts = 3;
 
     // Not the polling delay above: this grace lets the engine's write buffer make the collection
@@ -590,7 +597,13 @@ internal sealed class WorkflowEngineService : IWorkflowEngineService
             }
 
             await Task.Delay(currentDelayMs, ct);
-            currentDelayMs = Math.Min(currentDelayMs * 2, MaxWorkflowPollingDelayMs);
+            currentDelayMs =
+                stopwatch.ElapsedMilliseconds < WorkflowPollingTightWindowMs
+                    ? InitialWorkflowPollingDelayMs
+                    : Math.Min(
+                        currentDelayMs + (currentDelayMs * WorkflowPollingBackoffPercent / 100),
+                        MaxWorkflowPollingDelayMs
+                    );
         }
 
         ct.ThrowIfCancellationRequested();

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/WorkflowEngineService.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/WorkflowEngineService.cs
@@ -18,9 +18,30 @@ namespace Altinn.App.Core.Internal.WorkflowEngine;
 
 internal sealed class WorkflowEngineService : IWorkflowEngineService
 {
-    private const int InitialWorkflowPollingDelayMs = 100;
-    private const int MaxWorkflowPollingDelayMs = 2_000;
+    // A transition is only *observed* at a rung of the ladder these two constants define, so the poll
+    // schedule -- not the engine -- decides most of what a user experiences as "starting the form".
+    // At 100ms doubling to 2s the rungs sat at 0/100/300/700ms while a warm transition took ~115ms,
+    // which put nearly every transition on the 300ms rung and made a 10ms difference in engine time
+    // swing the response between ~145ms and ~350ms.
+    //
+    // 25ms capped at 100ms puts the rungs at 0/25/75/175/275/375..., so the observation lag stays
+    // bounded by 100ms across the whole plausible range of transition times. Measured over 20
+    // instantiations each, same engine build: median 279ms -> 235ms, worst case 382ms -> 285ms, and
+    // the spread collapses from 243ms to 70ms. A denser ladder (10ms capped at 50ms) lowered the
+    // median another ~34ms but raised the engine's own per-transition time ~18% with the extra
+    // collection reads -- not a trade worth making at production volume.
+    //
+    // Polling remains a stopgap: the engine already signals status changes internally, so a long-poll
+    // or completion callback on the collection endpoint would remove the lag rather than bound it.
+    private const int InitialWorkflowPollingDelayMs = 25;
+    private const int MaxWorkflowPollingDelayMs = 100;
     private const int AcceptanceProbeAttempts = 3;
+
+    // Deliberately not the polling delay above: this probe decides whether an enqueue whose outcome
+    // is unknown actually landed, so it must give the engine's write buffer time to make the
+    // collection visible before it concludes "not accepted". Tightening the poll ladder must not
+    // shorten that grace.
+    private const int AcceptanceProbeDelayMs = 100;
 
     // Mutable so tests can shrink the windows; production always runs the defaults.
     internal int WorkflowPollingTimeoutMs = 100_000;
@@ -463,7 +484,7 @@ internal sealed class WorkflowEngineService : IWorkflowEngineService
 
             if (attempt < AcceptanceProbeAttempts - 1)
             {
-                await Task.Delay(InitialWorkflowPollingDelayMs, ct);
+                await Task.Delay(AcceptanceProbeDelayMs, ct);
             }
         }
 

--- a/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/WorkflowEngineService.cs
+++ b/src/App/backend/src/Altinn.App.Core/Internal/WorkflowEngine/WorkflowEngineService.cs
@@ -18,29 +18,14 @@ namespace Altinn.App.Core.Internal.WorkflowEngine;
 
 internal sealed class WorkflowEngineService : IWorkflowEngineService
 {
-    // A transition is only *observed* at a rung of the ladder these two constants define, so the poll
-    // schedule -- not the engine -- decides most of what a user experiences as "starting the form".
-    // At 100ms doubling to 2s the rungs sat at 0/100/300/700ms while a warm transition took ~115ms,
-    // which put nearly every transition on the 300ms rung and made a 10ms difference in engine time
-    // swing the response between ~145ms and ~350ms.
-    //
-    // 25ms capped at 100ms puts the rungs at 0/25/75/175/275/375..., so the observation lag stays
-    // bounded by 100ms across the whole plausible range of transition times. Measured over 20
-    // instantiations each, same engine build: median 279ms -> 235ms, worst case 382ms -> 285ms, and
-    // the spread collapses from 243ms to 70ms. A denser ladder (10ms capped at 50ms) lowered the
-    // median another ~34ms but raised the engine's own per-transition time ~18% with the extra
-    // collection reads -- not a trade worth making at production volume.
-    //
-    // Polling remains a stopgap: the engine already signals status changes internally, so a long-poll
-    // or completion callback on the collection endpoint would remove the lag rather than bound it.
+    // A transition is only observed at a rung of this ladder, so the cap bounds how long the wait
+    // adds to a settled transition. Do not raise it without measuring.
     private const int InitialWorkflowPollingDelayMs = 25;
     private const int MaxWorkflowPollingDelayMs = 100;
     private const int AcceptanceProbeAttempts = 3;
 
-    // Deliberately not the polling delay above: this probe decides whether an enqueue whose outcome
-    // is unknown actually landed, so it must give the engine's write buffer time to make the
-    // collection visible before it concludes "not accepted". Tightening the poll ladder must not
-    // shorten that grace.
+    // Not the polling delay above: this grace lets the engine's write buffer make the collection
+    // visible before an unknown enqueue is concluded "not accepted".
     private const int AcceptanceProbeDelayMs = 100;
 
     // Mutable so tests can shrink the windows; production always runs the defaults.

--- a/src/Runtime/localtest/src/Startup.cs
+++ b/src/Runtime/localtest/src/Startup.cs
@@ -240,8 +240,15 @@ namespace LocalTest
                 app.UseHsts();
             }
 
-            app.UseHealthChecks("/health");
             app.UseMiddleware<ProxyMiddleware>();
+
+            // Registered after the proxy so that /health on a proxied component host reaches that
+            // component. Answering it here made a stopped component look healthy - a request to
+            // workflow-engine.local.altinn.cloud/health returned 200 while every other path on the
+            // same host returned 502 - which silently defeats any readiness gate waiting on it.
+            // Localtest's own hosts have no proxy route matching /health, so they still fall
+            // through to this.
+            app.UseHealthChecks("/health");
             app.UseWebSockets();
 
             var storagePath = new DirectoryInfo(localPlatformSettings.Value.LocalTestingStorageBasePath);

--- a/src/Runtime/localtest/src/Startup.cs
+++ b/src/Runtime/localtest/src/Startup.cs
@@ -242,12 +242,7 @@ namespace LocalTest
 
             app.UseMiddleware<ProxyMiddleware>();
 
-            // Registered after the proxy so that /health on a proxied component host reaches that
-            // component. Answering it here made a stopped component look healthy - a request to
-            // workflow-engine.local.altinn.cloud/health returned 200 while every other path on the
-            // same host returned 502 - which silently defeats any readiness gate waiting on it.
-            // Localtest's own hosts have no proxy route matching /health, so they still fall
-            // through to this.
+            // After the proxy: /health on a proxied component host must reach that component, not us.
             app.UseHealthChecks("/health");
             app.UseWebSockets();
 

--- a/src/Runtime/workflow-engine-app/infra/kustomize/base/deployment.yaml
+++ b/src/Runtime/workflow-engine-app/infra/kustomize/base/deployment.yaml
@@ -106,7 +106,10 @@ spec:
               mountPath: /tmp
           livenessProbe:
             httpGet:
-              path: /health/live
+              # The versionless /health* paths are 301 redirects to the aggregate endpoint, and
+              # kubelet counts a 3xx as a pass - so probing them made both probes succeed as soon
+              # as Kestrel bound, without ever evaluating a health check. Probe the real endpoints.
+              path: /api/v1/health/live
               port: 9090
             initialDelaySeconds: 2
             periodSeconds: 10
@@ -114,7 +117,7 @@ spec:
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /health/ready
+              path: /api/v1/health/ready
               port: 9090
             initialDelaySeconds: 2
             periodSeconds: 5

--- a/src/Runtime/workflow-engine-app/infra/kustomize/base/deployment.yaml
+++ b/src/Runtime/workflow-engine-app/infra/kustomize/base/deployment.yaml
@@ -106,9 +106,6 @@ spec:
               mountPath: /tmp
           livenessProbe:
             httpGet:
-              # The versionless /health* paths are 301 redirects to the aggregate endpoint, and
-              # kubelet counts a 3xx as a pass - so probing them made both probes succeed as soon
-              # as Kestrel bound, without ever evaluating a health check. Probe the real endpoints.
               path: /api/v1/health/live
               port: 9090
             initialDelaySeconds: 2

--- a/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/appsettings.json
+++ b/src/Runtime/workflow-engine-app/src/WorkflowEngine.App/appsettings.json
@@ -5,7 +5,8 @@
       "Microsoft.Hosting.Lifetime": "Information",
       "Microsoft.AspNetCore": "Warning",
       "Microsoft.EntityFrameworkCore": "Warning",
-      "WorkflowEngine.Data.Services": "Information"
+      "WorkflowEngine.Data.Services": "Information",
+      "WorkflowEngine.WarmUp": "Information"
     }
   },
   "AllowedHosts": "*",

--- a/src/Runtime/workflow-engine/AGENTS.md
+++ b/src/Runtime/workflow-engine/AGENTS.md
@@ -61,7 +61,7 @@ Reusable class library for async workflow processing. Provides the core engine, 
 - `GET /api/v1/{namespace}/mailboxes/{mailboxId:guid}` — status, deadline, both log counters, and the unpaired-delivery count
 - `DELETE /api/v1/{namespace}/mailboxes/{mailboxId:guid}` — close for deliveries and release every parked receiver, in one transaction; terminal and idempotent (202 effected, 200 replay with the original disposal)
 - `POST /api/v1/{namespace}/mailboxes/{mailboxId:guid}/deliveries` — deliver one message (202 appended, idempotent 200 on a replayed key, 409 always means _too late_). Full status tables for all four endpoints are in the [technical guide's API reference](docs/technical-guide.md#api-reference)
-- Health endpoints: `/health`, `/health/ready`, `/health/live`
+- Health endpoints: `/api/v1/health` (all checks), `/api/v1/health/ready` (checks tagged `ready`), `/api/v1/health/live`. The versionless `/health`, `/health/ready` and `/health/live` are **301 redirects to `/api/v1/health`** for convenience — never point a probe at them, because a 3xx counts as a pass and the redirect never evaluates the readiness check
 - `GET /dashboard/mailboxes` — mailboxes grouped under named collections, each log laid out position by position; a bounded fetch rather than a field on the live SSE stream. Payload and bounds in `src/WorkflowEngine.Core/wwwroot/DASHBOARD_SPEC.md`
 - Dashboard SSE/REST endpoints under `/dashboard/*` (see Dashboard docs)
 

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Core/Extensions/HostExtensions.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Core/Extensions/HostExtensions.cs
@@ -1,14 +1,28 @@
+using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using OpenTelemetry.Trace;
+using WorkflowEngine.Data.Constants;
+using WorkflowEngine.Data.Repository;
 using WorkflowEngine.Data.Services;
 using WorkflowEngine.Models;
 using WorkflowEngine.Telemetry;
+using WorkflowEngine.Telemetry.Extensions;
 
 namespace WorkflowEngine.Core.Extensions;
 
 internal static class HostExtensions
 {
+    /// <summary>
+    /// Namespace and collection key the startup warm-up reads from. Reserved by convention: no
+    /// caller enqueues here, so the reads miss and touch no real workflow. Correctness does not
+    /// depend on that - the reads are read-only whatever they find.
+    /// </summary>
+    private const string WarmUpNamespace = "__engine_warmup__";
+
+    private const string WarmUpCollectionKey = "__engine_warmup__";
+
     extension(IHost host)
     {
         /// <summary>
@@ -44,9 +58,70 @@ internal static class HostExtensions
             await migrationService.Migrate(cancellationToken);
         }
 
+        /// <summary>
+        /// Runs each of the engine's database read paths once so that the query plans, the EF model
+        /// bindings and the JIT work they trigger are paid for here instead of by the first request.
+        /// Called before Kestrel binds, so nothing can route to the engine until it is warm.
+        /// <para>
+        /// Every call is read-only: <see cref="IEngineRepository.FetchAndLockWorkflows"/> is asked
+        /// for zero rows, and the rest look up a namespace no workflow can be enqueued into. A
+        /// warm-up failure is logged and swallowed - a cold engine still works, so this must never
+        /// be the reason a host refuses to start.
+        /// </para>
+        /// </summary>
+        internal async Task WarmUpEngine(CancellationToken cancellationToken = default)
+        {
+            host.ForceInitializeTracerProvider();
+            using var activity = Metrics.Source.StartActivity("Engine.WarmUp");
+
+            using var scope = host.Services.CreateScope();
+            var logger = scope
+                .ServiceProvider.GetRequiredService<ILoggerFactory>()
+                .CreateLogger("WorkflowEngine.WarmUp");
+            var repo = scope.ServiceProvider.GetRequiredService<IEngineRepository>();
+
+            var started = Stopwatch.GetTimestamp();
+            try
+            {
+                // The processor's claim query, which the first transition's first step waits on.
+                // LIMIT 0 compiles the statement and opens the pool without claiming a workflow or
+                // stamping a lease.
+                await repo.FetchAndLockWorkflows(0, cancellationToken);
+
+                // The read paths a transition exercises: the workflow-with-steps include graph, the
+                // collection read the app's ProcessNext wait polls, the list endpoint, and the
+                // status rollup the metrics collector uses.
+                await repo.GetWorkflow(Guid.Empty, WarmUpNamespace, cancellationToken);
+                await repo.GetCollection(WarmUpCollectionKey, WarmUpNamespace, cancellationToken);
+                await repo.QueryWorkflows(
+                    pageSize: 1,
+                    statuses: PersistentItemStatusMap.Finished,
+                    namespaceFilter: WarmUpNamespace,
+                    cancellationToken: cancellationToken
+                );
+                await repo.CountWorkflowsByStatus(cancellationToken);
+
+                logger.WarmUpCompleted(Stopwatch.GetElapsedTime(started).TotalMilliseconds);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                activity?.Errored(ex);
+                logger.WarmUpFailed(ex);
+            }
+        }
+
         private void ForceInitializeTracerProvider()
         {
             _ = host.Services.GetService<TracerProvider>();
         }
     }
+}
+
+internal static partial class HostWarmUpLogs
+{
+    [LoggerMessage(LogLevel.Information, "Engine warm-up completed in {ElapsedMs:F0}ms")]
+    internal static partial void WarmUpCompleted(this ILogger logger, double elapsedMs);
+
+    [LoggerMessage(LogLevel.Warning, "Engine warm-up failed; the first request will pay the cold cost")]
+    internal static partial void WarmUpFailed(this ILogger logger, Exception exception);
 }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Core/Extensions/HostExtensions.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Core/Extensions/HostExtensions.cs
@@ -63,6 +63,12 @@ internal static class HostExtensions
         /// bindings and the JIT work they trigger are paid for here instead of by the first request.
         /// Called before Kestrel binds, so nothing can route to the engine until it is warm.
         /// <para>
+        /// On a freshly started engine the first enqueue cost ~195ms against ~6ms warm and the first
+        /// workflow ~375ms to settle against ~48ms; warming the read paths brings those to ~160ms and
+        /// ~270ms. The remainder sits in the HTTP pipeline and the enqueue write path, which a
+        /// read-only warm-up cannot reach.
+        /// </para>
+        /// <para>
         /// Every call is read-only: <see cref="IEngineRepository.FetchAndLockWorkflows"/> is asked
         /// for zero rows, and the rest look up a namespace no workflow can be enqueued into. A
         /// warm-up failure is logged and swallowed - a cold engine still works, so this must never

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Core/Extensions/WorkflowEngineAppExtensions.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Core/Extensions/WorkflowEngineAppExtensions.cs
@@ -41,11 +41,6 @@ public static class WorkflowEngineAppExtensions
             await app.ResetDatabaseConnectionsInDev();
             await app.ApplyDatabaseMigrations();
 
-            // Runs before Kestrel binds, so the engine is never reachable while still cold. On a
-            // freshly started engine the first enqueue cost ~195ms against ~6ms warm and the first
-            // workflow took ~375ms to settle against ~48ms; warming the read paths here brings those
-            // to ~160ms and ~270ms. The rest of the cold cost sits in the HTTP pipeline and the
-            // enqueue write path, which a read-only warm-up cannot reach - see the method docs.
             await app.WarmUpEngine();
 
             return app;

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Core/Extensions/WorkflowEngineAppExtensions.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Core/Extensions/WorkflowEngineAppExtensions.cs
@@ -41,6 +41,13 @@ public static class WorkflowEngineAppExtensions
             await app.ResetDatabaseConnectionsInDev();
             await app.ApplyDatabaseMigrations();
 
+            // Runs before Kestrel binds, so the engine is never reachable while still cold. On a
+            // freshly started engine the first enqueue cost ~195ms against ~6ms warm and the first
+            // workflow took ~375ms to settle against ~48ms; warming the read paths here brings those
+            // to ~160ms and ~270ms. The rest of the cold cost sits in the HTTP pipeline and the
+            // enqueue write path, which a read-only warm-up cannot reach - see the method docs.
+            await app.WarmUpEngine();
+
             return app;
         }
     }

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Data/Services/DbMaintenanceService.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Data/Services/DbMaintenanceService.cs
@@ -10,6 +10,9 @@ using WorkflowEngine.Resilience.Models;
 using WorkflowEngine.Telemetry;
 using WorkflowEngine.Telemetry.Extensions;
 
+// CA5394: retention jitter only spreads load, so a non-cryptographic source is the right tool.
+#pragma warning disable CA5394
+
 namespace WorkflowEngine.Data.Services;
 
 internal sealed class DbMaintenanceService(
@@ -99,13 +102,10 @@ internal sealed class DbMaintenanceService(
 
     /// <summary>
     /// A uniformly random offset in <c>[0, interval)</c>, used to place the first retention sweep
-    /// somewhere inside the interval instead of at startup. Jitter only needs to spread load, so a
-    /// non-cryptographic source is the right tool here.
+    /// somewhere inside the interval instead of at startup.
     /// </summary>
-#pragma warning disable CA5394 // Do not use insecure randomness
     private static TimeSpan RandomStartupOffset(TimeSpan interval) =>
         interval <= TimeSpan.Zero ? TimeSpan.Zero : Random.Shared.NextDouble() * interval;
-#pragma warning restore CA5394
 
     internal async Task PurgeExpiredWorkflows(DateTimeOffset now, RetentionSettings settings, CancellationToken ct)
     {

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Data/Services/DbMaintenanceService.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Data/Services/DbMaintenanceService.cs
@@ -38,8 +38,9 @@ internal sealed class DbMaintenanceService(
     /// Anchoring at a random point inside the retention interval - rather than at
     /// <see cref="DateTimeOffset.MinValue"/>, which is immediately due - keeps a start from
     /// scheduling a full drain on top of the requests the fresh instance is about to serve, and
-    /// de-synchronizes the replicas of a rollout that all start at once. A sweep still happens
-    /// within one interval of startup.
+    /// de-synchronizes the replicas of a rollout that all start at once. The check is only evaluated
+    /// once per maintenance iteration, so the first sweep lands within one retention interval plus
+    /// one <see cref="EngineSettings.MaintenanceInterval"/> of startup.
     /// </summary>
     private DateTimeOffset? _lastRetentionRun;
 

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Data/Services/DbMaintenanceService.cs
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Data/Services/DbMaintenanceService.cs
@@ -30,7 +30,15 @@ internal sealed class DbMaintenanceService(
         maxDelay: TimeSpan.FromMinutes(2)
     );
 
-    private DateTimeOffset _lastRetentionRun = DateTimeOffset.MinValue;
+    /// <summary>
+    /// When retention last swept, or <c>null</c> until the first maintenance iteration anchors it.
+    /// Anchoring at a random point inside the retention interval - rather than at
+    /// <see cref="DateTimeOffset.MinValue"/>, which is immediately due - keeps a start from
+    /// scheduling a full drain on top of the requests the fresh instance is about to serve, and
+    /// de-synchronizes the replicas of a rollout that all start at once. A sweep still happens
+    /// within one interval of startup.
+    /// </summary>
+    private DateTimeOffset? _lastRetentionRun;
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -47,6 +55,8 @@ internal sealed class DbMaintenanceService(
             {
                 var now = timeProvider.GetUtcNow();
                 var settings = options.Value;
+
+                _lastRetentionRun ??= now - RandomStartupOffset(settings.Retention.Interval);
 
                 if (now - _lastRetentionRun >= settings.Retention.Interval)
                 {
@@ -86,6 +96,16 @@ internal sealed class DbMaintenanceService(
 
         logger.ShuttingDown();
     }
+
+    /// <summary>
+    /// A uniformly random offset in <c>[0, interval)</c>, used to place the first retention sweep
+    /// somewhere inside the interval instead of at startup. Jitter only needs to spread load, so a
+    /// non-cryptographic source is the right tool here.
+    /// </summary>
+#pragma warning disable CA5394 // Do not use insecure randomness
+    private static TimeSpan RandomStartupOffset(TimeSpan interval) =>
+        interval <= TimeSpan.Zero ? TimeSpan.Zero : Random.Shared.NextDouble() * interval;
+#pragma warning restore CA5394
 
     internal async Task PurgeExpiredWorkflows(DateTimeOffset now, RetentionSettings settings, CancellationToken ct)
     {

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Repository.Tests/FetchAndLockTests.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Repository.Tests/FetchAndLockTests.cs
@@ -33,6 +33,28 @@ public sealed class FetchAndLockTests(PostgresFixture fixture) : IAsyncLifetime
     }
 
     [Fact]
+    public async Task FetchAndLock_WithZeroCount_ClaimsNothing()
+    {
+        // The startup warm-up calls FetchAndLock with a count of zero to compile this statement
+        // without taking work. If a zero count ever started claiming, the warm-up would stamp a lease
+        // on a workflow nobody is executing and strand it until the stale sweep reclaimed it.
+        await using var context = fixture.CreateDbContext();
+        var repo = fixture.CreateRepository();
+
+        var wf = await WorkflowTestHelper.InsertAndSetStatus(repo, context, PersistentItemStatus.Enqueued);
+
+        var workflows = await repo.FetchAndLockWorkflows(0, TestContext.Current.CancellationToken);
+
+        Assert.Empty(workflows);
+
+        var dbWf = await fixture.GetWorkflow(wf.DatabaseId);
+        Assert.NotNull(dbWf);
+        Assert.Equal(PersistentItemStatus.Enqueued, dbWf.Status);
+        Assert.Null(dbWf.LeaseToken);
+        Assert.Null(dbWf.HeartbeatAt);
+    }
+
+    [Fact]
     public async Task FetchAndLock_SkipsCompletedAndFailed()
     {
         await using var context = fixture.CreateDbContext();

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Repository.Tests/RetentionTests.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Repository.Tests/RetentionTests.cs
@@ -475,6 +475,119 @@ public sealed class RetentionTests(PostgresFixture fixture) : IAsyncLifetime
 
     // --- Helpers ---
 
+    [Fact]
+    public async Task Retention_FirstSweep_IsDeferredPastStartup()
+    {
+        // The last-run marker used to start at DateTimeOffset.MinValue, so every start of the service
+        // was immediately due for a full retention drain. On a database with a real backlog that put
+        // a multi-second bulk delete on top of the first requests the fresh instance served, and a
+        // rollout had every replica doing it at once.
+        var ct = TestContext.Current.CancellationToken;
+        await using var dataSource = NpgsqlDataSource.Create(fixture.ConnectionString);
+
+        var expiredWorkflowId = Guid.NewGuid();
+        await InsertWorkflow(
+            dataSource,
+            expiredWorkflowId,
+            status: PersistentItemStatus.Completed,
+            updatedAt: DateTimeOffset.UtcNow.AddDays(-31),
+            ct: ct
+        );
+
+        // Positive control: the stale sweep shares the loop iteration retention would have run in,
+        // so reclaiming this workflow proves the loop ran rather than never having started.
+        var staleWorkflowId = Guid.NewGuid();
+        await InsertWorkflow(
+            dataSource,
+            staleWorkflowId,
+            status: PersistentItemStatus.Processing,
+            updatedAt: DateTimeOffset.UtcNow.AddMinutes(-5),
+            ct: ct
+        );
+        await MakeHeartbeatStale(dataSource, staleWorkflowId, ct);
+
+        // A long interval places the deferred first sweep far outside the test window whatever the
+        // jitter picks.
+        using var limiter = new ConcurrencyLimiter(10, 10, 5);
+        using var service = new DbMaintenanceService(
+            NullLogger<DbMaintenanceService>.Instance,
+            TimeProvider.System,
+            dataSource,
+            CreateEngineSettings(retentionPeriod: TimeSpan.FromDays(30), interval: TimeSpan.FromDays(30)),
+            limiter
+        );
+
+        await service.StartAsync(ct);
+        try
+        {
+            await WaitUntilReclaimed(staleWorkflowId, ct);
+        }
+        finally
+        {
+            await service.StopAsync(ct);
+        }
+
+        await using var ctx = fixture.CreateDbContext();
+        var remaining = await ctx.Workflows.Select(w => w.Id).ToListAsync(ct);
+        Assert.Contains(expiredWorkflowId, remaining);
+    }
+
+    private static async Task MakeHeartbeatStale(NpgsqlDataSource dataSource, Guid id, CancellationToken ct)
+    {
+        await using var cmd = dataSource.CreateCommand(
+            "UPDATE engine.workflows SET heartbeat_at = @heartbeat WHERE id = @id"
+        );
+        cmd.Parameters.AddWithValue("id", id);
+        cmd.Parameters.AddWithValue("heartbeat", DateTimeOffset.UtcNow.AddMinutes(-5));
+        await cmd.ExecuteNonQueryAsync(ct);
+    }
+
+    private async Task WaitUntilReclaimed(Guid id, CancellationToken ct)
+    {
+        for (var attempt = 0; attempt < 100; attempt++)
+        {
+            await using var ctx = fixture.CreateDbContext();
+            var status = await ctx.Workflows.Where(w => w.Id == id).Select(w => w.Status).SingleAsync(ct);
+            if (status == PersistentItemStatus.Enqueued)
+            {
+                return;
+            }
+
+            await Task.Delay(50, ct);
+        }
+
+        Assert.Fail("Maintenance loop did not reclaim the stale workflow, so the test proves nothing.");
+    }
+
+    private static IOptions<EngineSettings> CreateEngineSettings(
+        TimeSpan retentionPeriod,
+        TimeSpan interval,
+        int batchSize = 1000
+    ) =>
+        Options.Create(
+            new EngineSettings
+            {
+                DefaultStepCommandTimeout = TimeSpan.FromSeconds(30),
+                MaxStepCommandTimeout = TimeSpan.FromHours(2),
+                DefaultStepRetryStrategy = null!,
+                DatabaseCommandTimeout = TimeSpan.FromSeconds(30),
+                DatabaseRetryStrategy = null!,
+                MetricsCollectionInterval = TimeSpan.FromSeconds(5),
+                MaxWorkflowsPerRequest = 100,
+                MaxStepsPerWorkflow = 50,
+                MaxLabels = 50,
+                HeartbeatInterval = TimeSpan.FromSeconds(3),
+                StaleWorkflowThreshold = TimeSpan.FromSeconds(15),
+                MaxReclaimCount = 3,
+                Retention = new RetentionSettings
+                {
+                    RetentionPeriod = retentionPeriod,
+                    BatchSize = batchSize,
+                    Interval = interval,
+                },
+            }
+        );
+
     private static async Task RunRetention(
         NpgsqlDataSource dataSource,
         TimeSpan retentionPeriod,

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Repository.Tests/RetentionTests.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Repository.Tests/RetentionTests.cs
@@ -478,10 +478,8 @@ public sealed class RetentionTests(PostgresFixture fixture) : IAsyncLifetime
     [Fact]
     public async Task Retention_FirstSweep_IsDeferredPastStartup()
     {
-        // The last-run marker used to start at DateTimeOffset.MinValue, so every start of the service
-        // was immediately due for a full retention drain. On a database with a real backlog that put
-        // a multi-second bulk delete on top of the first requests the fresh instance served, and a
-        // rollout had every replica doing it at once.
+        // A start must not be immediately due for a retention drain: on a real backlog that is a
+        // multi-second bulk delete landing on the first requests the fresh instance serves.
         var ct = TestContext.Current.CancellationToken;
         await using var dataSource = NpgsqlDataSource.Create(fixture.ConnectionString);
 

--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -24,6 +24,7 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ### Fixed
 
+- `studioctl env up` now waits for the workflow engine to actually be able to serve requests before reporting that the environment has started. It previously returned around 0.8 seconds early, and instantiating an app inside that window failed with "Instance initialization failed" and left an unusable instance behind.
 - `studioctl app upgrade` no longer fails when the upgrade completed but left steps for you to finish by hand.
 - `studioctl app upgrade v9` no longer adds a byte order mark to layout files that did not have one, and keeps Norwegian characters as they are instead of rewriting every "æ", "ø" and "å" as an escape sequence. Both turned a two-line migration into a diff across the whole file. Layout files containing comments are now left untouched and reported, rather than silently losing the comments to the rewrite.
 

--- a/src/cli/internal/cmd/env/localtest/components/workflow_engine.go
+++ b/src/cli/internal/cmd/env/localtest/components/workflow_engine.go
@@ -27,6 +27,25 @@ const (
 	postgresHealthRetries     = 9
 	postgresHealthStartPeriod = 30 * time.Second
 
+	workflowEngineHealthInterval    = 500 * time.Millisecond
+	workflowEngineHealthTimeout     = 5 * time.Second
+	workflowEngineHealthRetries     = 60
+	workflowEngineHealthStartPeriod = 2 * time.Second
+
+	// The aspnet base image ships no curl or wget, so the readiness probe speaks HTTP over bash's
+	// /dev/tcp. It targets the engine's real readiness endpoint: the versionless /health/ready is a
+	// 301 redirect to the aggregate endpoint, so it would report ready before the engine could
+	// serve. Kestrel binds only after UseWorkflowEngine() has migrated and warmed up, so a 200 here
+	// means an enqueue will be accepted.
+	//
+	// Without this check the container counts as ready the moment the process is launched (see
+	// containerHealthReady in devenv), and `env up` returned roughly 0.8s before the engine would
+	// accept a request. An app instantiating inside that window failed with HTTP 500
+	// "Instance initialization failed" and left an orphaned instance behind.
+	workflowEngineHealthProbe = `bash -c "exec 3<>/dev/tcp/127.0.0.1/` + workflowEngineHTTPPort +
+		` && printf 'GET /api/v1/health/ready HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' >&3` +
+		` && head -n 1 <&3 | grep -q ' 200 '"`
+
 	postgresUser     = "postgres"
 	postgresPassword = "postgres"
 	postgresDB       = "postgres"
@@ -130,6 +149,13 @@ func workflowEngineContainer(ctx *Options) *ContainerSpec {
 		[]string{ContainerWorkflowEngineDb, ContainerLocaltest},
 		nil,
 	)
+	spec.HealthCheck = &types.HealthCheck{
+		Test:        []string{"CMD-SHELL", workflowEngineHealthProbe},
+		Interval:    workflowEngineHealthInterval,
+		Timeout:     workflowEngineHealthTimeout,
+		Retries:     workflowEngineHealthRetries,
+		StartPeriod: workflowEngineHealthStartPeriod,
+	}
 	// Workflow-engine has no host-writable mounts, so use the image user instead of host UID/GID remapping.
 	spec.UseDefaultUser = true
 	return spec

--- a/src/cli/internal/cmd/env/localtest/components/workflow_engine.go
+++ b/src/cli/internal/cmd/env/localtest/components/workflow_engine.go
@@ -32,16 +32,8 @@ const (
 	workflowEngineHealthRetries     = 60
 	workflowEngineHealthStartPeriod = 2 * time.Second
 
-	// The aspnet base image ships no curl or wget, so the readiness probe speaks HTTP over bash's
-	// /dev/tcp. It targets the engine's real readiness endpoint: the versionless /health/ready is a
-	// 301 redirect to the aggregate endpoint, so it would report ready before the engine could
-	// serve. Kestrel binds only after UseWorkflowEngine() has migrated and warmed up, so a 200 here
-	// means an enqueue will be accepted.
-	//
-	// Without this check the container counts as ready the moment the process is launched (see
-	// containerHealthReady in devenv), and `env up` returned roughly 0.8s before the engine would
-	// accept a request. An app instantiating inside that window failed with HTTP 500
-	// "Instance initialization failed" and left an orphaned instance behind.
+	// The aspnet base image ships no curl or wget, so the probe speaks HTTP over bash's /dev/tcp;
+	// the versionless /health/ready is a redirect and would pass before the engine could serve.
 	workflowEngineHealthProbe = `bash -c "exec 3<>/dev/tcp/127.0.0.1/` + workflowEngineHTTPPort +
 		` && printf 'GET /api/v1/health/ready HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' >&3` +
 		` && head -n 1 <&3 | grep -q ' 200 '"`

--- a/src/cli/internal/cmd/env/localtest/manifest_internal_test.go
+++ b/src/cli/internal/cmd/env/localtest/manifest_internal_test.go
@@ -154,6 +154,7 @@ func TestResourceBuilder_DevWorkflowEngineExposesDbAndDisablesEngine(t *testing.
 
 func assertWorkflowEngineContainerConfig(t *testing.T, workflowEngine components.ContainerSpec) {
 	t.Helper()
+	assertWorkflowEngineHealthCheck(t, workflowEngine)
 	if got := workflowEngine.Ports; got != nil {
 		t.Fatalf("workflowEngine.Ports = %v, want nil", got)
 	}
@@ -491,4 +492,34 @@ func dependencyNames(deps []resource.ResourceRef) []string {
 		names = append(names, name)
 	}
 	return names
+}
+
+// The engine reports ready as soon as its process is launched unless a health check says otherwise,
+// which used to let `env up` return before an enqueue would be accepted. The probe has to target the
+// versioned readiness endpoint: /health/ready is a 301 redirect and would pass while the engine was
+// still starting.
+func assertWorkflowEngineHealthCheck(t *testing.T, workflowEngine components.ContainerSpec) {
+	t.Helper()
+	hc := workflowEngine.HealthCheck
+	if hc == nil {
+		t.Fatal("workflowEngine.HealthCheck = nil, want a readiness probe")
+	}
+	if len(hc.Test) != 2 || hc.Test[0] != "CMD-SHELL" {
+		t.Fatalf("workflowEngine.HealthCheck.Test = %v, want a CMD-SHELL probe", hc.Test)
+	}
+	probe := hc.Test[1]
+	if !strings.Contains(probe, "/api/v1/health/ready") {
+		t.Fatalf("workflowEngine.HealthCheck probe = %q, want it to request /api/v1/health/ready", probe)
+	}
+	if !strings.Contains(probe, "/dev/tcp/127.0.0.1/9090") {
+		t.Fatalf("workflowEngine.HealthCheck probe = %q, want it to connect to port 9090", probe)
+	}
+	if got := hc.Interval; got != 500*time.Millisecond {
+		t.Fatalf("workflowEngine.HealthCheck.Interval = %s, want 500ms", got)
+	}
+	// Interval * Retries has to cover a slow cold start (migrations plus warm-up) without letting a
+	// genuinely broken engine hold `env up` for long.
+	if budget := time.Duration(hc.Retries) * hc.Interval; budget < 20*time.Second {
+		t.Fatalf("workflowEngine.HealthCheck retry budget = %s, want at least 20s", budget)
+	}
 }


### PR DESCRIPTION
## Description

We had a report that the first app instantiation after `studioctl env up` (or after a deploy) felt much slower than it should, with no measurements behind it. I built a harness and measured it. The report is real and reproducible — **first instantiation 1174–1272 ms against a 346–368 ms steady-state median**, across three clean cycles — but splitting the request apart moved where the effort belongs. This PR fixes what the measurements actually blamed.

📊 **Full investigation, method and data: https://claude.ai/code/artifact/ac761458-dc7c-494c-8d24-4352ed20bfb4**

### 1. Nothing gated workflow-engine readiness — in three separate places

- **`studioctl env up` returned 821–841 ms before the engine would accept an enqueue** (n=3). The engine container declares no health check, and `containerHealthReady` treats an empty health status as ready, so "ready" meant "the process was launched". An instantiation inside that window doesn't just run slowly, it fails:

  ```
  HTTP 500 — "Instance initialization failed."
  detail: Runtime submitted the initial workflow, but could not
          determine whether the workflow engine accepted it.
  initializationState: workflowAcceptanceUnknown
  ```

  The instance row exists but has no workflow, so the developer is left with an orphaned instance and a failure that reads like a bug in their own app. With the health check the gap is **0 ms** — the first enqueue after `env up` returns is accepted (verified n=3).

- **Localtest answered `/health` for every proxied component host.** `UseHealthChecks("/health")` was registered before `ProxyMiddleware`, so `workflow-engine.local.altinn.cloud:8000/health` returned `200 OK` with the engine container **stopped**, while every other path on that host returned 502. Any readiness gate keyed on that URL was waiting on nothing. (This cost me a measurement round before I noticed.)

- **The Kubernetes probes never evaluated anything.** They pointed at `/health/live` and `/health/ready`, which are 301 redirects to the aggregate endpoint. kubelet counts a 3xx as a pass, so both probes succeeded the moment Kestrel bound — a pod whose database was unreachable still reported `Ready`. Now they probe `/api/v1/health/*`, and the engine's `AGENTS.md` says why the versionless paths must never be used for a probe.

### 2. The engine paid for JIT and query-plan compilation on the first real request

First enqueue ~195 ms against ~6 ms warm; first workflow ~375 ms to settle against ~48 ms (n=4 restarts). End to end the cold penalty concentrated in the *first step* of the transition — `UnlockTaskData` completed 225–314 ms after workflow creation while later steps ran 6–30 ms apart.

`UseWorkflowEngine()` now runs the engine's database read paths once before Kestrel binds, so it is never reachable while cold. Measured over four restart cycles: first enqueue → **~160 ms**, first settle → **~270 ms**, for ~500 ms of startup time now spent behind the readiness probe.

Every call is read-only. `FetchAndLockWorkflows` is asked for zero rows — which compiles the processor's claim statement without claiming work or stamping a lease — and a repository test pins that invariant, because a zero count that ever started claiming would strand a workflow until the stale sweep reclaimed it.

**Being straight about the ceiling:** this captures roughly 30% of the engine's cold cost, not all of it. The rest sits in the HTTP pipeline (Kestrel, routing, JSON) and the enqueue *write* path, which an in-process read-only warm-up cannot reach. In the investigation, driving one real throwaway workflow through the engine removed the cold cost **entirely** (first enqueue 6.5 ms, first settle 55 ms) — but it writes to the workflow tables. I left that as a decision for you rather than making it here.

### 3. A full retention sweep ran on every engine start

`_lastRetentionRun` began at `DateTimeOffset.MinValue`, so the first maintenance iteration of every start, restart and pod roll was immediately due. The sweep loops in 1000-row batches until drained, then runs `ANALYZE` on five tables, taking its slots from the same pool of ten (`Concurrency.MaxDbOperations: 10`) that enqueue and fetch need — and every replica of a rollout does it simultaneously.

Invisible locally, because nothing is 60 days old. Seeding an aged backlog shows both the cost and how it scales:

| Aged backlog | Drain time | 1st | 2nd | 3rd | 4th | 5th | 6th |
| --- | --- | --- | --- | --- | --- | --- | --- |
| none (baseline) | — | **696** | 379 | 361 | 358 | — | — |
| 60,000 workflows | ~4 s | **1398** | 376 | 380 | 357 | 144 | 350 |
| 300,000 workflows | 21.9 s | **1262** | **820** | **850** | **879** | **762** | 404 |

Client-visible `POST /instances`, in ms, engine restarted with the app already warm. At 300k rows the purge spent ~19 s of database time across 300 batches and degraded the first *six* instantiations. 300k terminal workflows over a 60-day window is not a large environment — this is the best candidate for why a deploy feels worse than a laptop.

The first sweep is now anchored at a random point inside the retention interval: still within one interval of startup, but not on top of startup, and replicas that start together no longer sweep together.

### 4. The runtime's poll ladder, not the engine, decided most of the latency

`WorkflowEngineService` polled starting at 100 ms and doubling to a 2 s cap, so a transition was only *observed* at 0/100/300/700/1500 ms after enqueue. Across 53 instantiations the client-visible latency clustered on exactly those rungs plus ~45 ms of fixed work — 145 ms, 351 ms, 719 ms — with almost nothing in between. A warm transition takes ~115 ms, 15 ms past the first rung, so nearly every instantiation waited until 300 ms and a 10 ms difference in engine time swung the response between ~145 ms and ~350 ms. The ladder also *amplifies* engine slowness: 220 ms of extra cold-engine work pushes completion onto the 700 ms rung and reaches the user as 400 ms.

The ladder has to be right on two axes, and my first attempt at this only measured one. Starting at 25 ms with a 100 ms cap fixed the latency cliff but broke the load side: a transition running to the 100 s timeout never stops polling tightly, costing **~1003 collection reads against the original ladder's ~55**. Every sample behind that change settled in ~115 ms, so it never exercised the tail at all — thanks to @danielskovli for catching it.

The shipped shape polls **50 ms flat for the first 2 s** — the window in which a synchronous completion is still plausible, and the same window as `WorkflowParkedReleaseGraceMs` — then backs off 50% per poll to the **original 2 s cap**, which bounds what a genuinely slow transition costs.

Measured against the same engine build, 15 instantiations per arm, three warm-ups discarded, with collection reads counted from the engine's own `pg_stat_statements`:

| Ladder | p10 | Median | p90 | Worst | Reads / instantiation | Polls for a 100 s transition |
| --- | --- | --- | --- | --- | --- | --- |
| `100 / ×2 / 2000` (today) | 136 | 160 | 367 | **407** | 2.5 | 55 |
| `25 / ×2 / 100` (rejected) | 213 | 220 | 232 | 238 | 4.0 | **1003** |
| **`50 flat → 2s, +50%, cap 2s`** (this PR) | **133** | **143** | **208** | **283** | 3.2 | 97 |

Median 160 → 143 ms, p90 367 → 208 ms (−43%), worst case 407 → 283 ms (−30%), for +0.7 reads on a fast instantiation and a tail bounded at ~1.8× rather than 18×.

The tight interval is the dial if that trade needs revisiting. Its cost is only paid by transitions that run the full window — but every *parked* transition does (a deferring service task, or now a `Held` mailbox receiver from #20091), so the poll count inside the 2 s window is what matters: 25 ms costs 82, **50 ms costs 42**, 75 ms costs 28, 100 ms costs 22, against 6 before this change.

Polling stays a stopgap, but I was wrong in an earlier revision of this description about how close a replacement is. **The engine has no push channel to the app.** The only push channel that exists feeds the dashboard SSE stream (`StatusChangeSignal` → `GET /dashboard/stream/live`), and it is driven by a payload-less global `NOTIFY status_changed` that cannot address a single collection — every listener wakes on every status change anywhere in the engine. Removing this lag therefore means designing a new client-facing mechanism (a long-poll or completion callback on the collection endpoint), not reusing existing plumbing. Worth a follow-up, but a real one.

### What this PR does not change, and why

- **The first instantiation after a cold start is still ~1.2 s.** It is dominated by the freshly started *app* — seven engine callbacks into a cold app — not by the engine. The engine warm-up moves the engine's share only, and I'd rather say so than imply otherwise.
- **`env up` now takes ~3.3 s instead of ~1.2 s**, because it actually waits for the engine (boot + warm-up + health-check granularity). That is the honest price of not reporting ready early, and it replaces a window where instantiation hard-failed.
- **The engine's `cpu: 10m` request with no limit** is likely the biggest production factor: CPU shares are proportional to the request, so a JIT-heavy startup gets a tiny share exactly when it needs the most. I did not touch it — I have no cluster to measure on, and changing production resource requests on manifest-reading alone isn't something to slip into a PR. Recommended as a follow-up with real measurement.
- **`localtest` and `pdf3` also have no container health check.** Only the engine is in scope here, since it is the only one I measured.

Reviewers may prefer this split by component — studioctl, localtest, workflow-engine and app-lib have different rollout paths. Each commit is self-contained if so.

## Verification

- [x] Related issues are connected (if applicable) — none known; opened from an unquantified performance report
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

**Automated:** workflow-engine `dotnet test WorkflowEngine.slnx` — 766 passed, 0 failed (incl. 148 integration tests exercising the full host with the warm-up in the pipeline). `Altinn.App.Core.Tests` — 3154 passed, 0 failed. studioctl `go test ./...` and `golangci-lint run ./...` clean. `yarn spell:quick` and `yarn docs:validate` clean.

New tests: `Retention_FirstSweep_IsDeferredPastStartup` (verified to fail when the production change is reverted, with a positive control proving the maintenance loop actually ran), `FetchAndLock_WithZeroCount_ClaimsNothing`, and health-check assertions in `assertWorkflowEngineContainerConfig`.

**Manual, end to end** — environment images built from this branch (`STUDIOCTL_INTERNAL_DEV=true`), 4 vCPU / 7.8 GiB arm64, podman 5.7.0:

```
$ studioctl env up   →  engine container reports (healthy)
   engine accepts the first enqueue 0 ms after env up returns   (was 821-841 ms of 502s)

$ podman stop localtest-workflow-engine
   workflow-engine.local.altinn.cloud:8000/health  ->  502     (was a false 200)
   local.altinn.cloud:8000/health                  ->  200     (localtest's own, unchanged)

$ podman logs localtest-workflow-engine
   info: WorkflowEngine.WarmUp[...] Engine warm-up completed in 498ms
```

Caveats on the numbers: the app under test was built from source in Debug, which overstates app-side JIT relative to the released app image (the engine numbers come from the real image). Everything ran on one node with four uncontended cores — no cluster, no network latency to Postgres, no noisy neighbours, so cluster numbers should be worse rather than better. The retention experiment used synthetic aged rows whose shape mirrors what instantiation produces; real backlogs carry dependency and link edges the purge must also check, so real drain times are likely longer than measured, not shorter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved environment startup checks so readiness is reported only when the workflow engine can serve requests.
  - Updated liveness and readiness checks to use the correct health endpoints.
  - Ensured proxied component health requests reach their intended component.
  - Adjusted workflow polling to provide a more responsive initial cadence with controlled backoff.

- **Reliability**
  - Added engine warm-up before accepting requests.
  - Deferred retention cleanup after startup to reduce load spikes.
  - Added readiness checks for local workflow-engine containers.
  - Prevented zero-count workflow fetches from claiming work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

