### PR TITLE
chore: release studioctl v0.1.0-preview.23

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -9,6 +9,8 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+## [0.1.0-preview.23] - 2026-09-04
+
 ### Added
 
 - `studioctl app upgrade v9` warns about the eFormidling client changes it cannot rewrite: `Altinn.EFormidlingClient.Extensions`, which has no replacement namespace; the `IEFormidlingClient` endpoints v9 removed, and the models that went with them; the status types now nested inside `Statuses`; the arkivmelding properties that became lists; the renamed Standard Business Document `Arkivmelding`; and references the namespace rewrite cannot reach — an aliased `using X = Altinn.Common.EFormidlingClient;`, one written with `global::`, or a name written out in full — since it only rewrites plain `using` directives matched by name. Each is reported separately, with the fix to apply.


### PR DESCRIPTION
## Description

Prepare release v0.1.0-preview.23

- [Added] `studioctl app upgrade v9` warns about the eFormidling client changes it cannot rewrite: `Altinn.EFormidlingClient.Extensions`, which has no replacement namespace; the `IEFormidlingClient` endpoints v9 removed, and the models that went with them; the status types now nested inside `Statuses`; the arkivmelding properties that became lists; the renamed Standard Business Document `Arkivmelding`; and references the namespace rewrite cannot reach — an aliased `using X = Altinn.Common.EFormidlingClient;`, one written with `global::`, or a name written out in full — since it only rewrites plain `using` directives matched by name. Each is reported separately, with the fix to apply.
- [Changed] Localtest now provides the storage endpoint v9 apps use to commit an instance's data, process state and events in one request. The localtest front page links to the workflow engine control panel.
- [Changed] Report a TODO in `studioctl app upgrade v9` when a layout set in `layout-sets.json` has no `dataType`, so `defaultDataType` is not migrated into `Settings.json` without notice. Connect the datamodel in the process editor after upgrade.
- [Changed] `studioctl app upgrade v9` now renames the SDK's misspelled C# API names to their corrected v9 US English spellings in your app code: the `OrganisationNumber`/`OrganisationOrPersonIdentifier` family becomes `OrganizationNumber`/`OrganizationOrPersonIdentifier` (with the Maskinporten `Organisation` properties), `IFileAnalyser`/`IFileAnalyserFactory` become `IFileAnalyzer`/`IFileAnalyzerFactory` with `Analyse` implementations renamed to `Analyze`, the `Features.FileAnalyzis` namespace becomes `Features.FileAnalysis`, and `InstansiationInstance` becomes `InstantiationInstance`. Only C# names and the OpenTelemetry contract change — routes and JSON payload keys keep their shipped spelling. The telemetry renames are deliberate and cannot be migrated by studioctl, because the affected state lives in your monitoring systems: the span `FileAnalysis.Analyse` is now `FileAnalysis.Analyze`, and the attribute keys `organisation.name`, `organisation.number` and `organisation.systemuser.id` are now spelled `organization.*` — update dashboards and alerts that key on them before upgrading. Names your app plausibly owns itself (such as an `OrganisationNumber` property on your own form model) are only renamed when they provably refer to the SDK, and every rewrite is listed in the upgrade output.
- [Changed] `studioctl app upgrade v9` renames the datepicker validation text keys in your app's own text resources: an override of `date_picker.min_date_exeeded` or `date_picker.max_date_exeeded` in `resource.*.json` is moved to the corrected v9 key (`…_exceeded`), so your customized message keeps applying instead of silently falling back to the built-in text.
- [Changed] `studioctl app upgrade v9` is clearer about what is left for you to do. All steps that leave manual work now print `TODO`, and sometimes alongside `WARN` lines explaining why
- [Changed] `studioctl app upgrade v9` now compiles the app against its current (v8) packages before touching anything, so the C# checks and rewrites work from exact type information instead of name matching. What you will notice: warnings no longer fire on your app's own types that happen to share a name with an SDK type (for example your own `ServiceTaskErrorHandling`); removed APIs are found in every spelling, including aliased and fully qualified uses; and `WithData` calls whose argument the upgrade previously could not classify — asking you to finish the rewrite by hand — are now rewritten automatically when the type is provable. The compilation adds some time to the upgrade (a few seconds with a warm package cache) and its duration is printed. When the app cannot be compiled — it did not build before the upgrade either, the SDK the app targets is not installed, or you are offline — the upgrade says so and runs exactly as before, with the previous name-based checks.
- [Changed] `studioctl app upgrade v9` reports the app owner's required policy rights more accurately. It no longer asks for `pay` or `sign` on payment and signing tasks, which are already covered by `write`. It now grants `delete` when the app deletes its instances at process end, and points out a missing `reject` right for any task that can be rejected.
- [Changed] `studioctl app upgrade v9` now replaces the retired `FileUploadWithTag` layout component with `FileUpload`, retaining its configured options so tagged attachments continue to work.
- [Changed] `studioctl app upgrade v9` renames legacy snake_case data model and text resource bindings on OrganizationLookup, PersonLookup, and RepeatingGroup components to their supported camelCase names.
- [Changed] `studioctl app upgrade v9` converts the two layout properties v9 removes from the components that fetch options or data lists. `mapping` becomes `queryParameters` holding `["dataModel", "<field>"]` expressions on `Checkboxes`, `Dropdown`, `FileUploadWithTag`, `Likert`, `List`, `MultipleSelect`, `Option` and `RadioButtons`, and `bindingToShowInSummary` on `List` becomes `summaryBinding`, naming the key in `dataModelBindings` instead of repeating the field. Repeating group row markers (`[{0}]`) are dropped, because an expression already resolves relative to the row it is rendered in. Anything the upgrade cannot decide for you — a query parameter name that is already taken, or a summary field no data model binding points at — is left in place and reported. `mapping` on `Button`, `InstantiationButton` and `PaymentDetails` is untouched: it is prefill and refetch configuration there, and v9 still supports it.
- [Changed] `studioctl app upgrade v9` now removes an explicit `Microsoft.Extensions.Logging.Debug` package reference, which fails to build on .NET 10 because the debug logger it provides is already built into the framework.
- [Changed] `studioctl app upgrade v9` rewrites the eFormidling client namespaces, which moved into `Altinn.App.Core` in v9: `Altinn.Common.EFormidlingClient` becomes `Altinn.App.Core.EFormidling.Interface`, and its `.Configuration`, `.Models` and `.Models.SBD` namespaces become the matching ones under `Altinn.App.Core.EFormidling`. For most apps this is a single `using` in the file implementing `IEFormidlingReceivers`.
- [Changed] Installing or updating studioctl now deletes the local workflow-engine database once. The app runtime changed how it hands process transitions to the workflow engine, so workflows started by earlier versions can no longer be resumed and would fail on their next step. Localtest instances and their data are kept; instances left mid-transition continue from the process step that was last saved. Run `studioctl env reset` if you also want to start from empty instance data.
- [Fixed] Localtest no longer stops answering on the host bridge after a client aborts a request.
- [Fixed] The workflow engine dashboard shows why a waiting step is deferred, keeps its horizontal scroll position while cards update, and reports the HTTP status of a failed app callback instead of a generic error.
- [Fixed] `studioctl env up` now waits for the workflow engine to actually be able to serve requests before reporting that the environment has started. It previously returned around 0.8 seconds early, and instantiating an app inside that window failed with "Instance initialization failed" and left an unusable instance behind.
- [Fixed] `studioctl app upgrade` no longer fails when the upgrade completed but left steps for you to finish by hand.
- [Fixed] `studioctl app upgrade v9` no longer adds a byte order mark to layout files that did not have one, and keeps Norwegian characters as they are instead of rewriting every "æ", "ø" and "å" as an escape sequence. Both turned a two-line migration into a diff across the whole file. Layout files containing comments are now left untouched and reported, rather than silently losing the comments to the rewrite.

@coderabbitai ignore

**Full Changelog**: https://github.com/Altinn/altinn-studio/compare/studioctl/v0.1.0-preview.22...studioctl/v0.1.0-preview.23