### PR TITLE
ci(workflow-engine-app): tag both TT rings on merge to main

### DIFF
--- a/.github/workflows/deploy-runtime-workflow-engine-app.yaml
+++ b/.github/workflows/deploy-runtime-workflow-engine-app.yaml
@@ -21,7 +21,7 @@ on:
       environments:
         description: "Runtime environments to tag. Comma-separated (e.g. at_ring1,at_ring2)."
         required: false
-        default: "at_ring2"
+        default: "at_ring2,tt_ring1,tt_ring2"
       tag-latest:
         description: 'Tag the GHCR image as "latest"'
         required: false
@@ -38,7 +38,7 @@ jobs:
     uses: ./.github/workflows/template-runtime-construct-environments.yaml
     with:
       inputs: ${{ toJSON(github.event.inputs) }}
-      override-default-runtime-environments: at_ring2
+      override-default-runtime-environments: at_ring2,tt_ring1,tt_ring2
 
   push-workflow-engine-app-artifact:
     name: Push workflow-engine-app as OCI artifact
@@ -140,6 +140,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ matrix.environment }}
     strategy:
+      fail-fast: false
       matrix:
         include: ${{ fromJson(needs.construct-rings-array.outputs.result) }}
     steps:


### PR DESCRIPTION
## Description

A merge to `main` that touches `workflow-engine-app` builds and pushes the config
artifact, then tags it for `at_ring2` only. Reaching TT needed a manual
`workflow_dispatch` after every merge.

This adds `tt_ring1` and `tt_ring2` alongside `at_ring2`, to both the push-to-main
default (`override-default-runtime-environments`) and the `workflow_dispatch` default.

`runtime_tt_ring1` and `runtime_tt_ring2` both require a reviewer from
`team-altinn-studio-kjøring` or `team-altinn-studio-flyt`, so a merge **queues** a
deployment to each ring rather than performing one. Approving a run now covers every
ring in one place, and any ring can be left unapproved.

`fail-fast: false` is set on the `tag-workflow-engine-app` matrix, matching
`deploy-admin-workflow-engine-db.yaml`. Without it, one declined or failing ring
cancels the sibling rings.

`tt02` clusters remain gated on `STUDIO_WORKFLOW_ENGINE_SUSPEND`, which the platform
configuration sets to `false` only where a workflow-engine database is provisioned
(today `ttd`). Tagging is a no-op on the rest.

## Verification

- `node --test .github/scripts/construct-environments.test.mjs` — 19/19 pass (the
  script is unchanged; the value it reads is generic).
- `construct-environments.mjs --mode runtime` with the new override resolves to
  `at_ring2 → runtime_at_ring2`, `tt_ring1 → runtime_tt_ring1`,
  `tt_ring2 → runtime_tt_ring2` in both push (`inputs=null`) and dispatch contexts.
- `prettier --check` clean.

## Related

`tt_ring1` has already been deployed to by hand this way (run
[33748488821](https://github.com/Altinn/altinn-studio/actions/runs/33748488821)); this
removes the manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Deployment configuration now supports additional runtime environment rings.
  - Deployment tagging can continue for remaining environments when one matrix job fails, improving overall workflow resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->