### PR TITLE
feat: show Designer warning for missing defaultDataType in v9

### DIFF
--- a/src/Designer/backend/src/Designer/Controllers/ValidationController.cs
+++ b/src/Designer/backend/src/Designer/Controllers/ValidationController.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Helpers;
 using Altinn.Studio.Designer.Models;
@@ -11,22 +13,58 @@ namespace Altinn.Studio.Designer.Controllers;
 [Authorize]
 [AutoValidateAntiforgeryToken]
 [Route("/designer/api/{org}/{app:regex(^(?!datamodels$)[[a-z]][[a-z0-9-]]{{1,28}}[[a-z0-9]]$)}/validation")]
-public class ValidationController(IAltinnAppServiceResourceService altinnAppServiceResourceService) : ControllerBase
+public class ValidationController(
+    IAltinnAppServiceResourceService altinnAppServiceResourceService,
+    ITaskDefaultDataTypeBindingValidator taskDefaultDataTypeBindingValidator
+) : ControllerBase
 {
     [HttpGet]
     public async Task<ActionResult> ValidateAltinnAppResource(string org, string app)
     {
         string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
+        var editingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(org, app, developer);
         ServiceResource serviceResource = await altinnAppServiceResourceService.GenerateServiceResourceFromApp(
             org,
             app,
             developer
         );
 
-        (bool isValid, ValidationProblemDetails? errors) = altinnAppServiceResourceService.ValidateServiceResource(
-            serviceResource
+        (bool isServiceResourceValid, ValidationProblemDetails? serviceResourceErrors) =
+            altinnAppServiceResourceService.ValidateServiceResource(serviceResource);
+
+        IReadOnlyDictionary<string, string[]> taskBindingErrors =
+            await taskDefaultDataTypeBindingValidator.ValidateAsync(editingContext);
+
+        Dictionary<string, string[]> mergedErrors = MergeValidationErrors(
+            serviceResourceErrors?.Errors,
+            taskBindingErrors
         );
 
-        return Ok(new { errors?.Errors, isValid });
+        bool isValid = isServiceResourceValid && taskBindingErrors.Count == 0;
+
+        return Ok(new { errors = mergedErrors, isValid });
+    }
+
+    private static Dictionary<string, string[]> MergeValidationErrors(
+        IDictionary<string, string[]>? serviceResourceErrors,
+        IReadOnlyDictionary<string, string[]> taskBindingErrors
+    )
+    {
+        var merged = new Dictionary<string, string[]>(StringComparer.Ordinal);
+
+        if (serviceResourceErrors != null)
+        {
+            foreach (KeyValuePair<string, string[]> entry in serviceResourceErrors)
+            {
+                merged[entry.Key] = entry.Value;
+            }
+        }
+
+        foreach (KeyValuePair<string, string[]> entry in taskBindingErrors)
+        {
+            merged[entry.Key] = entry.Value;
+        }
+
+        return merged;
     }
 }

--- a/src/Designer/backend/src/Designer/Controllers/ValidationController.cs
+++ b/src/Designer/backend/src/Designer/Controllers/ValidationController.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Helpers;
 using Altinn.Studio.Designer.Models;
@@ -19,7 +20,11 @@ public class ValidationController(
 ) : ControllerBase
 {
     [HttpGet]
-    public async Task<ActionResult> ValidateAltinnAppResource(string org, string app)
+    public async Task<ActionResult> ValidateAltinnAppResource(
+        string org,
+        string app,
+        CancellationToken cancellationToken
+    )
     {
         string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
         var editingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(org, app, developer);
@@ -33,7 +38,7 @@ public class ValidationController(
             altinnAppServiceResourceService.ValidateServiceResource(serviceResource);
 
         IReadOnlyDictionary<string, string[]> taskBindingErrors =
-            await taskDefaultDataTypeBindingValidator.ValidateAsync(editingContext);
+            await taskDefaultDataTypeBindingValidator.ValidateAsync(editingContext, cancellationToken);
 
         Dictionary<string, string[]> mergedErrors = MergeValidationErrors(
             serviceResourceErrors?.Errors,

--- a/src/Designer/backend/src/Designer/Infrastructure/ServiceRegistration.cs
+++ b/src/Designer/backend/src/Designer/Infrastructure/ServiceRegistration.cs
@@ -136,6 +136,7 @@ public static class ServiceRegistration
         services.AddTransient<IGitOpsManifestsRenderer, GitOpsManifestsRenderer>();
         services.AddTransient<IOrgLibraryService, OrgLibraryService>();
         services.AddTransient<IAltinnAppServiceResourceService, AltinnAppServiceResourceService>();
+        services.AddTransient<ITaskDefaultDataTypeBindingValidator, TaskDefaultDataTypeBindingValidator>();
         services.AddTransient<ICustomTemplateService, CustomTemplateService>();
         services.AddSingleton<IAppTemplateCatalog, AppTemplateCatalog>();
         services.AddTransient<IStudioOidcUsernameProvider, GiteaDbStudioOidcUsernameProvider>();

--- a/src/Designer/backend/src/Designer/Services/Implementation/Validation/TaskDefaultDataTypeBindingValidator.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/Validation/TaskDefaultDataTypeBindingValidator.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Altinn.Studio.Designer.Infrastructure.GitRepository;
+using Altinn.Studio.Designer.Models;
+using Altinn.Studio.Designer.Services.Interfaces;
+using Altinn.Studio.Designer.Services.Interfaces.Validation;
+using Altinn.Studio.Designer.TypedHttpClients.Exceptions;
+
+namespace Altinn.Studio.Designer.Services.Implementation.Validation;
+
+public class TaskDefaultDataTypeBindingValidator(
+    IAltinnGitRepositoryFactory altinnGitRepositoryFactory,
+    IAppVersionService appVersionService
+) : ITaskDefaultDataTypeBindingValidator
+{
+    private const string MissingBinding = "MISSING";
+    private const string DataTypeNotFound = "NOT_FOUND";
+
+    public async Task<IReadOnlyDictionary<string, string[]>> ValidateAsync(
+        AltinnRepoEditingContext editingContext,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (!appVersionService.IsV9App(editingContext))
+        {
+            return new Dictionary<string, string[]>();
+        }
+
+        AltinnAppGitRepository repository = altinnGitRepositoryFactory.GetAltinnAppGitRepository(
+            editingContext.Org,
+            editingContext.Repo,
+            editingContext.Developer
+        );
+
+        HashSet<string> dataTypeIds;
+        try
+        {
+            var applicationMetadata = await repository.GetApplicationMetadata(cancellationToken);
+            dataTypeIds =
+                applicationMetadata.DataTypes?.Select(dataType => dataType.Id).ToHashSet(StringComparer.Ordinal) ?? [];
+        }
+        catch (Exception)
+        {
+            return new Dictionary<string, string[]>();
+        }
+
+        IEnumerable<string> processTaskIds;
+        try
+        {
+            processTaskIds = repository.GetProcessDefinitions()?.Process?.Tasks?.Select(task => task.Id) ?? [];
+        }
+        catch (NotFoundHttpRequestException)
+        {
+            return new Dictionary<string, string[]>();
+        }
+
+        var errors = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+
+        foreach (string taskId in processTaskIds)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            LayoutSettings layoutSettings;
+            try
+            {
+                layoutSettings = await repository.GetLayoutSettings(taskId, cancellationToken);
+            }
+            catch (FileNotFoundException)
+            {
+                AddError(errors, MissingBindingKey(taskId), MissingBinding);
+                continue;
+            }
+
+            if (string.IsNullOrWhiteSpace(layoutSettings.DefaultDataType))
+            {
+                AddError(errors, MissingBindingKey(taskId), MissingBinding);
+                continue;
+            }
+
+            if (!dataTypeIds.Contains(layoutSettings.DefaultDataType))
+            {
+                AddError(errors, NotFoundBindingKey(taskId, layoutSettings.DefaultDataType), DataTypeNotFound);
+            }
+        }
+
+        return errors.ToDictionary(entry => entry.Key, entry => entry.Value.ToArray());
+    }
+
+    private static string MissingBindingKey(string taskId) => $"taskSettings[{taskId}].defaultDataType.missing";
+
+    private static string NotFoundBindingKey(string taskId, string dataTypeId) =>
+        $"taskSettings[{taskId}].defaultDataType.notFound.{dataTypeId}";
+
+    private static void AddError(Dictionary<string, List<string>> errors, string key, string message)
+    {
+        if (!errors.TryGetValue(key, out List<string>? list))
+        {
+            list = [];
+            errors[key] = list;
+        }
+
+        list.Add(message);
+    }
+}

--- a/src/Designer/backend/src/Designer/Services/Implementation/Validation/TaskDefaultDataTypeBindingValidator.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/Validation/TaskDefaultDataTypeBindingValidator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Infrastructure.GitRepository;
@@ -43,7 +44,7 @@ public class TaskDefaultDataTypeBindingValidator(
             dataTypeIds =
                 applicationMetadata.DataTypes?.Select(dataType => dataType.Id).ToHashSet(StringComparer.Ordinal) ?? [];
         }
-        catch (Exception)
+        catch (Exception exception) when (exception is IOException or JsonException)
         {
             return new Dictionary<string, string[]>();
         }

--- a/src/Designer/backend/src/Designer/Services/Implementation/Validation/TaskDefaultDataTypeBindingValidator.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/Validation/TaskDefaultDataTypeBindingValidator.cs
@@ -49,10 +49,14 @@ public class TaskDefaultDataTypeBindingValidator(
             return new Dictionary<string, string[]>();
         }
 
-        IEnumerable<string> processTaskIds;
+        IEnumerable<(string Id, string? TaskType)> processTasks;
         try
         {
-            processTaskIds = repository.GetProcessDefinitions()?.Process?.Tasks?.Select(task => task.Id) ?? [];
+            processTasks =
+                repository
+                    .GetProcessDefinitions()
+                    ?.Process?.Tasks?.Select(task => (task.Id, task.ExtensionElements?.TaskExtension?.TaskType))
+                ?? [];
         }
         catch (NotFoundHttpRequestException)
         {
@@ -61,9 +65,14 @@ public class TaskDefaultDataTypeBindingValidator(
 
         var errors = new Dictionary<string, List<string>>(StringComparer.Ordinal);
 
-        foreach (string taskId in processTaskIds)
+        foreach ((string taskId, string? taskType) in processTasks)
         {
             cancellationToken.ThrowIfCancellationRequested();
+
+            if (!RequiresDefaultDataTypeBinding(taskType))
+            {
+                continue;
+            }
 
             LayoutSettings layoutSettings;
             try
@@ -90,6 +99,11 @@ public class TaskDefaultDataTypeBindingValidator(
 
         return errors.ToDictionary(entry => entry.Key, entry => entry.Value.ToArray());
     }
+
+    private static bool RequiresDefaultDataTypeBinding(string? taskType) =>
+        string.Equals(taskType, "data", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(taskType, "payment", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(taskType, "signing", StringComparison.OrdinalIgnoreCase);
 
     private static string MissingBindingKey(string taskId) => $"taskSettings[{taskId}].defaultDataType.missing";
 

--- a/src/Designer/backend/src/Designer/Services/Interfaces/Validation/ITaskDefaultDataTypeBindingValidator.cs
+++ b/src/Designer/backend/src/Designer/Services/Interfaces/Validation/ITaskDefaultDataTypeBindingValidator.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Altinn.Studio.Designer.Models;
+
+namespace Altinn.Studio.Designer.Services.Interfaces.Validation;
+
+public interface ITaskDefaultDataTypeBindingValidator
+{
+    Task<IReadOnlyDictionary<string, string[]>> ValidateAsync(
+        AltinnRepoEditingContext editingContext,
+        CancellationToken cancellationToken = default
+    );
+}

--- a/src/Designer/backend/tests/Designer.Tests/Services/TaskDefaultDataTypeBindingValidatorTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/TaskDefaultDataTypeBindingValidatorTests.cs
@@ -1,0 +1,125 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Altinn.Studio.Designer.Factories;
+using Altinn.Studio.Designer.Models;
+using Altinn.Studio.Designer.Services.Implementation;
+using Altinn.Studio.Designer.Services.Implementation.Validation;
+using Designer.Tests.Utils;
+using Xunit;
+
+namespace Designer.Tests.Services;
+
+public class TaskDefaultDataTypeBindingValidatorTests
+{
+    private const string Org = "ttd";
+    private const string Developer = "testUser";
+
+    [Fact]
+    public async Task ValidateAsync_V9AppWithValidBinding_ReturnsNoErrors()
+    {
+        TaskDefaultDataTypeBindingValidator validator = CreateValidator();
+        AltinnRepoEditingContext editingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(
+            Org,
+            "app-with-layoutsets-v9",
+            Developer
+        );
+
+        IReadOnlyDictionary<string, string[]> errors = await validator.ValidateAsync(editingContext);
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_MissingDefaultDataType_ReturnsError()
+    {
+        string targetRepository = TestDataHelper.GenerateTestRepoName();
+        await TestDataHelper.CopyRepositoryForTest(Org, "app-with-layoutsets-v9", Developer, targetRepository);
+        string settingsPath = Path.Combine(
+            TestDataHelper.GetTestDataRepositoriesRootDirectory(),
+            Developer,
+            Org,
+            targetRepository,
+            "App",
+            "ui",
+            "Task_1",
+            "Settings.json"
+        );
+        await File.WriteAllTextAsync(
+            settingsPath,
+            """
+            {
+              "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/layout/layoutSettings.schema.v1.json",
+              "pages": { "order": ["Side1"] }
+            }
+            """
+        );
+
+        TaskDefaultDataTypeBindingValidator validator = CreateValidator();
+        AltinnRepoEditingContext editingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(
+            Org,
+            targetRepository,
+            Developer
+        );
+
+        IReadOnlyDictionary<string, string[]> errors = await validator.ValidateAsync(editingContext);
+
+        KeyValuePair<string, string[]> error = Assert.Single(errors);
+        Assert.Equal("taskSettings[Task_1].defaultDataType.missing", error.Key);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_DanglingDefaultDataType_ReturnsError()
+    {
+        string targetRepository = TestDataHelper.GenerateTestRepoName();
+        await TestDataHelper.CopyRepositoryForTest(Org, "app-with-layoutsets-v9", Developer, targetRepository);
+        string metadataPath = Path.Combine(
+            TestDataHelper.GetTestDataRepositoriesRootDirectory(),
+            Developer,
+            Org,
+            targetRepository,
+            "App",
+            "config",
+            "applicationmetadata.json"
+        );
+        await File.WriteAllTextAsync(
+            metadataPath,
+            """
+            {
+              "id": "ttd/app-with-layoutsets-v9",
+              "org": "ttd",
+              "title": { "nb": "app-with-layoutsets-v9" },
+              "dataTypes": [],
+              "partyTypesAllowed": {
+                "bankruptcyEstate": true,
+                "organisation": true,
+                "person": true,
+                "subUnit": true
+              },
+              "autoDeleteOnProcessEnd": false
+            }
+            """
+        );
+
+        TaskDefaultDataTypeBindingValidator validator = CreateValidator();
+        AltinnRepoEditingContext editingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(
+            Org,
+            targetRepository,
+            Developer
+        );
+
+        IReadOnlyDictionary<string, string[]> errors = await validator.ValidateAsync(editingContext);
+
+        KeyValuePair<string, string[]> error = Assert.Single(errors);
+        Assert.Equal("taskSettings[Task_1].defaultDataType.notFound.model", error.Key);
+    }
+
+    private static TaskDefaultDataTypeBindingValidator CreateValidator()
+    {
+        string repositoriesRoot = TestDataHelper.GetTestDataRepositoriesRootDirectory();
+        return new TaskDefaultDataTypeBindingValidator(
+            new AltinnGitRepositoryFactory(repositoriesRoot),
+            new AppVersionService(new AltinnGitRepositoryFactory(repositoriesRoot))
+        );
+    }
+}

--- a/src/Designer/backend/tests/Designer.Tests/Services/TaskDefaultDataTypeBindingValidatorTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/TaskDefaultDataTypeBindingValidatorTests.cs
@@ -114,6 +114,157 @@ public class TaskDefaultDataTypeBindingValidatorTests
         Assert.Equal("taskSettings[Task_1].defaultDataType.notFound.model", error.Key);
     }
 
+    [Fact]
+    public async Task ValidateAsync_FeedbackTaskWithoutSettings_ReturnsNoErrors()
+    {
+        string targetRepository = TestDataHelper.GenerateTestRepoName();
+        await TestDataHelper.CopyRepositoryForTest(Org, "app-with-layoutsets-v9", Developer, targetRepository);
+        string processPath = Path.Combine(
+            TestDataHelper.GetTestDataRepositoriesRootDirectory(),
+            Developer,
+            Org,
+            targetRepository,
+            "App",
+            "config",
+            "process",
+            "process.bpmn"
+        );
+        await File.WriteAllTextAsync(
+            processPath,
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:altinn="http://altinn.no/process" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Altinn_SingleDataTask_Process_Definition" targetNamespace="http://bpmn.io/schema/bpmn">
+              <bpmn:process id="SingleDataTask" isExecutable="false">
+                <bpmn:startEvent id="StartEvent_1">
+                  <bpmn:outgoing>SequenceFlow_1n56yn5</bpmn:outgoing>
+                </bpmn:startEvent>
+                <bpmn:task id="Task_1" name="Utfylling">
+                  <bpmn:extensionElements>
+                    <altinn:taskExtension>
+                      <altinn:taskType>data</altinn:taskType>
+                    </altinn:taskExtension>
+                  </bpmn:extensionElements>
+                  <bpmn:incoming>SequenceFlow_1n56yn5</bpmn:incoming>
+                  <bpmn:outgoing>Flow_to_feedback</bpmn:outgoing>
+                </bpmn:task>
+                <bpmn:task id="Activity_feedback" name="Altinn feedback task">
+                  <bpmn:extensionElements>
+                    <altinn:taskExtension>
+                      <altinn:taskType>feedback</altinn:taskType>
+                    </altinn:taskExtension>
+                  </bpmn:extensionElements>
+                  <bpmn:incoming>Flow_to_feedback</bpmn:incoming>
+                  <bpmn:outgoing>Flow_0gbacsh</bpmn:outgoing>
+                </bpmn:task>
+                <bpmn:endEvent id="EndEvent_1">
+                  <bpmn:incoming>Flow_0gbacsh</bpmn:incoming>
+                </bpmn:endEvent>
+                <bpmn:sequenceFlow id="SequenceFlow_1n56yn5" sourceRef="StartEvent_1" targetRef="Task_1" />
+                <bpmn:sequenceFlow id="Flow_to_feedback" sourceRef="Task_1" targetRef="Activity_feedback" />
+                <bpmn:sequenceFlow id="Flow_0gbacsh" sourceRef="Activity_feedback" targetRef="EndEvent_1" />
+              </bpmn:process>
+            </bpmn:definitions>
+            """
+        );
+
+        TaskDefaultDataTypeBindingValidator validator = CreateValidator();
+        AltinnRepoEditingContext editingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(
+            Org,
+            targetRepository,
+            Developer
+        );
+
+        IReadOnlyDictionary<string, string[]> errors = await validator.ValidateAsync(editingContext);
+
+        Assert.Empty(errors);
+    }
+
+    [Theory]
+    [InlineData("payment", "Activity_payment")]
+    [InlineData("signing", "Activity_signing")]
+    public async Task ValidateAsync_LayoutSetTaskWithoutDefaultDataType_ReturnsError(string taskType, string taskId)
+    {
+        string targetRepository = TestDataHelper.GenerateTestRepoName();
+        await TestDataHelper.CopyRepositoryForTest(Org, "app-with-layoutsets-v9", Developer, targetRepository);
+        string processPath = Path.Combine(
+            TestDataHelper.GetTestDataRepositoriesRootDirectory(),
+            Developer,
+            Org,
+            targetRepository,
+            "App",
+            "config",
+            "process",
+            "process.bpmn"
+        );
+        await File.WriteAllTextAsync(
+            processPath,
+            $$"""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:altinn="http://altinn.no/process" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Altinn_SingleDataTask_Process_Definition" targetNamespace="http://bpmn.io/schema/bpmn">
+              <bpmn:process id="SingleDataTask" isExecutable="false">
+                <bpmn:startEvent id="StartEvent_1">
+                  <bpmn:outgoing>SequenceFlow_1n56yn5</bpmn:outgoing>
+                </bpmn:startEvent>
+                <bpmn:task id="Task_1" name="Utfylling">
+                  <bpmn:extensionElements>
+                    <altinn:taskExtension>
+                      <altinn:taskType>data</altinn:taskType>
+                    </altinn:taskExtension>
+                  </bpmn:extensionElements>
+                  <bpmn:incoming>SequenceFlow_1n56yn5</bpmn:incoming>
+                  <bpmn:outgoing>Flow_to_task</bpmn:outgoing>
+                </bpmn:task>
+                <bpmn:task id="{{taskId}}" name="Altinn {{taskType}} task">
+                  <bpmn:extensionElements>
+                    <altinn:taskExtension>
+                      <altinn:taskType>{{taskType}}</altinn:taskType>
+                    </altinn:taskExtension>
+                  </bpmn:extensionElements>
+                  <bpmn:incoming>Flow_to_task</bpmn:incoming>
+                  <bpmn:outgoing>Flow_0gbacsh</bpmn:outgoing>
+                </bpmn:task>
+                <bpmn:endEvent id="EndEvent_1">
+                  <bpmn:incoming>Flow_0gbacsh</bpmn:incoming>
+                </bpmn:endEvent>
+                <bpmn:sequenceFlow id="SequenceFlow_1n56yn5" sourceRef="StartEvent_1" targetRef="Task_1" />
+                <bpmn:sequenceFlow id="Flow_to_task" sourceRef="Task_1" targetRef="{{taskId}}" />
+                <bpmn:sequenceFlow id="Flow_0gbacsh" sourceRef="{{taskId}}" targetRef="EndEvent_1" />
+              </bpmn:process>
+            </bpmn:definitions>
+            """
+        );
+        string settingsDir = Path.Combine(
+            TestDataHelper.GetTestDataRepositoriesRootDirectory(),
+            Developer,
+            Org,
+            targetRepository,
+            "App",
+            "ui",
+            taskId
+        );
+        Directory.CreateDirectory(settingsDir);
+        await File.WriteAllTextAsync(
+            Path.Combine(settingsDir, "Settings.json"),
+            """
+            {
+              "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/layout/layoutSettings.schema.v1.json",
+              "pages": { "order": ["Side1"] }
+            }
+            """
+        );
+
+        TaskDefaultDataTypeBindingValidator validator = CreateValidator();
+        AltinnRepoEditingContext editingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(
+            Org,
+            targetRepository,
+            Developer
+        );
+
+        IReadOnlyDictionary<string, string[]> errors = await validator.ValidateAsync(editingContext);
+
+        Assert.Contains($"taskSettings[{taskId}].defaultDataType.missing", errors.Keys);
+    }
+
     private static TaskDefaultDataTypeBindingValidator CreateValidator()
     {
         string repositoriesRoot = TestDataHelper.GetTestDataRepositoriesRootDirectory();

--- a/src/Designer/frontend/app-development/hooks/mutations/useAddLayoutSetMutation.test.ts
+++ b/src/Designer/frontend/app-development/hooks/mutations/useAddLayoutSetMutation.test.ts
@@ -52,7 +52,7 @@ describe('useAddLayoutSetMutation', () => {
     });
   });
 
-  it('Invalidates LayoutSetsExtended and LayoutSets caches on success', async () => {
+  it('Invalidates LayoutSetsExtended, LayoutSets, and AppValidation caches on success', async () => {
     const queryClientMock = createQueryClientMock();
     const invalidateQueriesSpy = jest.spyOn(queryClientMock, 'invalidateQueries');
     const addLayoutSetResult = renderHookWithProviders(
@@ -67,6 +67,9 @@ describe('useAddLayoutSetMutation', () => {
     });
     expect(invalidateQueriesSpy).toHaveBeenCalledWith({
       queryKey: [QueryKey.LayoutSets, org, app],
+    });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: [QueryKey.AppValidation, org, app],
     });
   });
 });

--- a/src/Designer/frontend/app-development/hooks/mutations/useAddLayoutSetMutation.ts
+++ b/src/Designer/frontend/app-development/hooks/mutations/useAddLayoutSetMutation.ts
@@ -17,6 +17,7 @@ export const useAddLayoutSetMutation = (org: string, app: string) => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QueryKey.LayoutSetsExtended, org, app] });
       queryClient.invalidateQueries({ queryKey: [QueryKey.LayoutSets, org, app] });
+      queryClient.invalidateQueries({ queryKey: [QueryKey.AppValidation, org, app] });
     },
   });
 };

--- a/src/Designer/frontend/app-development/hooks/mutations/useCreateDataModelMutation.ts
+++ b/src/Designer/frontend/app-development/hooks/mutations/useCreateDataModelMutation.ts
@@ -25,6 +25,7 @@ export const useCreateDataModelMutation = () => {
         queryClient.invalidateQueries({ queryKey: [QueryKey.DataModelsJson, org, app] }),
         queryClient.invalidateQueries({ queryKey: [QueryKey.DataModelsXsd, org, app] }),
         queryClient.invalidateQueries({ queryKey: [QueryKey.AppMetadataModelIds, org, app] }),
+        queryClient.invalidateQueries({ queryKey: [QueryKey.AppValidation, org, app] }),
       ]);
     },
   });

--- a/src/Designer/frontend/app-development/hooks/mutations/useDeleteDataModelMutation.test.ts
+++ b/src/Designer/frontend/app-development/hooks/mutations/useDeleteDataModelMutation.test.ts
@@ -88,7 +88,7 @@ describe('useDeleteDataModelMutation', () => {
     expect(client.getQueryData([QueryKey.JsonSchema, org, app, modelXsdPath])).toBeUndefined();
   });
 
-  it('Invalidates the appMetadataModelIds and appMetadata from the cache', async () => {
+  it('Invalidates the appMetadataModelIds, appMetadata, and appValidation from the cache', async () => {
     const client = createQueryClientMock();
     const invalidateQueriesSpy = jest.spyOn(client, 'invalidateQueries');
     client.setQueryData([QueryKey.DataModelsJson, org, app], [modelMetadataJson]);
@@ -98,12 +98,15 @@ describe('useDeleteDataModelMutation', () => {
     } = render({}, client);
     result.current.mutate(modelJsonPath);
     await waitFor(() => result.current.isSuccess);
-    expect(invalidateQueriesSpy).toHaveBeenCalledTimes(2);
+    expect(invalidateQueriesSpy).toHaveBeenCalledTimes(3);
     expect(invalidateQueriesSpy).toHaveBeenCalledWith({
       queryKey: [QueryKey.AppMetadataModelIds, org, app],
     });
     expect(invalidateQueriesSpy).toHaveBeenCalledWith({
       queryKey: [QueryKey.AppMetadata, org, app],
+    });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: [QueryKey.AppValidation, org, app],
     });
   });
 });

--- a/src/Designer/frontend/app-development/hooks/mutations/useDeleteDataModelMutation.ts
+++ b/src/Designer/frontend/app-development/hooks/mutations/useDeleteDataModelMutation.ts
@@ -27,15 +27,18 @@ export const useDeleteDataModelMutation = () => {
       await deleteDataModel(org, app, modelPath);
       return { jsonSchemaPath, xsdPath };
     },
-    onSuccess: ({ jsonSchemaPath, xsdPath }) => {
+    onSuccess: async ({ jsonSchemaPath, xsdPath }) => {
       queryClient.removeQueries({
         queryKey: [QueryKey.JsonSchema, org, app, jsonSchemaPath],
       });
       queryClient.removeQueries({
         queryKey: [QueryKey.JsonSchema, org, app, xsdPath],
       });
-      queryClient.invalidateQueries({ queryKey: [QueryKey.AppMetadataModelIds, org, app] });
-      queryClient.invalidateQueries({ queryKey: [QueryKey.AppMetadata, org, app] });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: [QueryKey.AppMetadataModelIds, org, app] }),
+        queryClient.invalidateQueries({ queryKey: [QueryKey.AppMetadata, org, app] }),
+        queryClient.invalidateQueries({ queryKey: [QueryKey.AppValidation, org, app] }),
+      ]);
     },
   });
 };

--- a/src/Designer/frontend/app-development/hooks/mutations/useDeleteLayoutSetMutation.test.ts
+++ b/src/Designer/frontend/app-development/hooks/mutations/useDeleteLayoutSetMutation.test.ts
@@ -3,6 +3,8 @@ import { renderHookWithProviders } from '../../test/mocks';
 import { waitFor } from '@testing-library/react';
 import { useDeleteLayoutSetMutation } from './useDeleteLayoutSetMutation';
 import { app, org } from '@studio/testing/testids';
+import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
+import { QueryKey } from 'app-shared/types/QueryKey';
 
 // Test data:
 const layoutSetToDeleteId = 'oldLayoutSetName';
@@ -19,5 +21,23 @@ describe('useDeleteLayoutSetMutation', () => {
 
     expect(queriesMock.deleteLayoutSet).toHaveBeenCalledTimes(1);
     expect(queriesMock.deleteLayoutSet).toHaveBeenCalledWith(org, app, layoutSetToDeleteId);
+  });
+
+  it('Invalidates AppValidation on success', async () => {
+    const queryClientMock = createQueryClientMock();
+    const invalidateQueriesSpy = jest.spyOn(queryClientMock, 'invalidateQueries');
+    const deleteLayoutSetResult = renderHookWithProviders(
+      {},
+      queryClientMock,
+    )(() => useDeleteLayoutSetMutation(org, app)).renderHookResult.result;
+
+    await deleteLayoutSetResult.current.mutateAsync({
+      layoutSetIdToUpdate: layoutSetToDeleteId,
+    });
+    await waitFor(() => expect(deleteLayoutSetResult.current.isSuccess).toBe(true));
+
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: [QueryKey.AppValidation, org, app],
+    });
   });
 });

--- a/src/Designer/frontend/app-development/hooks/mutations/useDeleteLayoutSetMutation.ts
+++ b/src/Designer/frontend/app-development/hooks/mutations/useDeleteLayoutSetMutation.ts
@@ -19,6 +19,7 @@ export const useDeleteLayoutSetMutation = (org: string, app: string) => {
       queryClient.invalidateQueries({ queryKey: [QueryKey.LayoutSetsExtended, org, app] });
       queryClient.invalidateQueries({ queryKey: [QueryKey.LayoutSets, org, app] });
       queryClient.invalidateQueries({ queryKey: [QueryKey.AppMetadataModelIds, org, app] });
+      queryClient.invalidateQueries({ queryKey: [QueryKey.AppValidation, org, app] });
     },
   });
 };

--- a/src/Designer/frontend/app-development/hooks/mutations/useUpdateProcessDataTypesMutation.test.ts
+++ b/src/Designer/frontend/app-development/hooks/mutations/useUpdateProcessDataTypesMutation.test.ts
@@ -43,12 +43,18 @@ describe('useUpdateProcessDataTypeMutation', () => {
 
     await renderHook({ queryClient });
 
-    expect(invalidateQueriesSpy).toHaveBeenCalledTimes(3);
+    expect(invalidateQueriesSpy).toHaveBeenCalledTimes(4);
     expect(invalidateQueriesSpy).toHaveBeenCalledWith({
       queryKey: [QueryKey.AppMetadataModelIds, org, app],
     });
     expect(invalidateQueriesSpy).toHaveBeenCalledWith({
       queryKey: [QueryKey.LayoutSets, org, app],
+    });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: [QueryKey.LayoutSetsExtended, org, app],
+    });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: [QueryKey.AppValidation, org, app],
     });
   });
 });

--- a/src/Designer/frontend/app-development/hooks/mutations/useUpdateProcessDataTypesMutation.ts
+++ b/src/Designer/frontend/app-development/hooks/mutations/useUpdateProcessDataTypesMutation.ts
@@ -12,6 +12,7 @@ export const useUpdateProcessDataTypesMutation = (org: string, app: string) => {
       await queryClient.invalidateQueries({ queryKey: [QueryKey.AppMetadataModelIds, org, app] });
       await queryClient.invalidateQueries({ queryKey: [QueryKey.LayoutSets, org, app] });
       await queryClient.invalidateQueries({ queryKey: [QueryKey.LayoutSetsExtended, org, app] });
+      await queryClient.invalidateQueries({ queryKey: [QueryKey.AppValidation, org, app] });
     },
   });
 };

--- a/src/Designer/frontend/language/src/nb.json
+++ b/src/Designer/frontend/language/src/nb.json
@@ -459,6 +459,8 @@
   "app_validation.app_metadata.warnings": "Appen mangler metadata og beskrivelser.",
   "app_validation.app_metadata.warnings_description": "Standard-verdier vil bli brukt for de manglende feltene. Gå til \"Om appen\"-fanen under innstillinger eller klikk på lenke i den enkelte feilmelding under for å legge til informasjonen.",
   "app_validation.heading": "Valideringsfeil",
+  "app_validation.task_settings.default_data_type.missing": "Oppgaven {{taskId}} mangler datamodell. Koble til en datamodell i Arbeidsflyt.",
+  "app_validation.task_settings.default_data_type.not_found": "Oppgaven {{taskId}} er fortsatt koblet til datamodellen «{{dataTypeId}}», men den finnes ikke lenger. Opprett datamodellen på nytt, eller velg en annen datamodell i Arbeidsflyt.",
   "branching.actions_heading": "Valg",
   "branching.delete_branch_dialog.description": "Bekreft at du vil slette grenen <strong>{{branchName}}</strong>. Du kan ikke gjenopprette den.",
   "branching.delete_branch_dialog.textfield_description": "Skriv inn navnet på grenen for å bekrefte.",

--- a/src/Designer/frontend/language/src/nb.json
+++ b/src/Designer/frontend/language/src/nb.json
@@ -461,7 +461,7 @@
   "app_validation.heading": "Valideringsfeil",
   "app_validation.task_settings.default_data_type.missing": "Oppgaven {{taskId}} mangler datamodell. Koble til en datamodell i Arbeidsflyt.",
   "app_validation.task_settings.default_data_type.not_found": "Oppgaven {{taskId}} er fortsatt koblet til datamodellen «{{dataTypeId}}», men den finnes ikke lenger. Opprett datamodellen på nytt, eller velg en annen datamodell i Arbeidsflyt.",
-  "app_validation.task_settings.errors": "Oppgaver mangler datamodellkobling.",
+  "app_validation.task_settings.errors": "Oppgaver mangler datamodellbinding.",
   "app_validation.task_settings.errors_description": "Uten datamodell kan appen krasje. Koble til en datamodell i Arbeidsflyt, eller klikk på lenken i den enkelte feilmeldingen under.",
   "branching.actions_heading": "Valg",
   "branching.delete_branch_dialog.description": "Bekreft at du vil slette grenen <strong>{{branchName}}</strong>. Du kan ikke gjenopprette den.",

--- a/src/Designer/frontend/language/src/nb.json
+++ b/src/Designer/frontend/language/src/nb.json
@@ -461,6 +461,8 @@
   "app_validation.heading": "Valideringsfeil",
   "app_validation.task_settings.default_data_type.missing": "Oppgaven {{taskId}} mangler datamodell. Koble til en datamodell i Arbeidsflyt.",
   "app_validation.task_settings.default_data_type.not_found": "Oppgaven {{taskId}} er fortsatt koblet til datamodellen «{{dataTypeId}}», men den finnes ikke lenger. Opprett datamodellen på nytt, eller velg en annen datamodell i Arbeidsflyt.",
+  "app_validation.task_settings.errors": "Oppgaver mangler datamodellkobling.",
+  "app_validation.task_settings.errors_description": "Uten datamodell kan appen krasje. Koble til en datamodell i Arbeidsflyt, eller klikk på lenken i den enkelte feilmeldingen under.",
   "branching.actions_heading": "Valg",
   "branching.delete_branch_dialog.description": "Bekreft at du vil slette grenen <strong>{{branchName}}</strong>. Du kan ikke gjenopprette den.",
   "branching.delete_branch_dialog.textfield_description": "Skriv inn navnet på grenen for å bekrefte.",

--- a/src/Designer/frontend/packages/shared/src/components/AppValidationDialog/AppValidationDialog.test.tsx
+++ b/src/Designer/frontend/packages/shared/src/components/AppValidationDialog/AppValidationDialog.test.tsx
@@ -93,4 +93,27 @@ describe('AppValidationDialog', () => {
     const expectedHref = `${APP_DEVELOPMENT_BASENAME}/${org}/${app}/app-settings?currentTab=about&focus=`;
     expect(link).toHaveAttribute('href', expectedHref);
   });
+
+  it('renders task settings errors in a dedicated danger alert', () => {
+    renderAppValidationDialog({
+      isValid: false,
+      errors: { 'taskSettings[Task_1].defaultDataType.missing': ['MISSING'] },
+    });
+
+    expect(screen.getByText(textMock('app_validation.task_settings.errors'))).toBeInTheDocument();
+    expect(
+      screen.getByText(textMock('app_validation.task_settings.errors_description')),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(textMock('app_validation.app_metadata.warnings')),
+    ).not.toBeInTheDocument();
+
+    const link = screen.getByText(
+      textMock('app_validation.task_settings.default_data_type.missing', { taskId: 'Task_1' }),
+    );
+    expect(link).toHaveAttribute(
+      'href',
+      `${APP_DEVELOPMENT_BASENAME}/${org}/${app}/process-editor`,
+    );
+  });
 });

--- a/src/Designer/frontend/packages/shared/src/components/AppValidationDialog/AppValidationDialog.tsx
+++ b/src/Designer/frontend/packages/shared/src/components/AppValidationDialog/AppValidationDialog.tsx
@@ -17,6 +17,7 @@ import {
 import { formatDateAndTime } from '../../utils/formatDateAndTime';
 import classes from './AppValidationDialog.module.css';
 import { type ErrorItem, mapErrorKeyErrorItems } from 'app-shared/utils/appValidationUtils';
+import { APP_DEVELOPMENT_BASENAME } from 'app-shared/constants';
 
 export const AppValidationDialog = () => {
   const { org, app } = useStudioEnvironmentParams();
@@ -65,9 +66,9 @@ const AltinnAppServiceResourceValidation = ({
   const { t } = useTranslation();
   const navigate = useNavigate();
 
-  const handleErrorLinkClick = (search: string) => (e: React.MouseEvent<HTMLAnchorElement>) => {
+  const handleErrorLinkClick = (fullHref: string) => (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
-    navigate({ pathname: `/${org}/${app}/app-settings`, search: `?${search}` });
+    navigate(fullHref.slice(APP_DEVELOPMENT_BASENAME.length));
   };
 
   const errorKeys = Object.keys(validationResult?.errors || {});
@@ -119,12 +120,12 @@ const AppValidationAlert = ({
       <StudioHeading className={classes.validationHeader}>{title}</StudioHeading>
       <StudioParagraph spacing>{description}</StudioParagraph>
       <StudioErrorSummary.List>
-        {errorItems.map(({ errorKey, search, fullHref, errorMessage }) => (
+        {errorItems.map(({ errorKey, fullHref, errorMessage }) => (
           <StudioErrorSummary.Item key={errorKey}>
             <StudioLink
               className={classes.validationLink}
               href={fullHref}
-              onClick={handleErrorLinkClick(search)}
+              onClick={handleErrorLinkClick(fullHref)}
             >
               {errorMessage}
             </StudioLink>

--- a/src/Designer/frontend/packages/shared/src/components/AppValidationDialog/AppValidationDialog.tsx
+++ b/src/Designer/frontend/packages/shared/src/components/AppValidationDialog/AppValidationDialog.tsx
@@ -73,7 +73,15 @@ const AltinnAppServiceResourceValidation = ({
 
   const errorKeys = Object.keys(validationResult?.errors || {});
 
-  const errorItems = mapErrorKeyErrorItems(errorKeys, 'danger', org, app, t);
+  const errorItems = mapErrorKeyErrorItems(errorKeys, 'danger', org, app, t, 'app_metadata');
+  const taskSettingsErrorItems = mapErrorKeyErrorItems(
+    errorKeys,
+    'danger',
+    org,
+    app,
+    t,
+    'task_settings',
+  );
   const warningItems = mapErrorKeyErrorItems(errorKeys, 'warning', org, app, t);
 
   return (
@@ -85,6 +93,15 @@ const AltinnAppServiceResourceValidation = ({
           handleErrorLinkClick={handleErrorLinkClick}
           title={t('app_validation.app_metadata.errors')}
           description={t('app_validation.app_metadata.errors_description')}
+        />
+      )}
+      {taskSettingsErrorItems.length > 0 && (
+        <AppValidationAlert
+          errorItems={taskSettingsErrorItems}
+          severity='danger'
+          handleErrorLinkClick={handleErrorLinkClick}
+          title={t('app_validation.task_settings.errors')}
+          description={t('app_validation.task_settings.errors_description')}
         />
       )}
       {warningItems.length > 0 && (

--- a/src/Designer/frontend/packages/shared/src/hooks/mutations/useBpmnMutation.ts
+++ b/src/Designer/frontend/packages/shared/src/hooks/mutations/useBpmnMutation.ts
@@ -13,6 +13,7 @@ export const useBpmnMutation = (org: string, app: string) => {
     mutationFn: ({ form }: UseBpmnMutationPayload) => updateBpmnXml(org, app, form),
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: [QueryKey.FetchBpmn, org, app] });
+      await queryClient.invalidateQueries({ queryKey: [QueryKey.AppValidation, org, app] });
     },
   });
 };

--- a/src/Designer/frontend/packages/shared/src/queryInvalidator/SyncSuccessQueriesInvalidator.test.ts
+++ b/src/Designer/frontend/packages/shared/src/queryInvalidator/SyncSuccessQueriesInvalidator.test.ts
@@ -30,7 +30,10 @@ describe('SyncSuccessQueriesInvalidator', () => {
         queryKey: [QueryKey.AppMetadata, org, app],
       }),
     );
-    expect(queryClientMock.invalidateQueries).toHaveBeenCalledTimes(1);
+    expect(queryClientMock.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: [QueryKey.AppValidation, org, app],
+    });
+    expect(queryClientMock.invalidateQueries).toHaveBeenCalledTimes(2);
   });
 
   it('should not invalidate query cache when invalidateQueriesByFileLocation is called with an unknown file name', async () => {
@@ -55,7 +58,10 @@ describe('SyncSuccessQueriesInvalidator', () => {
         queryKey: [QueryKey.FormLayoutSettings, org, app, selectedLayoutSet],
       });
     });
-    expect(queryClientMock.invalidateQueries).toHaveBeenCalledTimes(1);
+    expect(queryClientMock.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: [QueryKey.AppValidation, org, app],
+    });
+    expect(queryClientMock.invalidateQueries).toHaveBeenCalledTimes(2);
   });
 
   it('should invalidate layouts query cache with layoutSetName identifier when invalidateQueriesByFileLocation is called and layoutSetName has been set', async () => {

--- a/src/Designer/frontend/packages/shared/src/queryInvalidator/SyncSuccessQueriesInvalidator.test.ts
+++ b/src/Designer/frontend/packages/shared/src/queryInvalidator/SyncSuccessQueriesInvalidator.test.ts
@@ -64,6 +64,36 @@ describe('SyncSuccessQueriesInvalidator', () => {
     expect(queryClientMock.invalidateQueries).toHaveBeenCalledTimes(2);
   });
 
+  it('should invalidate AppValidation when process.bpmn is synced', async () => {
+    const queriesInvalidator = SyncSuccessQueriesInvalidator.getInstance(queryClientMock, org, app);
+
+    queriesInvalidator.invalidateQueriesByFileLocation('process.bpmn');
+
+    await waitFor(() => {
+      expect(queryClientMock.invalidateQueries).toHaveBeenCalledWith({
+        queryKey: [QueryKey.FetchBpmn, org, app],
+      });
+    });
+    expect(queryClientMock.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: [QueryKey.AppValidation, org, app],
+    });
+  });
+
+  it('should invalidate AppValidation when layout-sets.json is synced', async () => {
+    const queriesInvalidator = SyncSuccessQueriesInvalidator.getInstance(queryClientMock, org, app);
+
+    queriesInvalidator.invalidateQueriesByFileLocation('layout-sets.json');
+
+    await waitFor(() => {
+      expect(queryClientMock.invalidateQueries).toHaveBeenCalledWith({
+        queryKey: [QueryKey.LayoutSets, org, app],
+      });
+    });
+    expect(queryClientMock.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: [QueryKey.AppValidation, org, app],
+    });
+  });
+
   it('should invalidate layouts query cache with layoutSetName identifier when invalidateQueriesByFileLocation is called and layoutSetName has been set', async () => {
     const queriesInvalidator = SyncSuccessQueriesInvalidator.getInstance(queryClientMock, org, app);
     queriesInvalidator.layoutSetName = selectedLayoutSet;

--- a/src/Designer/frontend/packages/shared/src/queryInvalidator/SyncSuccessQueriesInvalidator.ts
+++ b/src/Designer/frontend/packages/shared/src/queryInvalidator/SyncSuccessQueriesInvalidator.ts
@@ -22,13 +22,19 @@ export class SyncSuccessQueriesInvalidator extends Queue {
 
   // Maps file names to their cache keys for invalidation upon sync success - can be extended to include more files
   private readonly fileNameCacheKeysMap: Record<string, Array<Array<QueryKey | string>>> = {
-    'applicationmetadata.json': [[QueryKey.AppMetadata, '[org]', '[app]']],
+    'applicationmetadata.json': [
+      [QueryKey.AppMetadata, '[org]', '[app]'],
+      [QueryKey.AppValidation, '[org]', '[app]'],
+    ],
     'layout-sets.json': [
       [QueryKey.LayoutSets, '[org]', '[app]'],
       [QueryKey.LayoutSetsExtended, '[org]', '[app]'],
     ],
     'policy.xml': [[QueryKey.AppPolicy, '[org]', '[app]']],
-    'Settings.json': [[QueryKey.FormLayoutSettings, '[org]', '[app]', '[layoutSetName]']],
+    'Settings.json': [
+      [QueryKey.FormLayoutSettings, '[org]', '[app]', '[layoutSetName]'],
+      [QueryKey.AppValidation, '[org]', '[app]'],
+    ],
   };
 
   // Maps folder names to their cache keys for invalidation upon sync success - can be extended to include more folders

--- a/src/Designer/frontend/packages/shared/src/queryInvalidator/SyncSuccessQueriesInvalidator.ts
+++ b/src/Designer/frontend/packages/shared/src/queryInvalidator/SyncSuccessQueriesInvalidator.ts
@@ -29,8 +29,13 @@ export class SyncSuccessQueriesInvalidator extends Queue {
     'layout-sets.json': [
       [QueryKey.LayoutSets, '[org]', '[app]'],
       [QueryKey.LayoutSetsExtended, '[org]', '[app]'],
+      [QueryKey.AppValidation, '[org]', '[app]'],
     ],
     'policy.xml': [[QueryKey.AppPolicy, '[org]', '[app]']],
+    'process.bpmn': [
+      [QueryKey.FetchBpmn, '[org]', '[app]'],
+      [QueryKey.AppValidation, '[org]', '[app]'],
+    ],
     'Settings.json': [
       [QueryKey.FormLayoutSettings, '[org]', '[app]', '[layoutSetName]'],
       [QueryKey.AppValidation, '[org]', '[app]'],

--- a/src/Designer/frontend/packages/shared/src/utils/appValidationUtils.test.ts
+++ b/src/Designer/frontend/packages/shared/src/utils/appValidationUtils.test.ts
@@ -137,5 +137,34 @@ describe('appValidationUtils', () => {
     it('returns undefined for unknown error keys', () => {
       expect(getFieldConfig('unknown_error_key')).toBeUndefined();
     });
+
+    it('returns task settings config for missing defaultDataType binding', () => {
+      expect(getFieldConfig('taskSettings[Task_1].defaultDataType.missing')).toEqual({
+        anchor: '',
+        translationKey: 'app_validation.task_settings.default_data_type.missing',
+        critical: false,
+        hrefPath: 'process-editor',
+        getTranslationParams: expect.any(Function),
+      });
+    });
+
+    it('maps task settings warning to process editor link', () => {
+      const result = mapErrorKeyErrorItems(
+        ['taskSettings[Task_1].defaultDataType.notFound.model'],
+        'warning',
+        'testOrg',
+        'testApp',
+        (key, params) => `${key}:${params?.taskId}:${params?.dataTypeId}`,
+      );
+
+      expect(result).toEqual([
+        {
+          errorKey: 'taskSettings[Task_1].defaultDataType.notFound.model',
+          search: 'currentTab=about&focus=',
+          fullHref: '/editor/testOrg/testApp/process-editor',
+          errorMessage: 'app_validation.task_settings.default_data_type.not_found:Task_1:model',
+        },
+      ]);
+    });
   });
 });

--- a/src/Designer/frontend/packages/shared/src/utils/appValidationUtils.test.ts
+++ b/src/Designer/frontend/packages/shared/src/utils/appValidationUtils.test.ts
@@ -142,19 +142,21 @@ describe('appValidationUtils', () => {
       expect(getFieldConfig('taskSettings[Task_1].defaultDataType.missing')).toEqual({
         anchor: '',
         translationKey: 'app_validation.task_settings.default_data_type.missing',
-        critical: false,
+        critical: true,
+        group: 'task_settings',
         hrefPath: 'process-editor',
         getTranslationParams: expect.any(Function),
       });
     });
 
-    it('maps task settings warning to process editor link', () => {
+    it('maps task settings danger to process editor link', () => {
       const result = mapErrorKeyErrorItems(
         ['taskSettings[Task_1].defaultDataType.notFound.model'],
-        'warning',
+        'danger',
         'testOrg',
         'testApp',
         (key, params) => `${key}:${params?.taskId}:${params?.dataTypeId}`,
+        'task_settings',
       );
 
       expect(result).toEqual([
@@ -165,6 +167,19 @@ describe('appValidationUtils', () => {
           errorMessage: 'app_validation.task_settings.default_data_type.not_found:Task_1:model',
         },
       ]);
+    });
+
+    it('does not include task settings errors in app_metadata danger group', () => {
+      const result = mapErrorKeyErrorItems(
+        ['taskSettings[Task_1].defaultDataType.missing', 'title.nb'],
+        'danger',
+        'testOrg',
+        'testApp',
+        (key) => key,
+        'app_metadata',
+      );
+
+      expect(result.map((item) => item.errorKey)).toEqual(['title.nb']);
     });
   });
 });

--- a/src/Designer/frontend/packages/shared/src/utils/appValidationUtils.ts
+++ b/src/Designer/frontend/packages/shared/src/utils/appValidationUtils.ts
@@ -4,6 +4,8 @@ export type FieldConfig = {
   anchor: string;
   translationKey: string;
   critical: boolean;
+  hrefPath?: string;
+  getTranslationParams?: (errorKey: string) => Record<string, string>;
 };
 
 export type ErrorItem = {
@@ -18,7 +20,7 @@ export const mapErrorKeyErrorItems = (
   severity: 'warning' | 'danger',
   org: string,
   app: string,
-  t: (key: string) => string,
+  t: (key: string, params?: Record<string, string>) => string,
 ): ErrorItem[] => {
   return errorKeys
     .filter((errorKey) => {
@@ -33,8 +35,12 @@ export const mapErrorKeyErrorItems = (
       const fieldConfig = getFieldConfig(errorKey);
       const anchor = fieldConfig?.anchor ?? '';
       const search = `currentTab=about&focus=${anchor}`;
-      const fullHref = `${APP_DEVELOPMENT_BASENAME}/${org}/${app}/app-settings?${search}`;
-      const errorMessage = t(fieldConfig?.translationKey ?? errorKey);
+      const fullHref = fieldConfig?.hrefPath
+        ? `${APP_DEVELOPMENT_BASENAME}/${org}/${app}/${fieldConfig.hrefPath}`
+        : `${APP_DEVELOPMENT_BASENAME}/${org}/${app}/app-settings?${search}`;
+      const errorMessage = fieldConfig?.getTranslationParams
+        ? t(fieldConfig.translationKey, fieldConfig.getTranslationParams(errorKey))
+        : t(fieldConfig?.translationKey ?? errorKey);
       return { errorKey, search, fullHref, errorMessage };
     });
 };
@@ -138,6 +144,24 @@ export const getFieldConfig = (errorKey: string): FieldConfig | undefined => {
       anchor: `contactPoints-${index}`,
       translationKey: 'app_validation.app_metadata.contact_points.incomplete',
       critical: true,
+    };
+  }
+
+  const taskSettingsMatch = errorKey.match(
+    /^taskSettings\[([^\]]+)\]\.defaultDataType\.(missing|notFound)(?:\.(.+))?$/,
+  );
+  if (taskSettingsMatch) {
+    const [, taskId, issue, dataTypeId] = taskSettingsMatch;
+    return {
+      anchor: '',
+      translationKey:
+        issue === 'missing'
+          ? 'app_validation.task_settings.default_data_type.missing'
+          : 'app_validation.task_settings.default_data_type.not_found',
+      critical: false,
+      hrefPath: 'process-editor',
+      getTranslationParams: () =>
+        issue === 'missing' ? { taskId } : { taskId, dataTypeId: dataTypeId ?? '' },
     };
   }
 

--- a/src/Designer/frontend/packages/shared/src/utils/appValidationUtils.ts
+++ b/src/Designer/frontend/packages/shared/src/utils/appValidationUtils.ts
@@ -5,6 +5,8 @@ export type FieldConfig = {
   translationKey: string;
   critical: boolean;
   hrefPath?: string;
+  /** Which alert box this error belongs to. Defaults to app_metadata. */
+  group?: 'app_metadata' | 'task_settings';
   getTranslationParams?: (errorKey: string) => Record<string, string>;
 };
 
@@ -21,13 +23,18 @@ export const mapErrorKeyErrorItems = (
   org: string,
   app: string,
   t: (key: string, params?: Record<string, string>) => string,
+  group: 'app_metadata' | 'task_settings' = 'app_metadata',
 ): ErrorItem[] => {
   return errorKeys
     .filter((errorKey) => {
       const fieldConfig = getFieldConfig(errorKey);
       if (!fieldConfig) {
         // If there's no specific field config, we treat it as a critical error for 'danger'
-        return severity === 'danger';
+        return severity === 'danger' && group === 'app_metadata';
+      }
+      const itemGroup = fieldConfig.group ?? 'app_metadata';
+      if (itemGroup !== group) {
+        return false;
       }
       return fieldConfig.critical === (severity === 'danger');
     })
@@ -158,7 +165,8 @@ export const getFieldConfig = (errorKey: string): FieldConfig | undefined => {
         issue === 'missing'
           ? 'app_validation.task_settings.default_data_type.missing'
           : 'app_validation.task_settings.default_data_type.not_found',
-      critical: false,
+      critical: true,
+      group: 'task_settings',
       hrefPath: 'process-editor',
       getTranslationParams: () =>
         issue === 'missing' ? { taskId } : { taskId, dataTypeId: dataTypeId ?? '' },


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

- Adds Designer validation for v9 apps for missing data model bindings.
- Shows clear warnings and links to `Arbeidsflyt`.


Solution: 

https://github.com/user-attachments/assets/00c79928-3c70-42d6-9f5d-34851bd3ac44


## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added validation for task default data-type bindings, including missing or unknown data models.
- Validation errors now link directly to the relevant process-editor task settings.
- Added Norwegian messages and a dedicated alert for task-settings validation issues.

## Bug Fixes
- App validation results now refresh automatically after data model, layout-set, process, and metadata changes.
- Improved validation navigation to open the correct application page and context.
- Added build-time checks for duplicate field IDs and undeclared data types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->