### PR TITLE
fix(localtest): keep host bridge responsive after cancellation

### DIFF
--- a/src/Runtime/localtest/src/HostBridge/HostBridgeClient.cs
+++ b/src/Runtime/localtest/src/HostBridge/HostBridgeClient.cs
@@ -193,6 +193,7 @@ public sealed class HostBridgeClient
             catch
             {
                 _pending.TryRemove(requestId, out _);
+                pending.Cancel();
                 throw;
             }
         }
@@ -230,6 +231,7 @@ public sealed class HostBridgeClient
             catch
             {
                 _pending.TryRemove(requestId, out _);
+                pending.Cancel();
                 throw;
             }
         }
@@ -572,6 +574,7 @@ public sealed class HostBridgeClient
                 FullMode = BoundedChannelFullMode.Wait,
             }
         );
+        private int _cancelled;
 
         public Task<ResponseStartFrame> Start => _start.Task;
         public ChannelReader<byte[]> Body => _body.Reader;
@@ -584,14 +587,30 @@ public sealed class HostBridgeClient
 
         public async Task AppendBody(byte[] payload, bool isFinal, CancellationToken cancellationToken)
         {
-            if (payload.Length > 0)
+            try
             {
-                HostBridgeProtocol.EnsureFrameWithinLimit(payload.Length);
-                await _body.Writer.WriteAsync(payload, cancellationToken);
-            }
+                if (Volatile.Read(ref _cancelled) != 0)
+                    return;
 
-            if (isFinal)
-                _body.Writer.TryComplete();
+                if (payload.Length > 0)
+                {
+                    HostBridgeProtocol.EnsureFrameWithinLimit(payload.Length);
+                    await _body.Writer.WriteAsync(payload, cancellationToken);
+                }
+
+                if (isFinal)
+                    _body.Writer.TryComplete();
+            }
+            catch (ChannelClosedException) when (Volatile.Read(ref _cancelled) != 0)
+            {
+                // The HTTP client can disconnect while the bridge is still receiving response frames.
+            }
+        }
+
+        public void Cancel()
+        {
+            Interlocked.Exchange(ref _cancelled, 1);
+            _body.Writer.TryComplete();
         }
 
         public void SetTrailers(Dictionary<string, string[]> trailers)

--- a/src/Runtime/localtest/src/HostBridge/HostBridgeClient.cs
+++ b/src/Runtime/localtest/src/HostBridge/HostBridgeClient.cs
@@ -415,6 +415,7 @@ public sealed class HostBridgeClient
         {
             if (_pending.TryRemove(requestId, out var pending))
             {
+                pending.Cancel();
                 pending.TrySetException(new OperationCanceledException());
                 try
                 {


### PR DESCRIPTION
## Description

A canceled streamed response could leave LocalTest's shared host-bridge receive loop waiting on a full body channel. Later Cypress requests through that runner would then time out even though LocalTest and the app processes were still healthy.

Close the pending response channel on client cancellation so the receive loop can continue processing requests.

Observed in [run 33832927565](https://github.com/Altinn/altinn-studio/actions/runs/33832927565/job/100900658332) and [run 33757830790](https://github.com/Altinn/altinn-studio/actions/runs/33757830790/job/100657113082).

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

`dotnet build LocalTest.sln` passes with zero warnings and errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of failed or cancelled requests by promptly cancelling pending responses.
  - Prevented cancelled responses from generating additional errors when communication channels close unexpectedly.
  - Improved reliability and stability during interrupted communication with the host bridge.
  - Ensured request failures and cancellations are handled cleanly without leaving pending operations active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->