### PR TITLE
chore: Avoid timeout of designer tests in CI

### DIFF
--- a/.github/workflows/designer-frontend-unit-tests.yml
+++ b/.github/workflows/designer-frontend-unit-tests.yml
@@ -61,7 +61,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: 'Testing'
     runs-on: self-hosted-ubuntu
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: 'Checking Out Code'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/src/Designer/frontend/package.json
+++ b/src/Designer/frontend/package.json
@@ -90,7 +90,7 @@
     "stats": "node stats.js",
     "syncpack": "npx syncpack fix-mismatches && npx syncpack format && npx syncpack set-semver-ranges",
     "test": "jest --maxWorkers=50% --config=jest.config.js",
-    "test:ci": "jest --ci --coverage --max-workers=2 --cacheDirectory=$(yarn config get cacheFolder) --config=jest.config.js",
+    "test:ci": "jest --ci --coverage --max-workers=4 --cacheDirectory=$(yarn config get cacheFolder) --config=jest.config.js",
     "typecheck": "tsc --noEmit -p .",
     "strict-null-checks": "tsc --noEmit -p tsconfig-strict.json",
     "playwright:test:all": "yarn workspace playwright-studio test:all",


### PR DESCRIPTION
We sometimes got timeout of designer unit test in CI (https://github.com/Altinn/altinn-studio/actions/runs/33619230560).

To avoid this I have increased max workers from 2 to 4. This is same as done for the App-Ci.
Also increased timeout from 30 min to 45 min. Should not be needed, so can consider to rewert that.

New run completed in 11 min : 
https://github.com/Altinn/altinn-studio/actions/runs/33862499538

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the Designer Frontend unit-test workflow timeout to allow longer-running test suites to complete.
  * Increased parallel test execution capacity in continuous integration, enabling tests to run with up to four workers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->