### PR TITLE
feat(localtest): link to workflow engine control panel

### DIFF
--- a/src/Runtime/localtest/src/Views/Shared/_Layout.cshtml
+++ b/src/Runtime/localtest/src/Views/Shared/_Layout.cshtml
@@ -37,6 +37,9 @@
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="StorageExplorer" asp-action="Index">Storage Explorer</a>
                         </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" href="http://workflow-engine.local.altinn.cloud:8000/">Workflow engine</a>
+                        </li>
                         <li class="nav-item grafana-item d-none">
                             <a class="nav-link text-dark" href="/grafana/">Grafana</a>
                         </li>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Add a "Workflow engine" item to the localtest navigation beside "Storage Explorer". The link opens the workflow engine control panel at `http://workflow-engine.local.altinn.cloud:8000/`, making a service that localtest already starts easier to find.

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

`dotnet build LocalTest.sln` completed with 0 warnings and 0 errors. The full spelling suite passed every available check; the Norwegian dictionary check was skipped because `hunspell` is not installed in the test environment.

Manually started localtest, the app frontend, and the `ttd/component-library` test app. Clicking "Workflow engine" navigated to the expected URL and loaded the control panel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Workflow engine” link to the navigation menu, providing direct access to the local workflow engine.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->