### PR TITLE
fix(workflow-engine): keep the pipeline's sideways scroll across live card rebuilds

### DIFF
--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Core/wwwroot/AGENTS.md
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Core/wwwroot/AGENTS.md
@@ -82,7 +82,7 @@ Some modules have circular call dependencies (e.g., `filters.js` calls `loadQuer
 - Cards use `data-*` attributes for filter matching (avoids reparsing): `data-namespace`, `data-collectionkey`, `data-labels`, `data-status`, `data-filter`
 - Workflow fingerprinting (`status + step statuses + retry counts + defer counts`) to skip unchanged DOM updates
 - Pulse animation sync after card re-render prevents CSS animation flicker
-- Pipeline scroll-on-change: only scrolls to active step when the processing step index changes
+- Pipeline scroll-on-change: a card rebuild keeps the operator's sideways pipeline scroll (`setCardHTMLKeepingPipelineScroll`); the pipeline only scrolls to the active step when the processing step index changes
 - Inline `onclick` handlers exposed via `window.*` for cards generated as HTML strings
 - URL state sync via `syncUrl()`/`restoreUrl()` — shareable URLs capture full dashboard state
 - Grafana trace links built from workflow `traceId` for Tempo integration

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Core/wwwroot/DASHBOARD_SPEC.md
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Core/wwwroot/DASHBOARD_SPEC.md
@@ -380,7 +380,7 @@ don't jump as retry/backoff/timing rows appear mid-processing; static pipelines
 drop the reservation. The phase-bracket headroom (`.pipeline-grouped`) applies only when at least
 one step maps to a phase.
 
-**Scroll-to-active:** When a card renders or updates, the pipeline scrolls horizontally to center the currently Processing, Requeued or Waiting step. Only triggers when the active step index actually changes (tracked per workflow via `_processingIdx`), preventing redundant scrolls on fingerprint-only updates. Fallback: scrolls to the end if no active step found.
+**Scroll-to-active:** When a card renders or updates, the pipeline scrolls horizontally to center the currently Processing, Requeued or Waiting step. Only triggers when the active step index actually changes (tracked per workflow via `_processingIdx`), preventing redundant scrolls on fingerprint-only updates. Fallback: scrolls to the end if no active step found. A rebuild that does not move the active step (a retry or deferral write-back of the same step, a relation landing) keeps the pipeline where the operator scrolled it: the card's HTML is swapped through `setCardHTMLKeepingPipelineScroll`, which carries the old `.pipeline` element's `scrollLeft` over to the new one.
 
 **BPMN grouping:** Steps are grouped by task phase using `stepPhase()` which maps command detail names to `start`/`end`/`process-end` phases. Groups show bracket lines and task labels from `parseTransition()`. The transition is parsed from `operationId` (format: `"Process next: TaskA → TaskB"`).
 

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Core/wwwroot/modules/features/live.js
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Core/wwwroot/modules/features/live.js
@@ -8,7 +8,7 @@ import {
     createWorkflowCard,
     setCardFilterData,
 } from '../shared/cards.js';
-import { scrollPipelineToActive } from '../shared/pipeline.js';
+import { scrollPipelineToActive, setCardHTMLKeepingPipelineScroll } from '../shared/pipeline.js';
 import { notifyStepChanged } from './modal.js';
 import { notifyWorkflowChanged } from './state-modal.js';
 import { notifyChainChanged } from './chain-modal.js';
@@ -38,6 +38,12 @@ const fingerprint = (wf) => {
 
 /** Index of the currently-processing step (for scroll-on-change). */
 const _processingIdx = /** @type {Record<string, number>} */ ({});
+
+/** @param {import('../core/state.js').Workflow} wf */
+const activeStepIndex = (wf) =>
+    wf.steps.findIndex(
+        (s) => s.status === 'Processing' || s.status === 'Requeued' || s.status === 'Waiting',
+    );
 
 /**
  * @param {import('../core/state.js').Workflow[]} workflows
@@ -100,13 +106,19 @@ export const updateLiveWorkflows = (workflows, recentKeys) => {
                 startedAt: wf.executionStartedAt || wf.createdAt,
             };
             state.workflowFingerprints[wf.databaseId] = fp;
+            // createWorkflowCard centers the active step itself; record which one so the first
+            // rebuild does not re-center a pipeline the operator has since scrolled.
+            _processingIdx[wf.databaseId] = activeStepIndex(wf);
             // New workflows can extend an open chain view (a fresh transition's Main +
             // side chains are new ids — nothing already rendered changes when they land).
             notifyChainChanged(wf.databaseId);
             notifyRecentChainsChanged(wf.databaseId);
         } else if (state.workflowFingerprints[wf.databaseId] !== fp) {
             const isCompact = card.classList.contains('compact');
-            card.innerHTML = isCompact ? buildCompactCardHTML(wf) : buildCardHTML(wf);
+            setCardHTMLKeepingPipelineScroll(
+                card,
+                isCompact ? buildCompactCardHTML(wf) : buildCardHTML(wf),
+            );
             setCardFilterData(card, wf);
 
             // Sync pulse animations so they don't restart from frame 0 on every innerHTML rebuild
@@ -117,14 +129,10 @@ export const updateLiveWorkflows = (workflows, recentKeys) => {
                 },
             );
 
-            // Only scroll the pipeline when the active step actually changes
+            // The rebuild kept the operator's sideways scroll; only re-center when the active step
+            // actually changes
             if (!isCompact) {
-                const curIdx = wf.steps.findIndex(
-                    (s) =>
-                        s.status === 'Processing' ||
-                        s.status === 'Requeued' ||
-                        s.status === 'Waiting',
-                );
+                const curIdx = activeStepIndex(wf);
                 if (curIdx !== _processingIdx[wf.databaseId]) {
                     _processingIdx[wf.databaseId] = curIdx;
                     scrollPipelineToActive(card);

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Core/wwwroot/modules/shared/cards.js
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Core/wwwroot/modules/shared/cards.js
@@ -10,7 +10,11 @@ import {
     fmtNamespace,
     abbrevGuids,
 } from '../core/helpers.js';
-import { buildPipelineHTML, scrollPipelineToActive } from './pipeline.js';
+import {
+    buildPipelineHTML,
+    scrollPipelineToActive,
+    setCardHTMLKeepingPipelineScroll,
+} from './pipeline.js';
 
 /** @param {string} text @param {string} [title] */
 export const copyIconHTML = (text, title) =>
@@ -305,7 +309,10 @@ const rerenderCards = (wfKey) => {
         if (card.closest('#scheduled-workflows')) continue;
         const isStatic = !card.closest('#live-workflows');
         const compact = card.classList.contains('compact');
-        card.innerHTML = compact ? buildCompactCardHTML(wf, isStatic) : buildCardHTML(wf, isStatic);
+        setCardHTMLKeepingPipelineScroll(
+            card,
+            compact ? buildCompactCardHTML(wf, isStatic) : buildCardHTML(wf, isStatic),
+        );
         setCardFilterData(card, wf);
     }
 };

--- a/src/Runtime/workflow-engine/src/WorkflowEngine.Core/wwwroot/modules/shared/pipeline.js
+++ b/src/Runtime/workflow-engine/src/WorkflowEngine.Core/wwwroot/modules/shared/pipeline.js
@@ -220,6 +220,24 @@ export const buildPipelineHTML = (wf, isStatic) => {
     return html;
 };
 
+/**
+ * Replaces a card's inner HTML while keeping its pipeline scrolled where the operator left it.
+ * A rebuild swaps the `.pipeline` element, and a fresh element starts at scrollLeft 0 — so without
+ * this every retry or deferral write-back snapped a sideways-scrolled pipeline back to its start.
+ * Callers that want the active step centered instead call {@link scrollPipelineToActive} afterwards.
+ * @param {HTMLElement} card
+ * @param {string} html
+ */
+export const setCardHTMLKeepingPipelineScroll = (card, html) => {
+    const before = /** @type {HTMLElement | null} */ (card.querySelector('.pipeline'));
+    const scrollLeft = before ? before.scrollLeft : 0;
+    card.innerHTML = html;
+    if (scrollLeft > 0) {
+        const after = /** @type {HTMLElement | null} */ (card.querySelector('.pipeline'));
+        if (after) after.scrollLeft = scrollLeft;
+    }
+};
+
 /** @param {HTMLElement} card */
 export const scrollPipelineToActive = (card) => {
     const p = card.querySelector('.pipeline');


### PR DESCRIPTION
## Description

Scrolling sideways in an active workflow's pipeline was undone on the next redraw: for a retrying or waiting step that is every retry or deferral write-back, since the live fingerprint includes `backoffUntil` and the retry count.

**Cause.** `live.js` rebuilds the card through `innerHTML`, which replaces the `.pipeline` element, and a fresh element starts at `scrollLeft` 0. The existing scroll-to-active logic only re-centres when the active step index changes and otherwise left the new pipeline at zero. A second quirk made the first rebuild after page load re-centre unconditionally: `_processingIdx` was never recorded when the card was created, so the first fingerprint change always compared against `undefined`.

**Fix.**
- New `setCardHTMLKeepingPipelineScroll(card, html)` in `pipeline.js` swaps the card's HTML and carries the old pipeline's `scrollLeft` over to the new one. Used by the fingerprint-driven rebuild in `live.js` and by `rerenderCards` in `cards.js` (relation landings re-render live cards too).
- `live.js` records the active step index when a card is created, so scroll-to-active fires only when the active step actually changes.
- Dashboard `AGENTS.md` and `DASHBOARD_SPEC.md` describe the behaviour.

Still deletes and recreates the row; this is the cheap fix rather than a DOM diff.

## Verification

- [x] Related issues are connected (if applicable) — none
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required) — ran the TestApp locally against a throwaway Postgres and drove the dashboard in headless Chrome at a 1000px viewport with a 26-step pipeline whose first step retries every 4s. **Before:** scroll the pipeline to 320, wait for the retry rebuild (↻1 → ↻2), scroll is back at 0. **After:** the same scenario keeps 320. A second scenario with twelve instant steps, a step that waits ~12s, then a forever-retrying step confirmed that card creation still centres the waiting step, that the active step advancing (index 12 → 13) still auto-centres the new step (0px off centre), and that a subsequent same-step retry keeps an operator scroll of 900.
- [ ] Relevant automated test added — the dashboard has no JS test harness; verified as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved horizontal pipeline scroll position when workflow cards refresh.
  * Prevented unnecessary scrolling to the active step when the active step has not changed.
  * Continued moving the pipeline to the active step when processing advances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->