### PR TITLE
ci: keep both approve workflow runs so Renovate sees a green branch

### DIFF
--- a/.github/workflows/approve-pr.yaml
+++ b/.github/workflows/approve-pr.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
+      cancel-in-progress: false
     steps:
       - name: Check if auto-approval is needed
         id: check-labels


### PR DESCRIPTION
## Description

When Renovate opens a PR with the `approve` label already attached, GitHub fires both `opened` and `labeled`, so the approve workflow starts twice. The concurrency rule cancelled the earlier run, leaving a check run with conclusion `cancelled` on the head commit. Renovate treats any non-successful check run as a yellow branch and never automerges it, which is why #20291 and #20290 sat approved but unmerged (see the Mend log: "Branch status yellow").

This keeps the concurrency group so the two runs still serialize, but no longer cancels the first. The second run finds the PR already approved and exits successfully, so both check runs end green. Human-labelled PRs are unaffected: they only ever fire `labeled`.

The two stuck PRs were unblocked by re-running their cancelled jobs.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Automated approval processing now allows a new run to proceed without cancelling an already-running approval check for the same pull request.
  - This helps ensure approval checks complete consistently when multiple runs are triggered close together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->