### PR TITLE
feat: deploy workflow-engine-app on tt02 with shared database (suspended by default)

### DIFF
--- a/infra/runtime/syncroot/tt02/kustomization.yaml
+++ b/infra/runtime/syncroot/tt02/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - ../base
   - ../grafana-manifests
+  - workflow-engine-app.yaml

--- a/infra/runtime/syncroot/tt02/workflow-engine-app.yaml
+++ b/infra/runtime/syncroot/tt02/workflow-engine-app.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: runtime-workflow-engine-app
+  labels:
+    altinn.studio/runtime: "true"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: runtime-environment
+  namespace: runtime-workflow-engine-app
+data:
+  upgrade_channel: ${UPGRADE_CHANNEL}
+  environment: ${ENVIRONMENT}
+  serviceowner: ${SERVICEOWNER_ID}
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: workflow-engine-app-repo
+  namespace: runtime-workflow-engine-app
+spec:
+  interval: 5m
+  provider: azure
+  ref:
+    tag: ${UPGRADE_CHANNEL}
+  timeout: 5m
+  url: oci://altinncr.azurecr.io/studio-apps/runtime-workflow-engine-app-repo
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: workflow-engine-app
+  namespace: runtime-workflow-engine-app
+spec:
+  # The app needs a provisioned database. The platform configuration sets this
+  # value to "false" only for clusters that have one. The default keeps the
+  # app suspended everywhere else.
+  suspend: ${STUDIO_WORKFLOW_ENGINE_SUSPEND:=true}
+  targetNamespace: runtime-workflow-engine-app
+  interval: 5m
+  retryInterval: 5m
+  timeout: 1m
+  prune: true
+  force: false
+  wait: true
+  path: ./${ENVIRONMENT}
+  sourceRef:
+    kind: OCIRepository
+    name: workflow-engine-app-repo
+    namespace: runtime-workflow-engine-app
+  postBuild:
+    substitute:
+      SERVICEOWNER_ID: ${SERVICEOWNER_ID}
+      ENVIRONMENT: ${ENVIRONMENT}
+      WORKFLOW_ENGINE_ENTRA_CLIENT_ID: ${STUDIO_WORKFLOW_ENGINE_CLIENT_ID}
+      WORKFLOW_ENGINE_DB_USERNAME: ${STUDIO_WORKFLOW_ENGINE_DB_USERNAME}
+      WORKFLOW_ENGINE_DB_HOST: workflow-engine-db-server-test.postgres.database.azure.com

--- a/infra/runtime/syncroot/tt02/workflow-engine-app.yaml
+++ b/infra/runtime/syncroot/tt02/workflow-engine-app.yaml
@@ -34,9 +34,13 @@ metadata:
   name: workflow-engine-app
   namespace: runtime-workflow-engine-app
 spec:
-  # The app needs a provisioned database. The platform configuration sets this
-  # value to "false" only for clusters that have one. The default keeps the
-  # app suspended everywhere else.
+  # Every serviceowner tt02 cluster applies this file. Only clusters with a
+  # provisioned workflow-engine database can run the app. The platform
+  # configuration sets STUDIO_WORKFLOW_ENGINE_SUSPEND to "false" on exactly
+  # those clusters (today: only ttd). On all other clusters the variable is
+  # not set. The default "true" then suspends this Kustomization. Flux deploys
+  # nothing on those clusters, so they get no failing pods. Remove this gate
+  # when every cluster has a database.
   suspend: ${STUDIO_WORKFLOW_ENGINE_SUSPEND:=true}
   targetNamespace: runtime-workflow-engine-app
   interval: 5m

--- a/src/Runtime/workflow-engine-app/infra/kustomize/tt02/kustomization.yaml
+++ b/src/Runtime/workflow-engine-app/infra/kustomize/tt02/kustomization.yaml
@@ -2,3 +2,20 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+patches:
+  - target:
+      kind: Deployment
+      name: workflow-engine-app
+    patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: workflow-engine-app
+      spec:
+        template:
+          spec:
+            containers:
+              - name: workflow-engine-app
+                env:
+                  - name: ConnectionStrings__WorkflowEngine
+                    value: "Host=${WORKFLOW_ENGINE_DB_HOST};Port=5432;Database=workflow_engine_${SERVICEOWNER_ID}_${ENVIRONMENT};Username=${WORKFLOW_ENGINE_DB_USERNAME};Ssl Mode=Require;GSS Encryption Mode=Disable"

--- a/src/Runtime/workflow-engine-app/infra/kustomize/tt02/kustomization.yaml
+++ b/src/Runtime/workflow-engine-app/infra/kustomize/tt02/kustomization.yaml
@@ -18,4 +18,4 @@ patches:
               - name: workflow-engine-app
                 env:
                   - name: ConnectionStrings__WorkflowEngine
-                    value: "Host=${WORKFLOW_ENGINE_DB_HOST};Port=5432;Database=workflow_engine_${SERVICEOWNER_ID}_${ENVIRONMENT};Username=${WORKFLOW_ENGINE_DB_USERNAME};Ssl Mode=Require;GSS Encryption Mode=Disable"
+                    value: "Host=${WORKFLOW_ENGINE_DB_HOST};Port=5432;Database=workflow_engine_${SERVICEOWNER_ID}_${ENVIRONMENT};Username=${WORKFLOW_ENGINE_DB_USERNAME};Ssl Mode=VerifyFull;GSS Encryption Mode=Disable"


### PR DESCRIPTION
## What

Deploy workflow-engine-app on tt02 through the runtime syncroot, the same way as at23 (#19354):

- `infra/runtime/syncroot/tt02/workflow-engine-app.yaml`: the wrapper (namespace, runtime-environment ConfigMap, OCIRepository, Kustomization). It is a copy of the at23 wrapper with one addition, see below.
- `src/Runtime/workflow-engine-app/infra/kustomize/tt02/`: the connection-string patch, identical to the at23 overlay. The database name derives per cluster.

## The suspend gate

The tt02 syncroot deploys to every serviceowner's tt02 cluster, but only clusters with a provisioned database can run the app. The wrapper's Kustomization therefore carries:

```
suspend: ${STUDIO_WORKFLOW_ENGINE_SUSPEND:=true}
```

The platform configuration sets the value to "false" only for clusters that have a database (ttd today). Everywhere else the variable is absent and the default keeps the app suspended. When the fleet database rollout completes, the platform flips the value and this gate disappears.

Both kustomize builds pass; the flux variables pass through unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deployment support for the workflow engine application in the TT02 runtime environment.
  * Added configurable environment, upgrade channel and service ownership settings.
  * Added PostgreSQL database connectivity for workflow engine operations, with secure connection settings.
  * The application remains paused by default and can be enabled only where the required database is available.
  * Added controlled configuration for application credentials and environment-specific deployment values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->