### PR TITLE
fix(renovate): replace unsupported config and unblock renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -120,7 +120,7 @@
       "description": "Skip @percy/cypress 3.1.9: it depends on a beta @percy/sdk-utils (1.32.3-beta.1) whose waitForReady DOM-readiness step hangs, timing out all Cypress Percy snapshots. Allow again once a fixed release (>3.1.9) ships.",
       "matchManagers": ["npm"],
       "matchPackageNames": ["@percy/cypress"],
-      "allowedVersions": "!=3.1.9"
+      "allowedVersions": "<3.1.9 || >3.1.9"
     },
     {
       "description": "Automerge non-major Altinn app template package updates (v8)",


### PR DESCRIPTION
## Description

Renovate has aborted every run on this repository since 13 August. The `allowedVersions` rule for `@percy/cypress` uses `!=3.1.9`, which npm semver does not parse, so Renovate stops with `config-validation` before creating or updating any branch, PR, or the Dependency Dashboard. Renovate reported this in #19975 the day the rule landed (via #19908).

This replaces the constraint with the equivalent range `<3.1.9 || >3.1.9`, which excludes the broken release and parses under npm versioning. Verified with the semver CLI that 3.1.8 and 3.2.0 satisfy the range and 3.1.9 does not.

Fixes #19975.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency updates to skip version 3.1.9 of the Percy Cypress integration while continuing to allow other compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->