### PR TITLE
feat(experimental): let the Agent image own the harness version

### DIFF
--- a/.github/workflows/approve-pr.yaml
+++ b/.github/workflows/approve-pr.yaml
@@ -25,21 +25,45 @@ jobs:
             exit 0
           fi
 
-          if ! permission=$(gh api repos/${{ github.repository }}/collaborators/"$ACTOR"/permission --jq '.permission' 2>/dev/null); then
-            echo "should_approve=false" >> $GITHUB_OUTPUT
-            echo "Could not determine permission for $ACTOR"
-            exit 0
-          fi
-
-          case "$permission" in
-            admin|maintain|write)
-              ;;
-            *)
+          if [[ "$ACTOR_ID" == "$RENOVATE_BOT_USER_ID" && "$ACTOR" == "renovate[bot]" ]]; then
+            if [[ "$AUTHOR_ID" != "$RENOVATE_BOT_USER_ID" ]]; then
               echo "should_approve=false" >> $GITHUB_OUTPUT
-              echo "User $ACTOR cannot use the approve label: $permission"
+              echo "Renovate may only approve its own pull requests"
               exit 0
-              ;;
-          esac
+            fi
+
+            if [[ "$HEAD_REPOSITORY" != "${{ github.repository }}" ]]; then
+              echo "should_approve=false" >> $GITHUB_OUTPUT
+              echo "Renovate may only approve pull requests from branches in this repository"
+              exit 0
+            fi
+
+            changed_files=$(gh pr view ${{ github.event.pull_request.number }} --repo "${{ github.repository }}" --json changedFiles,files --jq 'if (.files | length) == .changedFiles then .files[].path else "<incomplete file listing>" end')
+            disallowed_files=$(grep -Fxv -f <(printf '%s\n' "$RENOVATE_APPROVABLE_FILES" | sed '/^$/d') <<<"$changed_files" || true)
+
+            if [ -n "$disallowed_files" ]; then
+              echo "should_approve=false" >> $GITHUB_OUTPUT
+              echo "Renovate may not approve changes outside the approvable files:"
+              echo "$disallowed_files"
+              exit 0
+            fi
+          else
+            if ! permission=$(gh api repos/${{ github.repository }}/collaborators/"$ACTOR"/permission --jq '.permission' 2>/dev/null); then
+              echo "should_approve=false" >> $GITHUB_OUTPUT
+              echo "Could not determine permission for $ACTOR"
+              exit 0
+            fi
+
+            case "$permission" in
+              admin|maintain|write)
+                ;;
+              *)
+                echo "should_approve=false" >> $GITHUB_OUTPUT
+                echo "User $ACTOR cannot use the approve label: $permission"
+                exit 0
+                ;;
+            esac
+          fi
 
           # Check if already approved by github-actions bot
           reviews=$(gh pr view ${{ github.event.pull_request.number }} --repo "${{ github.repository }}" --json reviews --jq '.reviews[] | select((.author.login == "github-actions" or .author.login == "github-actions[bot]") and .state == "APPROVED")')
@@ -52,6 +76,12 @@ jobs:
           fi
         env:
           ACTOR: ${{ github.event.sender.login }}
+          ACTOR_ID: ${{ github.event.sender.id }}
+          AUTHOR_ID: ${{ github.event.pull_request.user.id }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          RENOVATE_BOT_USER_ID: "29139614"
+          RENOVATE_APPROVABLE_FILES: |
+            agents/Dockerfile
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Auto approve PR

--- a/agents/Dockerfile
+++ b/agents/Dockerfile
@@ -92,7 +92,7 @@ RUN git config --system credential.https://github.com.helper '!/usr/local/bin/gh
     && git config --system credential.https://gist.github.com.helper '!/usr/local/bin/gh auth git-credential'
 
 ARG CODEX_VERSION=0.149.1
-ARG CLAUDE_CODE_VERSION=2.1.239
+ARG CLAUDE_CODE_VERSION=2.1.259
 
 RUN npm install --global "@openai/codex@${CODEX_VERSION}" \
     && npm install --global --allow-scripts=@anthropic-ai/claude-code \

--- a/agents/full/agent.yaml
+++ b/agents/full/agent.yaml
@@ -22,7 +22,6 @@ spec:
     source: ../instructions.md
   harnesses:
     - type: claudeCode
-      version: "2.1.239"
       auth: mediated
       default: true
     # - type: codex

--- a/agents/minimal/agent.yaml
+++ b/agents/minimal/agent.yaml
@@ -22,7 +22,6 @@ spec:
     source: ../instructions.md
   harnesses:
     - type: claudeCode
-      version: "2.1.239"
       auth: mediated
       default: true
     # - type: codex

--- a/agents/worktree/agent.yaml
+++ b/agents/worktree/agent.yaml
@@ -27,7 +27,6 @@ spec:
     source: ../instructions.md
   harnesses:
     - type: claudeCode
-      version: "2.1.239"
       auth: mediated
   network:
     mode: mediated

--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,22 @@
       "depNameTemplate": "grafana/k6",
       "versioningTemplate": "docker",
       "autoReplaceStringTemplate": "grafana/k6:{{{newValue}}}-with-browser"
+    },
+    {
+      "customType": "regex",
+      "description": "Track the Claude Code release installed into the Agent images",
+      "managerFilePatterns": ["/^agents/Dockerfile$/"],
+      "matchStrings": ["ARG CLAUDE_CODE_VERSION=(?<currentValue>[\\w.-]+)"],
+      "datasourceTemplate": "npm",
+      "depNameTemplate": "@anthropic-ai/claude-code"
+    },
+    {
+      "customType": "regex",
+      "description": "Track the Codex release installed into the Agent images",
+      "managerFilePatterns": ["/^agents/Dockerfile$/"],
+      "matchStrings": ["ARG CODEX_VERSION=(?<currentValue>[\\w.-]+)"],
+      "datasourceTemplate": "npm",
+      "depNameTemplate": "@openai/codex"
     }
   ],
   "separateMultipleMajor": true,
@@ -125,6 +141,15 @@
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "Altinn app template NuGet packages (v9)",
       "groupSlug": "app-template-nuget-v9",
+      "addLabels": ["approve"],
+      "automerge": true
+    },
+    {
+      "description": "Automerge non-major harness releases installed into the Agent images so the published images track current Claude Code and Codex",
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": ["agents/Dockerfile"],
+      "matchPackageNames": ["@anthropic-ai/claude-code", "@openai/codex"],
+      "matchUpdateTypes": ["minor", "patch"],
       "addLabels": ["approve"],
       "automerge": true
     },

--- a/src/experimental/README.md
+++ b/src/experimental/README.md
@@ -86,6 +86,7 @@ not delete guest files that disappear from the source. Builders may use it to ow
 with the consequence that those files are reapplied on every Agent pass.
 
 `spec.harnesses` declares the harness installations available to Sessions and selects the default used for new Sessions.
+A declared `version` is verified against the image at setup; omit it when the image owns the version, so image bumps need no manifest change.
 `spec.instructions` names one harness-neutral Agent instruction file. Every declared Harness Adapter installs that source
 at its global instruction location: `~/.claude/CLAUDE.md` for Claude Code and `~/.codex/AGENTS.md` for Codex.
 Repository-local instruction files continue to be discovered by the harness itself.

--- a/src/experimental/agent/src/bin/agentctl/format.rs
+++ b/src/experimental/agent/src/bin/agentctl/format.rs
@@ -59,7 +59,12 @@ pub(crate) fn format_harnesses(spec: &agent::Spec) -> String {
             } else {
                 ""
             };
-            format!("{} {}{suffix}", harness.kind.as_str(), harness.version)
+            let version = harness
+                .version
+                .as_deref()
+                .map(|version| format!(" {version}"))
+                .unwrap_or_default();
+            format!("{}{version}{suffix}", harness.kind.as_str())
         })
         .collect::<Vec<_>>()
         .join(", ")

--- a/src/experimental/agent/src/harness/claude_code/mod.rs
+++ b/src/experimental/agent/src/harness/claude_code/mod.rs
@@ -102,7 +102,10 @@ pub(super) async fn bootstrap_linux(
     bootstrap::configure_linux(sandbox, home, instructions).await
 }
 
-pub(super) async fn verify_linux(sandbox: &sandbox::SandboxHandle, expected_version: &str) -> Result<(), Error> {
+pub(super) async fn verify_linux(
+    sandbox: &sandbox::SandboxHandle,
+    expected_version: Option<&str>,
+) -> Result<(), Error> {
     use sandbox::{SandboxPath, execution::ExecutionSpec};
 
     let output = sandbox
@@ -113,7 +116,7 @@ pub(super) async fn verify_linux(sandbox: &sandbox::SandboxHandle, expected_vers
         .await?;
     if !output.status.success() {
         return Err(Error::SandboxSetup(format!(
-            "declared Claude Code {expected_version:?} is missing or `claude --version` exited with code {}",
+            "Claude Code is missing or `claude --version` exited with code {}",
             output.status.code
         )));
     }
@@ -123,9 +126,9 @@ pub(super) async fn verify_linux(sandbox: &sandbox::SandboxHandle, expected_vers
         .split_whitespace()
         .next()
         .ok_or_else(|| Error::SandboxSetup("`claude --version` returned no version".into()))?;
-    if installed != expected_version {
+    if let Some(expected) = expected_version.filter(|expected| *expected != installed) {
         return Err(Error::SandboxSetup(format!(
-            "declared Claude Code version {expected_version:?} does not match installed version {installed:?}"
+            "declared Claude Code version {expected:?} does not match installed version {installed:?}"
         )));
     }
     Ok(())

--- a/src/experimental/agent/src/harness/codex/mod.rs
+++ b/src/experimental/agent/src/harness/codex/mod.rs
@@ -126,7 +126,10 @@ pub(super) async fn bootstrap_linux(
     bootstrap::configure_linux(sandbox, home, instructions).await
 }
 
-pub(super) async fn verify_linux(sandbox: &sandbox::SandboxHandle, expected_version: &str) -> Result<(), Error> {
+pub(super) async fn verify_linux(
+    sandbox: &sandbox::SandboxHandle,
+    expected_version: Option<&str>,
+) -> Result<(), Error> {
     use sandbox::{SandboxPath, execution::ExecutionSpec};
 
     let output = sandbox
@@ -137,7 +140,7 @@ pub(super) async fn verify_linux(sandbox: &sandbox::SandboxHandle, expected_vers
         .await?;
     if !output.status.success() {
         return Err(Error::SandboxSetup(format!(
-            "declared Codex {expected_version:?} is missing or `codex --version` exited with code {}",
+            "Codex is missing or `codex --version` exited with code {}",
             output.status.code
         )));
     }
@@ -147,9 +150,9 @@ pub(super) async fn verify_linux(sandbox: &sandbox::SandboxHandle, expected_vers
         .split_whitespace()
         .nth(1)
         .ok_or_else(|| Error::SandboxSetup("`codex --version` returned no version".into()))?;
-    if installed != expected_version {
+    if let Some(expected) = expected_version.filter(|expected| *expected != installed) {
         return Err(Error::SandboxSetup(format!(
-            "declared Codex version {expected_version:?} does not match installed version {installed:?}"
+            "declared Codex version {expected:?} does not match installed version {installed:?}"
         )));
     }
     Ok(())

--- a/src/experimental/agent/src/harness/mod.rs
+++ b/src/experimental/agent/src/harness/mod.rs
@@ -63,8 +63,9 @@ pub struct HarnessSpec {
     /// Closed harness family identifier.
     #[serde(rename = "type")]
     pub kind: Harness,
-    /// Version installed by the Agent image.
-    pub version: String,
+    /// Exact version installed by the Agent image; omitted when the image owns the version, so image bumps need no manifest change.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
     /// Authentication delivery mode.
     pub auth: HarnessAuthMode,
     /// Whether new Sessions select this installation when no harness is specified.
@@ -191,11 +192,11 @@ pub(crate) async fn bootstrap_linux(
     }
 }
 
-/// Verifies that the declared harness installation exists at the exact version.
+/// Verifies that the declared harness installation exists, at the exact version when one is declared.
 pub(crate) async fn verify_linux(
     harness: Harness,
     sandbox: &sandbox::SandboxHandle,
-    expected_version: &str,
+    expected_version: Option<&str>,
 ) -> Result<(), Error> {
     match harness {
         Harness::ClaudeCode => claude_code::verify_linux(sandbox, expected_version).await,

--- a/src/experimental/agent/src/manifest.rs
+++ b/src/experimental/agent/src/manifest.rs
@@ -321,7 +321,7 @@ impl Spec {
         let mut duplicate_harness = None;
         let mut default_count = 0;
         for (index, harness) in self.harnesses.iter().enumerate() {
-            if harness.version.is_empty() {
+            if harness.version.as_deref().is_some_and(str::is_empty) {
                 return Err(Error::Invalid(format!(
                     "spec.harnesses[{index}].version must not be empty"
                 )));

--- a/src/experimental/agent/src/sandbox/platform/linux.rs
+++ b/src/experimental/agent/src/sandbox/platform/linux.rs
@@ -95,7 +95,7 @@ impl PlatformAdapter for Linux {
 impl Linux {
     async fn setup(&self, record: &control_plane::AgentRecord, sandbox: &SandboxHandle) -> Result<(), Error> {
         for installation in &record.agent.spec.harnesses {
-            harness::verify_linux(installation.kind, sandbox, &installation.version).await?;
+            harness::verify_linux(installation.kind, sandbox, installation.version.as_deref()).await?;
         }
         run_checked(sandbox, "/usr/bin/install", ["-d", "-m", "0755", WORKING_DIRECTORY]).await?;
         configure_podman(sandbox).await?;

--- a/src/experimental/agent/tests/control_plane.rs
+++ b/src/experimental/agent/tests/control_plane.rs
@@ -556,7 +556,7 @@ async fn repeated_apply_is_idempotent_and_immutable_fields_are_rejected() {
 
     let mut mutable_change = request.clone();
     mutable_change.agent.spec.sandbox.retention_policy = Some(RetentionPolicy::Delete);
-    mutable_change.agent.spec.harnesses[0].version = "2.1.240".into();
+    mutable_change.agent.spec.harnesses[0].version = Some("2.1.240".into());
     mutable_change.agent.spec.harnesses[0].default = true;
     let updated_request = mutable_change.clone();
     let updated = fixture
@@ -565,14 +565,14 @@ async fn repeated_apply_is_idempotent_and_immutable_fields_are_rejected() {
         .await
         .expect("mutable update");
     assert_eq!(updated.metadata.generation, 2);
-    assert_eq!(updated.spec.harnesses[0].version, "2.1.240");
+    assert_eq!(updated.spec.harnesses[0].version.as_deref(), Some("2.1.240"));
     assert!(updated.spec.harnesses[0].default);
 
     let mut kind_set_change = updated_request.clone();
     kind_set_change.agent.spec.harnesses[0].default = true;
     kind_set_change.agent.spec.harnesses.push(agent::HarnessSpec {
         kind: agent::Harness::Codex,
-        version: "0.149.1".into(),
+        version: Some("0.149.1".into()),
         auth: agent::HarnessAuthMode::Mediated,
         default: false,
     });

--- a/src/experimental/agent/tests/manifest.rs
+++ b/src/experimental/agent/tests/manifest.rs
@@ -53,6 +53,43 @@ spec:
 }
 
 #[test]
+fn decodes_a_harness_without_a_declared_version() {
+    let bytes = br#"
+apiVersion: agents.platform/v1alpha1
+kind: Agent
+metadata:
+  name: worker
+spec:
+  sandbox:
+    image:
+      type: reference
+      reference: example.invalid/agent:latest
+    platform:
+      os: linux
+    resources:
+      cpu: "2"
+      memory: "1Gi"
+      rootFilesystem:
+        capacity: "4Gi"
+        mode: layered
+  home:
+    source: home
+  harnesses:
+    - type: claudeCode
+      auth: mediated
+  network:
+    mode: mediated
+    allow: all
+"#;
+
+    let agent = manifest::decode(bytes).expect("manifest without a harness version should decode");
+    assert_eq!(agent.spec.harnesses[0].version, None);
+
+    let value = serde_json::to_value(agent).expect("Agent JSON");
+    assert!(value["spec"]["harnesses"][0].get("version").is_none());
+}
+
+#[test]
 fn decodes_the_minimal_manifest() {
     let bytes = include_bytes!("../examples/minimal/agent.yaml");
     let agent = manifest::decode(bytes).expect("minimal manifest should decode");
@@ -199,7 +236,7 @@ fn validates_harness_installation_cardinality_and_defaults() {
 
     let mut codex = installation.clone();
     codex.kind = Harness::Codex;
-    codex.version = "0.149.1".into();
+    codex.version = Some("0.149.1".into());
 
     let mut no_default = support::agent("worker");
     no_default.spec.harnesses = vec![installation.clone(), codex.clone()];
@@ -225,7 +262,7 @@ fn rejects_manifest_secrets_owned_by_a_declared_harness() {
     let mut agent = support::agent("worker");
     let mut codex = agent.spec.harnesses[0].clone();
     codex.kind = Harness::Codex;
-    codex.version = "0.149.1".into();
+    codex.version = Some("0.149.1".into());
     codex.default = false;
     agent.spec.harnesses[0].default = true;
     agent.spec.harnesses.push(codex);

--- a/src/experimental/agent/tests/platform_linux.rs
+++ b/src/experimental/agent/tests/platform_linux.rs
@@ -123,7 +123,7 @@ async fn linux_setup_rewrites_configuration_without_owning_workspace_initializat
     resource.spec.harnesses[0].default = true;
     resource.spec.harnesses.push(agent::HarnessSpec {
         kind: agent::Harness::Codex,
-        version: "0.149.1".into(),
+        version: Some("0.149.1".into()),
         auth: agent::HarnessAuthMode::Mediated,
         default: false,
     });
@@ -317,6 +317,62 @@ async fn linux_setup_convergently_configures_podman_container_trust() {
     );
 
     assert_podman_setup_commands(&backend.execution_specs());
+}
+
+#[tokio::test(flavor = "local")]
+async fn linux_setup_accepts_any_installed_version_when_none_is_declared() {
+    let directory = TempDir::new().expect("temporary directory");
+    let home = directory.path().join("home");
+    std::fs::create_dir_all(&home).expect("home directory");
+    std::fs::write(directory.path().join("instructions.md"), "test instructions").expect("instruction file");
+    let agent_id: AgentId = "38f41de4-6ff7-4679-ae46-678bc61e4dcb".parse().expect("Agent ID");
+    let mut resource = support::agent("worker");
+    resource.metadata.generation = 1;
+    resource.spec.home.source = home;
+    resource.spec.harnesses[0].version = None;
+    let record = AgentRecord {
+        id: agent_id,
+        source_directory: PathBuf::from(directory.path()),
+        agent: resource,
+    };
+    let backend = Rc::new(memory::Provider::new());
+    backend.queue_execution_events_matching(
+        is_claude_version,
+        vec![
+            ExecutionEvent::Started { process_id: None },
+            ExecutionEvent::Stdout("2.1.258 (Claude Code)\n".into()),
+            ExecutionEvent::Exited(ExitStatus { code: 0 }),
+        ],
+    );
+    backend.queue_execution_events_matching(is_podman_presence_check, completed(1));
+    let service = SandboxService::new(backend.clone());
+    let spec = record
+        .agent
+        .spec
+        .sandbox
+        .resolve_from(&record.source_directory, &Platform::native("linux").architecture);
+    let sandbox = service
+        .ensure(&EnsureSandboxRequest::new(
+            record.sandbox_name().expect("Sandbox name"),
+            spec,
+        ))
+        .await
+        .expect("Sandbox");
+
+    Linux
+        .setup(&record, &sandbox)
+        .await
+        .expect("setup without a declared version");
+
+    assert_eq!(
+        backend
+            .execution_specs()
+            .iter()
+            .filter(|spec| is_claude_version(spec))
+            .count(),
+        1,
+        "the installation is still checked for presence"
+    );
 }
 
 #[tokio::test(flavor = "local")]

--- a/src/experimental/agent/tests/session_controller.rs
+++ b/src/experimental/agent/tests/session_controller.rs
@@ -229,7 +229,7 @@ async fn session_ensure_resolves_explicit_and_implicit_harnesses() {
     record.agent.spec.harnesses[0].default = true;
     record.agent.spec.harnesses.push(agent::HarnessSpec {
         kind: agent::Harness::Codex,
-        version: "0.149.1".into(),
+        version: Some("0.149.1".into()),
         auth: agent::HarnessAuthMode::Mediated,
         default: false,
     });

--- a/src/experimental/agent/tests/support/mod.rs
+++ b/src/experimental/agent/tests/support/mod.rs
@@ -52,7 +52,7 @@ pub(crate) fn agent(name: &str) -> Agent {
             }),
             harnesses: vec![HarnessSpec {
                 kind: Harness::ClaudeCode,
-                version: "2.1.239".into(),
+                version: Some("2.1.239".into()),
                 auth: HarnessAuthMode::Mediated,
                 default: false,
             }],


### PR DESCRIPTION
## Description

The Agent image now owns the Claude Code version instead of the Agent manifests. `spec.harnesses[].version` is optional: when declared it is still verified exactly against the installed harness at setup, and when omitted setup only checks that the harness is present. The published `agents/*` manifests drop their pins so an image bump no longer needs a manifest change.

The image keeps an exact pin (`CLAUDE_CODE_VERSION=2.1.259`) rather than the mutable `latest` npm tag. Renovate tracks the Claude Code and Codex releases installed into the image and automerges non-major bumps; the merge republishes the `latest` image tags through the existing `agents/**` path filter.

For the automerge to complete, the approve workflow now honours the `approve` label when Renovate applies it, under tight conditions: the event sender must be the Renovate app (matched by user id and login), the PR author must be Renovate, the head branch must live in this repository, and every changed file must be in an allowlist that currently holds only the Agent Dockerfile. Anything else falls through to the existing write-permission check for human senders. Because the workflow runs on `pull_request_target`, this takes effect for Renovate PRs opened after it is on `main`; the first few bumps will show whether it behaves.

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Harness configurations can now omit a specific tool version.
  - When no version is specified, setup accepts any installed harness release.
  - Specifying a version continues to enforce an exact version match.
  - Harness details display a version only when one is declared.

- **Documentation**
  - Updated guidance explains how declared and omitted harness versions are handled.

- **Updates**
  - Updated the bundled Claude Code release to version 2.1.259.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



