### PR TITLE
feat(experimental): create new agent with `c` in tui

### DIFF
--- a/src/experimental/agent/src/bin/agentctl/format.rs
+++ b/src/experimental/agent/src/bin/agentctl/format.rs
@@ -13,9 +13,22 @@ pub(crate) fn describe_agent_lines(agent: &Agent) -> Vec<String> {
         .and_then(agent::sandbox::Assignment::id)
         .map_or_else(|| "-".into(), ToString::to_string);
 
+    let source = agent.status.provenance.as_ref().map_or_else(
+        || "-".into(),
+        |provenance| {
+            provenance
+                .manifest_path
+                .as_ref()
+                .unwrap_or(&provenance.source_directory)
+                .display()
+                .to_string()
+        },
+    );
+
     let mut lines = vec![
         format!("Name:       {}", agent.metadata.name),
         format!("Generation: {}", agent.metadata.generation),
+        format!("Source:     {source}"),
         format!("Harnesses:  {}", format_harnesses(&agent.spec)),
         format!("Provider:   {provider}"),
         format!("Sandbox:    {sandbox}"),

--- a/src/experimental/agent/src/bin/agentctl/main.rs
+++ b/src/experimental/agent/src/bin/agentctl/main.rs
@@ -770,6 +770,8 @@ async fn read_apply_request(filename: PathBuf) -> Result<ApplyRequest, Error> {
         .to_path_buf();
     Ok(ApplyRequest {
         source_directory,
+        manifest_path: Some(filename),
+        create_only: false,
         agent,
     })
 }

--- a/src/experimental/agent/src/bin/agentctl/tui/app.rs
+++ b/src/experimental/agent/src/bin/agentctl/tui/app.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::{collections::HashSet, path::PathBuf};
 
 use agent::{
     Agent, ConditionStatus, Harness,
@@ -21,9 +21,10 @@ pub(crate) struct App {
     pub(crate) detail: Option<Detail>,
     pub(crate) modal: Option<Modal>,
     pub(crate) forwards: Vec<ForwardEntry>,
-    pub(crate) forwards_view: bool,
+    pub(crate) view: View,
     pub(crate) forward_selected: usize,
     pub(crate) creating: usize,
+    pub(crate) discovering: bool,
 }
 
 /// Display state of one process-owned port forward.
@@ -41,6 +42,13 @@ impl ForwardEntry {
         let local = self.local.strip_prefix("127.0.0.1:").unwrap_or(&self.local);
         format!("{local}:{}", self.guest_port)
     }
+}
+
+/// Which main screen the TUI is showing.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum View {
+    Tree,
+    Forwards,
 }
 
 pub(crate) struct Group {
@@ -72,7 +80,92 @@ pub(crate) enum Modal {
         harness: usize,
         error: Option<String>,
     },
+    CreateAgent(CreateForm),
     PortForward(ForwardForm),
+}
+
+/// One manifest source offered by the create-agent picker.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ManifestCandidate {
+    /// Full path of the manifest file.
+    pub(crate) path: PathBuf,
+    /// Decoded `metadata.name`, or why the manifest cannot be used.
+    pub(crate) name: Result<String, String>,
+}
+
+/// Create-agent form state: a manifest picker plus a placeholder-backed name.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct CreateForm {
+    pub(crate) candidates: Vec<ManifestCandidate>,
+    pub(crate) selected: usize,
+    pub(crate) name: String,
+    pub(crate) error: Option<String>,
+}
+
+impl CreateForm {
+    /// Returns the selected manifest's name, shown grayed while nothing is typed.
+    pub(crate) fn placeholder(&self) -> Option<&str> {
+        self.candidates.get(self.selected)?.name.as_deref().ok()
+    }
+
+    /// Applies one key press; a submitted or cancelled form returns its Action.
+    fn key(&mut self, key: KeyEvent, agents: &[Agent]) -> Option<Action> {
+        match key.code {
+            KeyCode::Esc => return Some(Action::None),
+            KeyCode::Enter => match self.submission(agents) {
+                Ok(action) => return Some(action),
+                Err(invalid) => self.error = Some(invalid),
+            },
+            KeyCode::Tab | KeyCode::Right | KeyCode::Down => self.select(1),
+            KeyCode::BackTab | KeyCode::Left | KeyCode::Up => self.select(-1),
+            KeyCode::Backspace => {
+                self.name.pop();
+                self.error = None;
+            }
+            KeyCode::Char(character)
+                if key.modifiers.difference(KeyModifiers::SHIFT).is_empty()
+                    && ::sandbox::SandboxName::accepts(character)
+                    && self.name.len() < ::sandbox::MAX_SANDBOX_NAME_BYTES =>
+            {
+                self.name.push(character);
+                self.error = None;
+            }
+            _ => {}
+        }
+        None
+    }
+
+    fn select(&mut self, delta: isize) {
+        if self.candidates.is_empty() {
+            return;
+        }
+        let length = isize::try_from(self.candidates.len()).unwrap_or(1);
+        let current = isize::try_from(self.selected).unwrap_or_default();
+        self.selected = usize::try_from((current + delta).rem_euclid(length)).unwrap_or_default();
+        self.error = None;
+    }
+
+    fn submission(&self, agents: &[Agent]) -> Result<Action, String> {
+        let candidate = self
+            .candidates
+            .get(self.selected)
+            .ok_or_else(|| "no manifest available; apply one with agentctl apply -f".to_owned())?;
+        let manifest_name = candidate.name.as_ref().map_err(Clone::clone)?;
+        let name = if self.name.is_empty() {
+            manifest_name.clone()
+        } else {
+            self.name.clone()
+        };
+        ::sandbox::SandboxName::new(name.clone()).map_err(|invalid| format!("name: {invalid}"))?;
+        if agents.iter().any(|agent| agent.metadata.name == name) {
+            return Err(format!("agent {name:?} already exists"));
+        }
+        Ok(Action::CreateAgent {
+            manifest: candidate.path.clone(),
+            name,
+            form: self.clone(),
+        })
+    }
 }
 
 /// k9s-style port-forward form state.
@@ -195,6 +288,12 @@ pub(crate) enum Action {
         session: SessionName,
         harness: Harness,
     },
+    OpenCreate,
+    CreateAgent {
+        manifest: PathBuf,
+        name: String,
+        form: CreateForm,
+    },
     Exec {
         agent: String,
     },
@@ -243,9 +342,10 @@ impl App {
             detail: None,
             modal: None,
             forwards: Vec::new(),
-            forwards_view: false,
+            view: View::Tree,
             forward_selected: 0,
             creating: 0,
+            discovering: false,
         }
     }
 
@@ -321,7 +421,7 @@ impl App {
         }
         // The error screen renders over the forwards view, so its keys must
         // win over forwards_key while an error is shown.
-        if self.forwards_view && self.error.is_none() {
+        if self.view == View::Forwards && self.error.is_none() {
             return self.forwards_key(key);
         }
         self.main_key(key)
@@ -334,7 +434,8 @@ impl App {
             KeyCode::Up | KeyCode::Char('k') => self.move_selection(-1),
             KeyCode::Char('r') => return Action::Refresh,
             KeyCode::Char('z') => self.toggle_all(),
-            KeyCode::Char('F') => self.forwards_view = true,
+            KeyCode::Char('F') => self.view = View::Forwards,
+            KeyCode::Char('c') => return Action::OpenCreate,
             _ => {
                 return match self.selected_row() {
                     Some(Row::Agent(group)) => self.agent_key(key, group),
@@ -348,7 +449,7 @@ impl App {
 
     fn forwards_key(&mut self, key: KeyEvent) -> Action {
         match key.code {
-            KeyCode::Esc | KeyCode::Char('q' | 'F') => self.forwards_view = false,
+            KeyCode::Esc | KeyCode::Char('q' | 'F') => self.view = View::Tree,
             KeyCode::Down | KeyCode::Char('j') => self.move_forward_selection(1),
             KeyCode::Up | KeyCode::Char('k') => self.move_forward_selection(-1),
             KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
@@ -542,6 +643,13 @@ impl App {
                 });
                 Action::None
             }
+            Some(Modal::CreateAgent(mut form)) => {
+                if let Some(action) = form.key(key, &self.agents) {
+                    return action;
+                }
+                self.modal = Some(Modal::CreateAgent(form));
+                Action::None
+            }
             Some(Modal::PortForward(mut form)) => {
                 if let Some(action) = form.key(key) {
                     return action;
@@ -550,6 +658,36 @@ impl App {
                 Action::None
             }
             None => Action::None,
+        }
+    }
+
+    /// Opens the create-agent modal, preselecting the highlighted Agent's manifest.
+    pub(crate) fn open_create(&mut self, candidates: Vec<ManifestCandidate>) {
+        let manifest = match self.selected_row() {
+            Some(Row::Agent(group) | Row::Session { group, .. }) => self
+                .group_agent(group)
+                .and_then(|agent| agent.status.provenance.as_ref())
+                .map(agent::Provenance::manifest_or_default),
+            None => None,
+        };
+        let selected = manifest
+            .and_then(|manifest| candidates.iter().position(|candidate| candidate.path == manifest))
+            .unwrap_or_default();
+        self.modal = Some(Modal::CreateAgent(CreateForm {
+            candidates,
+            selected,
+            name: String::new(),
+            error: None,
+        }));
+    }
+
+    pub(crate) fn select_agent(&mut self, name: &str) {
+        let position = self.rows.iter().position(|row| {
+            matches!(row, Row::Agent(group)
+                if self.group_agent(*group).is_some_and(|agent| agent.metadata.name == name))
+        });
+        if let Some(position) = position {
+            self.selected = position;
         }
     }
 
@@ -694,13 +832,14 @@ impl App {
             return match modal {
                 Modal::ConfirmDelete { .. } => vec![("y", "confirm"), ("n", "cancel")],
                 Modal::NewSession { .. } => vec![("enter", "create"), ("tab", "harness"), ("esc", "cancel")],
+                Modal::CreateAgent { .. } => vec![("enter", "create"), ("tab", "manifest"), ("esc", "cancel")],
                 Modal::PortForward { .. } => vec![("enter", "forward"), ("tab", "field"), ("esc", "cancel")],
             };
         }
         if self.detail.is_some() {
             return vec![("j/k", "scroll"), ("q", "back")];
         }
-        if self.forwards_view {
+        if self.view == View::Forwards {
             return vec![("e", "edit"), ("ctrl-d", "delete"), ("q", "back")];
         }
         match self.selected_row() {
@@ -709,6 +848,7 @@ impl App {
                 ("s", "describe"),
                 ("y", "yaml"),
                 ("n", "new session"),
+                ("c", "new agent"),
                 ("e", "exec"),
                 ("f", "forward"),
                 ("d", "delete"),
@@ -719,8 +859,9 @@ impl App {
                 ("s", "describe"),
                 ("y", "yaml"),
                 ("n", "new session"),
+                ("c", "new agent"),
             ],
-            None => Vec::new(),
+            None => vec![("c", "new agent")],
         }
     }
 }
@@ -1023,6 +1164,152 @@ mod tests {
         );
     }
 
+    fn candidates(entries: &[(&str, &str)]) -> Vec<ManifestCandidate> {
+        entries
+            .iter()
+            .map(|(directory, name)| ManifestCandidate {
+                path: PathBuf::from(directory).join("agent.yaml"),
+                name: Ok((*name).to_owned()),
+            })
+            .collect()
+    }
+
+    fn create_form(app: &App) -> &CreateForm {
+        let Some(Modal::CreateAgent(form)) = &app.modal else {
+            panic!("expected the CreateAgent modal");
+        };
+        form
+    }
+
+    #[test]
+    fn create_key_requests_manifest_discovery_even_without_agents() {
+        let mut app = App::new();
+        app.apply_snapshot(Vec::new(), Vec::new());
+        assert_eq!(app.hints(), vec![("c", "new agent")]);
+        assert_eq!(app.on_key(key(KeyCode::Char('c'))), Action::OpenCreate);
+        let mut app = populated();
+        assert_eq!(app.on_key(key(KeyCode::Char('c'))), Action::OpenCreate);
+        app.selected = 1;
+        assert_eq!(app.on_key(key(KeyCode::Char('c'))), Action::OpenCreate);
+    }
+
+    #[test]
+    fn open_create_preselects_the_highlighted_agents_manifest() {
+        let mut app = populated();
+        for agent in &mut app.agents {
+            if agent.metadata.name == "worker" {
+                agent.status.provenance = Some(agent::Provenance {
+                    source_directory: PathBuf::from("/sources/worker"),
+                    manifest_path: None,
+                });
+            }
+        }
+        app.selected = 3;
+        app.open_create(candidates(&[
+            ("/sources/builder", "builder"),
+            ("/sources/worker", "worker"),
+        ]));
+        let form = create_form(&app);
+        assert_eq!(form.selected, 1);
+        assert_eq!(form.placeholder(), Some("worker"));
+        assert_eq!(
+            app.hints(),
+            vec![("enter", "create"), ("tab", "manifest"), ("esc", "cancel")]
+        );
+    }
+
+    #[test]
+    fn create_form_submits_the_placeholder_name_when_nothing_is_typed() {
+        let mut app = populated();
+        app.open_create(candidates(&[("/sources/fresh", "fresh")]));
+        let Action::CreateAgent { manifest, name, .. } = app.on_key(key(KeyCode::Enter)) else {
+            panic!("expected a CreateAgent action");
+        };
+        assert_eq!(manifest, PathBuf::from("/sources/fresh/agent.yaml"));
+        assert_eq!(name, "fresh");
+        assert!(app.modal.is_none());
+    }
+
+    #[test]
+    fn create_form_placeholder_follows_selection_and_typed_names_win() {
+        let mut app = populated();
+        app.open_create(candidates(&[("/a", "alpha"), ("/b", "beta")]));
+        assert_eq!(create_form(&app).placeholder(), Some("alpha"));
+        app.on_key(key(KeyCode::Tab));
+        assert_eq!(create_form(&app).placeholder(), Some("beta"));
+        app.on_key(key(KeyCode::Char('m')));
+        app.on_key(key(KeyCode::Char('E')));
+        app.on_key(key(KeyCode::Char('y')));
+        assert_eq!(create_form(&app).name, "my");
+        let Action::CreateAgent { manifest, name, .. } = app.on_key(key(KeyCode::Enter)) else {
+            panic!("expected a CreateAgent action");
+        };
+        assert_eq!(manifest, PathBuf::from("/b/agent.yaml"));
+        assert_eq!(name, "my");
+    }
+
+    #[test]
+    fn create_form_reports_duplicates_and_invalid_names_on_submit() {
+        let mut app = populated();
+        app.open_create(candidates(&[("/sources/worker", "worker")]));
+        assert_eq!(app.on_key(key(KeyCode::Enter)), Action::None);
+        assert_eq!(
+            create_form(&app).error.as_deref(),
+            Some("agent \"worker\" already exists")
+        );
+        app.on_key(key(KeyCode::Char('-')));
+        assert_eq!(app.on_key(key(KeyCode::Enter)), Action::None);
+        let error = create_form(&app).error.as_deref().expect("invalid name error");
+        assert!(error.starts_with("name:"));
+        app.on_key(key(KeyCode::Backspace));
+        app.on_key(key(KeyCode::Char('w')));
+        app.on_key(key(KeyCode::Char('2')));
+        let Action::CreateAgent { name, .. } = app.on_key(key(KeyCode::Enter)) else {
+            panic!("expected a CreateAgent action");
+        };
+        assert_eq!(name, "w2");
+    }
+
+    #[test]
+    fn create_form_blocks_unreadable_manifests_and_empty_pickers() {
+        let mut app = populated();
+        app.open_create(vec![ManifestCandidate {
+            path: PathBuf::from("/gone/agent.yaml"),
+            name: Err("manifest cannot be decoded".into()),
+        }]);
+        assert_eq!(create_form(&app).placeholder(), None);
+        app.on_key(key(KeyCode::Enter));
+        assert_eq!(create_form(&app).error.as_deref(), Some("manifest cannot be decoded"));
+        app.on_key(key(KeyCode::Esc));
+        assert!(app.modal.is_none());
+        app.open_create(Vec::new());
+        app.on_key(key(KeyCode::Enter));
+        assert!(create_form(&app).error.is_some());
+    }
+
+    #[test]
+    fn create_form_selection_wraps_and_clears_errors() {
+        let mut app = populated();
+        app.open_create(candidates(&[("/a", "builder"), ("/b", "beta")]));
+        app.on_key(key(KeyCode::Enter));
+        assert!(create_form(&app).error.is_some());
+        app.on_key(key(KeyCode::Left));
+        let form = create_form(&app);
+        assert_eq!(form.selected, 1);
+        assert_eq!(form.error, None);
+        app.on_key(key(KeyCode::Tab));
+        assert_eq!(create_form(&app).selected, 0);
+    }
+
+    #[test]
+    fn select_agent_moves_the_selection_to_that_row() {
+        let mut app = populated();
+        app.select_agent("worker");
+        assert_eq!(app.selected, 2);
+        app.select_agent("missing");
+        assert_eq!(app.selected, 2);
+    }
+
     #[test]
     fn tones_reflect_agent_conditions_and_session_states() {
         let mut terminating = ready_agent("done");
@@ -1113,7 +1400,7 @@ mod tests {
             status: None,
         }]);
         app.on_key(key(KeyCode::Char('F')));
-        assert!(app.forwards_view);
+        assert_eq!(app.view, View::Forwards);
         assert_eq!(
             app.on_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL)),
             Action::DeleteForward { id: 7 }
@@ -1128,7 +1415,7 @@ mod tests {
         app.on_key(key(KeyCode::Esc));
         assert!(app.modal.is_none());
         app.on_key(key(KeyCode::Char('q')));
-        assert!(!app.forwards_view);
+        assert_eq!(app.view, View::Tree);
     }
 
     #[test]
@@ -1138,10 +1425,10 @@ mod tests {
         app.error = Some("control plane unreachable".into());
         assert_eq!(app.on_key(key(KeyCode::Char('r'))), Action::Refresh);
         assert_eq!(app.on_key(key(KeyCode::Char('q'))), Action::Quit);
-        assert!(app.forwards_view);
+        assert_eq!(app.view, View::Forwards);
         app.error = None;
         app.on_key(key(KeyCode::Char('q')));
-        assert!(!app.forwards_view);
+        assert_eq!(app.view, View::Tree);
     }
 
     #[test]

--- a/src/experimental/agent/src/bin/agentctl/tui/app.rs
+++ b/src/experimental/agent/src/bin/agentctl/tui/app.rs
@@ -25,6 +25,7 @@ pub(crate) struct App {
     pub(crate) forward_selected: usize,
     pub(crate) creating: usize,
     pub(crate) discovering: bool,
+    pub(crate) queued_candidates: Option<Vec<ManifestCandidate>>,
 }
 
 /// Display state of one process-owned port forward.
@@ -346,6 +347,7 @@ impl App {
             forward_selected: 0,
             creating: 0,
             discovering: false,
+            queued_candidates: None,
         }
     }
 
@@ -658,6 +660,28 @@ impl App {
                 Action::None
             }
             None => Action::None,
+        }
+    }
+
+    /// Opens the create-agent modal for finished discovery, or queues the
+    /// candidates while another view is open.
+    pub(crate) fn manifests_discovered(&mut self, candidates: Vec<ManifestCandidate>) {
+        if !std::mem::take(&mut self.discovering) {
+            return;
+        }
+        if self.idle() {
+            self.open_create(candidates);
+        } else {
+            self.queued_candidates = Some(candidates);
+        }
+    }
+
+    /// Opens the create-agent modal for candidates queued behind another view once it closes.
+    pub(crate) fn open_queued_create(&mut self) {
+        if self.idle()
+            && let Some(candidates) = self.queued_candidates.take()
+        {
+            self.open_create(candidates);
         }
     }
 
@@ -1191,6 +1215,31 @@ mod tests {
         assert_eq!(app.on_key(key(KeyCode::Char('c'))), Action::OpenCreate);
         app.selected = 1;
         assert_eq!(app.on_key(key(KeyCode::Char('c'))), Action::OpenCreate);
+    }
+
+    #[test]
+    fn discovery_results_wait_for_an_open_view_to_close() {
+        let mut app = populated();
+        app.manifests_discovered(candidates(&[("/sources/stale", "stale")]));
+        assert!(app.modal.is_none());
+
+        app.discovering = true;
+        app.on_key(key(KeyCode::Char('s')));
+        app.manifests_discovered(candidates(&[("/sources/worker", "worker")]));
+        assert!(!app.discovering);
+        assert!(app.modal.is_none());
+        app.open_queued_create();
+        assert!(app.modal.is_none());
+
+        app.on_key(key(KeyCode::Esc));
+        app.open_queued_create();
+        assert_eq!(create_form(&app).placeholder(), Some("worker"));
+        assert!(app.queued_candidates.is_none());
+
+        let mut app = populated();
+        app.discovering = true;
+        app.manifests_discovered(candidates(&[("/sources/worker", "worker")]));
+        assert_eq!(create_form(&app).placeholder(), Some("worker"));
     }
 
     #[test]

--- a/src/experimental/agent/src/bin/agentctl/tui/mod.rs
+++ b/src/experimental/agent/src/bin/agentctl/tui/mod.rs
@@ -2,10 +2,11 @@ mod app;
 mod terminal;
 mod view;
 
-use std::{io::IsTerminal as _, process::ExitCode, time::Duration};
+use std::{collections::HashSet, io::IsTerminal as _, path::PathBuf, process::ExitCode, time::Duration};
 
 use agent::{
-    Agent, Error, Harness, control_api::Client, local::home::ControlPlaneHome, sessions::Session, sessions::SessionName,
+    Agent, Error, Harness, control_api::Client, local::home::ControlPlaneHome, manifest, sessions::Session,
+    sessions::SessionName,
 };
 use crossterm::event::{Event, EventStream, KeyCode, KeyEventKind, KeyModifiers};
 use futures_util::StreamExt as _;
@@ -13,7 +14,8 @@ use sandbox::terminal::TerminalAttachOutcome;
 
 use crate::CommandResult;
 use crate::forward::{ForwardSpec, PortForward};
-use app::{Action, App, ForwardEntry, ForwardForm, Modal};
+use agent::manifest::MANIFEST_FILE;
+use app::{Action, App, CreateForm, ForwardEntry, ForwardForm, ManifestCandidate, Modal};
 use terminal::Tui;
 
 const REFRESH_INTERVAL: Duration = Duration::from_secs(2);
@@ -22,6 +24,7 @@ enum Input {
     Event(Option<std::io::Result<Event>>),
     Tick,
     ForwardCreated(CreateOutcome),
+    ManifestsDiscovered(Vec<ManifestCandidate>),
 }
 
 /// Completion of one background forward creation.
@@ -34,6 +37,7 @@ pub(crate) async fn run(home: &ControlPlaneHome, client: &Client) -> CommandResu
     let mut app = App::new();
     let mut forwards = ActiveForwards::default();
     let (created_tx, mut created_rx) = tokio::sync::mpsc::unbounded_channel::<CreateOutcome>();
+    let (discovered_tx, mut discovered_rx) = tokio::sync::mpsc::unbounded_channel::<Vec<ManifestCandidate>>();
     let mut tui = Tui::enter()?;
     let mut events = EventStream::new();
     let mut tick = tokio::time::interval_at(tokio::time::Instant::now() + REFRESH_INTERVAL, REFRESH_INTERVAL);
@@ -46,6 +50,7 @@ pub(crate) async fn run(home: &ControlPlaneHome, client: &Client) -> CommandResu
             event = events.next() => Input::Event(event),
             _ = tick.tick() => Input::Tick,
             Some(outcome) = created_rx.recv() => Input::ForwardCreated(outcome),
+            Some(candidates) = discovered_rx.recv() => Input::ManifestsDiscovered(candidates),
         };
         match input {
             Input::Tick => {
@@ -53,18 +58,10 @@ pub(crate) async fn run(home: &ControlPlaneHome, client: &Client) -> CommandResu
                     refresh(&mut app, &mut tui, client).await?;
                 }
             }
-            Input::ForwardCreated((agent, spec, replace, result)) => {
-                app.creating = app.creating.saturating_sub(1);
-                match result {
-                    Ok(forward) => forwards.push(agent, forward),
-                    Err(error) => {
-                        app.modal = Some(Modal::PortForward(ForwardForm::rejected(
-                            agent,
-                            &spec,
-                            replace,
-                            error.to_string(),
-                        )));
-                    }
+            Input::ForwardCreated(outcome) => forward_created(&mut app, &mut forwards, outcome),
+            Input::ManifestsDiscovered(candidates) => {
+                if std::mem::take(&mut app.discovering) && app.idle() {
+                    app.open_create(candidates);
                 }
             }
             Input::Event(None) => {
@@ -92,6 +89,15 @@ pub(crate) async fn run(home: &ControlPlaneHome, client: &Client) -> CommandResu
                             app.error = Some(error.to_string());
                         }
                         refresh(&mut app, &mut tui, client).await?;
+                    }
+                    Action::OpenCreate => {
+                        if !app.discovering {
+                            app.discovering = true;
+                            spawn_discovery(discovered_tx.clone(), app.agents.clone());
+                        }
+                    }
+                    Action::CreateAgent { manifest, name, form } => {
+                        create(&mut app, &mut tui, client, manifest, name, form).await?;
                     }
                     Action::CreateForward { agent, spec, replace } => {
                         if let Some(id) = replace {
@@ -165,6 +171,96 @@ fn spawn_create(
         .await;
         let _ = outcomes.send((agent, spec, replace, result));
     });
+}
+
+/// Discovers create-agent candidates off the event loop so a slow filesystem never freezes the UI.
+fn spawn_discovery(outcomes: tokio::sync::mpsc::UnboundedSender<Vec<ManifestCandidate>>, agents: Vec<Agent>) {
+    tokio::task::spawn_local(async move {
+        let candidates = manifest_candidates(std::env::current_dir().ok(), &agents).await;
+        let _ = outcomes.send(candidates);
+    });
+}
+
+/// Assembles create-agent candidates from the working directory and recorded Agent manifests.
+///
+/// The working directory is offered only when it holds a manifest; a recorded
+/// manifest that is unreadable stays listed so its error is visible.
+async fn manifest_candidates(current_directory: Option<PathBuf>, agents: &[Agent]) -> Vec<ManifestCandidate> {
+    let mut recorded: Vec<PathBuf> = agents
+        .iter()
+        .filter_map(|agent| agent.status.provenance.as_ref())
+        .map(agent::Provenance::manifest_or_default)
+        .collect();
+    recorded.sort();
+    recorded.dedup();
+    let paths = current_directory
+        .into_iter()
+        .map(|directory| (directory.join(MANIFEST_FILE), false))
+        .chain(recorded.into_iter().map(|path| (path, true)));
+    let mut seen = HashSet::new();
+    let mut candidates = Vec::new();
+    for (path, recorded) in paths {
+        let name = match tokio::fs::read(&path).await {
+            Ok(bytes) => manifest::decode(&bytes)
+                .map(|decoded| decoded.metadata.name)
+                .map_err(|error| error.to_string()),
+            Err(_) if !recorded => continue,
+            Err(error) => Err(error.to_string()),
+        };
+        let canonical = tokio::fs::canonicalize(&path).await.unwrap_or_else(|_| path.clone());
+        if !seen.insert(canonical) {
+            continue;
+        }
+        candidates.push(ManifestCandidate { path, name });
+    }
+    candidates
+}
+
+/// Applies the manifest under the chosen name; a rejection reopens the form with the error.
+async fn create(
+    app: &mut App,
+    tui: &mut Tui,
+    client: &Client,
+    manifest: PathBuf,
+    name: String,
+    mut form: CreateForm,
+) -> CommandResult<()> {
+    match create_agent(client, manifest, name).await {
+        Ok(applied) => {
+            refresh(app, tui, client).await?;
+            app.select_agent(&applied);
+        }
+        Err(error) => {
+            form.error = Some(error.to_string());
+            app.modal = Some(Modal::CreateAgent(form));
+        }
+    }
+    Ok(())
+}
+
+async fn create_agent(client: &Client, manifest: PathBuf, name: String) -> Result<String, Error> {
+    let mut request = crate::read_apply_request(manifest).await?;
+    request.agent.metadata.name = name;
+    request.create_only = true;
+    let applied = client.apply(request).await?;
+    Ok(applied.metadata.name)
+}
+
+/// Applies one completed background forward creation to the UI state.
+fn forward_created(app: &mut App, forwards: &mut ActiveForwards, outcome: CreateOutcome) {
+    let (agent, spec, replace, result) = outcome;
+    app.creating = app.creating.saturating_sub(1);
+    match result {
+        Ok(forward) => forwards.push(agent, forward),
+        Err(error) => {
+            app.modal = Some(Modal::PortForward(ForwardForm::rejected(
+                agent,
+                &spec,
+                replace,
+                error.to_string(),
+            )));
+        }
+    }
 }
 
 async fn refresh(app: &mut App, tui: &mut Tui, client: &Client) -> CommandResult<()> {
@@ -242,5 +338,138 @@ async fn exec(home: &ControlPlaneHome, client: &Client, agent: &str) -> Result<(
         _ => Err(Error::Session(
             "terminal execution returned an unsupported outcome".into(),
         )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used)]
+
+    use super::*;
+
+    fn manifest_yaml(name: &str) -> String {
+        format!(
+            "apiVersion: agents.platform/v1alpha1\n\
+             kind: Agent\n\
+             metadata:\n\
+             \x20 name: {name}\n\
+             spec:\n\
+             \x20 sandbox:\n\
+             \x20   image:\n\
+             \x20     type: build\n\
+             \x20     context: .\n\
+             \x20     dockerfile: Dockerfile\n\
+             \x20   platform:\n\
+             \x20     os: linux\n\
+             \x20   resources:\n\
+             \x20     cpu: \"1\"\n\
+             \x20     memory: \"1Gi\"\n\
+             \x20     rootFilesystem:\n\
+             \x20       capacity: \"8Gi\"\n\
+             \x20       mode: layered\n\
+             \x20 home:\n\
+             \x20   source: home\n\
+             \x20 harnesses:\n\
+             \x20   - type: claudeCode\n\
+             \x20     version: \"1.0.0\"\n\
+             \x20     auth: mediated\n\
+             \x20 secrets: []\n\
+             \x20 network:\n\
+             \x20   mode: mediated\n\
+             \x20   allow: all\n"
+        )
+    }
+
+    fn recorded_agent(name: &str, source: Option<&std::path::Path>) -> Agent {
+        let mut agent = manifest::decode(manifest_yaml(name).as_bytes()).expect("test manifest should decode");
+        agent.status.provenance = source.map(|directory| agent::Provenance {
+            source_directory: directory.to_path_buf(),
+            manifest_path: None,
+        });
+        agent
+    }
+
+    fn manifest_directory(root: &std::path::Path, name: &str, content: &str) -> PathBuf {
+        let directory = root.join(name);
+        std::fs::create_dir_all(&directory).expect("manifest directory should be created");
+        std::fs::write(directory.join(MANIFEST_FILE), content).expect("manifest should be written");
+        directory
+    }
+
+    fn empty_directory(root: &std::path::Path, name: &str) -> PathBuf {
+        let directory = root.join(name);
+        std::fs::create_dir_all(&directory).expect("directory should be created");
+        directory
+    }
+
+    #[tokio::test(flavor = "local")]
+    async fn discovery_offers_the_working_directory_and_recorded_manifests_once() {
+        let root = tempfile::tempdir().expect("temporary directory");
+        let cwd = manifest_directory(root.path(), "a-cwd", &manifest_yaml("local"));
+        let broken = manifest_directory(root.path(), "broken", "not a manifest");
+        let missing = empty_directory(root.path(), "missing");
+        let recorded = manifest_directory(root.path(), "recorded", &manifest_yaml("recorded"));
+        let agents = vec![
+            recorded_agent("recorded", Some(&recorded)),
+            recorded_agent("duplicate", Some(&cwd)),
+            recorded_agent("missing", Some(&missing)),
+            recorded_agent("broken", Some(&broken)),
+            recorded_agent("unknown", None),
+        ];
+
+        let candidates = manifest_candidates(Some(cwd.clone()), &agents).await;
+
+        assert_eq!(candidates.len(), 4);
+        assert_eq!(candidates[0].path, cwd.join(MANIFEST_FILE));
+        assert_eq!(candidates[0].name.as_deref(), Ok("local"));
+        assert_eq!(candidates[1].path, broken.join(MANIFEST_FILE));
+        assert!(candidates[1].name.is_err());
+        assert_eq!(candidates[2].path, missing.join(MANIFEST_FILE));
+        assert!(candidates[2].name.is_err());
+        assert_eq!(candidates[3].path, recorded.join(MANIFEST_FILE));
+        assert_eq!(candidates[3].name.as_deref(), Ok("recorded"));
+    }
+
+    #[tokio::test(flavor = "local")]
+    async fn discovery_uses_the_recorded_manifest_filename() {
+        let root = tempfile::tempdir().expect("temporary directory");
+        let source = empty_directory(root.path(), "custom");
+        let manifest = source.join("worker.yml");
+        std::fs::write(&manifest, manifest_yaml("custom")).expect("manifest should be written");
+        let mut agent = recorded_agent("custom", Some(&source));
+        agent
+            .status
+            .provenance
+            .as_mut()
+            .expect("provenance should be recorded")
+            .manifest_path = Some(manifest.clone());
+
+        let candidates = manifest_candidates(None, &[agent]).await;
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].path, manifest);
+        assert_eq!(candidates[0].name.as_deref(), Ok("custom"));
+    }
+
+    #[tokio::test(flavor = "local")]
+    async fn a_manifest_less_working_directory_never_hides_its_recorded_source() {
+        let root = tempfile::tempdir().expect("temporary directory");
+        let cwd = empty_directory(root.path(), "cwd");
+        let agents = vec![recorded_agent("worker", Some(&cwd))];
+
+        let candidates = manifest_candidates(Some(cwd.clone()), &agents).await;
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].path, cwd.join(MANIFEST_FILE));
+        assert!(candidates[0].name.is_err());
+    }
+
+    #[tokio::test(flavor = "local")]
+    async fn discovery_skips_a_working_directory_without_a_manifest() {
+        let root = tempfile::tempdir().expect("temporary directory");
+        let cwd = empty_directory(root.path(), "cwd");
+
+        assert!(manifest_candidates(Some(cwd), &[]).await.is_empty());
+        assert!(manifest_candidates(None, &[]).await.is_empty());
     }
 }

--- a/src/experimental/agent/src/bin/agentctl/tui/mod.rs
+++ b/src/experimental/agent/src/bin/agentctl/tui/mod.rs
@@ -44,6 +44,7 @@ pub(crate) async fn run(home: &ControlPlaneHome, client: &Client) -> CommandResu
     tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     refresh(&mut app, &mut tui, client).await?;
     loop {
+        app.open_queued_create();
         app.set_forwards(forwards.entries());
         tui.draw(&app)?;
         let input = tokio::select! {
@@ -59,11 +60,7 @@ pub(crate) async fn run(home: &ControlPlaneHome, client: &Client) -> CommandResu
                 }
             }
             Input::ForwardCreated(outcome) => forward_created(&mut app, &mut forwards, outcome),
-            Input::ManifestsDiscovered(candidates) => {
-                if std::mem::take(&mut app.discovering) && app.idle() {
-                    app.open_create(candidates);
-                }
-            }
+            Input::ManifestsDiscovered(candidates) => app.manifests_discovered(candidates),
             Input::Event(None) => {
                 tui.restore()?;
                 return Ok(ExitCode::SUCCESS);

--- a/src/experimental/agent/src/bin/agentctl/tui/view.rs
+++ b/src/experimental/agent/src/bin/agentctl/tui/view.rs
@@ -6,6 +6,7 @@ use ratatui::{
     widgets::{Block, Clear, List, ListItem, ListState, Paragraph, Wrap},
 };
 
+use super::MANIFEST_FILE;
 use super::app::{App, ForwardField, Modal, Tone};
 
 pub(crate) fn render(frame: &mut Frame, app: &App) {
@@ -16,7 +17,7 @@ pub(crate) fn render(frame: &mut Frame, app: &App) {
         render_detail(frame, body, detail);
     } else if let Some(error) = &app.error {
         render_error(frame, body, error);
-    } else if app.forwards_view {
+    } else if app.view == super::app::View::Forwards {
         render_forwards(frame, body, app);
     } else {
         render_tree(frame, body, app);
@@ -45,6 +46,9 @@ fn render_header(frame: &mut Frame, area: Rect, app: &App) {
     }
     if app.creating > 0 {
         spans.push(Span::styled(" · creating forward…", Style::new().fg(Color::Cyan)));
+    }
+    if app.discovering {
+        spans.push(Span::styled(" · scanning manifests…", Style::new().fg(Color::Cyan)));
     }
     frame.render_widget(Line::from(spans), area);
 }
@@ -207,6 +211,7 @@ fn render_modal(frame: &mut Frame, area: Rect, modal: &Modal) {
             lines.push(hint_line(&[("enter", "create"), ("tab", "harness"), ("esc", "cancel")]));
             popup(frame, area, " new session ", Color::Cyan, lines);
         }
+        Modal::CreateAgent(form) => render_create_agent(frame, area, form),
         Modal::PortForward(form) => {
             let mut lines = vec![
                 Line::from(format!("Agent:         {}", form.agent)),
@@ -233,6 +238,107 @@ fn render_modal(frame: &mut Frame, area: Rect, modal: &Modal) {
             popup(frame, area, title, Color::Cyan, lines);
         }
     }
+}
+
+fn render_create_agent(frame: &mut Frame, area: Rect, form: &super::app::CreateForm) {
+    let mut lines = form.candidates.get(form.selected).map_or_else(
+        || {
+            vec![
+                Line::from("No agent manifests found."),
+                Line::from(Span::styled(
+                    format!("Start the TUI from a directory containing {MANIFEST_FILE},"),
+                    Style::new().fg(Color::DarkGray),
+                )),
+                Line::from(Span::styled(
+                    "or apply one first: agentctl apply -f",
+                    Style::new().fg(Color::DarkGray),
+                )),
+            ]
+        },
+        |candidate| picker_lines(form, candidate),
+    );
+    if let Some(error) = &form.error {
+        lines.push(Line::from(Span::styled(error.clone(), Style::new().fg(Color::Red))));
+    }
+    lines.push(Line::default());
+    lines.push(hint_line(&[
+        ("enter", "create"),
+        ("tab", "manifest"),
+        ("esc", "cancel"),
+    ]));
+    popup(frame, area, " create agent ", Color::Cyan, lines);
+}
+
+fn picker_lines(form: &super::app::CreateForm, candidate: &super::app::ManifestCandidate) -> Vec<Line<'static>> {
+    let directory = candidate
+        .path
+        .parent()
+        .map_or_else(String::new, |parent| abbreviate_home(&parent.display().to_string()));
+    let mut manifest_spans = vec![
+        Span::raw("Manifest: "),
+        Span::styled("◂ ", Style::new().fg(Color::DarkGray)),
+    ];
+    if let Ok(name) = &candidate.name {
+        manifest_spans.push(Span::styled(name.clone(), Style::new().fg(Color::Cyan)));
+        manifest_spans.push(Span::styled(" | ", Style::new().fg(Color::DarkGray)));
+    }
+    manifest_spans.extend([
+        Span::styled(directory, Style::new().fg(Color::DarkGray)),
+        Span::styled(" ▸", Style::new().fg(Color::DarkGray)),
+        Span::styled(
+            format!("  {}/{}", form.selected + 1, form.candidates.len()),
+            Style::new().fg(Color::DarkGray),
+        ),
+    ]);
+    let mut lines = vec![Line::from(manifest_spans)];
+    if let Err(invalid) = &candidate.name {
+        lines.push(Line::from(Span::styled(
+            format!("          {invalid}"),
+            Style::new().fg(Color::Red),
+        )));
+    }
+    lines.push(Line::from(name_field_spans(form)));
+    lines
+}
+
+/// Renders the name input; an empty buffer shows the placeholder with a
+/// block cursor over its first character, so the cursor sits flush against
+/// the grayed text instead of leaving a cell-wide gap before it.
+fn name_field_spans(form: &super::app::CreateForm) -> Vec<Span<'static>> {
+    let mut spans = vec![Span::raw("Name:     ")];
+    if !form.name.is_empty() {
+        spans.push(Span::raw(form.name.clone()));
+        spans.push(Span::styled("▏", Style::new().fg(Color::Cyan)));
+        return spans;
+    }
+    let mut placeholder = form.placeholder().unwrap_or_default().chars();
+    match placeholder.next() {
+        Some(first) => {
+            spans.push(Span::styled(
+                first.to_string(),
+                Style::new().fg(Color::DarkGray).add_modifier(Modifier::REVERSED),
+            ));
+            spans.push(Span::styled(
+                placeholder.collect::<String>(),
+                Style::new().fg(Color::DarkGray),
+            ));
+        }
+        None => spans.push(Span::styled("▏", Style::new().fg(Color::Cyan))),
+    }
+    spans
+}
+
+fn abbreviate_home(path: &str) -> String {
+    abbreviate(path, std::env::var("HOME").ok().as_deref())
+}
+
+fn abbreviate(path: &str, home: Option<&str>) -> String {
+    home.filter(|home| !home.is_empty())
+        .and_then(|home| {
+            let rest = path.strip_prefix(home)?;
+            (rest.is_empty() || rest.starts_with('/')).then(|| format!("~{rest}"))
+        })
+        .unwrap_or_else(|| path.to_owned())
 }
 
 fn form_field(label: &str, value: &str, selected: bool) -> Line<'static> {
@@ -334,5 +440,114 @@ mod tests {
         assert!(text.contains("0 agents · 0 sessions · 0 running"));
         assert!(text.contains("loading…"));
         assert!(text.contains("j/k move · r refresh · F forwards · q quit"));
+    }
+
+    #[test]
+    fn create_agent_modal_shows_the_picker_and_placeholder_name() {
+        use super::super::app::{CreateForm, ManifestCandidate};
+
+        let mut app = App::new();
+        app.modal = Some(Modal::CreateAgent(CreateForm {
+            candidates: vec![
+                ManifestCandidate {
+                    path: std::path::PathBuf::from("/sources/full/agent.yaml"),
+                    name: Ok("full".into()),
+                },
+                ManifestCandidate {
+                    path: std::path::PathBuf::from("/sources/broken/agent.yaml"),
+                    name: Err("manifest cannot be decoded".into()),
+                },
+            ],
+            selected: 0,
+            name: String::new(),
+            error: None,
+        }));
+        let mut terminal = Terminal::new(TestBackend::new(80, 14)).expect("test terminal");
+        terminal.draw(|frame| render(frame, &app)).expect("modal draw");
+        let text = buffer_text(&terminal);
+        assert!(text.contains("create agent"));
+        assert!(text.contains("◂ full | /sources/full ▸"));
+        assert!(text.contains("1/2"));
+        assert!(text.contains("Name:     full"));
+        assert!(text.contains("enter create · tab manifest · esc cancel"));
+
+        let Some(Modal::CreateAgent(form)) = &mut app.modal else {
+            panic!("expected the CreateAgent modal");
+        };
+        form.selected = 1;
+        form.name = "copy".into();
+        form.error = Some("agent \"copy\" already exists".into());
+        terminal.draw(|frame| render(frame, &app)).expect("error draw");
+        let text = buffer_text(&terminal);
+        assert!(text.contains("◂ /sources/broken ▸"));
+        assert!(text.contains("manifest cannot be decoded"));
+        assert!(text.contains("Name:     copy▏"));
+        assert!(text.contains("agent \"copy\" already exists"));
+    }
+
+    #[test]
+    fn create_agent_placeholder_first_character_is_the_block_cursor() {
+        use super::super::app::{CreateForm, ManifestCandidate};
+
+        let form = CreateForm {
+            candidates: vec![ManifestCandidate {
+                path: std::path::PathBuf::from("/sources/full/agent.yaml"),
+                name: Ok("full".into()),
+            }],
+            selected: 0,
+            name: String::new(),
+            error: None,
+        };
+        let spans = name_field_spans(&form);
+        assert_eq!(spans[1].content, "f");
+        assert!(spans[1].style.add_modifier.contains(Modifier::REVERSED));
+        assert_eq!(spans[2].content, "ull");
+
+        let typed = CreateForm {
+            name: "my".into(),
+            ..form
+        };
+        let spans = name_field_spans(&typed);
+        assert_eq!(spans[1].content, "my");
+        assert_eq!(spans[2].content, "▏");
+    }
+
+    #[test]
+    fn header_reports_a_running_manifest_scan() {
+        let mut app = App::new();
+        app.discovering = true;
+        let mut terminal = Terminal::new(TestBackend::new(80, 12)).expect("test terminal");
+        terminal.draw(|frame| render(frame, &app)).expect("draw");
+        assert!(buffer_text(&terminal).contains("scanning manifests…"));
+    }
+
+    #[test]
+    fn create_agent_modal_explains_an_empty_picker() {
+        use super::super::app::CreateForm;
+
+        let mut app = App::new();
+        app.modal = Some(Modal::CreateAgent(CreateForm {
+            candidates: Vec::new(),
+            selected: 0,
+            name: String::new(),
+            error: None,
+        }));
+        let mut terminal = Terminal::new(TestBackend::new(80, 14)).expect("test terminal");
+        terminal.draw(|frame| render(frame, &app)).expect("empty draw");
+        let text = buffer_text(&terminal);
+        assert!(text.contains("No agent manifests found."));
+        assert!(text.contains("agentctl apply -f"));
+    }
+
+    #[test]
+    fn home_abbreviation_replaces_only_the_whole_home_component() {
+        assert_eq!(abbreviate("/Users/dev/code", Some("/Users/dev")), "~/code");
+        assert_eq!(abbreviate("/Users/dev", Some("/Users/dev")), "~");
+        assert_eq!(
+            abbreviate("/Users/devops/code", Some("/Users/dev")),
+            "/Users/devops/code"
+        );
+        assert_eq!(abbreviate("/srv/code", None), "/srv/code");
+        assert_eq!(abbreviate("/srv/code", Some("")), "/srv/code");
     }
 }

--- a/src/experimental/agent/src/control_plane/memory.rs
+++ b/src/experimental/agent/src/control_plane/memory.rs
@@ -60,8 +60,9 @@ impl AgentStore for InMemoryAgentStore {
         })
     }
 
-    fn put(&self, record: AgentRecord, expected_generation: u64) -> LocalFuture<'_, Result<(), Error>> {
+    fn put(&self, mut record: AgentRecord, expected_generation: u64) -> LocalFuture<'_, Result<(), Error>> {
         Box::pin(async move {
+            record.agent.status.provenance = None;
             let id = record.id;
             let name = record.agent.metadata.name.clone();
             let mut state = self.state.borrow_mut();
@@ -89,8 +90,9 @@ impl AgentStore for InMemoryAgentStore {
         })
     }
 
-    fn update_status(&self, id: AgentId, generation: u64, status: Status) -> LocalFuture<'_, Result<(), Error>> {
+    fn update_status(&self, id: AgentId, generation: u64, mut status: Status) -> LocalFuture<'_, Result<(), Error>> {
         Box::pin(async move {
+            status.provenance = None;
             let mut state = self.state.borrow_mut();
             let name = state
                 .records

--- a/src/experimental/agent/src/control_plane/reconciler.rs
+++ b/src/experimental/agent/src/control_plane/reconciler.rs
@@ -61,16 +61,16 @@ impl Reconciler {
                     return Err(error);
                 }
             };
-            let status = Status {
-                observed_generation: record.agent.metadata.generation,
-                sandbox: Some(crate::sandbox::Assignment::Selected { provider }),
-                conditions: vec![condition(
+            let status = Status::observed(
+                record.agent.metadata.generation,
+                Some(crate::sandbox::Assignment::Selected { provider }),
+                vec![condition(
                     READY,
                     ConditionStatus::False,
                     "ProviderSelected",
                     "Sandbox provisioning has not completed",
                 )],
-            };
+            );
             self.update_status(&record, status.clone()).await?;
             record.agent.status = status;
         }
@@ -79,14 +79,14 @@ impl Reconciler {
             Ok(ensured) => ensured,
             Err(error) => {
                 let message = error.to_string();
-                let status = Status {
-                    observed_generation: record.agent.metadata.generation,
-                    sandbox: record.agent.status.sandbox.clone(),
-                    conditions: vec![
+                let status = Status::observed(
+                    record.agent.metadata.generation,
+                    record.agent.status.sandbox.clone(),
+                    vec![
                         condition(READY, ConditionStatus::False, "SandboxReconcileFailed", &message),
                         condition(SANDBOX_READY, ConditionStatus::False, "ReconcileFailed", &message),
                     ],
-                };
+                );
                 self.update_status(&record, status).await?;
                 return Err(error);
             }
@@ -101,17 +101,17 @@ impl Reconciler {
             .provider()
             .clone();
 
-        let status = Status {
-            observed_generation: record.agent.metadata.generation,
-            sandbox: Some(crate::sandbox::Assignment::Materialized {
+        let status = Status::observed(
+            record.agent.metadata.generation,
+            Some(crate::sandbox::Assignment::Materialized {
                 provider,
                 id: ensured.id,
             }),
-            conditions: vec![
+            vec![
                 condition(SANDBOX_READY, ConditionStatus::True, "SandboxRunning", ""),
                 condition(READY, ConditionStatus::True, "SandboxReady", ""),
             ],
-        };
+        );
         self.update_status(&record, status).await?;
         if ensured.runtime_restarted {
             self.notify_sessions(record.id);
@@ -130,11 +130,11 @@ impl Reconciler {
     async fn record_failure(&self, record: &AgentRecord, reason: &str, error: &Error) -> Result<(), Error> {
         self.update_status(
             record,
-            Status {
-                observed_generation: record.agent.metadata.generation,
-                sandbox: record.agent.status.sandbox.clone(),
-                conditions: vec![condition(READY, ConditionStatus::False, reason, &error.to_string())],
-            },
+            Status::observed(
+                record.agent.metadata.generation,
+                record.agent.status.sandbox.clone(),
+                vec![condition(READY, ConditionStatus::False, reason, &error.to_string())],
+            ),
         )
         .await
     }

--- a/src/experimental/agent/src/control_plane/resource.rs
+++ b/src/experimental/agent/src/control_plane/resource.rs
@@ -43,6 +43,9 @@ pub struct AgentRecord {
     pub id: AgentId,
     /// Absolute directory against which manifest-relative sources are resolved.
     pub source_directory: std::path::PathBuf,
+    /// Absolute path of the manifest last applied, when the client reported it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub manifest_path: Option<std::path::PathBuf>,
     /// Desired state and most recently observed status.
     pub agent: Agent,
 }

--- a/src/experimental/agent/src/control_plane/service.rs
+++ b/src/experimental/agent/src/control_plane/service.rs
@@ -10,6 +10,12 @@ use super::{AgentRecord, SharedAgentStore, Wakeup};
 pub struct ApplyRequest {
     /// Absolute directory against which local manifest sources are resolved.
     pub source_directory: PathBuf,
+    /// Absolute path of the manifest being applied, recorded for discovery.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub manifest_path: Option<PathBuf>,
+    /// Fail instead of updating when the name already identifies an Agent.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub create_only: bool,
     /// Agent manifest to store.
     pub agent: Agent,
 }
@@ -49,6 +55,13 @@ impl ControlPlane {
         if !request.source_directory.is_absolute() {
             return Err(Error::Invalid("sourceDirectory must be absolute".into()));
         }
+        if let Some(manifest) = &request.manifest_path
+            && manifest.parent() != Some(request.source_directory.as_path())
+        {
+            return Err(Error::Invalid(
+                "manifestPath must name a file in sourceDirectory".into(),
+            ));
+        }
 
         let mut desired = request.agent;
         desired.clear_managed_fields();
@@ -58,13 +71,23 @@ impl ControlPlane {
         loop {
             let result = match self.store.get_by_name(&desired.metadata.name).await {
                 Ok(current) => {
+                    if request.create_only {
+                        return Err(Error::Invalid(format!(
+                            "an Agent named {:?} already exists",
+                            desired.metadata.name
+                        )));
+                    }
                     if current.agent.metadata.deletion_timestamp.is_some() {
                         return Err(Error::Conflict);
                     }
-                    validate_immutable_fields(&current, &desired, &request.source_directory)?;
-                    if current.agent.spec == desired.spec && current.source_directory == request.source_directory {
+                    if current.source_directory != request.source_directory {
+                        return Err(Error::Immutable("sourceDirectory"));
+                    }
+                    validate_immutable_fields(&current, &desired)?;
+                    let manifest_path = request.manifest_path.clone().or_else(|| current.manifest_path.clone());
+                    if current.agent.spec == desired.spec && current.manifest_path == manifest_path {
                         self.notifier.notify(current.id);
-                        return Ok(current.agent);
+                        return Ok(resource(current));
                     }
 
                     let expected_generation = current.agent.metadata.generation;
@@ -75,12 +98,13 @@ impl ControlPlane {
                             AgentRecord {
                                 id: current.id,
                                 source_directory: request.source_directory.clone(),
+                                manifest_path: manifest_path.clone(),
                                 agent: desired.clone(),
                             },
                             expected_generation,
                         )
                         .await
-                        .map(|()| current.id)
+                        .map(|()| (current.id, manifest_path))
                 }
                 Err(Error::NotFound) => {
                     let id = AgentId::generate();
@@ -90,12 +114,13 @@ impl ControlPlane {
                             AgentRecord {
                                 id,
                                 source_directory: request.source_directory.clone(),
+                                manifest_path: request.manifest_path.clone(),
                                 agent: desired.clone(),
                             },
                             0,
                         )
                         .await
-                        .map(|()| id)
+                        .map(|()| (id, request.manifest_path.clone()))
                 }
                 Err(error) => return Err(error),
             };
@@ -103,8 +128,12 @@ impl ControlPlane {
             match result {
                 Err(Error::Conflict) => {}
                 Err(error) => return Err(error),
-                Ok(id) => {
+                Ok((id, manifest_path)) => {
                     self.notifier.notify(id);
+                    desired.status.provenance = Some(crate::Provenance {
+                        source_directory: request.source_directory,
+                        manifest_path,
+                    });
                     return Ok(desired);
                 }
             }
@@ -117,7 +146,7 @@ impl ControlPlane {
     ///
     /// Returns an error when the Agent does not exist or storage fails.
     pub async fn get(&self, name: &str) -> Result<Agent, Error> {
-        self.store.get_by_name(name).await.map(|record| record.agent)
+        self.store.get_by_name(name).await.map(resource)
     }
 
     /// Lists every active Agent ordered by name.
@@ -129,7 +158,7 @@ impl ControlPlane {
         self.store
             .list()
             .await
-            .map(|records| records.into_iter().map(|record| record.agent).collect())
+            .map(|records| records.into_iter().map(resource).collect())
     }
 
     /// Resolves the closest Agent source directory containing `directory`.
@@ -161,11 +190,17 @@ impl ControlPlane {
         };
         matches.retain(|(_, candidate_depth)| *candidate_depth == depth);
         if matches.len() != 1 {
-            return Err(Error::Invalid(
-                "multiple Agents were applied from this directory; specify --agent".into(),
-            ));
+            let mut names = matches
+                .iter()
+                .map(|(record, _)| record.agent.metadata.name.clone())
+                .collect::<Vec<_>>();
+            names.sort();
+            return Err(Error::Invalid(format!(
+                "multiple Agents were applied from this directory ({}); specify --agent",
+                names.join(", ")
+            )));
         }
-        matches.pop().map(|(record, _)| record.agent).ok_or(Error::NotFound)
+        matches.pop().map(|(record, _)| resource(record)).ok_or(Error::NotFound)
     }
 
     /// Marks an Agent for asynchronous release. Repeated deletion is safe.
@@ -185,12 +220,18 @@ impl ControlPlane {
     }
 }
 
-fn validate_immutable_fields(
-    current: &AgentRecord,
-    desired: &Agent,
-    source_directory: &std::path::Path,
-) -> Result<(), Error> {
-    if current.agent.spec.sandbox.image != desired.spec.sandbox.image || current.source_directory != source_directory {
+/// Converts a stored record to its API representation, projecting provenance into status.
+fn resource(record: AgentRecord) -> Agent {
+    let mut agent = record.agent;
+    agent.status.provenance = Some(crate::Provenance {
+        source_directory: record.source_directory,
+        manifest_path: record.manifest_path,
+    });
+    agent
+}
+
+fn validate_immutable_fields(current: &AgentRecord, desired: &Agent) -> Result<(), Error> {
+    if current.agent.spec.sandbox.image != desired.spec.sandbox.image {
         return Err(Error::Immutable("spec.sandbox.image"));
     }
     if current.agent.spec.sandbox.platform != desired.spec.sandbox.platform {

--- a/src/experimental/agent/src/lib.rs
+++ b/src/experimental/agent/src/lib.rs
@@ -19,7 +19,8 @@ pub use control_plane::AgentId;
 pub use harness::{Harness, HarnessAuthMode, HarnessSpec};
 pub use manifest::{
     API_VERSION, Agent, Condition, ConditionStatus, HomeSpec, InstructionsSpec, KIND, Metadata, MountSpec,
-    NetworkAllow, NetworkMode, NetworkSpec, PlatformManifestSpec, SandboxManifestSpec, SecretSpec, Spec, Status,
+    NetworkAllow, NetworkMode, NetworkSpec, PlatformManifestSpec, Provenance, SandboxManifestSpec, SecretSpec, Spec,
+    Status,
 };
 
 use thiserror::Error;

--- a/src/experimental/agent/src/manifest.rs
+++ b/src/experimental/agent/src/manifest.rs
@@ -483,8 +483,12 @@ fn valid_environment_variable(value: &str) -> bool {
 }
 
 /// Most recently observed Agent state.
+///
+/// Unlike the rest of the manifest, unknown fields are tolerated so an older
+/// client can read responses from a newer control plane; status is
+/// API-managed and never authored by hand.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(deny_unknown_fields, rename_all = "camelCase")]
+#[serde(rename_all = "camelCase")]
 pub struct Status {
     /// Desired generation observed by the reconciler.
     #[serde(default, skip_serializing_if = "is_zero")]
@@ -495,11 +499,58 @@ pub struct Status {
     /// Normalized readiness conditions.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub conditions: Vec<Condition>,
+    /// Local origin of the desired state. Projected onto API responses from
+    /// the stored Agent record; stores scrub it, so it is never persisted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provenance: Option<Provenance>,
 }
 
 impl Status {
+    /// Creates reconciler-observed state; provenance stays API-projected.
+    #[must_use]
+    pub const fn observed(
+        observed_generation: u64,
+        sandbox: Option<crate::sandbox::Assignment>,
+        conditions: Vec<Condition>,
+    ) -> Self {
+        Self {
+            observed_generation,
+            sandbox,
+            conditions,
+            provenance: None,
+        }
+    }
+
     const fn is_empty(&self) -> bool {
-        self.observed_generation == 0 && self.sandbox.is_none() && self.conditions.is_empty()
+        self.observed_generation == 0
+            && self.sandbox.is_none()
+            && self.conditions.is_empty()
+            && self.provenance.is_none()
+    }
+}
+
+/// Conventional Agent manifest filename, used when a record predates path recording.
+pub const MANIFEST_FILE: &str = "agent.yaml";
+
+/// Local origin of an Agent's desired state.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct Provenance {
+    /// Absolute directory against which manifest-relative sources are resolved.
+    pub source_directory: std::path::PathBuf,
+    /// Absolute path of the manifest last applied, when the client reported it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub manifest_path: Option<std::path::PathBuf>,
+}
+
+impl Provenance {
+    /// Returns the recorded manifest path, falling back to [`MANIFEST_FILE`]
+    /// in the source directory for records that predate path recording.
+    #[must_use]
+    pub fn manifest_or_default(&self) -> std::path::PathBuf {
+        self.manifest_path
+            .clone()
+            .unwrap_or_else(|| self.source_directory.join(MANIFEST_FILE))
     }
 }
 

--- a/src/experimental/agent/src/manifest.rs
+++ b/src/experimental/agent/src/manifest.rs
@@ -533,8 +533,10 @@ impl Status {
 pub const MANIFEST_FILE: &str = "agent.yaml";
 
 /// Local origin of an Agent's desired state.
+///
+/// Part of [`Status`], so unknown fields are tolerated for the same reason.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(deny_unknown_fields, rename_all = "camelCase")]
+#[serde(rename_all = "camelCase")]
 pub struct Provenance {
     /// Absolute directory against which manifest-relative sources are resolved.
     pub source_directory: std::path::PathBuf,

--- a/src/experimental/agent/src/persistence/agents.rs
+++ b/src/experimental/agent/src/persistence/agents.rs
@@ -56,7 +56,10 @@ pub(super) fn list(connection: &Connection) -> Result<Vec<AgentRecord>, Error> {
 pub(super) fn put(connection: &mut Connection, record: &AgentRecord, expected_generation: u64) -> Result<(), Error> {
     let id = record.id;
     let name = &record.agent.metadata.name;
-    let source = serde_json::to_string(&record.source_directory)?;
+    let source = serde_json::to_string(&crate::Provenance {
+        source_directory: record.source_directory.clone(),
+        manifest_path: record.manifest_path.clone(),
+    })?;
     let desired = encode_desired(&record.agent)?;
     let transaction = connection.transaction().map_err(database_error)?;
     let changed = if expected_generation == 0 {
@@ -71,7 +74,7 @@ pub(super) fn put(connection: &mut Connection, record: &AgentRecord, expected_ge
                     source,
                     desired,
                     deletion_timestamp(&record.agent),
-                    serde_json::to_string(&record.agent.status)?
+                    encode_status(&record.agent.status)?
                 ],
             )
             .map_err(database_error)?
@@ -111,7 +114,7 @@ pub(super) fn update_status(
     let changed = transaction
         .execute(
             "UPDATE agents SET status_json = ?1 WHERE id = ?2 AND active_name IS NOT NULL",
-            params![serde_json::to_string(&status)?, id.to_string()],
+            params![encode_status(status)?, id.to_string()],
         )
         .map_err(database_error)?;
     if changed != 1 {
@@ -166,6 +169,22 @@ fn encode_desired(agent: &Agent) -> Result<String, Error> {
     serde_json::to_string(&desired).map_err(Error::from)
 }
 
+/// Serializes status for storage, scrubbing API-projected provenance.
+fn encode_status(status: &Status) -> Result<String, Error> {
+    let mut status = status.clone();
+    status.provenance = None;
+    serde_json::to_string(&status).map_err(Error::from)
+}
+
+/// Source-column payload: current writes store [`crate::Provenance`]; rows
+/// written before the manifest path was recorded hold a bare directory string.
+#[derive(serde::Deserialize)]
+#[serde(untagged)]
+enum StoredSource {
+    Provenance(crate::Provenance),
+    Directory(std::path::PathBuf),
+}
+
 fn deletion_timestamp(agent: &Agent) -> Option<i64> {
     agent
         .metadata
@@ -181,7 +200,10 @@ fn decode_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<AgentRecord> {
     let deletion = row.get::<_, Option<i64>>(4)?;
     let status = row.get::<_, String>(5)?;
     let id = id.parse::<AgentId>().map_err(conversion_error)?;
-    let source_directory = serde_json::from_str(&source).map_err(conversion_error)?;
+    let (source_directory, manifest_path) = match serde_json::from_str(&source).map_err(conversion_error)? {
+        StoredSource::Provenance(provenance) => (provenance.source_directory, provenance.manifest_path),
+        StoredSource::Directory(directory) => (directory, None),
+    };
     let mut agent = serde_json::from_str::<Agent>(&desired).map_err(conversion_error)?;
     if agent.metadata.name != active_name {
         return Err(rusqlite::Error::InvalidQuery);
@@ -194,6 +216,7 @@ fn decode_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<AgentRecord> {
     Ok(AgentRecord {
         id,
         source_directory,
+        manifest_path,
         agent,
     })
 }

--- a/src/experimental/agent/tests/control_api.rs
+++ b/src/experimental/agent/tests/control_api.rs
@@ -154,6 +154,8 @@ async fn health_reports_a_compatible_daemon() {
 fn request(name: &str) -> ApplyRequest {
     ApplyRequest {
         source_directory: std::env::temp_dir().join("agent-platform-source"),
+        manifest_path: None,
+        create_only: false,
         agent: agent(name),
     }
 }

--- a/src/experimental/agent/tests/control_plane.rs
+++ b/src/experimental/agent/tests/control_plane.rs
@@ -225,8 +225,14 @@ fn fixture() -> Fixture {
 }
 
 fn apply_request(name: &str) -> agent::control_plane::ApplyRequest {
+    apply_request_in(name, std::env::temp_dir().join("agent-platform-source"))
+}
+
+fn apply_request_in(name: &str, source_directory: PathBuf) -> agent::control_plane::ApplyRequest {
     agent::control_plane::ApplyRequest {
-        source_directory: std::env::temp_dir().join("agent-platform-source"),
+        manifest_path: Some(source_directory.join("agent.yaml")),
+        source_directory,
+        create_only: false,
         agent: agent(name),
     }
 }
@@ -266,11 +272,9 @@ async fn apply_stores_desired_state_without_running_inline() {
 async fn lists_agents_and_resolves_the_nearest_unique_source_directory() {
     let fixture = fixture();
     let root = std::env::temp_dir().join("agent-platform-sources");
-    let mut outer = apply_request("outer");
-    outer.source_directory = root.clone();
+    let outer = apply_request_in("outer", root.clone());
     fixture.control_plane.apply(outer).await.expect("outer Agent");
-    let mut inner = apply_request("inner");
-    inner.source_directory = root.join("nested");
+    let inner = apply_request_in("inner", root.join("nested"));
     fixture.control_plane.apply(inner).await.expect("inner Agent");
 
     let listed = fixture.control_plane.list().await.expect("list Agents");
@@ -307,8 +311,7 @@ async fn bind_mounts_resolve_from_the_manifest_and_drive_directory_inference_and
     let nested = root.join("src/feature");
     std::fs::create_dir_all(&manifest).expect("manifest directory");
     std::fs::create_dir_all(&nested).expect("nested workspace directory");
-    let mut request = apply_request("worker");
-    request.source_directory = manifest;
+    let mut request = apply_request_in("worker", manifest);
     request.agent.spec.sandbox.mounts.push(MountSpec::Bind {
         source: PathBuf::from("../.."),
         target: SandboxPath::new("/home/agent/code/altinn-studio"),
@@ -342,11 +345,130 @@ async fn bind_mounts_resolve_from_the_manifest_and_drive_directory_inference_and
 }
 
 #[tokio::test(flavor = "local")]
+async fn api_responses_carry_provenance_without_persisting_it() {
+    let fixture = fixture();
+    let request = apply_request("worker");
+    let expected = agent::Provenance {
+        source_directory: request.source_directory.clone(),
+        manifest_path: request.manifest_path.clone(),
+    };
+
+    let applied = fixture.control_plane.apply(request.clone()).await.expect("apply");
+    assert_eq!(applied.status.provenance.as_ref(), Some(&expected));
+
+    let unchanged = fixture.control_plane.apply(request).await.expect("unchanged apply");
+    assert_eq!(unchanged.status.provenance.as_ref(), Some(&expected));
+
+    let fetched = fixture.control_plane.get("worker").await.expect("get");
+    assert_eq!(fetched.status.provenance.as_ref(), Some(&expected));
+
+    let listed = fixture.control_plane.list().await.expect("list");
+    assert_eq!(listed[0].status.provenance.as_ref(), Some(&expected));
+
+    let resolved = fixture
+        .control_plane
+        .resolve_directory(&expected.source_directory)
+        .await
+        .expect("resolve directory");
+    assert_eq!(resolved.status.provenance.as_ref(), Some(&expected));
+
+    let record = stored(&fixture, "worker").await;
+    assert_eq!(record.agent.status.provenance, None);
+    assert_eq!(record.manifest_path, expected.manifest_path);
+
+    reconcile(&fixture, "worker").await;
+    let reconciled = fixture.control_plane.get("worker").await.expect("get after reconcile");
+    assert_eq!(reconciled.status.provenance.as_ref(), Some(&expected));
+    assert!(!reconciled.status.conditions.is_empty());
+    let record = stored(&fixture, "worker").await;
+    assert_eq!(record.agent.status.provenance, None);
+}
+
+#[tokio::test(flavor = "local")]
+async fn create_only_applies_reject_existing_names() {
+    let fixture = fixture();
+    let mut request = apply_request("worker");
+    request.create_only = true;
+    fixture
+        .control_plane
+        .apply(request.clone())
+        .await
+        .expect("initial create");
+
+    let error = fixture
+        .control_plane
+        .apply(request.clone())
+        .await
+        .expect_err("repeated create must fail");
+    assert!(matches!(error, Error::Invalid(message) if message.contains("already exists")));
+
+    request.create_only = false;
+    fixture.control_plane.apply(request).await.expect("upsert still works");
+}
+
+#[tokio::test(flavor = "local")]
+async fn applies_keep_the_recorded_manifest_path_unless_a_new_one_is_reported() {
+    let fixture = fixture();
+    let request = apply_request("worker");
+    let recorded = request.manifest_path.clone();
+    fixture.control_plane.apply(request.clone()).await.expect("apply");
+
+    let mut pathless = request.clone();
+    pathless.manifest_path = None;
+    fixture.control_plane.apply(pathless).await.expect("pathless apply");
+    assert_eq!(stored(&fixture, "worker").await.manifest_path, recorded);
+
+    let mut renamed = request.clone();
+    renamed.manifest_path = Some(request.source_directory.join("worker.yml"));
+    let applied = fixture
+        .control_plane
+        .apply(renamed.clone())
+        .await
+        .expect("renamed apply");
+    assert_eq!(stored(&fixture, "worker").await.manifest_path, renamed.manifest_path);
+    assert_eq!(
+        applied
+            .status
+            .provenance
+            .and_then(|provenance| provenance.manifest_path),
+        renamed.manifest_path
+    );
+
+    let mut foreign = request;
+    foreign.manifest_path = Some(PathBuf::from("/elsewhere/agent.yaml"));
+    let error = fixture
+        .control_plane
+        .apply(foreign)
+        .await
+        .expect_err("manifest outside sourceDirectory must fail");
+    assert!(matches!(error, Error::Invalid(message) if message.contains("manifestPath")));
+}
+
+#[tokio::test(flavor = "local")]
+async fn changing_the_source_directory_is_rejected_by_name() {
+    let fixture = fixture();
+    fixture
+        .control_plane
+        .apply(apply_request("worker"))
+        .await
+        .expect("apply");
+
+    let mut moved = apply_request("worker");
+    moved.source_directory = std::env::temp_dir().join("agent-platform-elsewhere");
+    moved.manifest_path = Some(moved.source_directory.join("agent.yaml"));
+    let error = fixture
+        .control_plane
+        .apply(moved)
+        .await
+        .expect_err("directory change must fail");
+    assert!(matches!(error, Error::Immutable("sourceDirectory")));
+}
+
+#[tokio::test(flavor = "local")]
 async fn changing_a_mount_is_rejected_for_an_existing_agent() {
     let fixture = fixture();
     let root = TempDirectory::new("immutable-mount");
-    let mut request = apply_request("worker");
-    request.source_directory = root.path().to_path_buf();
+    let mut request = apply_request_in("worker", root.path().to_path_buf());
     request.agent.spec.sandbox.mounts.push(MountSpec::Bind {
         source: PathBuf::from("."),
         target: SandboxPath::new("/home/agent/code/first"),

--- a/src/experimental/agent/tests/database.rs
+++ b/src/experimental/agent/tests/database.rs
@@ -2,7 +2,7 @@
 
 mod support;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use agent::{
     AgentId, Condition, ConditionStatus, Error, Status,
@@ -25,6 +25,7 @@ fn record_with_id(name: &str, generation: u64, id: AgentId) -> AgentRecord {
     AgentRecord {
         id,
         source_directory: PathBuf::from("/source"),
+        manifest_path: None,
         agent,
     }
 }
@@ -35,20 +36,53 @@ fn record(name: &str, generation: u64) -> AgentRecord {
 
 fn ready_record(name: &str, id: AgentId) -> AgentRecord {
     let mut ready = record_with_id(name, 1, id);
-    ready.agent.status = Status {
-        observed_generation: 1,
-        sandbox: Some(Assignment::Materialized {
+    ready.agent.status = Status::observed(
+        1,
+        Some(Assignment::Materialized {
             provider: ProviderId::new("memory").expect("Provider ID"),
             id: "3f978c33-4d43-4ea4-b58d-10b90ef166af".parse().expect("Sandbox ID"),
         }),
-        conditions: vec![Condition {
+        vec![Condition {
             kind: "Ready".into(),
             status: ConditionStatus::True,
             reason: "SandboxReady".into(),
             message: String::new(),
         }],
-    };
+    );
     ready
+}
+
+#[test]
+fn stores_scrub_projected_provenance_and_keep_recorded_manifest_paths() {
+    let directory = TempDir::new().expect("temporary directory");
+    let store = persistence::Database::open(&directory.path().join("control-plane.db")).expect("open database");
+    LocalRuntime::new().expect("local runtime").block_on(async {
+        let mut record = ready_record("worker", test_agent_id());
+        record.manifest_path = Some(PathBuf::from("/source/worker.yml"));
+        record.agent.status.provenance = Some(agent::Provenance {
+            source_directory: PathBuf::from("/leaked"),
+            manifest_path: None,
+        });
+        store.put(record.clone(), 0).await.expect("Agent stored");
+
+        let stored = store.get(record.id).await.expect("Agent loaded");
+        assert_eq!(stored.agent.status.provenance, None);
+        assert_eq!(stored.manifest_path.as_deref(), Some(Path::new("/source/worker.yml")));
+        assert_eq!(stored.source_directory, record.source_directory);
+
+        let mut status = stored.agent.status.clone();
+        status.provenance = Some(agent::Provenance {
+            source_directory: PathBuf::from("/leaked"),
+            manifest_path: None,
+        });
+        store
+            .update_status(record.id, stored.agent.metadata.generation, status)
+            .await
+            .expect("status updated");
+        let reloaded = store.get(record.id).await.expect("Agent reloaded");
+        assert_eq!(reloaded.agent.status.provenance, None);
+        assert_eq!(reloaded.agent.status.conditions, stored.agent.status.conditions);
+    });
 }
 
 #[test]

--- a/src/experimental/agent/tests/database.rs
+++ b/src/experimental/agent/tests/database.rs
@@ -82,6 +82,8 @@ fn stores_scrub_projected_provenance_and_keep_recorded_manifest_paths() {
         let reloaded = store.get(record.id).await.expect("Agent reloaded");
         assert_eq!(reloaded.agent.status.provenance, None);
         assert_eq!(reloaded.agent.status.conditions, stored.agent.status.conditions);
+        assert_eq!(reloaded.manifest_path.as_deref(), Some(Path::new("/source/worker.yml")));
+        assert_eq!(reloaded.source_directory, record.source_directory);
     });
 }
 

--- a/src/experimental/agent/tests/manifest.rs
+++ b/src/experimental/agent/tests/manifest.rs
@@ -278,3 +278,23 @@ fn rejects_manifest_secrets_owned_by_a_declared_harness() {
         Err(agent::Error::Invalid(message)) if message.contains("spec.secrets[0]")
     ));
 }
+
+#[test]
+fn status_tolerates_unknown_fields_inside_provenance() {
+    let status: agent::Status = serde_json::from_value(serde_json::json!({
+        "observedGeneration": 1,
+        "futureField": true,
+        "provenance": {
+            "sourceDirectory": "/source",
+            "manifestPath": "/source/worker.yml",
+            "futureField": "ignored"
+        }
+    }))
+    .expect("newer status should decode");
+    let provenance = status.provenance.expect("provenance");
+    assert_eq!(provenance.source_directory, std::path::Path::new("/source"));
+    assert_eq!(
+        provenance.manifest_path.as_deref(),
+        Some(std::path::Path::new("/source/worker.yml"))
+    );
+}

--- a/src/experimental/agent/tests/platform_api.rs
+++ b/src/experimental/agent/tests/platform_api.rs
@@ -17,22 +17,23 @@ use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 fn ready_record(name: &str, id: AgentId) -> AgentRecord {
     let mut resource = support::agent(name);
     resource.metadata.generation = 1;
-    resource.status = Status {
-        observed_generation: 1,
-        sandbox: Some(SandboxAssignment::Materialized {
+    resource.status = Status::observed(
+        1,
+        Some(SandboxAssignment::Materialized {
             provider: ProviderId::new("memory").expect("Provider ID"),
             id: "3f978c33-4d43-4ea4-b58d-10b90ef166af".parse().expect("Sandbox ID"),
         }),
-        conditions: vec![Condition {
+        vec![Condition {
             kind: "Ready".into(),
             status: ConditionStatus::True,
             reason: "SandboxReady".into(),
             message: String::new(),
         }],
-    };
+    );
     AgentRecord {
         id,
         source_directory: PathBuf::from("/source"),
+        manifest_path: None,
         agent: resource,
     }
 }

--- a/src/experimental/agent/tests/platform_linux.rs
+++ b/src/experimental/agent/tests/platform_linux.rs
@@ -130,6 +130,7 @@ async fn linux_setup_rewrites_configuration_without_owning_workspace_initializat
     let record = AgentRecord {
         id: agent_id,
         source_directory: directory.path().to_path_buf(),
+        manifest_path: None,
         agent: resource,
     };
 
@@ -257,6 +258,7 @@ async fn linux_setup_convergently_configures_podman_container_trust() {
     let record = AgentRecord {
         id: agent_id,
         source_directory: directory.path().to_path_buf(),
+        manifest_path: None,
         agent: resource,
     };
     let backend = Rc::new(memory::Provider::new());
@@ -387,6 +389,7 @@ async fn linux_setup_rejects_a_declared_harness_version_mismatch_before_injectio
     let record = AgentRecord {
         id: agent_id,
         source_directory: PathBuf::from(directory.path()),
+        manifest_path: None,
         agent: resource,
     };
     let backend = Rc::new(memory::Provider::new());

--- a/src/experimental/agent/tests/platform_linux.rs
+++ b/src/experimental/agent/tests/platform_linux.rs
@@ -335,6 +335,7 @@ async fn linux_setup_accepts_any_installed_version_when_none_is_declared() {
     let record = AgentRecord {
         id: agent_id,
         source_directory: PathBuf::from(directory.path()),
+        manifest_path: None,
         agent: resource,
     };
     let backend = Rc::new(memory::Provider::new());

--- a/src/experimental/agent/tests/session_controller.rs
+++ b/src/experimental/agent/tests/session_controller.rs
@@ -53,21 +53,21 @@ impl Reconcile<AgentId> for BlockingAgentReady {
                 .update_status(
                     id,
                     record.agent.metadata.generation,
-                    Status {
-                        observed_generation: record.agent.metadata.generation,
-                        sandbox: Some(SandboxAssignment::Materialized {
+                    Status::observed(
+                        record.agent.metadata.generation,
+                        Some(SandboxAssignment::Materialized {
                             provider: ProviderId::new("memory")?,
                             id: "3f978c33-4d43-4ea4-b58d-10b90ef166af"
                                 .parse()
                                 .map_err(|error| Error::Database(format!("test Sandbox ID: {error}")))?,
                         }),
-                        conditions: vec![Condition {
+                        vec![Condition {
                             kind: "Ready".into(),
                             status: ConditionStatus::True,
                             reason: "SandboxReady".into(),
                             message: String::new(),
                         }],
-                    },
+                    ),
                 )
                 .await
         })
@@ -200,22 +200,23 @@ impl Reconcile<SessionId> for BlockingReconcile {
 fn ready_record(name: &str, id: AgentId) -> AgentRecord {
     let mut resource = support::agent(name);
     resource.metadata.generation = 1;
-    resource.status = Status {
-        observed_generation: 1,
-        sandbox: Some(SandboxAssignment::Materialized {
+    resource.status = Status::observed(
+        1,
+        Some(SandboxAssignment::Materialized {
             provider: ProviderId::new("memory").expect("Provider ID"),
             id: "3f978c33-4d43-4ea4-b58d-10b90ef166af".parse().expect("Sandbox ID"),
         }),
-        conditions: vec![Condition {
+        vec![Condition {
             kind: "Ready".into(),
             status: ConditionStatus::True,
             reason: "SandboxReady".into(),
             message: String::new(),
         }],
-    };
+    );
     AgentRecord {
         id,
         source_directory: PathBuf::from("/source"),
+        manifest_path: None,
         agent: resource,
     }
 }
@@ -546,6 +547,7 @@ async fn session_ensure_persists_intent_before_waiting_for_agent_convergence() {
             AgentRecord {
                 id: agent_id,
                 source_directory: PathBuf::from("/source"),
+                manifest_path: None,
                 agent: resource,
             },
             0,

--- a/src/experimental/sandbox/src/name.rs
+++ b/src/experimental/sandbox/src/name.rs
@@ -28,6 +28,15 @@ impl SandboxName {
         Ok(Self(value))
     }
 
+    /// Returns whether `character` may appear anywhere in a Sandbox name.
+    ///
+    /// This is the per-keystroke filter for interactive input; the positional
+    /// rules (alphanumeric first and last byte) still apply at validation.
+    #[must_use]
+    pub const fn accepts(character: char) -> bool {
+        character.is_ascii_lowercase() || character.is_ascii_digit() || character == '-'
+    }
+
     /// Returns the name as text.
     #[must_use]
     pub fn as_str(&self) -> &str {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Create agents from discovered manifest files directly within the terminal interface.
  - Select a manifest, enter a name, and receive validation for invalid or duplicate names.
  - Agent details now display their source manifest or source directory.
  - Improved navigation between agent trees and port-forward views, including manifest-scanning status.
  - Agent records retain the applied manifest location for improved traceability.
  - Name entry filters unsupported characters as you type.

- **Bug Fixes**
  - Improved validation and error handling for manifest paths and create-only requests.
  - Preserved compatibility with previously stored agent records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->