### PR TITLE
fix: v9 Designer group layout config

### DIFF
--- a/src/Designer/backend/src/Designer/Services/Implementation/AppDevelopmentService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/AppDevelopmentService.cs
@@ -471,6 +471,22 @@ public class AppDevelopmentService : IAppDevelopmentService
             altinnRepoEditingContext.Repo,
             altinnRepoEditingContext.Developer
         );
+        if (_appVersionService.IsV9App(altinnRepoEditingContext))
+        {
+            Designer.Models.LayoutSettings layoutSettings = await altinnAppGitRepository.GetLayoutSettings(
+                layoutSetId,
+                cancellationToken
+            );
+            bool isSubform = layoutSettings.Type == Constants.General.SubformId;
+            return new LayoutSetConfig
+            {
+                Id = layoutSetId,
+                DataType = layoutSettings.DefaultDataType,
+                Type = layoutSettings.Type,
+                Tasks = isSubform ? null : new List<string> { layoutSetId },
+            };
+        }
+
         bool appUsesLayoutSets = altinnAppGitRepository.AppUsesLayoutSets();
         if (appUsesLayoutSets)
         {

--- a/src/Designer/backend/tests/Designer.Tests/Services/AppDevelopmentServiceTest.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/AppDevelopmentServiceTest.cs
@@ -432,6 +432,54 @@ public class AppDevelopmentServiceTest : IDisposable
         );
     }
 
+    [Fact]
+    public async Task GetLayoutSetConfig_WhenV9App_ShouldBuildConfigFromSettings()
+    {
+        // Arrange
+        AltinnRepoEditingContext editingContext = await PrepareV9Repo();
+
+        // Act
+        LayoutSetConfig layoutSetConfig = await _appDevelopmentService.GetLayoutSetConfig(editingContext, "Task_1");
+
+        // Assert
+        Assert.Equal("Task_1", layoutSetConfig.Id);
+        Assert.Equal("model", layoutSetConfig.DataType);
+        Assert.Null(layoutSetConfig.Type);
+        Assert.Equal("Task_1", Assert.Single(layoutSetConfig.Tasks));
+    }
+
+    [Fact]
+    public async Task GetLayoutSetConfig_WhenV9Subform_ShouldNotResolveTask()
+    {
+        // Arrange
+        AltinnRepoEditingContext editingContext = await PrepareV9Repo();
+
+        // Act
+        LayoutSetConfig layoutSetConfig = await _appDevelopmentService.GetLayoutSetConfig(
+            editingContext,
+            "moreInfoSubform"
+        );
+
+        // Assert
+        Assert.Equal("moreInfoSubform", layoutSetConfig.Id);
+        Assert.Equal("subform-model", layoutSetConfig.DataType);
+        Assert.Equal("subform", layoutSetConfig.Type);
+        Assert.Null(layoutSetConfig.Tasks);
+    }
+
+    private async Task<AltinnRepoEditingContext> PrepareV9Repo()
+    {
+        string targetRepository = TestDataHelper.GenerateTestRepoName();
+        _appVersionServiceMock.Setup(s => s.IsV9App(It.IsAny<AltinnRepoEditingContext>())).Returns(true);
+        CreatedTestRepoPath = await TestDataHelper.CopyRepositoryForTest(
+            _org,
+            "app-with-layoutsets-v9",
+            _developer,
+            targetRepository
+        );
+        return AltinnRepoEditingContext.FromOrgRepoDeveloper(_org, targetRepository, _developer);
+    }
+
     private List<string> GetFileNamesInLayoutSet(string layoutSetName)
     {
         string[] layoutSetFileNamesPaths = Directory.GetFiles(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The group config layout in designer v9 did not work such as adding new pages, configurate the group layout and etc.

The reason for this was the endpoint `GetLayoutSetConfig` was trying to get the config from `layout-sets.json` which not existing in v9. The config now lives in the layout set itself, `settings.json`. 

As we can see with these changes, the settings.json is now updated correctly when updating changes in group layout settings.

<img width="1740" height="898" alt="image" src="https://github.com/user-attachments/assets/fdbfe47f-e6fc-425c-905d-cfa42ff9e8d7" />

<!--- Describe your changes in detail -->

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout-set configuration handling for version 9 apps.
  * Layout settings now correctly identify data types, layout types and associated tasks.
  * Subforms no longer incorrectly resolve a task assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->