### PR TITLE
chore: release app v9.0.0-preview.5

### DIFF
--- a/src/App/backend/CHANGELOG.md
+++ b/src/App/backend/CHANGELOG.md
@@ -9,6 +9,8 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+## [9.0.0-preview.5] - 2026-09-04
+
 ### Added
 
 - New build-time check `ALTINNAPP0800`: your app's `config/authorization/policy.xml` must grant the app owner (your org) the rights the app uses on its own behalf, since it writes process transitions and instance data to Storage as the service owner rather than as the end user. A policy missing them now fails the build and names the actions to add, instead of surfacing as an unexplained authorization failure at runtime; `studioctl app upgrade` adds them for you. Where the policy cannot be evaluated with certainty you get the warning `ALTINNAPP0801` instead.


### PR DESCRIPTION
## Description

Prepare release v9.0.0-preview.5

- [Added] New build-time check `ALTINNAPP0800`: your app's `config/authorization/policy.xml` must grant the app owner (your org) the rights the app uses on its own behalf, since it writes process transitions and instance data to Storage as the service owner rather than as the end user. A policy missing them now fails the build and names the actions to add, instead of surfacing as an unexplained authorization failure at runtime; `studioctl app upgrade` adds them for you. Where the policy cannot be evaluated with certainty you get the warning `ALTINNAPP0801` instead.
- [Added] Add mailboxes — a service task can now be finished by a message that arrives later, instead of by polling for one. The stage that sends opens the mailbox in the same `Stage` call — `.Stage(SendIt, new MailboxOptions { Timeout = … }, out MailboxHandle answer)` — and is handed a `ServiceTaskMailbox`: publish its `Id` in the outbound message as the address the answer must be sent back to, and read `Deadline` as the answer-by time. The mailbox is then answered by a handler that reads what comes back. The simplest shape ends the pipeline right there, with the terminal that answers the mailbox in place of `Finally`: `.ConcludeOnReplies(answer, onMessage, onClosed)`. `onMessage` runs **once per message**, and is handed the message itself (its body, the sender's own message id — use it to keep side effects from repeating — when it was accepted, and its position in the exchange). Answer `ServiceTaskExchangeResult.AwaitNextReply()` to handle this message and wait for the next one, or conclude with `Success(action?)` / `FailedPermanent(...)` as usual; `FailedRetryable` retries the same message unchanged. An exchange of one answer needs nothing extra — it simply concludes on its first message. A conclusion closes the mailbox before anything downstream starts. Nothing polls and nothing holds a worker while an exchange is open — the instance simply reads as processing, so the frontend keeps showing the waiting state and the next action stays blocked until the task concludes. Exchanges lasting days are ordinary; `Timeout` is the whole exchange's deadline, measured from the moment the stage opens the mailbox, and it is not re-armed by messages arriving.
- [Added] A mailbox `Timeout` is measured against one limit: the workflow engine's `MaxMailboxTimeout`, **21 days by default**. A longer one is rejected when the mailbox opens, and the transition fails. Nothing else refuses a long exchange up front, but there is a property of **every** long-running workflow — not of mailboxes in particular — worth knowing about. The credentials a workflow uses to call back into your app are issued once, when it is enqueued, and expire together with the `WorkflowEngineCallback` app code that issued them; they are never renewed while it waits. A reply that arrives after that code has expired therefore cannot be handled — and it fails on your side of the wire, silently, without the sender ever learning that it did. `ForwardReply` **succeeds**, so the external system is told the answer landed and your receiving channel acks it; the message then counts as delivered and is never handed over again, while the workflow that should have handled it fails immediately and permanently and the instance shows the task as failed. There is no recovery for that instance: resuming the workflow replays the same stored credentials and fails the same way, and rotating a fresh app code in does not help either, because nothing re-issues the credentials of a workflow that is already enqueued — a new code protects the next exchange without rescuing a stuck one. A service task waiting out its wait budget fails the same way for the same reason. App codes are normally rotated far ahead of both the 21-day mailbox cap and the 14-day wait budget, so this does not arise in a correctly operated application.
- [Added] Add `IServiceTaskReplyForwarder`, which is how an answer from an external system reaches the service task waiting for it. Inject it wherever your app receives the message — a Fiks IO subscription handler, a webhook, a message consumer — and call `ForwardReply(mailboxId, serviceTaskType, payload, idempotencyKey)`, where `mailboxId` is the address the external system echoed back (the `ServiceTaskMailbox.Id` the declaring stage embedded in its request) and `serviceTaskType` is the `Type` of the service task whose reply handler should read it. The receiving channel does nothing else with the message: it is handled by the reply handler instead, with the retries, ordering and durability that come with it. **Pass the source's own message id as `idempotencyKey`** — message channels deliver at least once, so the same answer will sometimes be forwarded twice, and the key is what makes the second forward a recognized replay rather than a second copy for the handler to process; it is also what the handler reads back as the message's `IdempotencyKey`. **An answer that arrives early is not a problem**: a fast external system may answer while the sending transition is still finishing, and such an answer is kept and handled as soon as the exchange reaches it, so the receiving channel never has to delay or buffer. An answer that could not be handed over throws `ServiceTaskReplyForwardException` for the receiving channel to act on: `Outcome` says why (no mailbox has that address, the mailbox is closed, the payload is too large, the mailbox has taken as many messages as it may, the submission was rejected, the engine could not be reached, or the app cannot currently seal the answer) and `IsTransient` says whether forwarding it again could ever succeed — so the channel can dead-letter, report, retry or drop it, which is a decision only it can make. Only a connection problem is worth retrying; a rejected submission never becomes acceptable, and "the mailbox is closed" never means "too early". Resolve the forwarder per received message from a service scope; a subscriber that is a singleton `BackgroundService` should not hold on to one. The payload travels through the workflow engine in a tamper-evident envelope tied to that one mailbox, that one handler and that one message id, so the handler is guaranteed to read back exactly what was forwarded to it; the content itself came from outside and is still untrusted input. **Answers must be forwarded with this service — do not POST to the workflow engine's delivery endpoint directly**, because an answer that arrives without the envelope this service applies fails the task instead of being handled. Keep answers small — the workflow engine accepts 256 KB by default, and roughly half of that is usable for a JSON body once the envelope is applied — and put anything large in Storage, with the answer carrying a reference to it.
- [Added] When a mailbox reaches its deadline, or is closed by an operator, the `onClosed` handler runs instead of `onMessage` — the task's cue to conclude in its own words rather than being failed by a timeout it cannot explain. It is handed a `MailboxClosedReason` saying whether the deadline passed or the mailbox was closed on request, so the wording can differ ("the archive never confirmed before the deadline" reads differently from "the exchange was ended"). The two handlers are separate for a reason: an empty message is still a message and still runs `onMessage`, so a sender that delivers an empty body cannot be mistaken for the exchange ending.
- [Added] A service task can now hold **several exchanges, one after another**. Answer one without ending the task with `.HandleReplies(handle, onMessage, onClosed)` — the non-terminal sibling of `ConcludeOnReplies` — and the pipeline carries on with whatever is composed after it: more stages, another exchange, and eventually the terminal that concludes the task. The archive-then-journal shape is the motivating one: `.Stage(SendToArchive, …, out MailboxHandle archive).HandleReplies(archive, …).Stage(SendToJournal, …, out MailboxHandle journal).ConcludeOnReplies(journal, …)`. A handler that answers without concluding gets the **stage** vocabulary plus one addition: return `ServiceTaskStageExchangeResult.AwaitNextReply()` to be called again on the next message, `ServiceTaskStageResult.Completed()` to end the exchange and let the pipeline continue, and `FailedRetryable`/`FailedPermanent`/`Defer` meaning exactly what they mean in a stage. Concluding the task and advancing the process are deliberately not on offer there — that is the terminal's job, and it is the compiler that says so. Its `onClosed` reads the same way: `Completed()` when the exchange was one the task can live without, a failure when it was not. Exchanges run one at a time, in the order their **handlers** are composed rather than the order the sends are, so both messages can go out up front and still be read one exchange at a time; messages for a later exchange wait in its mailbox until the pipeline reaches its handler, so nothing is lost and nothing is handled early. Each mailbox's `Timeout` still runs from the moment its own stage opened it, which makes stage placement the decision: sends composed up front mean a later exchange's deadline is already ticking while an earlier exchange runs, while a send composed after a handler starts its clock once that exchange is over. Pushed far enough, that has a consequence worth designing for: a mailbox opened up front can reach its deadline before the pipeline ever arrives at its handler — and if nothing arrived in the meantime, `onClosed` then runs without a single message having been read. Give an up-front send a `Timeout` that covers every exchange ahead of it, or compose its stage later. Every mailbox must be answered by exactly one handler, and answered before the pipeline ends — a handle answered twice, and a mailbox left for a handler that was never composed, both fail app startup pointing at the stage that opened it. And because an exchange does not have to be the last thing a task does, a pipeline that opens a mailbox may also end with `Finally` — with stages after the last exchange if you want them — as long as a `HandleReplies` handler answered every mailbox it opened. If a handler fails the task part-way along the chain, only its own mailbox is closed: a later mailbox an up-front send already opened keeps its own deadline, so resuming the task can replay the failed handler and carry the chain on from there rather than starting the exchange over.
- [Added] A mailbox-opening stage can now **conclude the whole task**, for the send whose failure already settles the matter. Its work returns `ServiceTaskOpeningStageResult` — the stage vocabulary (`Completed`, `Defer`, `FailedRetryable`, `FailedPermanent`) plus `Conclude(ServiceTaskResult)`. A conclusion closes every mailbox the task has opened before anything downstream starts, waits for no answer, skips the rest of the pipeline, and advances the process (or not) per the carried result — `Success(action?)` advances, `FailedPermanent` fails the task with the mailboxes closed. Use it when the answer can never arrive and the failure is remediated case-side — a recipient address that does not exist — where waiting out the exchange's deadline would only delay the same verdict. It is honored from **every** mailbox-opening stage, wherever the send sits in the pipeline — the stages composed after it are work the conclusion never starts, so nothing about the composition around the send decides whether concluding from it is allowed. A send whose outcome is unknown — a timeout, a cut-off attempt — should keep returning `FailedRetryable`, and an app-level failure (credentials, configuration) should be an ordinary `FailedPermanent` rather than a conclusion: concluding closes the mailbox, and a workflow resumed after the fix needs it open for its answers.
- [Added] Add analyzer rules `ALTINNAPP0702` and `ALTINNAPP0703` (errors): answering the same mailbox twice, and opening one nothing answers, are now build errors as well as app startup failures. `ALTINNAPP0702` reports a handle passed to `HandleReplies` or `ConcludeOnReplies` when an earlier handler already answered it in the same unbroken run of code — a fluent `Define` chain, typically; each mailbox is answered exactly once, so the second handler could never run. `ALTINNAPP0703` reports a mailbox-opening `Stage` whose handle is never used again, which leaves the messages that come back with no handler. Both stay silent where the answer is not clear from the code alone — a handle kept in a field, handed to a helper method, answered once per `if`/`else` branch, or answered twice inside a branch or loop body the app may never run — and those cases still fail app startup with the same explanation.
- [Changed] Breaking: the eFormidling client is now part of `Altinn.App.Core` instead of the separate `Altinn.Common.EFormidlingClient` package, which is no longer published. The types keep their names and change namespace: `Altinn.Common.EFormidlingClient` to `Altinn.App.Core.EFormidling.Interface`, and its `.Configuration`, `.Models` and `.Models.SBD` namespaces to the matching ones under `Altinn.App.Core.EFormidling`. For most apps that is one `using` in the file implementing `IEFormidlingReceivers`, and `studioctl app upgrade v9` rewrites it. Remove any `PackageReference` your app declares to `Altinn.Common.EFormidlingClient`, or the same types arrive twice.
- [Changed] Breaking: the `IEFormidlingClient` methods changed shape. The `Dictionary<string, string>` of request headers is gone — the client builds its own. Every method takes a `CancellationToken`, so a shipment observes cancellation during a call rather than only between calls. `UploadAttachment` returns `Task` rather than `Task<bool>`: it only ever returned `true` or threw.
- [Changed] eFormidling shipments now authenticate with a service owner token rather than the current user's. A shipment runs from a workflow-engine callback, where there is no signed-in user to borrow a token from, and the resulting failure was reported as a missing integration point access token — naming the wrong header. Status polling is unchanged and still needs no token at all.
- [Changed] Breaking: a failed eFormidling request throws `PlatformHttpException` rather than `WebException`. The status code and response body are properties on the exception (`StatusCode`, `Response.Content`) rather than interpolated into its message, so code that recognized a specific error by searching the message text should read those instead. Response bodies no longer appear verbatim in exception messages — the snapshot caps and redacts them.
- [Changed] Breaking: the Standard Business Document's `Arkivmelding` is now `ArkivmeldingMetadata`, and the `DPF` type it refers to is now `Dpf`. The old name collided with the Noark 5 `Arkivmelding` in a sibling namespace, so code handling both had to alias one of them. The Noark type is unchanged, the property is still called `Arkivmelding`, and the JSON still serializes to `arkivmelding`. Only code that builds the SBD envelope by hand is affected, which the built-in shipment does not require.
- [Changed] Breaking: four arkivmelding properties are now lists, matching the Noark 5 schema, which has always declared them as `maxOccurs="unbounded"`: `Mappe.Basisregistrering`, `Basisregistrering.Dokumentbeskrivelse`, `Basisregistrering.Korrespondansepart` and `Dokumentbeskrivelse.Dokumentobjekt`. A journalpost could previously describe only one document and name only one correspondence party, and a folder could hold only one registration, so a main document with attachments could not be expressed at all. Wrap your existing initialisers in a collection. `Basisregistrering` also gained an optional `Dokumentobjekt` list, for document objects the schema allows to hang directly off the registration itself. `studioctl app upgrade v9` reports the files to update, and apps carrying their own copy of these models are unaffected.
- [Changed] Breaking: the status model's helper types are now nested inside `Statuses`: `Content` is `Statuses.Entry`, `Sort` is `Statuses.SortInfo`, and `Pageable` is `Statuses.PageInfo`. `Statuses` itself keeps its name, and the JSON on the wire is unchanged. `studioctl app upgrade v9` reports the usages to qualify.
- [Changed] eFormidling now fails at startup, rather than at the first shipment, when `EFormidlingClientSettings.BaseUrl` is missing for an environment where an eFormidling task is enabled. An app that registers its own `IEFormidlingService` is not asked for one. A `BaseUrl` without a trailing slash also no longer silently drops its last path segment from every request.
- [Changed] The eFormidling client emits telemetry, like the app's other HTTP clients, and no longer logs whole response bodies at debug level.
- [Changed] Breaking: the eFormidling data models are `sealed` — the Noark 5 arkivmelding types, the Standard Business Document types, and `Statuses`. They are serialization models with no inheritance contract, and nothing in the fleet derives from them. The exception type, the default receivers implementation and `EFormidlingClientSettings` are unchanged, since deriving from those is a reasonable thing to do.
- [Changed] When Altinn Authorization denies the app while it is acting as the service owner, the app now logs what that means instead of only the bare `403`: which app owner was denied, that the rights belong to the org rather than the end user, that `config/authorization/policy.xml` is where to fix it, and which action the current task needs. The process-callback span also carries the attribute `authorization.service_owner.denied` in that case, so this failure can be separated from a transient platform failure in monitoring — it needs a policy change for every instance of the app, not a redrive. Nothing else about the failure changes — it is retried and reported exactly as before.
- [Changed] Breaking: pipeline stages no longer have names. Compose a stage with `pipeline.Stage(work, options?)` — the name argument and its validations are gone — and open a mailbox with the same `Stage(work, options, out handle)` overload as before. A stage's identity is now its **position** in the pipeline, which travels through every step, reply and OperationId (`ExecuteServiceTask: 2`, `MintMailbox: 1`). Every step of a service task now carries a position that way, the one that finishes the task included, so a service task with no stages of its own shows up as `ExecuteServiceTask: 0` rather than a bare `ExecuteServiceTask` — repoint any dashboard, log search or alert matching that exact operation name. Names never guaranteed compatibility across deploys anyway: a redeploy can keep every name and still break an exchange already in flight. What that leaves is the general versioning rule the app developer owns, with no tripwire from the workflow engine: reshaping a pipeline between deploys — inserting, reordering or removing stages — shifts those positions behind workflows already enqueued and fails them loudly, exactly as any other mid-flight change to the composed process, an edited BPMN file above all.
- [Changed] Breaking: a service task's pipeline can only be composed on the builder its `Define` is handed — `new ServiceTaskPipelineBuilder()` no longer compiles from an app. Compose on the parameter and return what its terminal gives you. A `Define` that composed on a builder of its own could spread one pipeline over two, and a mailbox declared on the builder it did not return from was silently lost.
- [Changed] Breaking: the answers a service task can give are a closed set. Declaring your own subclass of any of the result types — `ServiceTaskResult`, `ServiceTaskExchangeResult`, `ServiceTaskStageResult`, `ServiceTaskStageExchangeResult` or `ServiceTaskOpeningStageResult` — no longer compiles. Return one of the results their factory methods produce (`Success`, `SuccessWithoutAutoAdvance`, `Completed`, `FailedRetryable`, `FailedPermanent`, `Defer`, `AwaitNextReply`, `Conclude`), which is what every stage, `Finally` and reply handler already returns. A hand-written result had no meaning the runtime could act on, and it was handled badly: returned from a stage or `Finally` it was quietly concluded as a **success**, and returned from a reply handler it failed the step and retried without ever converging. A result type the runtime does not recognize now fails the task permanently and names the type, so the mistake is reported instead of guessed at.
- [Changed] Breaking: `IDataClient.GetBinaryData` now throws `PlatformHttpException` when the data element does not exist, instead of returning `null` from a method whose signature says it never does. Its sibling `GetBinaryDataStream` already behaved this way. If your app relied on the `null` to detect a missing data element, catch `PlatformHttpException` and check for `HttpStatusCode.NotFound` instead. Code that did not check for `null` — the common case — now gets a clear error naming the failed request rather than a `NullReferenceException` further along.
- [Changed] Breaking: a **Fiks Arkiv service task now waits for the archive to answer** instead of finishing as soon as the message is handed to Fiks IO. It sends the archive record, then handles each message the archive sends back — the acknowledgement, and then the receipt or an error — and concludes on the one that settles the matter. `successHandling` therefore describes what happens **once the archive has confirmed the record**, not what happens after a successful send: `moveToNextTask` advances the process when the receipt arrives, `markInstanceComplete` marks the instance just before it, and the receipt is stored as the configured `confirmationRecord` as part of that same transition. `errorHandling` describes what happens when **the archive reports that it could not create the record**. Nothing polls and nothing holds a worker while the archive is thinking: the instance reads as processing, the frontend keeps showing the waiting state, and the next action stays blocked until the task concludes. The archive has **seven days** to answer, after which the task fails naming what never arrived, so a shipment nobody answered reaches your monitoring instead of waiting forever.
- [Changed] Breaking: `errorHandling` now governs every way **the archiving cannot succeed for this case** — the archive rejecting the record, or a recipient account that does not exist. Either fails identically on every retry and is remediated case-side, so it concludes down the same path — `moveToNextTask: true` advances the process (the `action` still defaults to `reject`), and otherwise the task fails with a message that names what to fix. **Fiks IO refusing the app's integration credentials is different**: that is an operations problem no citizen action helps, so it fails the task immediately for the app owner to see in monitoring — `errorHandling` is not consulted — and it deliberately does not conclude the exchange, so fixing the credentials and resuming the workflow re-runs the send and lets the exchange complete normally. **Transient and unknown-outcome send failures are outside both** — a Maskinporten failure or a transport failure among them, since either can heal: handing the archive record to Fiks IO is retried and then fails the task, because advancing past a shipment that may never have left would leave nothing waiting for a receipt that can never arrive — and being cut off mid-send never concludes either way, because the shipment may still have left. Similarly, a receipt that arrives but cannot be read as an archive receipt now fails the task rather than advancing with no confirmation record to show. **An archiving that cannot succeed fails the task unless `errorHandling.moveToNextTask` is explicitly `true`** — the setting's default flipped from `true` to `false`, so omitting the block and writing one without `moveToNextTask` mean the same thing, and an empty block can no longer silently advance past a rejected archival. An app that wants the failure to advance the process must say `"moveToNextTask": true`. `successHandling` is symmetric already — omitted or default, the receipt advances the process.
- [Changed] Breaking: the outbound Fiks IO **`klientKorrelasjonsId` now carries the reply address** — the id of the mailbox waiting for the archive's answer — rather than the instance URL. It is the one field Fiks IO echoes back on every reply, so it is what routes an answer to the task waiting for it. The instance URL still travels to the archive inside the arkivmelding, as the recipient korrespondansepart's reference, which is the durable place to look for it; `IFiksArkivConfigResolver.GetInstanceReference` (renamed from `GetCorrelationId`, since the value no longer rides the transport correlation id) still supplies that value. An integration that read the instance URL off the transport correlation id of a Fiks Arkiv reply must read it from the arkivmelding instead.
- [Changed] Breaking: `IFiksArkivResponseHandler` is replaced by `IFiksArkivMessageHandler` — one **optional** hook, called once per message the archive sends back, **from inside the process transition the message belongs to** — with the workflow engine's retries behind it — rather than inline in the Fiks IO subscriber against whatever task the instance had reached by then. Its single method, `HandleMessage(FiksArkivReceivedMessage, ServiceTaskContext)`, receives the parsed message (its identifiers and typed payloads, with `IsError`/`IsReceipt`/`IsAcknowledgement` saying what arrived — the success/error method split is gone) and the executing task's context, so anything it stages through `context.InstanceDataMutator` is saved in the same durable transition that stores the receipt, where the old handler had to write out-of-band against Storage. **It must not move the process**: the task applies `successHandling`/`errorHandling` itself, and a handler that calls `process/next` anyway is **refused with `409 Conflict` — "the current task is still being processed by the workflow engine"** — because the transition it is running inside is still active. Nothing is advanced twice; what happens instead is that the shipment stalls, if the handler lets that failure propagate: the message is retried until the receive workflow fails terminally, and the archiving concludes nothing until an operator resumes it. A handler that throws is retried with the same message, and the task concludes nothing until it succeeds; delivery is at least once, with `message.MessageId` as the deduplication key. There is no default implementation and none is needed — the task logs every message it handles — so register yours with `.WithMessageHandler<T>()` (previously `.WithResponseHandler<T>()`) only when the app has bookkeeping of its own, such as copying the archive's case number out of the receipt into instance data. Anything that must go back to the archive has to be sent as a new message: the Fiks IO connection the message arrived on is gone by the time the handler runs.
- [Changed] Breaking: two trace spans no longer appear for Fiks Arkiv. The per-message handler span (raised around `IFiksArkivResponseHandler` in the Fiks IO subscriber) is gone, because the subscriber no longer runs the handler — the work it covered is now inside the service task's own step, which the workflow engine traces. And the `process/next` span the built-in response handler used to raise is gone with the call itself, since the task's verdict advances the process instead. Dashboards or alerts keyed on either span need repointing at the workflow engine's step and workflow telemetry.
- [Changed] Breaking: `IFiksArkivHost` is removed from the public API, and with it the ability to send Fiks Arkiv messages outside the service task. A fire-and-forget send was never routable back to a waiting task, so the archive exchange is now owned end to end by the Fiks Arkiv service task: every shipment carries the reply address of the mailbox waiting for its answer. `FiksIOReceivedMessage` is again exactly what a live Fiks IO subscription delivers — the replayed variant, whose `Responder` and stream members could only throw, is gone along with `IsReplayed` — and the `Altinn.App.Clients.Fiks` package no longer depends on `Altinn.App.Api`.
- [Fixed] Dispose the streams you get from `IDataClient.GetBinaryData`, `IDataClient.GetBinaryDataStream` and `IPdfGeneratorClient.GeneratePdf` once you have finished reading them — each one holds an HTTP response open until it is disposed, and disposing the stream releases it. The interfaces now say so. Code that already disposed these streams is unaffected, and code that does not is no worse off than before. The app's other HTTP clients now release their responses promptly too, which needs nothing from you.
- [Fixed] The eFormidling client releases its HTTP responses, and reports an empty or malformed response body as an error rather than returning null.
- [Fixed] An eFormidling shipment the integrasjonspunkt rejects — a `400 Bad Request` for an SBD it will not accept, or any other 4xx answer — now fails the process step permanently, with the integrasjonspunkt's own explanation in the failure message, instead of surfacing as a server error that the workflow engine retried every few minutes for a day. The delivery status check is handled the same way. Answers that may change on a retry — `5xx`, `408 Request Timeout` and `429 Too Many Requests` — are still retried with backoff.
- [Fixed] Breaking: `Basisregistrering.ArkivertDato` is now a `DateTime?`. The schema makes `arkivertDato` optional, but as a plain `DateTime` it was written on every shipment whether you set it or not, so a registration that was never archived still claimed an archive date of `0001-01-01` — alongside no `arkivertAv`, which has always omitted itself when unset. Leave it null and the element is omitted. Code that assigns a `DateTime` is unaffected; code that reads one back needs to handle null.
- [Fixed] The arkivmelding is now written in the element order the Noark 5 schema requires. `Arkivmelding`, `Mappe` and `Klassifikasjon` had their members sorted by name, which emits the elements out of sequence — `antallFiler` ahead of `system`, and a folder's case-handling fields ahead of the registrations they are supposed to follow — so a validating archive could reject the shipment. `journaldato` is also emitted as a date rather than a date and time, matching the schema. This changes the XML your app produces, not the code that produces it.
- [Removed] Breaking: eight `IEFormidlingClient` members that nothing was calling — `GetCapabilities`, `GetAllConversations`, `GetConversationById`, `GetConversationByMessageId`, `GetAllMessageStatuses`, `FindOutGoingMessages`, `SubscribeeFormidling` and `UnSubscribeeFormidling` — along with the `Capabilities`, `Conversation` and `CreateSubscription` models only they used. What a shipment is made of remains: `CreateMessage`, `UploadAttachment`, `SendMessage` and `GetMessageStatusById`. Call the integrasjonspunkt's REST API directly if you need any of the rest.
- [Removed] Breaking: `Altinn.EFormidlingClient.Extensions.HttpClientExtension`, whose `GetAsync`/`PostAsync`/`PutAsync`/`DeleteAsync` overloads took a dictionary of request headers. There is no replacement, and `Altinn.App.Core.Extensions.HttpClientExtension` is a different type with different overloads, not a substitute. If your app used these for its own HTTP calls, build the `HttpRequestMessage`, add the headers to it, and call `HttpClient.SendAsync`. `studioctl app upgrade v9` reports the files to change.
- [Removed] Breaking: remove the in-process retry layer from `Altinn.App.Clients.Fiks` — the Polly resilience pipeline around Fiks IO sends, and with it the `WithResiliencePipeline` builder method and the `FiksIOConstants.UserDefinedResiliencePipelineId` constant. One retry mechanism remains for the Fiks Arkiv service task: the workflow engine's own step retries, which are durable, visible in the workflow status, and correctly paced — the in-process quick retries duplicated them, and the per-attempt timeout could re-send a message whose response was merely slow. A send now makes one attempt per call, bounded by the caller's `CancellationToken`. An app using `IFiksIOClient` standalone owns its own resilience: wrap the client in whatever retry policy fits the call site.
- [Removed] Breaking: remove the obsolete `Altinn.App.Core.Interface.IData` interface. Use `Altinn.App.Core.Internal.Data.IDataClient` instead.

@coderabbitai ignore

**Full Changelog**: https://github.com/Altinn/altinn-studio/compare/app/v9.0.0-preview.4...app/v9.0.0-preview.5