### PR TITLE
fix: invalidate `FormLayoutSettings`on datatype connect and omit null `defaultDataType`

### DIFF
--- a/src/Designer/backend/src/Designer/Controllers/AppDevelopmentController.cs
+++ b/src/Designer/backend/src/Designer/Controllers/AppDevelopmentController.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Altinn.Studio.DataModeling.Metamodel;
@@ -32,6 +33,13 @@ namespace Altinn.Studio.Designer.Controllers;
 [Route("designer/api/{org}/{app:regex(^(?!datamodels$)[[a-z]][[a-z0-9-]]{{1,28}}[[a-z0-9]]$)}/app-development")]
 public class AppDevelopmentController : Controller
 {
+    private static readonly JsonSerializerOptions s_jsonSerializerOptions = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+    };
+
     private readonly IAppDevelopmentService _appDevelopmentService;
     private readonly IRepository _repository;
     private readonly ISourceControl _sourceControl;
@@ -426,7 +434,7 @@ public class AppDevelopmentController : Controller
 
                     await _appDevelopmentService.SaveLayoutSettings(
                         editingContext,
-                        JsonSerializer.SerializeToNode(layoutSettings)
+                        JsonSerializer.SerializeToNode(layoutSettings, s_jsonSerializerOptions)
                             ?? throw new JsonException("Failed to serialize layout settings."),
                         layoutSet.Id,
                         cancellationToken
@@ -444,7 +452,7 @@ public class AppDevelopmentController : Controller
 
                     await _appDevelopmentService.SaveLayoutSettings(
                         editingContext,
-                        JsonSerializer.SerializeToNode(newLayoutSettings)
+                        JsonSerializer.SerializeToNode(newLayoutSettings, s_jsonSerializerOptions)
                             ?? throw new JsonException("Failed to serialize layout settings."),
                         layoutSet.Id,
                         cancellationToken

--- a/src/Designer/frontend/app-development/hooks/mutations/useUpdateProcessDataTypesMutation.test.ts
+++ b/src/Designer/frontend/app-development/hooks/mutations/useUpdateProcessDataTypesMutation.test.ts
@@ -43,12 +43,15 @@ describe('useUpdateProcessDataTypeMutation', () => {
 
     await renderHook({ queryClient });
 
-    expect(invalidateQueriesSpy).toHaveBeenCalledTimes(3);
+    expect(invalidateQueriesSpy).toHaveBeenCalledTimes(4);
     expect(invalidateQueriesSpy).toHaveBeenCalledWith({
       queryKey: [QueryKey.AppMetadataModelIds, org, app],
     });
     expect(invalidateQueriesSpy).toHaveBeenCalledWith({
       queryKey: [QueryKey.LayoutSets, org, app],
+    });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: [QueryKey.FormLayoutSettings, org, app],
     });
   });
 });

--- a/src/Designer/frontend/app-development/hooks/mutations/useUpdateProcessDataTypesMutation.test.ts
+++ b/src/Designer/frontend/app-development/hooks/mutations/useUpdateProcessDataTypesMutation.test.ts
@@ -51,6 +51,9 @@ describe('useUpdateProcessDataTypeMutation', () => {
       queryKey: [QueryKey.LayoutSets, org, app],
     });
     expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: [QueryKey.LayoutSetsExtended, org, app],
+    });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
       queryKey: [QueryKey.FormLayoutSettings, org, app],
     });
   });

--- a/src/Designer/frontend/app-development/hooks/mutations/useUpdateProcessDataTypesMutation.ts
+++ b/src/Designer/frontend/app-development/hooks/mutations/useUpdateProcessDataTypesMutation.ts
@@ -12,6 +12,7 @@ export const useUpdateProcessDataTypesMutation = (org: string, app: string) => {
       await queryClient.invalidateQueries({ queryKey: [QueryKey.AppMetadataModelIds, org, app] });
       await queryClient.invalidateQueries({ queryKey: [QueryKey.LayoutSets, org, app] });
       await queryClient.invalidateQueries({ queryKey: [QueryKey.LayoutSetsExtended, org, app] });
+      await queryClient.invalidateQueries({ queryKey: [QueryKey.FormLayoutSettings, org, app] });
     },
   });
 };


### PR DESCRIPTION

## Description

- Invalidates the Utforming `FormLayoutSettings` cache after connecting or disconnecting a datamodel in `Arbeidsflyt`, so a stale cache cannot overwrite `defaultDataType` in `Settings.json`.
- Fixes serialization in `UpdateValidationOnNavigationLayoutSettings` so null `defaultDataType` is omitted instead of written as `"defaultDataType": null`.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated layout settings handling to use consistent camelCase formatting and omit empty values.
  * Layout and form settings now refresh correctly after process data type updates, ensuring the latest configuration is displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->