### PR TITLE
chore: update ds from 1.13.3 to 1.20.1

### DIFF
--- a/src/Designer/frontend/libs/studio-components/package.json
+++ b/src/Designer/frontend/libs/studio-components/package.json
@@ -11,8 +11,8 @@
     "typecheck": "tsc --noEmit -p ./"
   },
   "dependencies": {
-    "@digdir/designsystemet-css": "1.13.3",
-    "@digdir/designsystemet-react": "1.13.3",
+    "@digdir/designsystemet-css": "1.20.1",
+    "@digdir/designsystemet-react": "1.20.1",
     "@digdir/designsystemet-theme": "1.11.0",
     "@studio/hooks": "workspace:^",
     "@studio/icons": "workspace:^",

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioBooleanToggleGroup/StudioBooleanToggleGroup.stories.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioBooleanToggleGroup/StudioBooleanToggleGroup.stories.tsx
@@ -11,6 +11,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Preview: Story = {
   args: {
+    'aria-label': 'Boolean toggle',
     value: false,
     trueLabel: 'Yes',
     falseLabel: 'No',

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioBooleanToggleGroup/StudioBooleanToggleGroup.test.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioBooleanToggleGroup/StudioBooleanToggleGroup.test.tsx
@@ -11,7 +11,7 @@ const trueLabel = 'True';
 const falseLabel = 'False';
 const groupName = 'Boolean toggle';
 const defaultProps: StudioBooleanToggleGroupProps = {
-  'data-toggle-group': groupName,
+  'aria-label': groupName,
   trueLabel,
   falseLabel,
 };

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioBooleanToggleGroup/StudioBooleanToggleGroup.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioBooleanToggleGroup/StudioBooleanToggleGroup.tsx
@@ -11,7 +11,7 @@ export type StudioBooleanToggleGroupProps = Override<
     trueLabel: string;
     falseLabel: string;
   },
-  WithoutAsChild<ToggleGroupProps>
+  WithoutAsChild<Extract<ToggleGroupProps, { 'aria-label': string }>>
 >;
 
 const StudioBooleanToggleGroup = forwardRef<HTMLFieldSetElement, StudioBooleanToggleGroupProps>(

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioErrorSummary/StudioErrorSummary.test.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioErrorSummary/StudioErrorSummary.test.tsx
@@ -1,4 +1,4 @@
-import type { Ref } from 'react';
+import type { ComponentRef, Ref } from 'react';
 import { render, screen } from '@testing-library/react';
 import type { RenderResult } from '@testing-library/react';
 import { StudioErrorSummary } from './';
@@ -29,7 +29,9 @@ describe('StudioErrorSummary', () => {
   });
 
   it('should support forwarding the ref', () => {
-    testRefForwarding<HTMLDivElement>((ref) => renderStudioErrorSummary({}, ref));
+    testRefForwarding<ComponentRef<typeof StudioErrorSummary>>((ref) =>
+      renderStudioErrorSummary({}, ref),
+    );
   });
 });
 
@@ -39,7 +41,7 @@ const item2: string = 'Test Item 2';
 
 function renderStudioErrorSummary(
   props: StudioErrorSummaryProps,
-  ref?: Ref<HTMLDivElement>,
+  ref?: Ref<ComponentRef<typeof StudioErrorSummary>>,
 ): RenderResult {
   return render(
     <StudioErrorSummary {...props} ref={ref}>

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioErrorSummary/StudioErrorSummary.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioErrorSummary/StudioErrorSummary.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from 'react';
-import type { ReactElement, Ref } from 'react';
+import type { ComponentRef, ReactElement, Ref } from 'react';
 import { ErrorSummary } from '@digdir/designsystemet-react';
 import type { ErrorSummaryProps } from '@digdir/designsystemet-react';
 import type { WithoutAsChild } from '../../types/WithoutAsChild';
@@ -8,7 +8,7 @@ export type StudioErrorSummaryProps = WithoutAsChild<ErrorSummaryProps>;
 
 function StudioErrorSummary(
   { children, ...rest }: StudioErrorSummaryProps,
-  ref: Ref<HTMLDivElement>,
+  ref: Ref<ComponentRef<typeof ErrorSummary>>,
 ): ReactElement {
   return (
     <ErrorSummary ref={ref} {...rest}>

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioExpression/SimplifiedEditor/BooleanEditor/BooleanEditor.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioExpression/SimplifiedEditor/BooleanEditor/BooleanEditor.tsx
@@ -21,7 +21,7 @@ export const BooleanEditor = ({ expression, onChange }: BooleanEditorProps): Rea
     <div className={classes.booleanEditor}>
       <StudioBooleanToggleGroup
         className={classes.toggle}
-        data-toggle-group=' ' // Todo: Give this element a name: https://github.com/Altinn/altinn-studio/issues/18503
+        aria-label=' ' // Todo: Give this element a name: https://github.com/Altinn/altinn-studio/issues/18503
         falseLabel={texts.false}
         onChange={onChange}
         trueLabel={texts.true}

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioExpression/SimplifiedEditor/LogicalExpressionEditor/SubExpression/SubExpressionValueSelector/SubExpressionValueContentInput/BooleanInput.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioExpression/SimplifiedEditor/LogicalExpressionEditor/SubExpression/SubExpressionValueSelector/SubExpressionValueContentInput/BooleanInput.tsx
@@ -14,7 +14,7 @@ export const BooleanInput = ({
 
   return (
     <StudioBooleanToggleGroup
-      data-toggle-group=' ' // Todo: Give this element a name: https://github.com/Altinn/altinn-studio/issues/18503
+      aria-label=' ' // Todo: Give this element a name: https://github.com/Altinn/altinn-studio/issues/18503
       falseLabel={texts.false}
       onChange={handleChange}
       trueLabel={texts.true}

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioSearch/StudioSearch.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioSearch/StudioSearch.tsx
@@ -1,10 +1,10 @@
 import React, { forwardRef, useId } from 'react';
-import { Label, Search, type SearchProps } from '@digdir/designsystemet-react';
+import { Label, Search, type SearchInputProps } from '@digdir/designsystemet-react';
 import type { WithoutAsChild } from '../../types/WithoutAsChild';
 import { StudioValidationMessage } from '../StudioValidationMessage';
 import classes from './StudioSearch.module.css';
 
-export type StudioSearchProps = WithoutAsChild<SearchProps> & {
+export type StudioSearchProps = WithoutAsChild<SearchInputProps> & {
   label: React.ReactNode;
   id?: string;
   value?: string;

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioSkeleton/StudioSkeleton.test.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioSkeleton/StudioSkeleton.test.tsx
@@ -10,7 +10,7 @@ import { testRootClassNameAppending } from '../../test-utils/testRootClassNameAp
 describe('StudioSkeleton', () => {
   it('Renders a rectangle by default', () => {
     const skeleton = renderAndGetSkeleton();
-    expect(skeleton).toHaveAttribute('data-variant', 'rectangle');
+    expect(skeleton).not.toHaveAttribute('data-variant');
   });
 
   it.each(['rectangle', 'circle', 'text'] as const)('Renders the %s variant', (variant) => {

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioToggleGroup/StudioToggleGroup.test.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioToggleGroup/StudioToggleGroup.test.tsx
@@ -17,9 +17,14 @@ describe('StudioToggleGroup', () => {
   });
 });
 
-const renderStudioToggleGroup = (props: StudioToggleGroupProps): RenderResult => {
+type RenderProps = Omit<
+  StudioToggleGroupProps,
+  'aria-label' | 'aria-labelledby' | 'data-toggle-group'
+>;
+
+const renderStudioToggleGroup = (props: RenderProps): RenderResult => {
   return render(
-    <StudioToggleGroup data-toggle-group='Name' {...props}>
+    <StudioToggleGroup aria-label='Name' {...props}>
       <StudioToggleGroup.Item>{mockItemText}</StudioToggleGroup.Item>
     </StudioToggleGroup>,
   );

--- a/src/Designer/frontend/packages/policy-editor/src/components/PolicyCardRules/PolicyRule/PolicyActions/PolicyActions.test.tsx
+++ b/src/Designer/frontend/packages/policy-editor/src/components/PolicyCardRules/PolicyRule/PolicyActions/PolicyActions.test.tsx
@@ -34,7 +34,9 @@ describe('PolicyActions', () => {
   it('offers every available action as an option', () => {
     renderPolicyActions();
 
-    const options = within(getOptionList()).getAllByRole('option', { hidden: true });
+    const options = within(getOptionList())
+      .getAllByRole('option', { hidden: true })
+      .filter((option) => !option.hidden);
     expect(options.map((option) => option.textContent)).toEqual([
       mockActionOption1,
       mockActionOption2,

--- a/src/Designer/frontend/packages/process-editor/src/components/ConfigPanel/ConfigContent/EditDataTypes/SelectDataTypes/SelectDataTypes.test.tsx
+++ b/src/Designer/frontend/packages/process-editor/src/components/ConfigPanel/ConfigContent/EditDataTypes/SelectDataTypes/SelectDataTypes.test.tsx
@@ -37,7 +37,7 @@ describe('SelectDataTypes', () => {
         mutateDataTypes: mutateDataTypesMock,
       },
     );
-    const suggestionInput = screen.getByRole('textbox', {
+    const suggestionInput = screen.getByRole('combobox', {
       name: textMock('process_editor.configuration_panel_set_data_model_label'),
     });
     await user.click(suggestionInput);
@@ -57,7 +57,7 @@ describe('SelectDataTypes', () => {
     const dataModelIds = ['dataModel1', 'dataModel2'];
     renderSelectDataTypes({ dataModelIds, existingDataType });
 
-    const suggestionInput = screen.getByRole('textbox', {
+    const suggestionInput = screen.getByRole('combobox', {
       name: textMock('process_editor.configuration_panel_set_data_model_label'),
     });
 
@@ -81,7 +81,7 @@ describe('SelectDataTypes', () => {
         mutateDataTypes: mutateDataTypesMock,
       },
     );
-    const suggestionInput = screen.getByRole('textbox', {
+    const suggestionInput = screen.getByRole('combobox', {
       name: textMock('process_editor.configuration_panel_set_data_model_label'),
     });
     await user.click(suggestionInput);
@@ -130,7 +130,7 @@ describe('SelectDataTypes', () => {
         mutateDataTypes: mutateDataTypesMock,
       },
     );
-    const suggestionInput = screen.getByRole('textbox', {
+    const suggestionInput = screen.getByRole('combobox', {
       name: textMock('process_editor.configuration_panel_set_data_model_label'),
     });
     await user.click(suggestionInput);

--- a/src/Designer/frontend/packages/process-editor/src/components/ConfigPanel/ConfigContent/EditDataTypesToSign/EditDataTypesToSign.test.tsx
+++ b/src/Designer/frontend/packages/process-editor/src/components/ConfigPanel/ConfigContent/EditDataTypesToSign/EditDataTypesToSign.test.tsx
@@ -47,7 +47,7 @@ describe('EditDataTypesToSign', () => {
   it('should display a suggestion input with an error message when task has no data type', () => {
     renderEditDataType();
 
-    const suggestionInput = screen.getByRole('textbox', {
+    const suggestionInput = screen.getByRole('combobox', {
       name: textMock('process_editor.configuration_panel_set_data_types_to_sign'),
     });
     expect(suggestionInput).toBeInvalid();
@@ -65,7 +65,7 @@ describe('EditDataTypesToSign', () => {
 
     renderEditDataType();
 
-    const suggestionInput = screen.getByRole('textbox', {
+    const suggestionInput = screen.getByRole('combobox', {
       name: textMock('process_editor.configuration_panel_set_data_types_to_sign'),
     });
 

--- a/src/Designer/frontend/packages/process-editor/src/components/ConfigPanel/ConfigContent/EditDataTypesToSign/SelectDataTypesToSign/SelectDataTypesToSign.test.tsx
+++ b/src/Designer/frontend/packages/process-editor/src/components/ConfigPanel/ConfigContent/EditDataTypesToSign/SelectDataTypesToSign/SelectDataTypesToSign.test.tsx
@@ -88,7 +88,7 @@ describe('SelectDataTypesToSign', () => {
 
     renderSelectDataTypesToSign(existingDataTypesProps);
 
-    const suggestionInput = screen.getByRole('textbox', {
+    const suggestionInput = screen.getByRole('combobox', {
       name: textMock('process_editor.configuration_panel_set_data_types_to_sign'),
     });
     await user.click(suggestionInput);
@@ -118,7 +118,7 @@ describe('SelectDataTypesToSign', () => {
 
     renderSelectDataTypesToSign(existingDataTypesProps);
 
-    const suggestionInput = screen.getByRole('textbox', {
+    const suggestionInput = screen.getByRole('combobox', {
       name: textMock('process_editor.configuration_panel_set_data_types_to_sign'),
     });
     await user.click(suggestionInput);

--- a/src/Designer/frontend/packages/process-editor/src/components/ConfigPanel/ConfigContent/EditUniqueFromSignaturesInDataTypes/SelectUniqueFromSignaturesInDataTypes/SelectUniqueFromSignaturesInDataTypes.test.tsx
+++ b/src/Designer/frontend/packages/process-editor/src/components/ConfigPanel/ConfigContent/EditUniqueFromSignaturesInDataTypes/SelectUniqueFromSignaturesInDataTypes/SelectUniqueFromSignaturesInDataTypes.test.tsx
@@ -93,7 +93,7 @@ describe('SelectUniqueFromSignaturesInDataTypes', () => {
 
     renderSelectDataTypes(existingDataTypesProps);
 
-    const suggestionInput = screen.getByRole('textbox', {
+    const suggestionInput = screen.getByRole('combobox', {
       name: textMock('process_editor.configuration_panel_set_unique_from_signatures_in_data_types'),
     });
     await user.click(suggestionInput);

--- a/src/Designer/frontend/packages/process-editor/src/components/ConfigPanel/ConfigServiceTask/ConfigPdfServiceTask/ConfigPdfServiceTask.test.tsx
+++ b/src/Designer/frontend/packages/process-editor/src/components/ConfigPanel/ConfigServiceTask/ConfigPdfServiceTask/ConfigPdfServiceTask.test.tsx
@@ -249,7 +249,7 @@ describe('ConfigPdfServiceTask', () => {
       renderConfigPdfServiceTask();
 
       // PdfAutomaticTaskSelection renders a combobox
-      expect(screen.getByRole('textbox')).toBeInTheDocument();
+      expect(screen.getByRole('combobox')).toBeInTheDocument();
     });
 
     it('should render PdfLayoutBasedSection when in layout-based mode', async () => {

--- a/src/Designer/frontend/packages/process-editor/src/components/ConfigPanel/ConfigServiceTask/ConfigPdfServiceTask/PdfAutomaticTaskSelection/PdfAutomaticTaskSelection.test.tsx
+++ b/src/Designer/frontend/packages/process-editor/src/components/ConfigPanel/ConfigServiceTask/ConfigPdfServiceTask/PdfAutomaticTaskSelection/PdfAutomaticTaskSelection.test.tsx
@@ -51,7 +51,7 @@ describe('PdfAutomaticTaskSelection', () => {
   it('should render task selector combobox', () => {
     renderPdfAutomaticTaskSelection();
 
-    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
   });
 
   it('should display available tasks as options', async () => {
@@ -59,7 +59,7 @@ describe('PdfAutomaticTaskSelection', () => {
 
     renderPdfAutomaticTaskSelection();
 
-    const combobox = screen.getByRole('textbox');
+    const combobox = screen.getByRole('combobox');
     await user.click(combobox);
 
     expect(
@@ -75,7 +75,7 @@ describe('PdfAutomaticTaskSelection', () => {
 
     renderPdfAutomaticTaskSelection();
 
-    const combobox = screen.getByRole('textbox');
+    const combobox = screen.getByRole('combobox');
     await user.click(combobox);
 
     const option = screen.getByRole('option', { name: /Task 1.*\(task_1\)/, hidden: true });
@@ -90,7 +90,7 @@ describe('PdfAutomaticTaskSelection', () => {
 
     renderPdfAutomaticTaskSelection(['task_1']);
 
-    await user.click(screen.getByRole('textbox'));
+    await user.click(screen.getByRole('combobox'));
 
     const selectedTaskChip = screen.getByRole('option', {
       name: /^Task 1 \(task_1\), /,
@@ -106,7 +106,7 @@ describe('PdfAutomaticTaskSelection', () => {
 
     renderPdfAutomaticTaskSelection();
 
-    const combobox = screen.getByRole('textbox');
+    const combobox = screen.getByRole('combobox');
     await user.click(combobox);
 
     await user.click(screen.getByRole('option', { name: /Task 1.*\(task_1\)/, hidden: true }));
@@ -133,7 +133,7 @@ describe('PdfAutomaticTaskSelection', () => {
 
       renderPdfAutomaticTaskSelection();
 
-      const combobox = screen.getByRole('textbox');
+      const combobox = screen.getByRole('combobox');
       await user.click(combobox);
 
       expect(screen.getByRole('option', { name: /\(task_1\)/, hidden: true })).toBeInTheDocument();
@@ -154,7 +154,7 @@ describe('PdfAutomaticTaskSelection', () => {
 
       renderPdfAutomaticTaskSelection();
 
-      const combobox = screen.getByRole('textbox');
+      const combobox = screen.getByRole('combobox');
       await user.click(combobox);
 
       expect(screen.getByRole('option', { name: /\(task_1\)/, hidden: true })).toBeInTheDocument();
@@ -166,7 +166,7 @@ describe('PdfAutomaticTaskSelection', () => {
 
       renderPdfAutomaticTaskSelection();
 
-      const combobox = screen.getByRole('textbox');
+      const combobox = screen.getByRole('combobox');
       await user.click(combobox);
 
       expect(

--- a/src/Designer/frontend/packages/ux-editor-v4/src/components/Properties/EditSubformTableColumns/ColumnElement/EditColumnElement/EditColumnElement.test.tsx
+++ b/src/Designer/frontend/packages/ux-editor-v4/src/components/Properties/EditSubformTableColumns/ColumnElement/EditColumnElement/EditColumnElement.test.tsx
@@ -77,7 +77,7 @@ describe('EditColumnElementComponentSelect', () => {
           'ux_editor.properties_panel.subform_table_columns.no_components_available_message',
         ),
       ),
-    ).not.toBeInTheDocument();
+    ).not.toBeVisible();
   });
 
   it('should render just components with labels and data model bindings', async () => {

--- a/src/Designer/frontend/packages/ux-editor/src/components/Properties/EditSubformTableColumns/ColumnElement/EditColumnElement/EditColumnElement.test.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/components/Properties/EditSubformTableColumns/ColumnElement/EditColumnElement/EditColumnElement.test.tsx
@@ -77,7 +77,7 @@ describe('EditColumnElementComponentSelect', () => {
           'ux_editor.properties_panel.subform_table_columns.no_components_available_message',
         ),
       ),
-    ).not.toBeInTheDocument();
+    ).not.toBeVisible();
   });
 
   it('should render just components with labels and data model bindings', async () => {

--- a/src/Designer/frontend/resourceadm/testing/playwright/pages/ResourcePage.ts
+++ b/src/Designer/frontend/resourceadm/testing/playwright/pages/ResourcePage.ts
@@ -101,9 +101,10 @@ export class ResourcePage extends ResourceEnvironment {
     this.addPolicyRuleButton = this.page.getByRole('button', {
       name: textMock('policy_editor.card_button_text'),
     });
-    this.policyActionDropdown = this.page.getByRole('combobox', {
-      name: textMock('policy_editor.rule_card_actions_title'),
-    });
+    this.policyActionDropdown = this.page.getByLabel(
+      textMock('policy_editor.rule_card_actions_title'),
+      { exact: true },
+    );
     this.policySubjectAccordion = this.page
       .locator('summary')
       .filter({ hasText: textMock('policy_editor.org_subjects_header') });

--- a/src/Designer/frontend/testing/playwright/pages/ProcessEditorPage/DataModelConfig.ts
+++ b/src/Designer/frontend/testing/playwright/pages/ProcessEditorPage/DataModelConfig.ts
@@ -23,9 +23,10 @@ export class DataModelConfig extends BasePage {
   }
 
   public async waitForComboboxToBeVisible(): Promise<void> {
-    const combobox = this.page.getByRole('combobox', {
-      name: this.textMock('process_editor.configuration_panel_set_data_model_label'),
-    });
+    const combobox = this.page.getByLabel(
+      this.textMock('process_editor.configuration_panel_set_data_model_label'),
+      { exact: true },
+    );
     await expect(combobox).toBeVisible();
   }
 
@@ -54,8 +55,8 @@ export class DataModelConfig extends BasePage {
 
   public async clickOnCombobox(): Promise<void> {
     await this.page
-      .getByRole('combobox', {
-        name: this.textMock('process_editor.configuration_panel_set_data_model_label'),
+      .getByLabel(this.textMock('process_editor.configuration_panel_set_data_model_label'), {
+        exact: true,
       })
       .click();
   }
@@ -100,11 +101,10 @@ export class DataModelConfig extends BasePage {
 
   public async clickOnAddDataModelCombobox(): Promise<void> {
     await this.page
-      .getByRole('combobox', {
-        name: this.textMock(
-          'process_editor.configuration_panel_custom_receipt_select_data_model_label',
-        ),
-      })
+      .getByLabel(
+        this.textMock('process_editor.configuration_panel_custom_receipt_select_data_model_label'),
+        { exact: true },
+      )
       .click();
   }
 }

--- a/src/Designer/frontend/testing/playwright/pages/ProcessEditorPage/SigningTaskConfig.ts
+++ b/src/Designer/frontend/testing/playwright/pages/ProcessEditorPage/SigningTaskConfig.ts
@@ -8,8 +8,8 @@ export class SigningTaskConfig extends BasePage {
 
   public async clickDataTypesToSignCombobox(): Promise<void> {
     await this.page
-      .getByRole('combobox', {
-        name: this.textMock('process_editor.configuration_panel_set_data_types_to_sign'),
+      .getByLabel(this.textMock('process_editor.configuration_panel_set_data_types_to_sign'), {
+        exact: true,
       })
       .click();
   }

--- a/src/Designer/frontend/testing/setupTests.ts
+++ b/src/Designer/frontend/testing/setupTests.ts
@@ -64,6 +64,17 @@ Object.defineProperty(document, 'getAnimations', {
   writable: true,
 });
 
+// document.elementFromPoint must be mocked because the Popover component from the design system uses
+// it to check whether it is the top layer, but jsdom has no layout, so every element reports a
+// zero-sized rect. Returning the open popover lets the Escape key reach it.
+Object.defineProperty(document, 'elementFromPoint', {
+  value: () =>
+    Array.from(document.querySelectorAll<HTMLElement>('[popover]')).findLast(
+      (element) => element.matches(':popover-open') || element.classList.contains(':popover-open'),
+    ) ?? document.body,
+  writable: true,
+});
+
 // Use Node's implementation of Web Crypto API, since Jest does not have access to browser's Web Crypto API
 Object.defineProperty(window, 'crypto', {
   value: webcrypto,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1976,12 +1976,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@digdir/designsystemet-css@npm:1.13.3":
-  version: 1.13.3
-  resolution: "@digdir/designsystemet-css@npm:1.13.3"
+"@digdir/designsystemet-css@npm:1.20.1":
+  version: 1.20.1
+  resolution: "@digdir/designsystemet-css@npm:1.20.1"
   dependencies:
-    "@digdir/designsystemet-types": "npm:1.13.3"
-  checksum: 10/d34da3c7045c9c021642d18a479827e52f55b7b6635c3b8f92ecbd9d950b762e228a37396b3bfbfb28975eebfb65deff62b7ebffc4dee0c0ddd7b8e975a647d4
+    "@digdir/designsystemet-types": "npm:1.20.1"
+  checksum: 10/a763795a1aea87618b3a2f839cebfaa38c1ae2180b82988ae703967ae48a2e7a1c1b30ae2c02f18ca5ba926f6331fb81eca457e97045f87c05b9835e854a6d23
   languageName: node
   linkType: hard
 
@@ -2006,22 +2006,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@digdir/designsystemet-react@npm:1.13.3":
-  version: 1.13.3
-  resolution: "@digdir/designsystemet-react@npm:1.13.3"
+"@digdir/designsystemet-react@npm:1.20.1":
+  version: 1.20.1
+  resolution: "@digdir/designsystemet-react@npm:1.20.1"
   dependencies:
-    "@digdir/designsystemet-types": "npm:1.13.3"
-    "@digdir/designsystemet-web": "npm:1.13.3"
-    "@floating-ui/dom": "npm:^1.7.6"
+    "@digdir/designsystemet-types": "npm:1.20.1"
+    "@digdir/designsystemet-web": "npm:1.20.1"
+    "@floating-ui/dom": "npm:^1.8.0"
     "@floating-ui/react": "npm:0.26.23"
-    "@navikt/aksel-icons": "npm:^8.9.0"
-    "@radix-ui/react-slot": "npm:^1.2.4"
-    "@tanstack/react-virtual": "npm:^3.13.23"
+    "@navikt/aksel-icons": "npm:^8.16.1"
+    "@radix-ui/react-slot": "npm:^1.3.3"
+    "@tanstack/react-virtual": "npm:^3.14.9"
     clsx: "npm:^2.1.1"
   peerDependencies:
     react: ">=18.3.1 || ^19.0.0"
     react-dom: ">=18.3.1 || ^19.0.0"
-  checksum: 10/b3ff755473afbf0e2445b4aeb22fbb55ea5c054bfc80e5eaf6f3bef14dc5d94b908c19014b8bcdedf4c7be22aa584571c5da47083b56d5661b9ade80960d1726
+  checksum: 10/9572c75bab155068716a65a892b8201351253d4f97173984b2e06cd5f61eb000687a10bcac3122b1694b9b9b5d8db4f2b2dcd1e3f3b4eb531c84b0df05b1681f
   languageName: node
   linkType: hard
 
@@ -2034,10 +2034,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@digdir/designsystemet-types@npm:1.13.3":
-  version: 1.13.3
-  resolution: "@digdir/designsystemet-types@npm:1.13.3"
-  checksum: 10/6036ee6a2e0923a60fa038232e0edd078f026990151d43cee06e4c68766181fe21a4fe857a1822032010e095cee1135e1bd39b6e5c36f1c4d407920c8cb03ff8
+"@digdir/designsystemet-types@npm:1.20.1":
+  version: 1.20.1
+  resolution: "@digdir/designsystemet-types@npm:1.20.1"
+  checksum: 10/05b05ce3855a95d15f12500667f75417a2bb1d0b4e28b3c77b63fc76b121fda8651ce82393e286a826b7e75bdcecf69730094fea6d8b3d03ea5601695f583b8c
   languageName: node
   linkType: hard
 
@@ -2048,16 +2048,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@digdir/designsystemet-web@npm:1.13.3":
-  version: 1.13.3
-  resolution: "@digdir/designsystemet-web@npm:1.13.3"
+"@digdir/designsystemet-web@npm:1.20.1":
+  version: 1.20.1
+  resolution: "@digdir/designsystemet-web@npm:1.20.1"
   dependencies:
-    "@floating-ui/dom": "npm:^1.7.6"
-    "@u-elements/u-combobox": "npm:^1.0.7"
-    "@u-elements/u-datalist": "npm:^1.1.0"
+    "@floating-ui/dom": "npm:^1.8.0"
+    "@u-elements/u-combobox": "npm:^2.1.3"
+    "@u-elements/u-datalist": "npm:^2.0.3"
     "@u-elements/u-details": "npm:^1.0.0"
-    "@u-elements/u-tabs": "npm:^1.0.1"
-  checksum: 10/71a3c0659e935ebf57c5e1ecffdc73e7dbc9b58de05cc784e7b71251ce565028a78a1685d0fe756e258ffb814bbf40b89ebfea67abd9653bac6d72213579474a
+    "@u-elements/u-tabs": "npm:^1.0.4"
+  checksum: 10/5655606ce185a2a6a643ad4d40c1830ab68ab20b1e22ec735f1c6b2e206eda1281219f7ea357931efc3f0b5416bc23190d01578da87b800f19da699904842c5a
   languageName: node
   linkType: hard
 
@@ -2770,13 +2770,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@floating-ui/dom@npm:^1.7.4, @floating-ui/dom@npm:^1.7.5, @floating-ui/dom@npm:^1.7.6":
+"@floating-ui/core@npm:^1.8.0":
+  version: 1.8.0
+  resolution: "@floating-ui/core@npm:1.8.0"
+  dependencies:
+    "@floating-ui/utils": "npm:^0.2.12"
+  checksum: 10/762cd5677fd4e82597db2efdd8f1e81d248eac5615d8be755e1bbb5f12a14c56a6bccd735676374d4914db7ccb3f09ec405ec7433e8c48a5521f5d66dc8dd5d6
+  languageName: node
+  linkType: hard
+
+"@floating-ui/dom@npm:^1.7.4, @floating-ui/dom@npm:^1.7.5":
   version: 1.7.6
   resolution: "@floating-ui/dom@npm:1.7.6"
   dependencies:
     "@floating-ui/core": "npm:^1.7.5"
     "@floating-ui/utils": "npm:^0.2.11"
   checksum: 10/84dff2ffdf85c8b92d7edafc543c55869abbeaeb3007fa983159467e050153b507a0f5fe8e84f88c3f28c35a82de9df9c20a6eef5560cbba3afae19141444ff2
+  languageName: node
+  linkType: hard
+
+"@floating-ui/dom@npm:^1.8.0":
+  version: 1.8.0
+  resolution: "@floating-ui/dom@npm:1.8.0"
+  dependencies:
+    "@floating-ui/core": "npm:^1.8.0"
+    "@floating-ui/utils": "npm:^0.2.12"
+  checksum: 10/2e7d75fb702875a62795dd8529569f27eff53167768d75476056d6bf824a1ba608177a8877ed9d728eadb5787b4bd07b043fb2c3125b7ad2505a398680b323c0
   languageName: node
   linkType: hard
 
@@ -2810,6 +2829,13 @@ __metadata:
   version: 0.2.11
   resolution: "@floating-ui/utils@npm:0.2.11"
   checksum: 10/72150138ba1c274d757a1da85233202fa9fdfd2272ec1fb0883eb0ffdf138863af81573049ed2c20b98adb4b7ae2236065541ce14037fe328955089831a678d5
+  languageName: node
+  linkType: hard
+
+"@floating-ui/utils@npm:^0.2.12":
+  version: 0.2.12
+  resolution: "@floating-ui/utils@npm:0.2.12"
+  checksum: 10/ec4e176fb22d33d75df752c5acf82dcaacae40ed2d09c1a5015cb4081318fff20260db216678e952344b95f90c6b43214762b69eba7c51556ecd82c35a795cff
   languageName: node
   linkType: hard
 
@@ -3628,7 +3654,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/aksel-icons@npm:8.16.1":
+"@navikt/aksel-icons@npm:8.16.1, @navikt/aksel-icons@npm:^8.16.1":
   version: 8.16.1
   resolution: "@navikt/aksel-icons@npm:8.16.1"
   checksum: 10/7b90c92406d6ed6ba7c4116e7468c60af9eda2cab42984b7633d2da861b027fd199d9af4b32ab177d43e2ce25fd24a944ee10ff0386a8c4f9b9b68416bb27dc2
@@ -3642,7 +3668,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/aksel-icons@npm:^8.2.0, @navikt/aksel-icons@npm:^8.9.0":
+"@navikt/aksel-icons@npm:^8.2.0":
   version: 8.10.5
   resolution: "@navikt/aksel-icons@npm:8.10.5"
   checksum: 10/6a7b005e664c326e840111bba62845c8106d140030ceca2d400fca75aadd5e7e0fdf3e7f959cd233f0c93ff22ebeca78941b8a7f83d0e2cca0e47b5d75583261
@@ -4604,6 +4630,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-compose-refs@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@radix-ui/react-compose-refs@npm:1.1.5"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/ffc1a289d944ba9db818bc645e44efb6ce122a1585b61fcd97737ba4d18b60ca585b3d46ff1836b6ad6c4a21c795c5082d540af58cb32daa1b692dffed3d2a15
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-slot@npm:^1.2.4":
   version: 1.2.4
   resolution: "@radix-ui/react-slot@npm:1.2.4"
@@ -4616,6 +4655,21 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/b37e37455b92789758980359d73ab5a5f5d1c12af480c775519bd15c556b891642d472accf05b30d520751489ca74cdb8fd7866064abc7942f0437371be28e51
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-slot@npm:^1.3.3":
+  version: 1.3.3
+  resolution: "@radix-ui/react-slot@npm:1.3.3"
+  dependencies:
+    "@radix-ui/react-compose-refs": "npm:1.1.5"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/97f305fb29c6284e1292cfee441cd807744f32322c0a1b541190a294f878edacce3bc37c174b4024724210243dad7b4feb762222e4c43668db2b65b9576d222a
   languageName: node
   linkType: hard
 
@@ -5438,8 +5492,8 @@ __metadata:
   resolution: "@studio/components@workspace:src/Designer/frontend/libs/studio-components"
   dependencies:
     "@chromatic-com/storybook": "npm:^5.0.1"
-    "@digdir/designsystemet-css": "npm:1.13.3"
-    "@digdir/designsystemet-react": "npm:1.13.3"
+    "@digdir/designsystemet-css": "npm:1.20.1"
+    "@digdir/designsystemet-react": "npm:1.20.1"
     "@digdir/designsystemet-theme": "npm:1.11.0"
     "@storybook/addon-docs": "npm:10.5.7"
     "@storybook/addon-links": "npm:10.5.7"
@@ -5805,7 +5859,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/react-virtual@npm:^3.13.18, @tanstack/react-virtual@npm:^3.13.23":
+"@tanstack/react-virtual@npm:^3.13.18":
   version: 3.13.23
   resolution: "@tanstack/react-virtual@npm:3.13.23"
   dependencies:
@@ -5817,10 +5871,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tanstack/react-virtual@npm:^3.14.9":
+  version: 3.14.10
+  resolution: "@tanstack/react-virtual@npm:3.14.10"
+  dependencies:
+    "@tanstack/virtual-core": "npm:3.17.8"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10/2cfb17980499f927c783d0e1dbd2a080433338db358e2cbef5db37fc953207255b88aaa78592081ec9c1c1a6a1e86158e45cb80f3d82700128b8ce292136b534
+  languageName: node
+  linkType: hard
+
 "@tanstack/virtual-core@npm:3.13.23":
   version: 3.13.23
   resolution: "@tanstack/virtual-core@npm:3.13.23"
   checksum: 10/17f6e3c3f56d2d91d5818981416a628db2e1038f6a13f39f60e5b2bdcff04b99fba0e79640a6667ea9ef70756a2a086fb468f8b5f065faea9f1a47f8aa3722a5
+  languageName: node
+  linkType: hard
+
+"@tanstack/virtual-core@npm:3.17.8":
+  version: 3.17.8
+  resolution: "@tanstack/virtual-core@npm:3.17.8"
+  checksum: 10/b115caa01ccc748b97b5f1df7ee26e32fe82586da25d900630dc91297d35acaf90709cb5bf7fc0b85a86124aeb640cec7ac1a59ff6de9a6d25b7f53ddfce6a41
   languageName: node
   linkType: hard
 
@@ -6806,10 +6879,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@u-elements/u-combobox@npm:^2.1.3":
+  version: 2.1.3
+  resolution: "@u-elements/u-combobox@npm:2.1.3"
+  checksum: 10/e405c3c4dda7fbcc9533d418916043cdb848cb30966614fc4b0dc614d919ec0110b1b632fa01a0e32227affacd334c003d9d54890c96a258dfa959010b2f0362
+  languageName: node
+  linkType: hard
+
 "@u-elements/u-datalist@npm:^1.1.0":
   version: 1.1.0
   resolution: "@u-elements/u-datalist@npm:1.1.0"
   checksum: 10/8e219056cff5383119d906356ade3ce8b2d2dbcca8abc2c38c43bd21b99c6d93d875acb55d89959a3dc107fabe6a772d67bd21995bb4e6b88b53b37e37424103
+  languageName: node
+  linkType: hard
+
+"@u-elements/u-datalist@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "@u-elements/u-datalist@npm:2.0.3"
+  checksum: 10/d14255d9b899cb60b5b2d0ddbd7b43d71f3c8856672695d9c19c5b78edb807ec7058f3acdb4a429b7f82e9a0de2e5e53535e8c8f222e1abf3fe9577ea03cd679
   languageName: node
   linkType: hard
 
@@ -6827,7 +6914,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@u-elements/u-tabs@npm:^1.0.1":
+"@u-elements/u-tabs@npm:^1.0.4":
   version: 1.0.4
   resolution: "@u-elements/u-tabs@npm:1.0.4"
   checksum: 10/70393d1515c889d4889aab37a0e40c3be464161be34622c720be2b1717779d1f622352c91194e7382b4aca51ccd3b5cab0fbc83f1b41f8815a760974b60feb7a


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Now that @digdir/designsystemet-* is declared only in @studio/components (#20225), the upgrade touches one package.

- Type fixes for StudioSearch and StudioErrorSummary
- Moved off the deprecated data-toggle-group
- Adapted Suggestion and Popover tests:  Suggestion filters options by input content, so tests must clear the field first.
- setupTests.ts mocks document.elementFromPoint, which popover uses for its top-layer check and jsdom does not implement

<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Accessibility**
  - Improved accessible labelling for boolean toggle groups using ARIA labels.
  - Updated controls to expose the correct combobox roles.

- **Improvements**
  - Refined error summary ref handling and search input compatibility.
  - Updated UI components to align with the latest design system improvements.
  - Refined skeleton rendering and visibility behaviour.

- **Tests**
  - Updated component and end-to-end tests to reflect accessibility, visibility, and control behaviour.
  - Improved popover and keyboard interaction support in the test environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->