### PR TITLE
fix(experimental): launch agent sandbox on the fable model alias

### DIFF
--- a/src/experimental/agent/src/harness/claude_code/bootstrap/linux.rs
+++ b/src/experimental/agent/src/harness/claude_code/bootstrap/linux.rs
@@ -46,7 +46,7 @@ pub(super) async fn configure(sandbox: &SandboxHandle, home: &str, instructions:
         )
         .await?;
     // HACK: the mediated setup token is inference-only, so Claude Code cannot read the account's
-    // plan entitlement and gates Fable 5 behind a usage-credits prompt. Declaring the subscription
+    // plan entitlement and gates Fable behind a usage-credits prompt. Declaring the subscription
     // type and rate-limit tier in the settings env satisfies the client-side plan-inclusion check
     // (the literal "max" tier is what the check looks for, regardless of the real plan); the server
     // still authorizes inference independently. Both are required — the type alone unblocks Max

--- a/src/experimental/agent/src/harness/claude_code/mod.rs
+++ b/src/experimental/agent/src/harness/claude_code/mod.rs
@@ -136,12 +136,12 @@ pub(super) async fn verify_linux(
 
 pub(super) fn launch_linux(home: &str, resume: Option<&str>) -> ProcessLaunch {
     let config = format!("{home}/.claude");
-    // The mediated setup token cannot enumerate models, so Fable 5 never appears in the /model
+    // The mediated setup token cannot enumerate models, so Fable never appears in the /model
     // picker (same inference-only-scope limitation as the usage-credits gate handled in bootstrap).
-    // Launch on Fable 5 directly; users can still switch to the listed models via /model. Revisit
-    // when github.com/anthropics/claude-code#79360 ships.
-    let base =
-        format!("claude --dangerously-skip-permissions --model claude-fable-5 --settings {config}/agent-settings.json");
+    // Launch on the `fable` alias directly so the sandbox tracks the latest Fable release; users
+    // can still switch to the listed models via /model. Revisit when
+    // github.com/anthropics/claude-code#79360 ships.
+    let base = format!("claude --dangerously-skip-permissions --model fable --settings {config}/agent-settings.json");
     // Claude Code currently reports UUID conversation IDs. Keep that
     // harness-specific constraint out of the generic Session reconciler.
     let resume = resume.and_then(|native| native.parse::<uuid::Uuid>().ok());


### PR DESCRIPTION
## Description

agentd launched Claude Code in the sandbox with `--model claude-fable-5`, which pins Claude Fable 5 and silently stayed a generation behind once Fable 5.1 shipped. Claude Code resolves the `fable` alias to the latest Fable release, so the launch command now uses that alias and the sandbox picks up new Fable models as they ship.

Comments that named "Fable 5" are updated to refer to the family, since neither the /model picker limitation nor the plan-entitlement workaround is specific to a generation.

## Verification

- `cargo fmt --check`, `cargo check`, and `cargo test claude_code` in `src/experimental/agent` pass.
- `yarn spell:quick` passes on the changed files.
