### PR TITLE
chore: syncing all

### DIFF
--- a/src/Altinn.App.Clients.Fiks/Constants/FiksArkivConstants.cs
+++ b/src/Altinn.App.Clients.Fiks/Constants/FiksArkivConstants.cs
@@ -1,3 +1,5 @@
+using Altinn.App.Clients.Fiks.FiksArkiv.Models;
+using KS.Fiks.Arkiv.Models.V1.Kodelister;
 using KS.Fiks.Arkiv.Models.V1.Meldingstyper;
 
 namespace Altinn.App.Clients.Fiks.Constants;
@@ -37,11 +39,16 @@ public static class FiksArkivConstants
         public const string ArchiveRecordCreationReceipt = FiksArkivMeldingtype.ArkivmeldingOpprettKvittering;
     }
 
+    /// <summary>
+    /// Classification IDs for Fiks Arkiv messages.
+    /// </summary>
+    /// <remarks>Callers can also specify their own, additional, classifications via
+    /// <see cref="FiksArkivMetadataSettings.CaseFileClassifications"/>.</remarks>
     internal static class ClassificationId
     {
-        public const string NationalIdentityNumber = "Fødselsnummer";
-        public const string OrganizationNumber = "Organisasjonsnummer";
+        public static readonly string NationalIdentityNumber = KlassifikasjonstypeKoder.Foedselsnummer.Verdi;
+        public const string OrganizationNumber = "ORGNR";
         public const string AltinnUserId = "AltinnBrukerId";
-        public const string SystemUserId = "SystembrukerId";
+        public const string SystemUserId = "AltinnSystembrukerId";
     }
 }

--- a/src/Altinn.App.Clients.Fiks/Extensions/FiksArkivClassificationExtensions.cs
+++ b/src/Altinn.App.Clients.Fiks/Extensions/FiksArkivClassificationExtensions.cs
@@ -1,0 +1,16 @@
+using Altinn.App.Clients.Fiks.FiksArkiv.Models;
+using KS.Fiks.Arkiv.Models.V1.Arkivering.Arkivmelding;
+
+namespace Altinn.App.Clients.Fiks.Extensions;
+
+internal static class FiksArkivClassificationExtensions
+{
+    public static Klassifikasjon ToKlassifikasjon(this FiksArkivClassification classification) =>
+        new()
+        {
+            KlassifikasjonssystemID = classification.SystemId,
+            KlasseID = classification.ClassificationId,
+            Tittel = classification.Title,
+            ErSkjermet = classification.IsRestricted,
+        };
+}

--- a/src/Altinn.App.Clients.Fiks/Extensions/FiksArkivCodeExtensions.cs
+++ b/src/Altinn.App.Clients.Fiks/Extensions/FiksArkivCodeExtensions.cs
@@ -1,0 +1,20 @@
+using Altinn.App.Clients.Fiks.FiksArkiv.Models;
+using KS.Fiks.Arkiv.Models.V1.Metadatakatalog;
+
+namespace Altinn.App.Clients.Fiks.Extensions;
+
+internal static class FiksArkivCodeExtensions
+{
+    public static T? ToExternal<T>(this FiksArkivCode? code)
+        where T : Kode, new()
+    {
+        if (code is null)
+            return null;
+
+        return new T
+        {
+            KodeProperty = code.Code,
+            Beskrivelse = !string.IsNullOrWhiteSpace(code.Description) ? code.Description : null,
+        };
+    }
+}

--- a/src/Altinn.App.Clients.Fiks/FiksArkiv/FiksArkivConfigResolver.cs
+++ b/src/Altinn.App.Clients.Fiks/FiksArkiv/FiksArkivConfigResolver.cs
@@ -118,8 +118,22 @@ internal sealed class FiksArkivConfigResolver : IFiksArkivConfigResolver
                 x => ParseString(x, nameof(FiksArkivMetadataSettings.CaseFileId)),
                 cancellationToken
             );
+            var caseFileAdministrativeUnit = await GetBindableConfigValue(
+                layoutState,
+                instance,
+                _fiksArkivSettings.Metadata.CaseFileAdministrativeUnit,
+                x => ParseString(x, nameof(FiksArkivMetadataSettings.CaseFileAdministrativeUnit)),
+                cancellationToken
+            );
 
-            return new FiksArkivDocumentMetadata(systemId, ruleId, caseFileId, caseFileTitle, journalEntryTitle);
+            return new FiksArkivDocumentMetadata(
+                systemId,
+                ruleId,
+                caseFileId,
+                caseFileTitle,
+                journalEntryTitle,
+                caseFileAdministrativeUnit
+            );
         }
         catch (Exception e)
         {
@@ -212,23 +226,35 @@ internal sealed class FiksArkivConfigResolver : IFiksArkivConfigResolver
         );
 
     /// <inheritdoc />
-    public async Task<Klassifikasjon> GetInstanceOwnerClassification(
+    public async Task<IReadOnlyList<Klassifikasjon>> GetCaseFileClassifications(
         Authenticated auth,
         CancellationToken cancellationToken = default
     )
     {
-        cancellationToken.ThrowIfCancellationRequested();
+        var entries = _fiksArkivSettings.Metadata?.CaseFileClassifications;
+        if (entries is null || entries.Count == 0)
+            return [];
 
-        return auth switch
+        var result = new List<Klassifikasjon>(entries.Count);
+        foreach (var entry in entries)
         {
-            Authenticated.User user => await KlassifikasjonFactory.CreateUser(user), // Note: Doesn't accept cancellation token.. yet
-            Authenticated.SystemUser systemUser => KlassifikasjonFactory.CreateSystemUser(systemUser),
-            Authenticated.ServiceOwner serviceOwner => KlassifikasjonFactory.CreateServiceOwner(serviceOwner),
-            Authenticated.Org org => KlassifikasjonFactory.CreateOrganization(org),
-            _ => throw new FiksArkivException(
-                $"Could not determine submitter details from authentication context: {auth}"
-            ),
-        };
+            var classification = entry.Source switch
+            {
+                FiksArkivClassificationSource.InstanceOwner => await GetInstanceOwnerClassification(
+                    auth,
+                    cancellationToken: cancellationToken
+                ),
+                null => entry.ToKlassifikasjon(),
+                _ => throw new FiksArkivException($"Unsupported classification source: {entry.Source}"),
+            };
+
+            // Forward the IsRestricted value from config
+            classification.ErSkjermet = entry.IsRestricted;
+
+            result.Add(classification);
+        }
+
+        return result;
     }
 
     /// <inheritdoc />
@@ -298,6 +324,25 @@ internal sealed class FiksArkivConfigResolver : IFiksArkivConfigResolver
     {
         var unitOfWork = await _instanceDataUnitOfWorkInitializer.Init(instance, null, null);
         return await _layoutStateInitializer.Init(unitOfWork, null);
+    }
+
+    private static async Task<Klassifikasjon> GetInstanceOwnerClassification(
+        Authenticated auth,
+        CancellationToken cancellationToken = default
+    )
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return auth switch
+        {
+            Authenticated.User user => await KlassifikasjonFactory.CreateUser(user),
+            Authenticated.SystemUser systemUser => KlassifikasjonFactory.CreateSystemUser(systemUser),
+            Authenticated.ServiceOwner serviceOwner => KlassifikasjonFactory.CreateServiceOwner(serviceOwner),
+            Authenticated.Org org => KlassifikasjonFactory.CreateOrganization(org),
+            _ => throw new FiksArkivException(
+                $"Could not determine submitter details from authentication context: {auth}"
+            ),
+        };
     }
 
     private static async Task<T?> GetBindableConfigValue<T>(

--- a/src/Altinn.App.Clients.Fiks/FiksArkiv/FiksArkivDefaultPayloadGenerator.cs
+++ b/src/Altinn.App.Clients.Fiks/FiksArkiv/FiksArkivDefaultPayloadGenerator.cs
@@ -14,7 +14,6 @@ using KS.Fiks.Arkiv.Models.V1.Kodelister;
 using KS.Fiks.Arkiv.Models.V1.Metadatakatalog;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Kode = KS.Fiks.Arkiv.Models.V1.Kodelister.Kode;
 
 namespace Altinn.App.Clients.Fiks.FiksArkiv;
@@ -27,7 +26,6 @@ internal sealed class FiksArkivDefaultPayloadGenerator : IFiksArkivPayloadGenera
     private readonly ILogger<FiksArkivDefaultPayloadGenerator> _logger;
     private readonly IHostEnvironment _hostEnvironment;
     private readonly IFiksArkivConfigResolver _fiksArkivConfigResolver;
-    private readonly FiksIOSettings _fiksIOSettings;
     private readonly TimeProvider _timeProvider;
 
     private bool _indentXmlSerialization => !_hostEnvironment.IsProduction();
@@ -39,7 +37,6 @@ internal sealed class FiksArkivDefaultPayloadGenerator : IFiksArkivPayloadGenera
         ILogger<FiksArkivDefaultPayloadGenerator> logger,
         IHostEnvironment hostEnvironment,
         IFiksArkivConfigResolver fiksArkivConfigResolver,
-        IOptions<FiksIOSettings> fiksIOSettings,
         TimeProvider? timeProvider = null
     )
     {
@@ -49,7 +46,6 @@ internal sealed class FiksArkivDefaultPayloadGenerator : IFiksArkivPayloadGenera
         _logger = logger;
         _hostEnvironment = hostEnvironment;
         _fiksArkivConfigResolver = fiksArkivConfigResolver;
-        _fiksIOSettings = fiksIOSettings.Value;
         _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
@@ -67,6 +63,7 @@ internal sealed class FiksArkivDefaultPayloadGenerator : IFiksArkivPayloadGenera
                 $"Unsupported message type: {messageType}. {nameof(FiksArkivDefaultPayloadGenerator)} can only handle {FiksArkivConstants.MessageTypes.CreateArchiveRecord} requests."
             );
 
+        var now = _timeProvider.GetUtcNow();
         var appMetadata = await _appMetadata.GetApplicationMetadata();
         var documentCreator = appMetadata.AppIdentifier.Org;
         var archiveDocuments = await GetArchiveDocuments(instance, cancellationToken);
@@ -74,7 +71,7 @@ internal sealed class FiksArkivDefaultPayloadGenerator : IFiksArkivPayloadGenera
         var documentMetadata = await _fiksArkivConfigResolver.GetArchiveDocumentMetadata(instance, cancellationToken);
         var recipientParty = _fiksArkivConfigResolver.GetRecipientParty(instance, recipient);
         var instanceOwnerParty = await _fiksArkivConfigResolver.GetInstanceOwnerParty(instance, cancellationToken);
-        var instanceOwnerClassification = await _fiksArkivConfigResolver.GetInstanceOwnerClassification(
+        var caseFileClassifications = await _fiksArkivConfigResolver.GetCaseFileClassifications(
             _authenticationContext.Current,
             cancellationToken
         );
@@ -83,9 +80,12 @@ internal sealed class FiksArkivDefaultPayloadGenerator : IFiksArkivPayloadGenera
         {
             Tittel = documentMetadata?.CaseFileTitle ?? defaultDocumentTitle,
             OffentligTittel = documentMetadata?.CaseFileTitle ?? defaultDocumentTitle,
-            AdministrativEnhet = new AdministrativEnhet { Navn = documentCreator },
-            Saksaar = _timeProvider.GetLocalNow().Year,
-            Saksdato = _timeProvider.GetLocalNow().DateTime,
+            AdministrativEnhet = new AdministrativEnhet
+            {
+                Navn = documentMetadata?.CaseFileAdministrativeUnit ?? documentCreator,
+            },
+            Saksaar = now.Year,
+            Saksdato = now.UtcDateTime,
             ReferanseEksternNoekkel = new EksternNoekkel
             {
                 Fagsystem = appMetadata.AppIdentifier.ToString(),
@@ -93,13 +93,16 @@ internal sealed class FiksArkivDefaultPayloadGenerator : IFiksArkivPayloadGenera
             },
         };
 
-        caseFile.Klassifikasjon.Add(instanceOwnerClassification);
+        foreach (var classification in caseFileClassifications)
+        {
+            caseFile.Klassifikasjon.Add(classification);
+        }
 
         var journalEntry = new Journalpost
         {
-            Journalaar = _timeProvider.GetLocalNow().Year,
-            DokumentetsDato = _timeProvider.GetLocalNow().DateTime,
-            SendtDato = _timeProvider.GetLocalNow().DateTime,
+            Journalaar = now.Year,
+            DokumentetsDato = now.UtcDateTime,
+            SendtDato = now.UtcDateTime,
             Tittel = documentMetadata?.JournalEntryTitle ?? defaultDocumentTitle,
             OffentligTittel = documentMetadata?.JournalEntryTitle ?? defaultDocumentTitle,
             OpprettetAv = documentCreator,
@@ -131,12 +134,12 @@ internal sealed class FiksArkivDefaultPayloadGenerator : IFiksArkivPayloadGenera
         }
 
         // Main form data file
-        journalEntry.Dokumentbeskrivelse.Add(GetDocumentDescription(archiveDocuments.PrimaryDocument));
+        journalEntry.Dokumentbeskrivelse.Add(GetDocumentDescription(archiveDocuments.PrimaryDocument, now));
 
         // Attachments
         foreach (var attachment in archiveDocuments.AttachmentDocuments)
         {
-            journalEntry.Dokumentbeskrivelse.Add(GetDocumentDescription(attachment));
+            journalEntry.Dokumentbeskrivelse.Add(GetDocumentDescription(attachment, now));
         }
 
         // Archive record
@@ -170,6 +173,8 @@ internal sealed class FiksArkivDefaultPayloadGenerator : IFiksArkivPayloadGenera
             primaryDataElement,
             primaryDocumentSettings.Filename,
             DokumenttypeKoder.Dokument,
+            primaryDocumentSettings.Format,
+            primaryDocumentSettings.Variant,
             instanceId,
             cancellationToken
         );
@@ -191,6 +196,8 @@ internal sealed class FiksArkivDefaultPayloadGenerator : IFiksArkivPayloadGenera
                             x,
                             attachmentSetting.Filename,
                             DokumenttypeKoder.Vedlegg,
+                            attachmentSetting.Format,
+                            attachmentSetting.Variant,
                             instanceId,
                             cancellationToken
                         )
@@ -206,6 +213,8 @@ internal sealed class FiksArkivDefaultPayloadGenerator : IFiksArkivPayloadGenera
         DataElement dataElement,
         string? filename,
         Kode fileTypeCode,
+        FiksArkivCode? fileFormat,
+        FiksArkivCode? fileVariant,
         InstanceIdentifier instanceId,
         CancellationToken cancellationToken = default
     )
@@ -225,11 +234,13 @@ internal sealed class FiksArkivDefaultPayloadGenerator : IFiksArkivPayloadGenera
                     cancellationToken: cancellationToken
                 )
             ),
-            fileTypeCode
+            fileTypeCode,
+            fileFormat,
+            fileVariant
         );
     }
 
-    private Dokumentbeskrivelse GetDocumentDescription(MessagePayloadWrapper payloadWrapper)
+    private static Dokumentbeskrivelse GetDocumentDescription(MessagePayloadWrapper payloadWrapper, DateTimeOffset now)
     {
         var documentClassification =
             payloadWrapper.FileTypeCode == DokumenttypeKoder.Dokument
@@ -254,25 +265,16 @@ internal sealed class FiksArkivDefaultPayloadGenerator : IFiksArkivPayloadGenera
                 KodeProperty = documentClassification.Verdi,
                 Beskrivelse = documentClassification.Beskrivelse,
             },
-            OpprettetDato = _timeProvider.GetLocalNow().DateTime,
+            OpprettetDato = now.UtcDateTime,
         };
 
         metadata.Dokumentobjekt.Add(
             new Dokumentobjekt
             {
-                SystemID = new SystemID
-                {
-                    Value = _fiksIOSettings.AccountId.ToString(),
-                    Label = FiksArkivConstants.AltinnSystemId,
-                },
                 Filnavn = payloadWrapper.Payload.Filename,
                 ReferanseDokumentfil = payloadWrapper.Payload.Filename,
-                Format = new Format { KodeProperty = payloadWrapper.Payload.GetDotlessFileExtension() },
-                Variantformat = new Variantformat
-                {
-                    KodeProperty = VariantformatKoder.Produksjonsformat.Verdi,
-                    Beskrivelse = VariantformatKoder.Produksjonsformat.Beskrivelse,
-                },
+                Format = payloadWrapper.GetFileFormat(),
+                Variantformat = payloadWrapper.GetFileVariant(),
             }
         );
 

--- a/src/Altinn.App.Clients.Fiks/FiksArkiv/IFiksArkivConfigResolver.cs
+++ b/src/Altinn.App.Clients.Fiks/FiksArkiv/IFiksArkivConfigResolver.cs
@@ -54,9 +54,11 @@ public interface IFiksArkivConfigResolver
     Task<Korrespondansepart?> GetInstanceOwnerParty(Instance instance, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Gets the classification of the instance owner (klassifikasjon).
+    /// Gets the case file classifications (klassifikasjoner) for the shipment.
+    /// Always includes the instance owner classification derived from <paramref name="auth"/>, followed by any
+    /// classifications configured in <see cref="FiksArkivMetadataSettings.CaseFileClassifications"/>.
     /// </summary>
-    Task<Klassifikasjon> GetInstanceOwnerClassification(
+    Task<IReadOnlyList<Klassifikasjon>> GetCaseFileClassifications(
         Authenticated auth,
         CancellationToken cancellationToken = default
     );

--- a/src/Altinn.App.Clients.Fiks/FiksArkiv/Models/FiksArkivDocumentMetadata.cs
+++ b/src/Altinn.App.Clients.Fiks/FiksArkiv/Models/FiksArkivDocumentMetadata.cs
@@ -8,10 +8,12 @@ namespace Altinn.App.Clients.Fiks.FiksArkiv.Models;
 /// <param name="CaseFileId">The case file's identifier (XML tag: mappe->referanseEksternNoekkel->noekkel)</param>
 /// <param name="CaseFileTitle">The case file's title (XML tag: mappe->tittel)</param>
 /// <param name="JournalEntryTitle">The journal entry's title (XML tag: registrering->tittel)</param>
+/// <param name="CaseFileAdministrativeUnit">The case file's administrative unit (XML tag: mappe->administrativEnhet)</param>
 public sealed record FiksArkivDocumentMetadata(
     string? SystemId,
     string? RuleId,
     string? CaseFileId,
     string? CaseFileTitle,
-    string? JournalEntryTitle
+    string? JournalEntryTitle,
+    string? CaseFileAdministrativeUnit
 );

--- a/src/Altinn.App.Clients.Fiks/FiksArkiv/Models/FiksArkivSettings.cs
+++ b/src/Altinn.App.Clients.Fiks/FiksArkiv/Models/FiksArkivSettings.cs
@@ -123,11 +123,28 @@ public sealed record FiksArkivMetadataSettings
     public FiksArkivBindableValue<string>? CaseFileTitle { get; set; }
 
     /// <summary>
+    /// Optional classifications (klassifikasjon) to attach to the generated saksmappe (case file) element in the arkivmelding.xml.
+    /// Entries are emitted in the order listed. Each entry is either a built-in dynamic
+    /// <see cref="FiksArkivClassification.Source"/> (e.g. the instance owner identity) or an explicitly
+    /// configured system/class/title. The instance owner classification is no longer added implicitly;
+    /// add an entry with <see cref="FiksArkivClassificationSource.InstanceOwner"/> to include it.
+    /// </summary>
+    [JsonPropertyName("caseFileClassifications")]
+    public IReadOnlyList<FiksArkivClassification>? CaseFileClassifications { get; set; }
+
+    /// <summary>
     /// The title to use for the generated journalpost (journal entry) element in the arkivmelding.xml.
     /// If no title is provided, the value will default to the application title as defined in applicationmetadata.json.
     /// </summary>
     [JsonPropertyName("journalEntryTitle")]
     public FiksArkivBindableValue<string>? JournalEntryTitle { get; set; }
+
+    /// <summary>
+    /// The administrative unit (administrativEnhet) to use for the generated saksmappe (case file) element in the arkivmelding.xml.
+    /// If no value is provided, the application owner's organization code will be used.
+    /// </summary>
+    [JsonPropertyName("caseFileAdministrativeUnit")]
+    public FiksArkivBindableValue<string>? CaseFileAdministrativeUnit { get; set; }
 
     /// <summary>
     /// Internal validation based on the requirements of <see cref="FiksArkivDefaultPayloadGenerator"/>
@@ -141,6 +158,16 @@ public sealed record FiksArkivMetadataSettings
         CaseFileId?.Validate($"{propertyName}.{nameof(CaseFileId)}", dataTypes, appModelResolver);
         CaseFileTitle?.Validate($"{propertyName}.{nameof(CaseFileTitle)}", dataTypes, appModelResolver);
         JournalEntryTitle?.Validate($"{propertyName}.{nameof(JournalEntryTitle)}", dataTypes, appModelResolver);
+        CaseFileAdministrativeUnit?.Validate(
+            $"{propertyName}.{nameof(CaseFileAdministrativeUnit)}",
+            dataTypes,
+            appModelResolver
+        );
+
+        foreach (var classification in CaseFileClassifications ?? [])
+        {
+            classification.Validate($"{propertyName}.{nameof(CaseFileClassifications)}");
+        }
     }
 }
 
@@ -412,6 +439,20 @@ public sealed record FiksArkivDataTypeSettings
     public string? Filename { get; set; }
 
     /// <summary>
+    /// Optional override for the document format (<c>dokumentobjekt.format</c>), e.g. <c>PDF/A</c>.
+    /// If not specified, the dotless file extension is used.
+    /// </summary>
+    [JsonPropertyName("format")]
+    public FiksArkivCode? Format { get; set; }
+
+    /// <summary>
+    /// Optional variant descriptor for the document (<c>dokumentobjekt.variantformat</c>), e.g. "P/Produksjonsformat" or "A/Arkivformat".
+    /// If not specified, the variant information is omitted.
+    /// </summary>
+    [JsonPropertyName("variant")]
+    public FiksArkivCode? Variant { get; set; }
+
+    /// <summary>
     /// Internal validation based on the requirements of <see cref="FiksArkivDefaultPayloadGenerator"/>
     /// </summary>
     internal void Validate(string propertyName, IReadOnlyList<DataType> dataTypes, bool requireFilename = false)
@@ -429,6 +470,9 @@ public sealed record FiksArkivDataTypeSettings
             throw new FiksArkivConfigurationException(
                 $"{propertyName}.{nameof(Filename)} configuration is required, but missing."
             );
+
+        Format?.Validate($"{propertyName}.{nameof(Format)}");
+        Variant?.Validate($"{propertyName}.{nameof(Variant)}");
     }
 
     /// <summary>
@@ -436,4 +480,113 @@ public sealed record FiksArkivDataTypeSettings
     /// </summary>
     public string GetFilenameOrDefault(string defaultExtension = "xml") =>
         !string.IsNullOrWhiteSpace(Filename) ? Filename : $"{DataType}.{defaultExtension.TrimStart('.')}";
+}
+
+/// <summary>
+/// Represents a code + description, analogous to <c>KS.Fiks.Arkiv.Models.V1.Metadatakatalog.Kode</c>
+/// </summary>
+public sealed record FiksArkivCode
+{
+    /// <summary>
+    /// The code.
+    /// </summary>
+    [JsonPropertyName("code")]
+    public required string Code { get; set; }
+
+    /// <summary>
+    /// An optional description.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    internal void Validate(string propertyName)
+    {
+        if (string.IsNullOrWhiteSpace(Code))
+            throw new FiksArkivConfigurationException(
+                $"{propertyName}.{nameof(Code)} cannot be empty or contain only whitespace. If you wish to omit this item, remove the {propertyName} configuration entry entirely."
+            );
+    }
+}
+
+/// <summary>
+/// Represents a single classification (klassifikasjon) entry attached to the saksmappe (case file).
+/// </summary>
+public sealed record FiksArkivClassification
+{
+    /// <summary>
+    /// Opt-in to a built-in, library-resolved dynamic classification (e.g. the instance owner identity).
+    /// When set, the system/class/title are resolved at shipment time and the explicit
+    /// <see cref="SystemId"/>/<see cref="ClassificationId"/>/<see cref="Title"/> fields must be left unset.
+    /// The optional <see cref="IsRestricted"/> flag is still honored.
+    /// </summary>
+    [JsonPropertyName("source")]
+    public FiksArkivClassificationSource? Source { get; set; }
+
+    /// <summary>
+    /// The identifier of the classification system this entry belongs to (klassifikasjonssystemID).
+    /// Required for an explicit entry; omit when <see cref="Source"/> is set.
+    /// </summary>
+    [JsonPropertyName("systemId")]
+    public string? SystemId { get; set; }
+
+    /// <summary>
+    /// The identifier of the class within the classification system (klasseID).
+    /// Required for an explicit entry; omit when <see cref="Source"/> is set.
+    /// </summary>
+    [JsonPropertyName("classificationId")]
+    public string? ClassificationId { get; set; }
+
+    /// <summary>
+    /// A human-readable title for the classification entry (tittel).
+    /// Required for an explicit entry; omit when <see cref="Source"/> is set.
+    /// </summary>
+    [JsonPropertyName("title")]
+    public string? Title { get; set; }
+
+    /// <summary>
+    /// Optional flag indicating that the classification is restricted (erSkjermet).
+    /// Leave <c>null</c> to omit the property from the resulting XML. Applies to both explicitly configured
+    /// and <see cref="Source"/>-resolved classifications.
+    /// </summary>
+    [JsonPropertyName("isRestricted")]
+    public bool? IsRestricted { get; set; }
+
+    internal void Validate(string propertyName)
+    {
+        if (Source is not null)
+        {
+            if (SystemId is not null || ClassificationId is not null || Title is not null)
+                throw new FiksArkivConfigurationException(
+                    $"{propertyName}.{nameof(Source)} cannot be combined with {nameof(SystemId)}, {nameof(ClassificationId)} or {nameof(Title)}. A source-based classification is fully resolved by the library."
+                );
+
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(SystemId))
+            throw new FiksArkivConfigurationException(
+                $"{propertyName}.{nameof(SystemId)} configuration is required, but missing. Did you mean to set {nameof(Source)}?"
+            );
+
+        if (string.IsNullOrWhiteSpace(ClassificationId))
+            throw new FiksArkivConfigurationException(
+                $"{propertyName}.{nameof(ClassificationId)} configuration is required, but missing."
+            );
+
+        if (string.IsNullOrWhiteSpace(Title))
+            throw new FiksArkivConfigurationException(
+                $"{propertyName}.{nameof(Title)} configuration is required, but missing."
+            );
+    }
+}
+
+/// <summary>
+/// Built-in, library-resolved dynamic classification sources for a <see cref="FiksArkivClassification"/>.
+/// </summary>
+public enum FiksArkivClassificationSource
+{
+    /// <summary>
+    /// The instance owner identity derived from the authentication context at execution time.
+    /// </summary>
+    InstanceOwner,
 }

--- a/src/Altinn.App.Clients.Fiks/FiksArkiv/Models/MessagePayloadWrapper.cs
+++ b/src/Altinn.App.Clients.Fiks/FiksArkiv/Models/MessagePayloadWrapper.cs
@@ -1,6 +1,19 @@
+using Altinn.App.Clients.Fiks.Extensions;
 using Altinn.App.Clients.Fiks.FiksIO.Models;
-using KS.Fiks.Arkiv.Models.V1.Kodelister;
+using KS.Fiks.Arkiv.Models.V1.Metadatakatalog;
+using Kode = KS.Fiks.Arkiv.Models.V1.Kodelister.Kode;
 
 namespace Altinn.App.Clients.Fiks.FiksArkiv.Models;
 
-internal sealed record MessagePayloadWrapper(FiksIOMessagePayload Payload, Kode FileTypeCode);
+internal sealed record MessagePayloadWrapper(
+    FiksIOMessagePayload Payload,
+    Kode FileTypeCode,
+    FiksArkivCode? FileFormat,
+    FiksArkivCode? FileVariant
+)
+{
+    public Format GetFileFormat() =>
+        FileFormat?.ToExternal<Format>() ?? new Format { KodeProperty = Payload.GetDotlessFileExtension() };
+
+    public Variantformat? GetFileVariant() => FileVariant?.ToExternal<Variantformat>();
+}

--- a/src/App/backend/src/Altinn.App.Clients.Fiks/FiksArkiv/FiksArkivConfigResolver.cs
+++ b/src/App/backend/src/Altinn.App.Clients.Fiks/FiksArkiv/FiksArkivConfigResolver.cs
@@ -118,8 +118,22 @@ internal sealed class FiksArkivConfigResolver : IFiksArkivConfigResolver
             x => ParseMetadataString(x, nameof(FiksArkivMetadataSettings.CaseFileId)),
             cancellationToken
         );
+        var caseFileAdministrativeUnit = await GetBindableConfigValue(
+            layoutState,
+            instance,
+            _fiksArkivSettings.Metadata.CaseFileAdministrativeUnit,
+            x => ParseMetadataString(x, nameof(FiksArkivMetadataSettings.CaseFileAdministrativeUnit)),
+            cancellationToken
+        );
 
-        return new FiksArkivDocumentMetadata(systemId, ruleId, caseFileId, caseFileTitle, journalEntryTitle);
+        return new FiksArkivDocumentMetadata(
+            systemId,
+            ruleId,
+            caseFileId,
+            caseFileTitle,
+            journalEntryTitle,
+            caseFileAdministrativeUnit
+        );
     }
 
     /// <inheritdoc />
@@ -206,23 +220,35 @@ internal sealed class FiksArkivConfigResolver : IFiksArkivConfigResolver
         );
 
     /// <inheritdoc />
-    public async Task<Klassifikasjon> GetInstanceOwnerClassification(
+    public async Task<IReadOnlyList<Klassifikasjon>> GetCaseFileClassifications(
         Authenticated auth,
         CancellationToken cancellationToken = default
     )
     {
-        cancellationToken.ThrowIfCancellationRequested();
+        var entries = _fiksArkivSettings.Metadata?.CaseFileClassifications;
+        if (entries is null || entries.Count == 0)
+            return [];
 
-        return auth switch
+        var result = new List<Klassifikasjon>(entries.Count);
+        foreach (var entry in entries)
         {
-            Authenticated.User user => await KlassifikasjonFactory.CreateUser(user), // Note: Doesn't accept cancellation token.. yet
-            Authenticated.SystemUser systemUser => KlassifikasjonFactory.CreateSystemUser(systemUser),
-            Authenticated.ServiceOwner serviceOwner => KlassifikasjonFactory.CreateServiceOwner(serviceOwner),
-            Authenticated.Org org => KlassifikasjonFactory.CreateOrganization(org),
-            _ => throw new FiksArkivException(
-                $"Could not determine submitter details from authentication context: {auth}"
-            ),
-        };
+            var classification = entry.Source switch
+            {
+                FiksArkivClassificationSource.InstanceOwner => await GetInstanceOwnerClassification(
+                    auth,
+                    cancellationToken: cancellationToken
+                ),
+                null => entry.ToKlassifikasjon(),
+                _ => throw new FiksArkivException($"Unsupported classification source: {entry.Source}"),
+            };
+
+            // Forward the IsRestricted value from config
+            classification.ErSkjermet = entry.IsRestricted;
+
+            result.Add(classification);
+        }
+
+        return result;
     }
 
     /// <inheritdoc />
@@ -286,6 +312,25 @@ internal sealed class FiksArkivConfigResolver : IFiksArkivConfigResolver
         }
 
         return null;
+    }
+
+    private static async Task<Klassifikasjon> GetInstanceOwnerClassification(
+        Authenticated auth,
+        CancellationToken cancellationToken = default
+    )
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return auth switch
+        {
+            Authenticated.User user => await KlassifikasjonFactory.CreateUser(user), // Note: Doesn't accept cancellation token.. yet
+            Authenticated.SystemUser systemUser => KlassifikasjonFactory.CreateSystemUser(systemUser),
+            Authenticated.ServiceOwner serviceOwner => KlassifikasjonFactory.CreateServiceOwner(serviceOwner),
+            Authenticated.Org org => KlassifikasjonFactory.CreateOrganization(org),
+            _ => throw new FiksArkivException(
+                $"Could not determine submitter details from authentication context: {auth}"
+            ),
+        };
     }
 
     private static async Task<T?> GetBindableConfigValue<T>(

--- a/src/App/backend/src/Altinn.App.Clients.Fiks/FiksArkiv/FiksArkivDefaultPayloadGenerator.cs
+++ b/src/App/backend/src/Altinn.App.Clients.Fiks/FiksArkiv/FiksArkivDefaultPayloadGenerator.cs
@@ -4,16 +4,18 @@ using Altinn.App.Clients.Fiks.Exceptions;
 using Altinn.App.Clients.Fiks.Extensions;
 using Altinn.App.Clients.Fiks.FiksArkiv.Models;
 using Altinn.App.Clients.Fiks.FiksIO.Models;
+using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.Auth;
 using Altinn.App.Core.Internal.App;
-using Altinn.App.Core.Internal.Data;
-using Altinn.App.Core.Models;
+using Altinn.App.Core.Internal.AppModel;
+using Altinn.App.Core.Internal.Process.Elements;
 using Altinn.Platform.Storage.Interface.Models;
 using KS.Fiks.Arkiv.Models.V1.Arkivering.Arkivmelding;
 using KS.Fiks.Arkiv.Models.V1.Kodelister;
 using KS.Fiks.Arkiv.Models.V1.Metadatakatalog;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Kode = KS.Fiks.Arkiv.Models.V1.Kodelister.Kode;
 
 namespace Altinn.App.Clients.Fiks.FiksArkiv;
@@ -21,40 +23,41 @@ namespace Altinn.App.Clients.Fiks.FiksArkiv;
 internal sealed class FiksArkivDefaultPayloadGenerator : IFiksArkivPayloadGenerator
 {
     private readonly IAppMetadata _appMetadata;
-    private readonly IDataClient _dataClient;
     private readonly IAuthenticationContext _authenticationContext;
     private readonly ILogger<FiksArkivDefaultPayloadGenerator> _logger;
     private readonly IHostEnvironment _hostEnvironment;
     private readonly IFiksArkivConfigResolver _fiksArkivConfigResolver;
-    private readonly TimeProvider _timeProvider;
+    private readonly FiksArkivSettings _fiksArkivSettings;
+    private readonly IAppModel _appModelResolver;
 
     private bool _indentXmlSerialization => !_hostEnvironment.IsProduction();
 
     public FiksArkivDefaultPayloadGenerator(
         IAppMetadata appMetadata,
-        IDataClient dataClient,
         IAuthenticationContext authenticationContext,
         ILogger<FiksArkivDefaultPayloadGenerator> logger,
         IHostEnvironment hostEnvironment,
         IFiksArkivConfigResolver fiksArkivConfigResolver,
-        TimeProvider? timeProvider = null
+        IAppModel appModelResolver,
+        IOptions<FiksArkivSettings> fiksArkivSettings
     )
     {
         _appMetadata = appMetadata;
-        _dataClient = dataClient;
         _authenticationContext = authenticationContext;
         _logger = logger;
         _hostEnvironment = hostEnvironment;
         _fiksArkivConfigResolver = fiksArkivConfigResolver;
-        _timeProvider = timeProvider ?? TimeProvider.System;
+        _appModelResolver = appModelResolver;
+        _fiksArkivSettings = fiksArkivSettings.Value;
     }
 
     /// <inheritdoc />
     public async Task<IEnumerable<FiksIOMessagePayload>> GeneratePayload(
         string taskId,
-        Instance instance,
         FiksArkivRecipient recipient,
         string messageType,
+        DateTimeOffset executionReferenceTime,
+        IInstanceDataAccessor dataAccessor,
         CancellationToken cancellationToken = default
     )
     {
@@ -63,12 +66,19 @@ internal sealed class FiksArkivDefaultPayloadGenerator : IFiksArkivPayloadGenera
                 $"Unsupported message type: {messageType}. {nameof(FiksArkivDefaultPayloadGenerator)} can only handle {FiksArkivConstants.MessageTypes.CreateArchiveRecord} requests."
             );
 
-        var now = _timeProvider.GetUtcNow();
+        // Every generated date derives from the one retry-stable reference time the workflow engine supplies, so a
+        // retried step reproduces the exact same archive record. It is normalized to UTC so the arkivmelding carries
+        // unambiguous, offset-qualified timestamps regardless of the offset the caller used.
+        DateTimeOffset referenceTime = executionReferenceTime.ToUniversalTime();
+        var instance = dataAccessor.Instance;
         var appMetadata = await _appMetadata.GetApplicationMetadata();
         var documentCreator = appMetadata.AppIdentifier.Org;
-        var archiveDocuments = await GetArchiveDocuments(instance, cancellationToken);
+        var archiveDocuments = await GetArchiveDocuments(dataAccessor, cancellationToken);
         var defaultDocumentTitle = await _fiksArkivConfigResolver.GetApplicationTitle(cancellationToken);
-        var documentMetadata = await _fiksArkivConfigResolver.GetArchiveDocumentMetadata(instance, cancellationToken);
+        var documentMetadata = await _fiksArkivConfigResolver.GetArchiveDocumentMetadata(
+            dataAccessor,
+            cancellationToken
+        );
         var recipientParty = _fiksArkivConfigResolver.GetRecipientParty(instance, recipient);
         var instanceOwnerParty = await _fiksArkivConfigResolver.GetInstanceOwnerParty(instance, cancellationToken);
         var caseFileClassifications = await _fiksArkivConfigResolver.GetCaseFileClassifications(
@@ -84,8 +94,8 @@ internal sealed class FiksArkivDefaultPayloadGenerator : IFiksArkivPayloadGenera
             {
                 Navn = documentMetadata?.CaseFileAdministrativeUnit ?? documentCreator,
             },
-            Saksaar = now.Year,
-            Saksdato = now.UtcDateTime,
+            Saksaar = referenceTime.Year,
+            Saksdato = referenceTime.UtcDateTime,
             ReferanseEksternNoekkel = new EksternNoekkel
             {
                 Fagsystem = appMetadata.AppIdentifier.ToString(),
@@ -100,9 +110,9 @@ internal sealed class FiksArkivDefaultPayloadGenerator : IFiksArkivPayloadGenera
 
         var journalEntry = new Journalpost
         {
-            Journalaar = now.Year,
-            DokumentetsDato = now.UtcDateTime,
-            SendtDato = now.UtcDateTime,
+            Journalaar = referenceTime.Year,
+            DokumentetsDato = referenceTime.UtcDateTime,
+            SendtDato = referenceTime.UtcDateTime,
             Tittel = documentMetadata?.JournalEntryTitle ?? defaultDocumentTitle,
             OffentligTittel = documentMetadata?.JournalEntryTitle ?? defaultDocumentTitle,
             OpprettetAv = documentCreator,
@@ -134,12 +144,12 @@ internal sealed class FiksArkivDefaultPayloadGenerator : IFiksArkivPayloadGenera
         }
 
         // Main form data file
-        journalEntry.Dokumentbeskrivelse.Add(GetDocumentDescription(archiveDocuments.PrimaryDocument, now));
+        journalEntry.Dokumentbeskrivelse.Add(GetDocumentDescription(archiveDocuments.PrimaryDocument, referenceTime));
 
         // Attachments
         foreach (var attachment in archiveDocuments.AttachmentDocuments)
         {
-            journalEntry.Dokumentbeskrivelse.Add(GetDocumentDescription(attachment, now));
+            journalEntry.Dokumentbeskrivelse.Add(GetDocumentDescription(attachment, referenceTime));
         }
 
         // Archive record
@@ -162,11 +172,12 @@ internal sealed class FiksArkivDefaultPayloadGenerator : IFiksArkivPayloadGenera
     }
 
     private async Task<FiksArkivDocuments> GetArchiveDocuments(
-        Instance instance,
+        IInstanceDataAccessor dataAccessor,
         CancellationToken cancellationToken = default
     )
     {
-        InstanceIdentifier instanceId = new(instance.Id);
+        cancellationToken.ThrowIfCancellationRequested();
+        var instance = dataAccessor.Instance;
         var primaryDocumentSettings = _fiksArkivConfigResolver.PrimaryDocumentSettings;
         var primaryDataElement = instance.GetRequiredDataElement(primaryDocumentSettings.DataType);
         var primaryDocument = await GetPayload(
@@ -175,16 +186,13 @@ internal sealed class FiksArkivDefaultPayloadGenerator : IFiksArkivPayloadGenera
             DokumenttypeKoder.Dokument,
             primaryDocumentSettings.Format,
             primaryDocumentSettings.Variant,
-            instanceId,
-            cancellationToken
+            dataAccessor
         );
 
         List<MessagePayloadWrapper> attachmentDocuments = [];
         foreach (var attachmentSetting in _fiksArkivConfigResolver.AttachmentSettings)
         {
-            IReadOnlyList<DataElement> dataElements = instance
-                .GetOptionalDataElements(attachmentSetting.DataType)
-                .ToList();
+            IReadOnlyList<DataElement> dataElements = [.. instance.GetOptionalDataElements(attachmentSetting.DataType)];
 
             if (dataElements.Any() is false)
                 continue;
@@ -198,8 +206,7 @@ internal sealed class FiksArkivDefaultPayloadGenerator : IFiksArkivPayloadGenera
                             DokumenttypeKoder.Vedlegg,
                             attachmentSetting.Format,
                             attachmentSetting.Variant,
-                            instanceId,
-                            cancellationToken
+                            dataAccessor
                         )
                     )
                 )
@@ -209,38 +216,33 @@ internal sealed class FiksArkivDefaultPayloadGenerator : IFiksArkivPayloadGenera
         return new FiksArkivDocuments(primaryDocument, attachmentDocuments);
     }
 
-    private async Task<MessagePayloadWrapper> GetPayload(
+    private static async Task<MessagePayloadWrapper> GetPayload(
         DataElement dataElement,
         string? filename,
         Kode fileTypeCode,
         FiksArkivCode? fileFormat,
         FiksArkivCode? fileVariant,
-        InstanceIdentifier instanceId,
-        CancellationToken cancellationToken = default
+        IInstanceDataAccessor dataAccessor
     )
     {
-        if (string.IsNullOrWhiteSpace(filename) is false)
-            dataElement.Filename = filename;
-        else if (string.IsNullOrWhiteSpace(dataElement.Filename))
-            dataElement.Filename = $"{dataElement.DataType}{dataElement.GetExtensionForContentType()}";
+        string payloadFilename = string.IsNullOrWhiteSpace(filename)
+            ? string.IsNullOrWhiteSpace(dataElement.Filename)
+                ? $"{dataElement.DataType}{dataElement.GetExtensionForContentType()}"
+                : dataElement.Filename
+            : filename;
 
         return new MessagePayloadWrapper(
-            new FiksIOMessagePayload(
-                dataElement.Filename,
-                await _dataClient.GetDataBytes(
-                    instanceId.InstanceOwnerPartyId,
-                    instanceId.InstanceGuid,
-                    Guid.Parse(dataElement.Id),
-                    cancellationToken: cancellationToken
-                )
-            ),
+            new FiksIOMessagePayload(payloadFilename, await dataAccessor.GetBinaryData(dataElement)),
             fileTypeCode,
             fileFormat,
             fileVariant
         );
     }
 
-    private static Dokumentbeskrivelse GetDocumentDescription(MessagePayloadWrapper payloadWrapper, DateTimeOffset now)
+    private static Dokumentbeskrivelse GetDocumentDescription(
+        MessagePayloadWrapper payloadWrapper,
+        DateTimeOffset referenceTime
+    )
     {
         var documentClassification =
             payloadWrapper.FileTypeCode == DokumenttypeKoder.Dokument
@@ -265,7 +267,7 @@ internal sealed class FiksArkivDefaultPayloadGenerator : IFiksArkivPayloadGenera
                 KodeProperty = documentClassification.Verdi,
                 Beskrivelse = documentClassification.Beskrivelse,
             },
-            OpprettetDato = now.UtcDateTime,
+            OpprettetDato = referenceTime.UtcDateTime,
         };
 
         metadata.Dokumentobjekt.Add(
@@ -279,5 +281,28 @@ internal sealed class FiksArkivDefaultPayloadGenerator : IFiksArkivPayloadGenera
         );
 
         return metadata;
+    }
+
+    /// <inheritdoc />
+    public Task ValidateConfiguration(
+        IReadOnlyList<DataType> configuredDataTypes,
+        IReadOnlyList<ProcessTask> configuredProcessTasks
+    )
+    {
+        if (_fiksArkivSettings.Recipient is null)
+            throw new FiksArkivConfigurationException(
+                $"{nameof(FiksArkivSettings.Recipient)} configuration is required, but missing."
+            );
+        _fiksArkivSettings.Recipient.Validate(configuredDataTypes, _appModelResolver);
+
+        if (_fiksArkivSettings.Documents is null)
+            throw new FiksArkivConfigurationException(
+                $"{nameof(FiksArkivSettings.Documents)} configuration is required, but missing."
+            );
+        _fiksArkivSettings.Documents.Validate(configuredDataTypes);
+
+        _fiksArkivSettings.Metadata?.Validate(configuredDataTypes, _appModelResolver);
+
+        return Task.CompletedTask;
     }
 }

--- a/src/App/backend/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/FiksArkivDefaultPayloadGeneratorTest.cs
+++ b/src/App/backend/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/FiksArkivDefaultPayloadGeneratorTest.cs
@@ -5,14 +5,13 @@ using Altinn.App.Clients.Fiks.FiksArkiv.Models;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.Auth;
-using Altinn.App.Core.Internal.Data;
 using Altinn.App.Core.Internal.Language;
 using Altinn.App.Core.Models;
 using Altinn.App.Tests.Common.Auth;
 using Altinn.Platform.Register.Models;
 using Altinn.Platform.Storage.Interface.Models;
+using KS.Fiks.Arkiv.Models.V1.Arkivering.Arkivmelding;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Time.Testing;
 using Moq;
 
 namespace Altinn.App.Clients.Fiks.Tests.FiksArkiv;
@@ -24,8 +23,7 @@ public class FiksArkivDefaultPayloadGeneratorTest
     private static readonly XsdValidator _xsdValidator = new();
     private static readonly DateTimeOffset _now = DateTimeOffset.Parse("2025-10-24T09:58:00.000000Z");
 
-    // Built fresh per test invocation because the production code mutates DataElement.Filename;
-    // reusing a static instance leaks state across test cases.
+    // Built fresh per test invocation so no test case can leak instance state into another.
     private static Instance NewDefaultInstance() =>
         new()
         {
@@ -262,14 +260,16 @@ public class FiksArkivDefaultPayloadGeneratorTest
     {
         // Arrange
         await using var fixture = CreateFixture(testCase);
+        var dataAccessor = Factories.DataAccessor(NewDefaultInstance());
 
         // Act
         var result = (
             await fixture.FiksArkivPayloadGenerator.GeneratePayload(
                 "",
-                NewDefaultInstance(),
                 testCase.Recipient,
-                FiksArkivConstants.MessageTypes.CreateArchiveRecord
+                FiksArkivConstants.MessageTypes.CreateArchiveRecord,
+                _now,
+                dataAccessor.Object
             )
         ).ToList();
 
@@ -296,13 +296,80 @@ public class FiksArkivDefaultPayloadGeneratorTest
         var ex = await Assert.ThrowsAsync<FiksArkivException>(() =>
             fixture.FiksArkivPayloadGenerator.GeneratePayload(
                 "",
-                new Instance(),
                 Factories.Recipient("-", "-"),
-                "non-create-type"
+                "non-create-type",
+                _now,
+                Mock.Of<IInstanceDataAccessor>()
             )
         );
 
         Assert.Contains("Unsupported message type", ex.Message);
+    }
+
+    [Fact]
+    internal async Task GeneratePayload_ReadsDocumentBytesFromAccessor()
+    {
+        // Arrange: one primary document and one attachment => exactly two reads, all through the caller's unit of
+        // work. Storage must never be consulted directly, or a retried step could archive different bytes than the
+        // ones staged on the unit of work.
+        var testCase = TestCases.Select(x => (TestCase)x[0]).Single(x => x.TestIdentifier == "1");
+        await using var fixture = CreateFixture(testCase);
+        var dataAccessor = Factories.DataAccessor(NewDefaultInstance(), "Accessor content");
+
+        // Act
+        var result = await fixture.FiksArkivPayloadGenerator.GeneratePayload(
+            "",
+            testCase.Recipient,
+            FiksArkivConstants.MessageTypes.CreateArchiveRecord,
+            _now,
+            dataAccessor.Object
+        );
+
+        // Assert
+        Assert.NotNull(result);
+        dataAccessor.Verify(x => x.GetBinaryData(It.IsAny<DataElementIdentifier>()), Times.Exactly(2));
+        fixture.DataClientMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    internal async Task GeneratePayload_WithExecutionReferenceTime_UsesOneUtcInstantForEveryGeneratedDate()
+    {
+        // Arrange: the reference time arrives with a non-UTC offset, and its local calendar date is already in the
+        // next year. Every generated date must derive from the same UTC instant, so the case year stays 2025.
+        var testCase = TestCases.Select(x => (TestCase)x[0]).Single(x => x.TestIdentifier == "1");
+        await using var fixture = CreateFixture(testCase);
+        var dataAccessor = Factories.DataAccessor(NewDefaultInstance());
+        DateTimeOffset executionReferenceTime = DateTimeOffset.Parse("2026-01-01T02:15:45+05:45");
+        DateTime expectedUtcTime = new(2025, 12, 31, 20, 30, 45, DateTimeKind.Utc);
+
+        // Act
+        var result = await fixture.FiksArkivPayloadGenerator.GeneratePayload(
+            "Task_1",
+            testCase.Recipient,
+            FiksArkivConstants.MessageTypes.CreateArchiveRecord,
+            executionReferenceTime,
+            dataAccessor.Object
+        );
+
+        // Assert
+        string archiveMessageXml = result
+            .Single(x => x.Filename == FiksArkivConstants.Filenames.ArchiveRecord)
+            .Data.ReadToString();
+        Arkivmelding archiveMessage = archiveMessageXml.DeserializeXml<Arkivmelding>()!;
+        Saksmappe caseFile = Assert.IsType<Saksmappe>(archiveMessage.Mappe);
+        Journalpost journalEntry = Assert.IsType<Journalpost>(archiveMessage.Registrering);
+
+        Assert.Equal(expectedUtcTime.Year, caseFile.Saksaar);
+        Assert.Equal(expectedUtcTime.Date, caseFile.Saksdato);
+        Assert.Equal(expectedUtcTime.Year, journalEntry.Journalaar);
+        Assert.Equal(expectedUtcTime.Date, journalEntry.DokumentetsDato);
+        Assert.Equal(expectedUtcTime, journalEntry.SendtDato);
+        Assert.NotEmpty(journalEntry.Dokumentbeskrivelse);
+        Assert.All(journalEntry.Dokumentbeskrivelse, document => Assert.Equal(expectedUtcTime, document.OpprettetDato));
+
+        // The wire format carries the UTC designator, so the archive never has to guess the offset.
+        Assert.Contains("<sendtDato>2025-12-31T20:30:45Z</sendtDato>", archiveMessageXml);
+        Assert.DoesNotContain("2026", archiveMessageXml);
     }
 
     private static TestFixture CreateFixture(TestCase testCase)
@@ -311,7 +378,6 @@ public class FiksArkivDefaultPayloadGeneratorTest
             services =>
             {
                 services.AddFiksArkiv().WithFiksArkivConfig("CustomFiksArkivSettings");
-                services.AddSingleton<TimeProvider>(new FakeTimeProvider(_now));
                 services.Configure<GeneralSettings>(options =>
                 {
                     options.HostName = "the-hostname";
@@ -335,17 +401,6 @@ public class FiksArkivDefaultPayloadGeneratorTest
         fixture
             .PartyClientMock.Setup(x => x.GetParty(It.IsAny<int>()))
             .Returns(() => ResolveInstanceOwnerParty(testCase.Auth));
-        fixture
-            .DataClientMock.Setup(x =>
-                x.GetDataBytes(
-                    It.IsAny<int>(),
-                    It.IsAny<Guid>(),
-                    It.IsAny<Guid>(),
-                    It.IsAny<StorageAuthenticationMethod?>(),
-                    It.IsAny<CancellationToken>()
-                )
-            )
-            .ReturnsAsync("Mocked content"u8.ToArray());
 
         return fixture;
     }
@@ -469,5 +524,18 @@ public class FiksArkivDefaultPayloadGeneratorTest
                 Filename = filename,
                 ContentType = contentType,
             };
+
+        // The generator reads every document through the caller's unit of work, never through Storage directly,
+        // so the accessor is the only data source a test has to provide.
+        public static Mock<IInstanceDataAccessor> DataAccessor(Instance instance, string content = "Mocked content")
+        {
+            var dataAccessor = new Mock<IInstanceDataAccessor>();
+            dataAccessor.Setup(x => x.Instance).Returns(instance);
+            dataAccessor
+                .Setup(x => x.GetBinaryData(It.IsAny<DataElementIdentifier>()))
+                .ReturnsAsync(System.Text.Encoding.UTF8.GetBytes(content));
+
+            return dataAccessor;
+        }
     }
 }

--- a/src/App/backend/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/FiksArkivDefaultPayloadGeneratorTest.cs
+++ b/src/App/backend/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/FiksArkivDefaultPayloadGeneratorTest.cs
@@ -310,11 +310,11 @@ public class FiksArkivDefaultPayloadGeneratorTest
     internal async Task GeneratePayload_ReadsDocumentBytesFromAccessor()
     {
         // Arrange: one primary document and one attachment => exactly two reads, all through the caller's unit of
-        // work. Storage must never be consulted directly, or a retried step could archive different bytes than the
-        // ones staged on the unit of work.
+        // work, or a retried step could archive different bytes than the ones staged on it. The strict mock pins
+        // down exactly which accessor members the pipeline touches; a new read fails here instead of going unnoticed.
         var testCase = TestCases.Select(x => (TestCase)x[0]).Single(x => x.TestIdentifier == "1");
         await using var fixture = CreateFixture(testCase);
-        var dataAccessor = Factories.DataAccessor(NewDefaultInstance(), "Accessor content");
+        var dataAccessor = Factories.DataAccessor(NewDefaultInstance(), "Accessor content", MockBehavior.Strict);
 
         // Act
         var result = await fixture.FiksArkivPayloadGenerator.GeneratePayload(
@@ -328,19 +328,19 @@ public class FiksArkivDefaultPayloadGeneratorTest
         // Assert
         Assert.NotNull(result);
         dataAccessor.Verify(x => x.GetBinaryData(It.IsAny<DataElementIdentifier>()), Times.Exactly(2));
-        fixture.DataClientMock.VerifyNoOtherCalls();
     }
 
     [Fact]
     internal async Task GeneratePayload_WithExecutionReferenceTime_UsesOneUtcInstantForEveryGeneratedDate()
     {
-        // Arrange: the reference time arrives with a non-UTC offset, and its local calendar date is already in the
-        // next year. Every generated date must derive from the same UTC instant, so the case year stays 2025.
+        // Arrange: half past midnight on New Year's Day in Oslo, which is still New Year's Eve in UTC. Every generated
+        // date must derive from the same UTC instant: the offset-less date and year fields follow the UTC calendar
+        // day, and the timestamps carry the UTC designator, so the archive never has to guess the offset.
         var testCase = TestCases.Select(x => (TestCase)x[0]).Single(x => x.TestIdentifier == "1");
         await using var fixture = CreateFixture(testCase);
         var dataAccessor = Factories.DataAccessor(NewDefaultInstance());
-        DateTimeOffset executionReferenceTime = DateTimeOffset.Parse("2026-01-01T02:15:45+05:45");
-        DateTime expectedUtcTime = new(2025, 12, 31, 20, 30, 45, DateTimeKind.Utc);
+        DateTimeOffset executionReferenceTime = DateTimeOffset.Parse("2026-01-01T00:30:45+01:00");
+        DateTime expectedUtcTime = new(2025, 12, 31, 23, 30, 45, DateTimeKind.Utc);
 
         // Act
         var result = await fixture.FiksArkivPayloadGenerator.GeneratePayload(
@@ -367,9 +367,12 @@ public class FiksArkivDefaultPayloadGeneratorTest
         Assert.NotEmpty(journalEntry.Dokumentbeskrivelse);
         Assert.All(journalEntry.Dokumentbeskrivelse, document => Assert.Equal(expectedUtcTime, document.OpprettetDato));
 
-        // The wire format carries the UTC designator, so the archive never has to guess the offset.
-        Assert.Contains("<sendtDato>2025-12-31T20:30:45Z</sendtDato>", archiveMessageXml);
-        Assert.DoesNotContain("2026", archiveMessageXml);
+        Assert.Contains("<saksaar>2025</saksaar>", archiveMessageXml);
+        Assert.Contains("<saksdato>2025-12-31</saksdato>", archiveMessageXml);
+        Assert.Contains("<journalaar>2025</journalaar>", archiveMessageXml);
+        Assert.Contains("<dokumentetsDato>2025-12-31</dokumentetsDato>", archiveMessageXml);
+        Assert.Contains("<sendtDato>2025-12-31T23:30:45Z</sendtDato>", archiveMessageXml);
+        Assert.Contains("<opprettetDato>2025-12-31T23:30:45Z</opprettetDato>", archiveMessageXml);
     }
 
     private static TestFixture CreateFixture(TestCase testCase)
@@ -527,10 +530,18 @@ public class FiksArkivDefaultPayloadGeneratorTest
 
         // The generator reads every document through the caller's unit of work, never through Storage directly,
         // so the accessor is the only data source a test has to provide.
-        public static Mock<IInstanceDataAccessor> DataAccessor(Instance instance, string content = "Mocked content")
+        public static Mock<IInstanceDataAccessor> DataAccessor(
+            Instance instance,
+            string content = "Mocked content",
+            MockBehavior behavior = MockBehavior.Default
+        )
         {
-            var dataAccessor = new Mock<IInstanceDataAccessor>();
+            var dataAccessor = new Mock<IInstanceDataAccessor>(behavior);
             dataAccessor.Setup(x => x.Instance).Returns(instance);
+            // The config resolver initializes layout state for the accessor's task and language when it resolves
+            // bound metadata. Under MockBehavior.Strict these are the only reads allowed besides the document bytes.
+            dataAccessor.Setup(x => x.TaskId).Returns("Task_1");
+            dataAccessor.Setup(x => x.Language).Returns((string?)null);
             dataAccessor
                 .Setup(x => x.GetBinaryData(It.IsAny<DataElementIdentifier>()))
                 .ReturnsAsync(System.Text.Encoding.UTF8.GetBytes(content));

--- a/src/App/backend/test/Altinn.App.Clients.Fiks.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/src/App/backend/test/Altinn.App.Clients.Fiks.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -63,7 +63,7 @@ namespace Altinn.App.Clients.Fiks.FiksArkiv
         Altinn.App.Clients.Fiks.FiksArkiv.Models.FiksArkivDataTypeSettings PrimaryDocumentSettings { get; }
         System.Threading.Tasks.Task<string> GetApplicationTitle(System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task<Altinn.App.Clients.Fiks.FiksArkiv.Models.FiksArkivDocumentMetadata?> GetArchiveDocumentMetadata(Altinn.App.Core.Features.IInstanceDataAccessor dataAccessor, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.Task<KS.Fiks.Arkiv.Models.V1.Arkivering.Arkivmelding.Klassifikasjon> GetInstanceOwnerClassification(Altinn.App.Core.Features.Auth.Authenticated auth, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<KS.Fiks.Arkiv.Models.V1.Arkivering.Arkivmelding.Klassifikasjon>> GetCaseFileClassifications(Altinn.App.Core.Features.Auth.Authenticated auth, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task<KS.Fiks.Arkiv.Models.V1.Arkivering.Arkivmelding.Korrespondansepart?> GetInstanceOwnerParty(Altinn.Platform.Storage.Interface.Models.Instance instance, System.Threading.CancellationToken cancellationToken = default);
         string GetInstanceReference(Altinn.Platform.Storage.Interface.Models.Instance instance);
         System.Threading.Tasks.Task<Altinn.App.Clients.Fiks.FiksArkiv.Models.FiksArkivRecipient> GetRecipient(Altinn.App.Core.Features.IInstanceDataAccessor dataAccessor, System.Threading.CancellationToken cancellationToken = default);
@@ -89,6 +89,32 @@ namespace Altinn.App.Clients.Fiks.FiksArkiv.Models
         [System.Text.Json.Serialization.JsonPropertyName("value")]
         public T Value { get; set; }
     }
+    public sealed class FiksArkivClassification : System.IEquatable<Altinn.App.Clients.Fiks.FiksArkiv.Models.FiksArkivClassification>
+    {
+        public FiksArkivClassification() { }
+        [System.Text.Json.Serialization.JsonPropertyName("classificationId")]
+        public string? ClassificationId { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("isRestricted")]
+        public bool? IsRestricted { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("source")]
+        public Altinn.App.Clients.Fiks.FiksArkiv.Models.FiksArkivClassificationSource? Source { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("systemId")]
+        public string? SystemId { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("title")]
+        public string? Title { get; set; }
+    }
+    public enum FiksArkivClassificationSource
+    {
+        InstanceOwner = 0,
+    }
+    public sealed class FiksArkivCode : System.IEquatable<Altinn.App.Clients.Fiks.FiksArkiv.Models.FiksArkivCode>
+    {
+        public FiksArkivCode() { }
+        [System.Text.Json.Serialization.JsonPropertyName("code")]
+        public required string Code { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("description")]
+        public string? Description { get; set; }
+    }
     public sealed class FiksArkivDataModelBinding : System.IEquatable<Altinn.App.Clients.Fiks.FiksArkiv.Models.FiksArkivDataModelBinding>
     {
         public FiksArkivDataModelBinding() { }
@@ -105,11 +131,16 @@ namespace Altinn.App.Clients.Fiks.FiksArkiv.Models
         public required string DataType { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("filename")]
         public string? Filename { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("format")]
+        public Altinn.App.Clients.Fiks.FiksArkiv.Models.FiksArkivCode? Format { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("variant")]
+        public Altinn.App.Clients.Fiks.FiksArkiv.Models.FiksArkivCode? Variant { get; set; }
         public string GetFilenameOrDefault(string defaultExtension = "xml") { }
     }
     public sealed class FiksArkivDocumentMetadata : System.IEquatable<Altinn.App.Clients.Fiks.FiksArkiv.Models.FiksArkivDocumentMetadata>
     {
-        public FiksArkivDocumentMetadata(string? SystemId, string? RuleId, string? CaseFileId, string? CaseFileTitle, string? JournalEntryTitle) { }
+        public FiksArkivDocumentMetadata(string? SystemId, string? RuleId, string? CaseFileId, string? CaseFileTitle, string? JournalEntryTitle, string? CaseFileAdministrativeUnit) { }
+        public string? CaseFileAdministrativeUnit { get; init; }
         public string? CaseFileId { get; init; }
         public string? CaseFileTitle { get; init; }
         public string? JournalEntryTitle { get; init; }
@@ -135,6 +166,10 @@ namespace Altinn.App.Clients.Fiks.FiksArkiv.Models
     public sealed class FiksArkivMetadataSettings : System.IEquatable<Altinn.App.Clients.Fiks.FiksArkiv.Models.FiksArkivMetadataSettings>
     {
         public FiksArkivMetadataSettings() { }
+        [System.Text.Json.Serialization.JsonPropertyName("caseFileAdministrativeUnit")]
+        public Altinn.App.Clients.Fiks.FiksArkiv.Models.FiksArkivBindableValue<string>? CaseFileAdministrativeUnit { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("caseFileClassifications")]
+        public System.Collections.Generic.IReadOnlyList<Altinn.App.Clients.Fiks.FiksArkiv.Models.FiksArkivClassification>? CaseFileClassifications { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("caseFileId")]
         public Altinn.App.Clients.Fiks.FiksArkiv.Models.FiksArkivBindableValue<string>? CaseFileId { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("caseFileTitle")]

--- a/test/Altinn.App.Clients.Fiks.Tests/Extensions/ListExtensionsTests.cs
+++ b/test/Altinn.App.Clients.Fiks.Tests/Extensions/ListExtensionsTests.cs
@@ -12,7 +12,9 @@ public class ListExtensionsTests
         return filenames
             .Select(filename => new MessagePayloadWrapper(
                 new FiksIOMessagePayload(filename, Stream.Null),
-                new Kode(".", string.Empty)
+                new Kode(".", string.Empty),
+                FileFormat: null,
+                FileVariant: null
             ))
             .ToList();
     }

--- a/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/.Verify/FiksArkivConfigResolverTest.GetCaseFileClassifications_ResolvesInstanceOwnerSource_ForKnownAuthenticationTypes.Org.verified.txt
+++ b/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/.Verify/FiksArkivConfigResolverTest.GetCaseFileClassifications_ResolvesInstanceOwnerSource_ForKnownAuthenticationTypes.Org.verified.txt
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <klassifikasjon xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivmelding/opprett/v1">
-  <klassifikasjonssystemID>Organisasjonsnummer</klassifikasjonssystemID>
+  <klassifikasjonssystemID>ORGNR</klassifikasjonssystemID>
   <klasseID>405003309</klasseID>
 </klassifikasjon>

--- a/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/.Verify/FiksArkivConfigResolverTest.GetCaseFileClassifications_ResolvesInstanceOwnerSource_ForKnownAuthenticationTypes.ServiceOwner.verified.txt
+++ b/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/.Verify/FiksArkivConfigResolverTest.GetCaseFileClassifications_ResolvesInstanceOwnerSource_ForKnownAuthenticationTypes.ServiceOwner.verified.txt
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <klassifikasjon xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivmelding/opprett/v1">
-  <klassifikasjonssystemID>Fødselsnummer</klassifikasjonssystemID>
-  <klasseID>12345678901</klasseID>
-  <tittel>Test Testesen</tittel>
+  <klassifikasjonssystemID>ORGNR</klassifikasjonssystemID>
+  <klasseID>405003309</klasseID>
+  <tittel>tdd</tittel>
 </klassifikasjon>

--- a/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/.Verify/FiksArkivConfigResolverTest.GetCaseFileClassifications_ResolvesInstanceOwnerSource_ForKnownAuthenticationTypes.SystemUser.verified.txt
+++ b/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/.Verify/FiksArkivConfigResolverTest.GetCaseFileClassifications_ResolvesInstanceOwnerSource_ForKnownAuthenticationTypes.SystemUser.verified.txt
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <klassifikasjon xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivmelding/opprett/v1">
-  <klassifikasjonssystemID>Organisasjonsnummer</klassifikasjonssystemID>
-  <klasseID>405003309</klasseID>
-  <tittel>tdd</tittel>
+  <klassifikasjonssystemID>AltinnSystembrukerId</klassifikasjonssystemID>
+  <klasseID>f58fe166-bc22-4899-beb7-c3e8e3332f43</klasseID>
+  <tittel>310702641</tittel>
 </klassifikasjon>

--- a/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/.Verify/FiksArkivConfigResolverTest.GetCaseFileClassifications_ResolvesInstanceOwnerSource_ForKnownAuthenticationTypes.User.verified.txt
+++ b/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/.Verify/FiksArkivConfigResolverTest.GetCaseFileClassifications_ResolvesInstanceOwnerSource_ForKnownAuthenticationTypes.User.verified.txt
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <klassifikasjon xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivmelding/opprett/v1">
-  <klassifikasjonssystemID>SystembrukerId</klassifikasjonssystemID>
-  <klasseID>f58fe166-bc22-4899-beb7-c3e8e3332f43</klasseID>
-  <tittel>310702641</tittel>
+  <klassifikasjonssystemID>PNR</klassifikasjonssystemID>
+  <klasseID>12345678901</klasseID>
+  <tittel>Test Testesen</tittel>
 </klassifikasjon>

--- a/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/.Verify/FiksArkivDefaultPayloadGeneratorTest.GeneratePayload_GeneratesCorrectPayload.1.verified.txt
+++ b/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/.Verify/FiksArkivDefaultPayloadGeneratorTest.GeneratePayload_GeneratesCorrectPayload.1.verified.txt
@@ -6,7 +6,7 @@
     <tittel>Test app</tittel>
     <offentligTittel>Test app</offentligTittel>
     <klassifikasjon>
-      <klassifikasjonssystemID>Fødselsnummer</klassifikasjonssystemID>
+      <klassifikasjonssystemID>PNR</klassifikasjonssystemID>
       <klasseID>12345678901</klasseID>
       <tittel>Test Testesen</tittel>
     </klassifikasjon>
@@ -39,17 +39,12 @@
         <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Dokumentet er ferdigstilt</beskrivelse>
       </dokumentstatus>
       <tittel>model.xml</tittel>
-      <opprettetDato>2025-10-24T09:58:00</opprettetDato>
+      <opprettetDato>2025-10-24T09:58:00Z</opprettetDato>
       <tilknyttetRegistreringSom>
         <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">H</kode>
         <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Hoveddokument</beskrivelse>
       </tilknyttetRegistreringSom>
       <dokumentobjekt>
-        <systemID label="Altinn Studio">f41af07b-47c3-4d3a-9a34-1baa0f575101</systemID>
-        <variantformat>
-          <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">P</kode>
-          <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Produksjonsformat</beskrivelse>
-        </variantformat>
         <format>
           <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">XML</kode>
         </format>
@@ -67,17 +62,12 @@
         <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Dokumentet er ferdigstilt</beskrivelse>
       </dokumentstatus>
       <tittel>ref-data-as-pdf.pdf</tittel>
-      <opprettetDato>2025-10-24T09:58:00</opprettetDato>
+      <opprettetDato>2025-10-24T09:58:00Z</opprettetDato>
       <tilknyttetRegistreringSom>
         <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">V</kode>
         <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Vedlegg</beskrivelse>
       </tilknyttetRegistreringSom>
       <dokumentobjekt>
-        <systemID label="Altinn Studio">f41af07b-47c3-4d3a-9a34-1baa0f575101</systemID>
-        <variantformat>
-          <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">P</kode>
-          <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Produksjonsformat</beskrivelse>
-        </variantformat>
         <format>
           <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">PDF</kode>
         </format>
@@ -94,6 +84,21 @@
         <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Mottaker</beskrivelse>
       </korrespondanseparttype>
       <korrespondansepartNavn>Recipient Name</korrespondansepartNavn>
+      <deresReferanse>https://ttd.apps.the-hostname/ttd/test-app/instances/12345/88d9baf8-2f9f-4e66-9a2f-7d345e60ed90</deresReferanse>
+    </korrespondansepart>
+    <korrespondansepart>
+      <korrespondansepartID>501337</korrespondansepartID>
+      <korrespondanseparttype>
+        <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">EA</kode>
+        <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Avsender</beskrivelse>
+      </korrespondanseparttype>
+      <korrespondansepartNavn>Test Testesen</korrespondansepartNavn>
+      <personid>12345678901</personid>
+      <postadresse>Street 1</postadresse>
+      <postnummer>0123</postnummer>
+      <poststed>City</poststed>
+      <telefonnummer>phone-no</telefonnummer>
+      <telefonnummer>mobile-no</telefonnummer>
     </korrespondansepart>
     <referanseEksternNoekkel>
       <fagsystem xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">ttd/test-app</fagsystem>
@@ -109,6 +114,6 @@
       <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Journalført</beskrivelse>
     </journalstatus>
     <dokumentetsDato>2025-10-24</dokumentetsDato>
-    <sendtDato>2025-10-24T09:58:00</sendtDato>
+    <sendtDato>2025-10-24T09:58:00Z</sendtDato>
   </registrering>
 </arkivmelding>

--- a/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/.Verify/FiksArkivDefaultPayloadGeneratorTest.GeneratePayload_GeneratesCorrectPayload.4.verified.txt
+++ b/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/.Verify/FiksArkivDefaultPayloadGeneratorTest.GeneratePayload_GeneratesCorrectPayload.4.verified.txt
@@ -6,7 +6,7 @@
     <tittel>Custom Case File Title</tittel>
     <offentligTittel>Custom Case File Title</offentligTittel>
     <klassifikasjon>
-      <klassifikasjonssystemID>Organisasjonsnummer</klassifikasjonssystemID>
+      <klassifikasjonssystemID>ORGNR</klassifikasjonssystemID>
       <klasseID>405003309</klasseID>
     </klassifikasjon>
     <referanseEksternNoekkel>
@@ -38,17 +38,12 @@
         <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Dokumentet er ferdigstilt</beskrivelse>
       </dokumentstatus>
       <tittel>Form.xml</tittel>
-      <opprettetDato>2025-10-24T09:58:00</opprettetDato>
+      <opprettetDato>2025-10-24T09:58:00Z</opprettetDato>
       <tilknyttetRegistreringSom>
         <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">H</kode>
         <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Hoveddokument</beskrivelse>
       </tilknyttetRegistreringSom>
       <dokumentobjekt>
-        <systemID label="Altinn Studio">f41af07b-47c3-4d3a-9a34-1baa0f575101</systemID>
-        <variantformat>
-          <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">P</kode>
-          <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Produksjonsformat</beskrivelse>
-        </variantformat>
         <format>
           <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">XML</kode>
         </format>
@@ -65,17 +60,21 @@
         <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Mottaker</beskrivelse>
       </korrespondanseparttype>
       <korrespondansepartNavn>Recipient Name</korrespondansepartNavn>
+      <deresReferanse>https://ttd.apps.the-hostname/ttd/test-app/instances/12345/88d9baf8-2f9f-4e66-9a2f-7d345e60ed90</deresReferanse>
     </korrespondansepart>
     <korrespondansepart>
-      <korrespondansepartID>altinn-party-id</korrespondansepartID>
+      <korrespondansepartID>5001337</korrespondansepartID>
       <korrespondanseparttype>
         <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">EA</kode>
         <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Avsender</beskrivelse>
       </korrespondanseparttype>
-      <korrespondansepartNavn>Instance Owner Org Name</korrespondansepartNavn>
-      <organisasjonid>org-number</organisasjonid>
-      <telefonnummer>duplicate-phone-no</telefonnummer>
-      <telefonnummer>duplicate-mobile-no</telefonnummer>
+      <korrespondansepartNavn>Test AS</korrespondansepartNavn>
+      <organisasjonid>405003309</organisasjonid>
+      <postadresse>Street 1</postadresse>
+      <postnummer>0123</postnummer>
+      <poststed>City</poststed>
+      <telefonnummer>phone-no</telefonnummer>
+      <telefonnummer>mobile-no</telefonnummer>
     </korrespondansepart>
     <referanseEksternNoekkel>
       <fagsystem xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">ttd/test-app</fagsystem>
@@ -91,6 +90,6 @@
       <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Journalført</beskrivelse>
     </journalstatus>
     <dokumentetsDato>2025-10-24</dokumentetsDato>
-    <sendtDato>2025-10-24T09:58:00</sendtDato>
+    <sendtDato>2025-10-24T09:58:00Z</sendtDato>
   </registrering>
 </arkivmelding>

--- a/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/.Verify/FiksArkivDefaultPayloadGeneratorTest.GeneratePayload_GeneratesCorrectPayload.5.verified.txt
+++ b/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/.Verify/FiksArkivDefaultPayloadGeneratorTest.GeneratePayload_GeneratesCorrectPayload.5.verified.txt
@@ -1,19 +1,29 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <arkivmelding xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivmelding/opprett/v1">
-  <system>custom-system-id</system>
-  <regel>custom-rule-id</regel>
-  <antallFiler>5</antallFiler>
+  <system>Altinn Studio</system>
+  <antallFiler>2</antallFiler>
   <mappe xsi:type="saksmappe">
-    <tittel>Custom Case File Title</tittel>
-    <offentligTittel>Custom Case File Title</offentligTittel>
+    <tittel>Test app</tittel>
+    <offentligTittel>Test app</offentligTittel>
     <klassifikasjon>
-      <klassifikasjonssystemID>AltinnSystembrukerId</klassifikasjonssystemID>
-      <klasseID>f58fe166-bc22-4899-beb7-c3e8e3332f43</klasseID>
-      <tittel>310702641</tittel>
+      <klassifikasjonssystemID>PNR</klassifikasjonssystemID>
+      <klasseID>12345678901</klasseID>
+      <tittel>Test Testesen</tittel>
+    </klassifikasjon>
+    <klassifikasjon>
+      <klassifikasjonssystemID>custom-system</klassifikasjonssystemID>
+      <klasseID>custom-class</klasseID>
+      <tittel>Custom Classification</tittel>
+    </klassifikasjon>
+    <klassifikasjon>
+      <klassifikasjonssystemID>custom-system-2</klassifikasjonssystemID>
+      <klasseID>custom-class-2</klasseID>
+      <tittel>Restricted Classification</tittel>
+      <erSkjermet>true</erSkjermet>
     </klassifikasjon>
     <referanseEksternNoekkel>
       <fagsystem xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">ttd/test-app</fagsystem>
-      <noekkel xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">custom-case-file-id</noekkel>
+      <noekkel xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">12345/88d9baf8-2f9f-4e66-9a2f-7d345e60ed90</noekkel>
     </referanseEksternNoekkel>
     <saksaar>2025</saksaar>
     <saksdato>2025-10-24</saksdato>
@@ -27,7 +37,7 @@
     <referanseForelderMappe>
       <referanseEksternNoekkel xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">
         <fagsystem>ttd/test-app</fagsystem>
-        <noekkel>custom-case-file-id</noekkel>
+        <noekkel>12345/88d9baf8-2f9f-4e66-9a2f-7d345e60ed90</noekkel>
       </referanseEksternNoekkel>
     </referanseForelderMappe>
     <dokumentbeskrivelse>
@@ -39,38 +49,19 @@
         <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">F</kode>
         <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Dokumentet er ferdigstilt</beskrivelse>
       </dokumentstatus>
-      <tittel>Form.xml</tittel>
+      <tittel>Form.pdf</tittel>
       <opprettetDato>2025-10-24T09:58:00Z</opprettetDato>
       <tilknyttetRegistreringSom>
         <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">H</kode>
         <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Hoveddokument</beskrivelse>
       </tilknyttetRegistreringSom>
       <dokumentobjekt>
+        <variantformat>
+          <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">A</kode>
+          <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Arkivformat</beskrivelse>
+        </variantformat>
         <format>
-          <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">XML</kode>
-        </format>
-        <filnavn>Form.xml</filnavn>
-        <referanseDokumentfil>Form.xml</referanseDokumentfil>
-      </dokumentobjekt>
-    </dokumentbeskrivelse>
-    <dokumentbeskrivelse>
-      <dokumenttype>
-        <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">VEDLEGG</kode>
-        <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Vedlegg</beskrivelse>
-      </dokumenttype>
-      <dokumentstatus>
-        <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">F</kode>
-        <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Dokumentet er ferdigstilt</beskrivelse>
-      </dokumentstatus>
-      <tittel>Form.pdf</tittel>
-      <opprettetDato>2025-10-24T09:58:00Z</opprettetDato>
-      <tilknyttetRegistreringSom>
-        <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">V</kode>
-        <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Vedlegg</beskrivelse>
-      </tilknyttetRegistreringSom>
-      <dokumentobjekt>
-        <format>
-          <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">PDF</kode>
+          <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">PDF/A</kode>
         </format>
         <filnavn>Form.pdf</filnavn>
         <referanseDokumentfil>Form.pdf</referanseDokumentfil>
@@ -85,7 +76,7 @@
         <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">F</kode>
         <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Dokumentet er ferdigstilt</beskrivelse>
       </dokumentstatus>
-      <tittel>receipt2.pdf</tittel>
+      <tittel>ref-data-as-pdf.pdf</tittel>
       <opprettetDato>2025-10-24T09:58:00Z</opprettetDato>
       <tilknyttetRegistreringSom>
         <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">V</kode>
@@ -95,58 +86,12 @@
         <format>
           <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">PDF</kode>
         </format>
-        <filnavn>receipt2.pdf</filnavn>
-        <referanseDokumentfil>receipt2.pdf</referanseDokumentfil>
+        <filnavn>ref-data-as-pdf.pdf</filnavn>
+        <referanseDokumentfil>ref-data-as-pdf.pdf</referanseDokumentfil>
       </dokumentobjekt>
     </dokumentbeskrivelse>
-    <dokumentbeskrivelse>
-      <dokumenttype>
-        <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">VEDLEGG</kode>
-        <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Vedlegg</beskrivelse>
-      </dokumenttype>
-      <dokumentstatus>
-        <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">F</kode>
-        <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Dokumentet er ferdigstilt</beskrivelse>
-      </dokumentstatus>
-      <tittel>letter.docx</tittel>
-      <opprettetDato>2025-10-24T09:58:00Z</opprettetDato>
-      <tilknyttetRegistreringSom>
-        <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">V</kode>
-        <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Vedlegg</beskrivelse>
-      </tilknyttetRegistreringSom>
-      <dokumentobjekt>
-        <format>
-          <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">DOCX</kode>
-        </format>
-        <filnavn>letter.docx</filnavn>
-        <referanseDokumentfil>letter.docx</referanseDokumentfil>
-      </dokumentobjekt>
-    </dokumentbeskrivelse>
-    <dokumentbeskrivelse>
-      <dokumenttype>
-        <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">VEDLEGG</kode>
-        <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Vedlegg</beskrivelse>
-      </dokumenttype>
-      <dokumentstatus>
-        <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">F</kode>
-        <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Dokumentet er ferdigstilt</beskrivelse>
-      </dokumentstatus>
-      <tittel>drawing_1a.jpg</tittel>
-      <opprettetDato>2025-10-24T09:58:00Z</opprettetDato>
-      <tilknyttetRegistreringSom>
-        <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">V</kode>
-        <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Vedlegg</beskrivelse>
-      </tilknyttetRegistreringSom>
-      <dokumentobjekt>
-        <format>
-          <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">JPG</kode>
-        </format>
-        <filnavn>drawing_1a.jpg</filnavn>
-        <referanseDokumentfil>drawing_1a.jpg</referanseDokumentfil>
-      </dokumentobjekt>
-    </dokumentbeskrivelse>
-    <tittel>Custom Journal Entry Title</tittel>
-    <offentligTittel>Custom Journal Entry Title</offentligTittel>
+    <tittel>Test app</tittel>
+    <offentligTittel>Test app</offentligTittel>
     <korrespondansepart>
       <korrespondansepartID>recipient-id</korrespondansepartID>
       <korrespondanseparttype>
@@ -157,13 +102,13 @@
       <deresReferanse>https://ttd.apps.the-hostname/ttd/test-app/instances/12345/88d9baf8-2f9f-4e66-9a2f-7d345e60ed90</deresReferanse>
     </korrespondansepart>
     <korrespondansepart>
-      <korrespondansepartID>5001337</korrespondansepartID>
+      <korrespondansepartID>501337</korrespondansepartID>
       <korrespondanseparttype>
         <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">EA</kode>
         <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Avsender</beskrivelse>
       </korrespondanseparttype>
-      <korrespondansepartNavn>Test AS</korrespondansepartNavn>
-      <organisasjonid>310702641</organisasjonid>
+      <korrespondansepartNavn>Test Testesen</korrespondansepartNavn>
+      <personid>12345678901</personid>
       <postadresse>Street 1</postadresse>
       <postnummer>0123</postnummer>
       <poststed>City</poststed>
@@ -172,7 +117,7 @@
     </korrespondansepart>
     <referanseEksternNoekkel>
       <fagsystem xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">ttd/test-app</fagsystem>
-      <noekkel xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">custom-case-file-id</noekkel>
+      <noekkel xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">12345/88d9baf8-2f9f-4e66-9a2f-7d345e60ed90</noekkel>
     </referanseEksternNoekkel>
     <journalaar>2025</journalaar>
     <journalposttype>

--- a/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/.Verify/FiksArkivDefaultPayloadGeneratorTest.GeneratePayload_GeneratesCorrectPayload.6.verified.txt
+++ b/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/.Verify/FiksArkivDefaultPayloadGeneratorTest.GeneratePayload_GeneratesCorrectPayload.6.verified.txt
@@ -5,11 +5,6 @@
   <mappe xsi:type="saksmappe">
     <tittel>Test app</tittel>
     <offentligTittel>Test app</offentligTittel>
-    <klassifikasjon>
-      <klassifikasjonssystemID>ORGNR</klassifikasjonssystemID>
-      <klasseID>405003309</klasseID>
-      <tittel>tdd</tittel>
-    </klassifikasjon>
     <referanseEksternNoekkel>
       <fagsystem xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">ttd/test-app</fagsystem>
       <noekkel xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">12345/88d9baf8-2f9f-4e66-9a2f-7d345e60ed90</noekkel>
@@ -38,7 +33,7 @@
         <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">F</kode>
         <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Dokumentet er ferdigstilt</beskrivelse>
       </dokumentstatus>
-      <tittel>Form.xml</tittel>
+      <tittel>model.xml</tittel>
       <opprettetDato>2025-10-24T09:58:00Z</opprettetDato>
       <tilknyttetRegistreringSom>
         <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">H</kode>
@@ -48,8 +43,8 @@
         <format>
           <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">XML</kode>
         </format>
-        <filnavn>Form.xml</filnavn>
-        <referanseDokumentfil>Form.xml</referanseDokumentfil>
+        <filnavn>model.xml</filnavn>
+        <referanseDokumentfil>model.xml</referanseDokumentfil>
       </dokumentobjekt>
     </dokumentbeskrivelse>
     <tittel>Test app</tittel>
@@ -61,22 +56,7 @@
         <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Mottaker</beskrivelse>
       </korrespondanseparttype>
       <korrespondansepartNavn>Recipient Name</korrespondansepartNavn>
-      <organisasjonid>123456789</organisasjonid>
       <deresReferanse>https://ttd.apps.the-hostname/ttd/test-app/instances/12345/88d9baf8-2f9f-4e66-9a2f-7d345e60ed90</deresReferanse>
-    </korrespondansepart>
-    <korrespondansepart>
-      <korrespondansepartID>5001337</korrespondansepartID>
-      <korrespondanseparttype>
-        <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">EA</kode>
-        <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Avsender</beskrivelse>
-      </korrespondanseparttype>
-      <korrespondansepartNavn>Test AS</korrespondansepartNavn>
-      <organisasjonid>405003309</organisasjonid>
-      <postadresse>Street 1</postadresse>
-      <postnummer>0123</postnummer>
-      <poststed>City</poststed>
-      <telefonnummer>phone-no</telefonnummer>
-      <telefonnummer>mobile-no</telefonnummer>
     </korrespondansepart>
     <referanseEksternNoekkel>
       <fagsystem xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">ttd/test-app</fagsystem>

--- a/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/.Verify/FiksArkivDefaultPayloadGeneratorTest.GeneratePayload_GeneratesCorrectPayload.7.verified.txt
+++ b/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/.Verify/FiksArkivDefaultPayloadGeneratorTest.GeneratePayload_GeneratesCorrectPayload.7.verified.txt
@@ -7,9 +7,20 @@
     <tittel>Custom Case File Title</tittel>
     <offentligTittel>Custom Case File Title</offentligTittel>
     <klassifikasjon>
-      <klassifikasjonssystemID>AltinnSystembrukerId</klassifikasjonssystemID>
-      <klasseID>f58fe166-bc22-4899-beb7-c3e8e3332f43</klasseID>
-      <tittel>310702641</tittel>
+      <klassifikasjonssystemID>ORGNR</klassifikasjonssystemID>
+      <klasseID>405003309</klasseID>
+      <tittel>tdd</tittel>
+    </klassifikasjon>
+    <klassifikasjon>
+      <klassifikasjonssystemID>custom-system</klassifikasjonssystemID>
+      <klasseID>custom-class</klasseID>
+      <tittel>Custom Classification</tittel>
+    </klassifikasjon>
+    <klassifikasjon>
+      <klassifikasjonssystemID>custom-system-2</klassifikasjonssystemID>
+      <klasseID>custom-class-2</klasseID>
+      <tittel>Restricted Classification</tittel>
+      <erSkjermet>true</erSkjermet>
     </klassifikasjon>
     <referanseEksternNoekkel>
       <fagsystem xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">ttd/test-app</fagsystem>
@@ -18,7 +29,7 @@
     <saksaar>2025</saksaar>
     <saksdato>2025-10-24</saksdato>
     <administrativEnhet>
-      <navn xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">ttd</navn>
+      <navn xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Custom Administrative Unit</navn>
     </administrativEnhet>
   </mappe>
   <registrering xsi:type="journalpost">
@@ -39,18 +50,22 @@
         <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">F</kode>
         <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Dokumentet er ferdigstilt</beskrivelse>
       </dokumentstatus>
-      <tittel>Form.xml</tittel>
+      <tittel>Form.pdf</tittel>
       <opprettetDato>2025-10-24T09:58:00Z</opprettetDato>
       <tilknyttetRegistreringSom>
         <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">H</kode>
         <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Hoveddokument</beskrivelse>
       </tilknyttetRegistreringSom>
       <dokumentobjekt>
+        <variantformat>
+          <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">A</kode>
+          <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Arkivformat</beskrivelse>
+        </variantformat>
         <format>
-          <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">XML</kode>
+          <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">PDF/A</kode>
         </format>
-        <filnavn>Form.xml</filnavn>
-        <referanseDokumentfil>Form.xml</referanseDokumentfil>
+        <filnavn>Form.pdf</filnavn>
+        <referanseDokumentfil>Form.pdf</referanseDokumentfil>
       </dokumentobjekt>
     </dokumentbeskrivelse>
     <dokumentbeskrivelse>
@@ -62,18 +77,22 @@
         <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">F</kode>
         <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Dokumentet er ferdigstilt</beskrivelse>
       </dokumentstatus>
-      <tittel>Form.pdf</tittel>
+      <tittel>Attachment.pdf</tittel>
       <opprettetDato>2025-10-24T09:58:00Z</opprettetDato>
       <tilknyttetRegistreringSom>
         <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">V</kode>
         <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Vedlegg</beskrivelse>
       </tilknyttetRegistreringSom>
       <dokumentobjekt>
+        <variantformat>
+          <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">P</kode>
+          <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Produksjonsformat</beskrivelse>
+        </variantformat>
         <format>
-          <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">PDF</kode>
+          <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">PDF/A</kode>
         </format>
-        <filnavn>Form.pdf</filnavn>
-        <referanseDokumentfil>Form.pdf</referanseDokumentfil>
+        <filnavn>Attachment.pdf</filnavn>
+        <referanseDokumentfil>Attachment.pdf</referanseDokumentfil>
       </dokumentobjekt>
     </dokumentbeskrivelse>
     <dokumentbeskrivelse>
@@ -154,6 +173,7 @@
         <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Mottaker</beskrivelse>
       </korrespondanseparttype>
       <korrespondansepartNavn>Recipient Name</korrespondansepartNavn>
+      <organisasjonid>123456789</organisasjonid>
       <deresReferanse>https://ttd.apps.the-hostname/ttd/test-app/instances/12345/88d9baf8-2f9f-4e66-9a2f-7d345e60ed90</deresReferanse>
     </korrespondansepart>
     <korrespondansepart>
@@ -163,7 +183,7 @@
         <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Avsender</beskrivelse>
       </korrespondanseparttype>
       <korrespondansepartNavn>Test AS</korrespondansepartNavn>
-      <organisasjonid>310702641</organisasjonid>
+      <organisasjonid>405003309</organisasjonid>
       <postadresse>Street 1</postadresse>
       <postnummer>0123</postnummer>
       <poststed>City</poststed>

--- a/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/FiksArkivConfigResolverTest.cs
+++ b/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/FiksArkivConfigResolverTest.cs
@@ -148,18 +148,20 @@ public class FiksArkivConfigResolverTest
     }
 
     [Theory]
-    [InlineData(null, null, null, null, null)]
-    [InlineData("the-system-id", null, null, null, null)]
-    [InlineData(null, "the-rule-id", null, null, null)]
-    [InlineData(null, null, "the-case-file-id", null, null)]
-    [InlineData(null, null, null, "the-case-file-title", null)]
-    [InlineData(null, null, null, null, "the-journal-entry-title")]
+    [InlineData(null, null, null, null, null, null)]
+    [InlineData("the-system-id", null, null, null, null, null)]
+    [InlineData(null, "the-rule-id", null, null, null, null)]
+    [InlineData(null, null, "the-case-file-id", null, null, null)]
+    [InlineData(null, null, null, "the-case-file-title", null, null)]
+    [InlineData(null, null, null, null, "the-journal-entry-title", null)]
+    [InlineData(null, null, null, null, null, "the-case-file-administrative-unit")]
     public async Task GetArchiveDocumentMetadata_ResolvesCorrectly_StaticValues(
         string? systemId,
         string? ruleId,
         string? caseFileId,
         string? caseFileTitle,
-        string? journalEntryTitle
+        string? journalEntryTitle,
+        string? caseFileAdministrativeUnit
     )
     {
         // Arrange
@@ -174,6 +176,9 @@ public class FiksArkivConfigResolverTest
                 JournalEntryTitle = journalEntryTitle is null
                     ? null
                     : TestHelpers.BindableValueFactory(journalEntryTitle),
+                CaseFileAdministrativeUnit = caseFileAdministrativeUnit is null
+                    ? null
+                    : TestHelpers.BindableValueFactory(caseFileAdministrativeUnit),
             },
         };
         await using var fixture = TestFixture.Create(
@@ -191,6 +196,7 @@ public class FiksArkivConfigResolverTest
         Assert.Equal(caseFileId, result?.CaseFileId);
         Assert.Equal(caseFileTitle, result?.CaseFileTitle);
         Assert.Equal(journalEntryTitle, result?.JournalEntryTitle);
+        Assert.Equal(caseFileAdministrativeUnit, result?.CaseFileAdministrativeUnit);
     }
 
     [Fact]
@@ -202,6 +208,7 @@ public class FiksArkivConfigResolverTest
             systemId = "bound-system-id",
             ruleId = "bound-rule-id",
             caseFileId = "bound-case-file-id",
+            caseFileAdministrativeUnit = "bound-case-file-administrative-unit",
             titles = new { caseFile = "bound-case-file-title", journalEntry = "bound-journal-entry-title" },
         };
         var modelDataType = new DataType { Id = "model" };
@@ -217,6 +224,10 @@ public class FiksArkivConfigResolverTest
                 CaseFileId = TestHelpers.BindableValueFactory<string>(modelDataType.Id, "caseFileId"),
                 CaseFileTitle = TestHelpers.BindableValueFactory<string>(modelDataType.Id, "titles.caseFile"),
                 JournalEntryTitle = TestHelpers.BindableValueFactory<string>(modelDataType.Id, "titles.journalEntry"),
+                CaseFileAdministrativeUnit = TestHelpers.BindableValueFactory<string>(
+                    modelDataType.Id,
+                    "caseFileAdministrativeUnit"
+                ),
             },
         };
 
@@ -259,6 +270,7 @@ public class FiksArkivConfigResolverTest
         Assert.Equal(model.caseFileId, result.CaseFileId);
         Assert.Equal(model.titles.caseFile, result.CaseFileTitle);
         Assert.Equal(model.titles.journalEntry, result.JournalEntryTitle);
+        Assert.Equal(model.caseFileAdministrativeUnit, result.CaseFileAdministrativeUnit);
     }
 
     [Fact]
@@ -455,7 +467,7 @@ public class FiksArkivConfigResolverTest
     [InlineData(typeof(Authenticated.SystemUser))]
     [InlineData(typeof(Authenticated.ServiceOwner))]
     [InlineData(typeof(Authenticated.Org))]
-    public async Task GetInstanceOwnerClassification_ReturnsExpectedValue_ForKnownAuthenticationTypes(Type authType)
+    public async Task GetCaseFileClassifications_ResolvesInstanceOwnerSource_ForKnownAuthenticationTypes(Type authType)
     {
         // Arrange
         Authenticated auth = authType switch
@@ -469,29 +481,205 @@ public class FiksArkivConfigResolverTest
             _ => throw new NotSupportedException(),
         };
 
-        await using var fixture = TestFixture.Create(services => services.AddFiksArkiv());
+        var fiksArkivSettingsOverride = new FiksArkivSettings
+        {
+            Metadata = new FiksArkivMetadataSettings
+            {
+                CaseFileClassifications =
+                [
+                    new FiksArkivClassification { Source = FiksArkivClassificationSource.InstanceOwner },
+                ],
+            },
+        };
+        await using var fixture = TestFixture.Create(
+            services => services.AddFiksArkiv().WithFiksArkivConfig("CustomFiksArkivSettings"),
+            [("CustomFiksArkivSettings", fiksArkivSettingsOverride)],
+            useDefaultFiksArkivSettings: false
+        );
 
         // Act
-        var result = await fixture.FiksArkivConfigResolver.GetInstanceOwnerClassification(auth);
+        var result = await fixture.FiksArkivConfigResolver.GetCaseFileClassifications(auth);
 
         // Assert
         Assert.NotNull(result);
-        var serialized = result.SerializeXml(indent: true);
+        Assert.Single(result);
+        var serialized = result[0].SerializeXml(indent: true);
         var xml = Encoding.UTF8.GetString(serialized.Span);
         await Verify(xml).UseDefaultSettings(authType.Name.Split("+").Last());
     }
 
     [Fact]
-    public async Task GetInstanceOwnerClassification_ThrowsException_ForUnknownAuthenticationTypes()
+    public async Task GetCaseFileClassifications_ThrowsException_ForUnknownAuthenticationTypes()
     {
         // Arrange
         var auth = TestAuthentication.GetNoneAuthentication();
-        await using var fixture = TestFixture.Create(services => services.AddFiksArkiv());
+        var fiksArkivSettingsOverride = new FiksArkivSettings
+        {
+            Metadata = new FiksArkivMetadataSettings
+            {
+                CaseFileClassifications =
+                [
+                    new FiksArkivClassification { Source = FiksArkivClassificationSource.InstanceOwner },
+                ],
+            },
+        };
+        await using var fixture = TestFixture.Create(
+            services => services.AddFiksArkiv().WithFiksArkivConfig("CustomFiksArkivSettings"),
+            [("CustomFiksArkivSettings", fiksArkivSettingsOverride)],
+            useDefaultFiksArkivSettings: false
+        );
 
         // Act
         await Assert.ThrowsAsync<FiksArkivException>(() =>
-            fixture.FiksArkivConfigResolver.GetInstanceOwnerClassification(auth)
+            fixture.FiksArkivConfigResolver.GetCaseFileClassifications(auth)
         );
+    }
+
+    [Fact]
+    public async Task GetCaseFileClassifications_ResolvesEntriesInConfiguredOrder()
+    {
+        // Arrange
+        var fiksArkivSettingsOverride = new FiksArkivSettings
+        {
+            Metadata = new FiksArkivMetadataSettings
+            {
+                CaseFileClassifications =
+                [
+                    new FiksArkivClassification { Source = FiksArkivClassificationSource.InstanceOwner },
+                    new FiksArkivClassification
+                    {
+                        SystemId = "configured-system-1",
+                        ClassificationId = "configured-class-1",
+                        Title = "Configured 1",
+                    },
+                    new FiksArkivClassification
+                    {
+                        SystemId = "configured-system-2",
+                        ClassificationId = "configured-class-2",
+                        Title = "Configured 2",
+                        IsRestricted = true,
+                    },
+                ],
+            },
+        };
+        await using var fixture = TestFixture.Create(
+            services => services.AddFiksArkiv().WithFiksArkivConfig("CustomFiksArkivSettings"),
+            [("CustomFiksArkivSettings", fiksArkivSettingsOverride)],
+            useDefaultFiksArkivSettings: false
+        );
+
+        // Act
+        var result = await fixture.FiksArkivConfigResolver.GetCaseFileClassifications(
+            TestAuthentication.GetServiceOwnerAuthentication()
+        );
+
+        // Assert
+        Assert.Equal(3, result.Count);
+        // [0] is the resolved instance owner (service owner => organization number).
+        Assert.Equal("ORGNR", result[0].KlassifikasjonssystemID);
+        Assert.Equal("configured-system-1", result[1].KlassifikasjonssystemID);
+        Assert.Equal("configured-class-1", result[1].KlasseID);
+        Assert.Equal("Configured 1", result[1].Tittel);
+        Assert.Null(result[1].ErSkjermet);
+        Assert.Equal("configured-system-2", result[2].KlassifikasjonssystemID);
+        Assert.Equal("configured-class-2", result[2].KlasseID);
+        Assert.Equal("Configured 2", result[2].Tittel);
+        Assert.True(result[2].ErSkjermet);
+    }
+
+    [Fact]
+    public async Task GetCaseFileClassifications_OmitsInstanceOwner_WhenSourceNotConfigured()
+    {
+        // Arrange
+        var fiksArkivSettingsOverride = new FiksArkivSettings
+        {
+            Metadata = new FiksArkivMetadataSettings
+            {
+                CaseFileClassifications =
+                [
+                    new FiksArkivClassification
+                    {
+                        SystemId = "configured-system-1",
+                        ClassificationId = "configured-class-1",
+                        Title = "Configured 1",
+                    },
+                ],
+            },
+        };
+        await using var fixture = TestFixture.Create(
+            services => services.AddFiksArkiv().WithFiksArkivConfig("CustomFiksArkivSettings"),
+            [("CustomFiksArkivSettings", fiksArkivSettingsOverride)],
+            useDefaultFiksArkivSettings: false
+        );
+
+        // Act
+        var result = await fixture.FiksArkivConfigResolver.GetCaseFileClassifications(
+            TestAuthentication.GetServiceOwnerAuthentication()
+        );
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal("configured-system-1", result[0].KlassifikasjonssystemID);
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(false, false)]
+    [InlineData(null, null)]
+    public async Task GetCaseFileClassifications_HonorsIsRestricted_ForInstanceOwnerSource(
+        bool? isRestricted,
+        bool? expectedErSkjermet
+    )
+    {
+        // Arrange: a source-resolved classification (resolves to an organization number for a service owner)
+        // should still honor the configured restriction flag, regardless of the resolved party type.
+        var fiksArkivSettingsOverride = new FiksArkivSettings
+        {
+            Metadata = new FiksArkivMetadataSettings
+            {
+                CaseFileClassifications =
+                [
+                    new FiksArkivClassification
+                    {
+                        Source = FiksArkivClassificationSource.InstanceOwner,
+                        IsRestricted = isRestricted,
+                    },
+                ],
+            },
+        };
+        await using var fixture = TestFixture.Create(
+            services => services.AddFiksArkiv().WithFiksArkivConfig("CustomFiksArkivSettings"),
+            [("CustomFiksArkivSettings", fiksArkivSettingsOverride)],
+            useDefaultFiksArkivSettings: false
+        );
+
+        // Act
+        var result = await fixture.FiksArkivConfigResolver.GetCaseFileClassifications(
+            TestAuthentication.GetServiceOwnerAuthentication()
+        );
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal("ORGNR", result[0].KlassifikasjonssystemID);
+        Assert.Equal(expectedErSkjermet, result[0].ErSkjermet);
+    }
+
+    [Fact]
+    public async Task GetCaseFileClassifications_ReturnsEmpty_WhenNoClassificationsConfigured()
+    {
+        // Arrange
+        await using var fixture = TestFixture.Create(
+            services => services.AddFiksArkiv(),
+            useDefaultFiksArkivSettings: false
+        );
+
+        // Act
+        var result = await fixture.FiksArkivConfigResolver.GetCaseFileClassifications(
+            TestAuthentication.GetServiceOwnerAuthentication()
+        );
+
+        // Assert
+        Assert.Empty(result);
     }
 
     // csharpier-ignore-start

--- a/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/FiksArkivDefaultPayloadGeneratorTest.cs
+++ b/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/FiksArkivDefaultPayloadGeneratorTest.cs
@@ -1,21 +1,17 @@
 using Altinn.App.Clients.Fiks.Constants;
 using Altinn.App.Clients.Fiks.Exceptions;
 using Altinn.App.Clients.Fiks.Extensions;
-using Altinn.App.Clients.Fiks.Factories;
-using Altinn.App.Clients.Fiks.FiksArkiv;
 using Altinn.App.Clients.Fiks.FiksArkiv.Models;
-using Altinn.App.Clients.Fiks.FiksIO.Models;
+using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.Auth;
-using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.Data;
+using Altinn.App.Core.Internal.Language;
 using Altinn.App.Core.Models;
 using Altinn.App.Tests.Common.Auth;
+using Altinn.Platform.Register.Models;
 using Altinn.Platform.Storage.Interface.Models;
-using KS.Fiks.Arkiv.Models.V1.Arkivering.Arkivmelding;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Time.Testing;
 using Moq;
 
@@ -26,109 +22,237 @@ public class FiksArkivDefaultPayloadGeneratorTest
     //Example Instance ID = "12345/88d9baf8-2f9f-4e66-9a2f-7d345e60ed90"
 
     private static readonly XsdValidator _xsdValidator = new();
-    private static readonly Guid _fiksIOSenderAccount = Guid.Parse("f41af07b-47c3-4d3a-9a34-1baa0f575101");
     private static readonly DateTimeOffset _now = DateTimeOffset.Parse("2025-10-24T09:58:00.000000Z");
 
-    private static readonly Instance _defaultInstance = Factories.Instance(
-        "12345/88d9baf8-2f9f-4e66-9a2f-7d345e60ed90",
-        [
-            Factories.DataElement("model", null, "application/xml"),
-            Factories.DataElement("ref-data-as-pdf", null, "application/pdf"),
-            Factories.DataElement("something-uploaded", "receipt2.pdf", null),
-            Factories.DataElement("something-uploaded", "letter.docx", null),
-            Factories.DataElement("something-uploaded", "drawing_1a.jpg", null),
-        ]
-    );
+    // Built fresh per test invocation because the production code mutates DataElement.Filename;
+    // reusing a static instance leaks state across test cases.
+    private static Instance NewDefaultInstance() =>
+        new()
+        {
+            Id = "12345/88d9baf8-2f9f-4e66-9a2f-7d345e60ed90",
+            AppId = "ttd/test-app",
+            InstanceOwner = new InstanceOwner { PartyId = "12345" },
+            Data =
+            [
+                Factories.DataElement("model", null, "application/xml"),
+                Factories.DataElement("ref-data-as-pdf", null, "application/pdf"),
+                Factories.DataElement("something-uploaded", "receipt2.pdf", null),
+                Factories.DataElement("something-uploaded", "letter.docx", null),
+                Factories.DataElement("something-uploaded", "drawing_1a.jpg", null),
+            ],
+        };
 
-    private static class Auth
+    private static class AuthTypes
     {
         public static readonly Authenticated User = TestAuthentication.GetUserAuthentication();
         public static readonly Authenticated SystemUser = TestAuthentication.GetSystemUserAuthentication();
         public static readonly Authenticated ServiceOwner = TestAuthentication.GetServiceOwnerAuthentication();
         public static readonly Authenticated Org = TestAuthentication.GetOrgAuthentication();
+
+        // No authenticated identity => no associated party => the instance owner party resolves to null.
+        public static readonly Authenticated None = TestAuthentication.GetNoneAuthentication();
     }
 
     public static IEnumerable<object[]> TestCases =>
         [
-            TestCase.Create(
-                testIdentifier: "1",
-                fiksArkivMessageType: FiksArkivConstants.MessageTypes.CreateArchiveRecord,
-                expectedAttachmentFilenames: ["model.xml", "ref-data-as-pdf.pdf"],
-                primaryDocumentSettings: Factories.DocumentSettings("model"),
-                attachmentSettings: [Factories.DocumentSettings("ref-data-as-pdf")],
-                archiveDocumentMetadata: null,
-                recipientParty: Factories.RecipientParty("recipient-id", "Recipient Name"),
-                instanceOwnerParty: null,
-                instanceOwnerClassification: Factories.InstanceOwnerClassification(Auth.User)
+            new TestCase(
+                TestIdentifier: "1",
+                Settings: new FiksArkivSettings
+                {
+                    Documents = new FiksArkivDocumentSettings
+                    {
+                        PrimaryDocument = Factories.DocumentSettings("model"),
+                        Attachments = [Factories.DocumentSettings("ref-data-as-pdf")],
+                    },
+                    Metadata = new FiksArkivMetadataSettings
+                    {
+                        CaseFileClassifications = [Factories.InstanceOwnerClassification()],
+                    },
+                },
+                Auth: AuthTypes.User,
+                Recipient: Factories.Recipient("recipient-id", "Recipient Name"),
+                ExpectedAttachmentFilenames: ["model.xml", "ref-data-as-pdf.pdf"]
             ),
-            TestCase.Create(
-                testIdentifier: "2",
-                fiksArkivMessageType: FiksArkivConstants.MessageTypes.CreateArchiveRecord,
-                expectedAttachmentFilenames: ["Form.xml", "Form.pdf", "receipt2.pdf", "letter.docx", "drawing_1a.jpg"],
-                primaryDocumentSettings: Factories.DocumentSettings("model", "Form.xml"),
-                attachmentSettings:
+            new TestCase(
+                TestIdentifier: "2",
+                Settings: new FiksArkivSettings
+                {
+                    Documents = new FiksArkivDocumentSettings
+                    {
+                        PrimaryDocument = Factories.DocumentSettings("model", "Form.xml"),
+                        Attachments =
+                        [
+                            Factories.DocumentSettings("ref-data-as-pdf", "Form.pdf"),
+                            Factories.DocumentSettings("something-uploaded"),
+                        ],
+                    },
+                    Metadata = new FiksArkivMetadataSettings
+                    {
+                        SystemId = TestHelpers.BindableValueFactory("custom-system-id"),
+                        RuleId = TestHelpers.BindableValueFactory("custom-rule-id"),
+                        CaseFileId = TestHelpers.BindableValueFactory("custom-case-file-id"),
+                        CaseFileTitle = TestHelpers.BindableValueFactory("Custom Case File Title"),
+                        JournalEntryTitle = TestHelpers.BindableValueFactory("Custom Journal Entry Title"),
+                        CaseFileClassifications = [Factories.InstanceOwnerClassification()],
+                    },
+                },
+                Auth: AuthTypes.SystemUser,
+                Recipient: Factories.Recipient("recipient-id", "Recipient Name"),
+                ExpectedAttachmentFilenames: ["Form.xml", "Form.pdf", "receipt2.pdf", "letter.docx", "drawing_1a.jpg"]
+            ),
+            new TestCase(
+                TestIdentifier: "3",
+                Settings: new FiksArkivSettings
+                {
+                    Documents = new FiksArkivDocumentSettings
+                    {
+                        PrimaryDocument = Factories.DocumentSettings("model", "Form.xml"),
+                        Attachments = [Factories.DocumentSettings("doesnt-exist")],
+                    },
+                    Metadata = new FiksArkivMetadataSettings
+                    {
+                        CaseFileClassifications = [Factories.InstanceOwnerClassification()],
+                    },
+                },
+                Auth: AuthTypes.ServiceOwner,
+                Recipient: Factories.Recipient("recipient-id", "Recipient Name", "123456789"),
+                ExpectedAttachmentFilenames: ["Form.xml"]
+            ),
+            new TestCase(
+                TestIdentifier: "4",
+                Settings: new FiksArkivSettings
+                {
+                    Documents = new FiksArkivDocumentSettings
+                    {
+                        PrimaryDocument = Factories.DocumentSettings("model", "Form.xml"),
+                        Attachments = null,
+                    },
+                    Metadata = new FiksArkivMetadataSettings
+                    {
+                        SystemId = TestHelpers.BindableValueFactory("custom-system-id"),
+                        CaseFileTitle = TestHelpers.BindableValueFactory("Custom Case File Title"),
+                        JournalEntryTitle = TestHelpers.BindableValueFactory("Custom Journal Entry Title"),
+                        CaseFileClassifications = [Factories.InstanceOwnerClassification()],
+                    },
+                },
+                Auth: AuthTypes.Org,
+                Recipient: Factories.Recipient("recipient-id", "Recipient Name"),
+                ExpectedAttachmentFilenames: ["Form.xml"]
+            ),
+            new TestCase(
+                TestIdentifier: "5",
+                Settings: new FiksArkivSettings
+                {
+                    Documents = new FiksArkivDocumentSettings
+                    {
+                        PrimaryDocument = Factories.DocumentSettings(
+                            "model",
+                            "Form.pdf",
+                            formatCode: "PDF/A",
+                            variant: new FiksArkivCode { Code = "A", Description = "Arkivformat" }
+                        ),
+                        Attachments = [Factories.DocumentSettings("ref-data-as-pdf")],
+                    },
+                    Metadata = new FiksArkivMetadataSettings
+                    {
+                        CaseFileClassifications =
+                        [
+                            Factories.InstanceOwnerClassification(),
+                            Factories.ConfiguredClassification(
+                                "custom-system",
+                                "custom-class",
+                                "Custom Classification"
+                            ),
+                            Factories.ConfiguredClassification(
+                                "custom-system-2",
+                                "custom-class-2",
+                                "Restricted Classification",
+                                isRestricted: true
+                            ),
+                        ],
+                    },
+                },
+                Auth: AuthTypes.User,
+                Recipient: Factories.Recipient("recipient-id", "Recipient Name"),
+                ExpectedAttachmentFilenames: ["Form.pdf", "ref-data-as-pdf.pdf"]
+            ),
+            // Bare-minimum configuration: only the required PrimaryDocument is set. No metadata, attachments
+            // or classifications are configured, so the generated payload exercises the library defaults
+            // (default system id, application title fallbacks, instance id as case file key, no classifications).
+            new TestCase(
+                TestIdentifier: "6",
+                Settings: new FiksArkivSettings
+                {
+                    Documents = new FiksArkivDocumentSettings { PrimaryDocument = Factories.DocumentSettings("model") },
+                },
+                // Authenticated.None resolves no instance owner party, asserting the generator omits the Avsender
+                // korrespondansepart and still produces a schema-valid arkivmelding.
+                Auth: AuthTypes.None,
+                Recipient: Factories.Recipient("recipient-id", "Recipient Name"),
+                ExpectedAttachmentFilenames: ["model.xml"]
+            ),
+            // Maximal configuration: every payload-relevant override turned on at once. Primary document and an
+            // attachment both carry custom filename/format/variant, all metadata fields are set, the classification
+            // list mixes the dynamic instance-owner source with explicit (incl. restricted) entries, and an instance
+            // owner party is resolved so both a recipient and a sender korrespondansepart are emitted.
+            new TestCase(
+                TestIdentifier: "7",
+                Settings: new FiksArkivSettings
+                {
+                    Documents = new FiksArkivDocumentSettings
+                    {
+                        PrimaryDocument = Factories.DocumentSettings(
+                            "model",
+                            "Form.pdf",
+                            formatCode: "PDF/A",
+                            variant: new FiksArkivCode { Code = "A", Description = "Arkivformat" }
+                        ),
+                        Attachments =
+                        [
+                            Factories.DocumentSettings(
+                                "ref-data-as-pdf",
+                                "Attachment.pdf",
+                                formatCode: "PDF/A",
+                                variant: new FiksArkivCode { Code = "P", Description = "Produksjonsformat" }
+                            ),
+                            Factories.DocumentSettings("something-uploaded"),
+                        ],
+                    },
+                    Metadata = new FiksArkivMetadataSettings
+                    {
+                        SystemId = TestHelpers.BindableValueFactory("custom-system-id"),
+                        RuleId = TestHelpers.BindableValueFactory("custom-rule-id"),
+                        CaseFileId = TestHelpers.BindableValueFactory("custom-case-file-id"),
+                        CaseFileTitle = TestHelpers.BindableValueFactory("Custom Case File Title"),
+                        JournalEntryTitle = TestHelpers.BindableValueFactory("Custom Journal Entry Title"),
+                        CaseFileAdministrativeUnit = TestHelpers.BindableValueFactory("Custom Administrative Unit"),
+                        CaseFileClassifications =
+                        [
+                            Factories.InstanceOwnerClassification(),
+                            Factories.ConfiguredClassification(
+                                "custom-system",
+                                "custom-class",
+                                "Custom Classification"
+                            ),
+                            Factories.ConfiguredClassification(
+                                "custom-system-2",
+                                "custom-class-2",
+                                "Restricted Classification",
+                                isRestricted: true
+                            ),
+                        ],
+                    },
+                },
+                Auth: AuthTypes.ServiceOwner,
+                Recipient: Factories.Recipient("recipient-id", "Recipient Name", "123456789"),
+                ExpectedAttachmentFilenames:
                 [
-                    Factories.DocumentSettings("ref-data-as-pdf", "Form.pdf"),
-                    Factories.DocumentSettings("something-uploaded"),
-                ],
-                archiveDocumentMetadata: Factories.Metadata(
-                    "custom-system-id",
-                    "custom-rule-id",
-                    "custom-case-file-id",
-                    "Custom Case File Title",
-                    "Custom Journal Entry Title"
-                ),
-                recipientParty: Factories.RecipientParty("recipient-id", "Recipient Name"),
-                instanceOwnerParty: null,
-                instanceOwnerClassification: Factories.InstanceOwnerClassification(Auth.SystemUser)
-            ),
-            TestCase.Create(
-                testIdentifier: "3",
-                fiksArkivMessageType: FiksArkivConstants.MessageTypes.CreateArchiveRecord,
-                expectedAttachmentFilenames: ["Form.xml"],
-                primaryDocumentSettings: Factories.DocumentSettings("model", "Form.xml"),
-                attachmentSettings: [Factories.DocumentSettings("doesnt-exist")],
-                archiveDocumentMetadata: null,
-                recipientParty: Factories.RecipientParty("recipient-id", "Recipient Name", "123456789", "Ref-001"),
-                instanceOwnerParty: Factories.InstanceOwnerOwnerParty(
-                    "altinn-party-id",
-                    "Instance Owner Person Name",
-                    "national-id-no",
-                    null,
-                    "phone-no",
-                    "mobile-no",
-                    "Street 1",
-                    "0123",
-                    "City"
-                ),
-                instanceOwnerClassification: Factories.InstanceOwnerClassification(Auth.ServiceOwner)
-            ),
-            TestCase.Create(
-                testIdentifier: "4",
-                fiksArkivMessageType: FiksArkivConstants.MessageTypes.CreateArchiveRecord,
-                expectedAttachmentFilenames: ["Form.xml"],
-                primaryDocumentSettings: Factories.DocumentSettings("model", "Form.xml"),
-                attachmentSettings: null,
-                archiveDocumentMetadata: Factories.Metadata(
-                    systemId: "custom-system-id",
-                    caseFileTitle: "Custom Case File Title",
-                    journalEntryTitle: "Custom Journal Entry Title",
-                    ruleId: null,
-                    caseFileId: null
-                ),
-                recipientParty: Factories.RecipientParty("recipient-id", "Recipient Name"),
-                instanceOwnerParty: Factories.InstanceOwnerOwnerParty(
-                    "altinn-party-id",
-                    "Instance Owner Org Name",
-                    null,
-                    "org-number",
-                    "duplicate-phone-no",
-                    "duplicate-mobile-no",
-                    "Street 1",
-                    null,
-                    "City"
-                ),
-                instanceOwnerClassification: Factories.InstanceOwnerClassification(Auth.Org)
+                    "Form.pdf",
+                    "Attachment.pdf",
+                    "receipt2.pdf",
+                    "letter.docx",
+                    "drawing_1a.jpg",
+                ]
             ),
         ];
 
@@ -137,13 +261,17 @@ public class FiksArkivDefaultPayloadGeneratorTest
     internal async Task GeneratePayload_GeneratesCorrectPayload(TestCase testCase)
     {
         // Arrange
-        var fixture = testCase.Fixture;
+        await using var fixture = CreateFixture(testCase);
 
         // Act
-        var result = await fixture.GeneratePayload(
-            _defaultInstance,
-            FiksArkivConstants.MessageTypes.CreateArchiveRecord
-        );
+        var result = (
+            await fixture.FiksArkivPayloadGenerator.GeneratePayload(
+                "",
+                NewDefaultInstance(),
+                testCase.Recipient,
+                FiksArkivConstants.MessageTypes.CreateArchiveRecord
+            )
+        ).ToList();
 
         // Assert
         Assert.NotNull(result);
@@ -163,214 +291,174 @@ public class FiksArkivDefaultPayloadGeneratorTest
     [Fact]
     public async Task GeneratePayload_ThrowsException_ForUnsupportedMessageType()
     {
-        var fixture = PayloadGeneratorFixture.Create(null!, null!, null, null!, null!, null!, null!);
+        await using var fixture = TestFixture.Create(services => services.AddFiksArkiv());
 
         var ex = await Assert.ThrowsAsync<FiksArkivException>(() =>
-            fixture.GeneratePayload(Factories.Instance(null!, []), "non-create-type")
+            fixture.FiksArkivPayloadGenerator.GeneratePayload(
+                "",
+                new Instance(),
+                Factories.Recipient("-", "-"),
+                "non-create-type"
+            )
         );
 
         Assert.Contains("Unsupported message type", ex.Message);
     }
 
-    internal sealed record TestCase(
-        PayloadGeneratorFixture Fixture,
-        string MessageType,
-        IEnumerable<string> ExpectedAttachmentFilenames,
-        string TestIdentifier
-    )
+    private static TestFixture CreateFixture(TestCase testCase)
     {
-        public static TestCase Create(
-            string testIdentifier,
-            string fiksArkivMessageType,
-            IEnumerable<string> expectedAttachmentFilenames,
-            FiksArkivDataTypeSettings primaryDocumentSettings,
-            IReadOnlyList<FiksArkivDataTypeSettings>? attachmentSettings,
-            FiksArkivDocumentMetadata? archiveDocumentMetadata,
-            Korrespondansepart recipientParty,
-            Korrespondansepart? instanceOwnerParty,
-            Klassifikasjon instanceOwnerClassification,
-            string applicationTitle = "Test app",
-            string appId = "ttd/test-app"
-        )
+        var fixture = TestFixture.Create(
+            services =>
+            {
+                services.AddFiksArkiv().WithFiksArkivConfig("CustomFiksArkivSettings");
+                services.AddSingleton<TimeProvider>(new FakeTimeProvider(_now));
+                services.Configure<GeneralSettings>(options =>
+                {
+                    options.HostName = "the-hostname";
+                    options.ExternalAppBaseUrl = "https://{org}.apps.{hostName}/{org}/{app}/";
+                });
+            },
+            [("CustomFiksArkivSettings", testCase.Settings)],
+            useDefaultFiksArkivSettings: false
+        );
+
+        fixture
+            .AppMetadataMock.Setup(x => x.GetApplicationMetadata())
+            .ReturnsAsync(new ApplicationMetadata("ttd/test-app"));
+        fixture
+            .TranslationServiceMock.Setup(x => x.TranslateTextKey("appName", LanguageConst.Nb, null))
+            .ReturnsAsync("Test app");
+        fixture.AuthenticationContextMock.SetupGet(x => x.Current).Returns(testCase.Auth);
+        // The instance owner party is resolved from the same authenticated identity that drives the classification,
+        // so the submitter and the instance owner stay consistent instead of being hand-rolled per case. An
+        // Authenticated.None identity has no party, modelling an unresolved instance owner (no Avsender emitted).
+        fixture
+            .PartyClientMock.Setup(x => x.GetParty(It.IsAny<int>()))
+            .Returns(() => ResolveInstanceOwnerParty(testCase.Auth));
+        fixture
+            .DataClientMock.Setup(x =>
+                x.GetDataBytes(
+                    It.IsAny<int>(),
+                    It.IsAny<Guid>(),
+                    It.IsAny<Guid>(),
+                    It.IsAny<StorageAuthenticationMethod?>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync("Mocked content"u8.ToArray());
+
+        return fixture;
+    }
+
+    // Each authenticated identity carries its own associated party (see TestAuthentication), so we reuse that
+    // rather than constructing a separate instance owner party that could drift from the auth context.
+    // Authenticated.None has no party and resolves to null, modelling an instance owner that cannot be resolved.
+    private static async Task<Party?> ResolveInstanceOwnerParty(Authenticated auth)
+    {
+        Party? authParty = auth switch
         {
-            return new TestCase(
-                PayloadGeneratorFixture.Create(
-                    primaryDocumentSettings,
-                    attachmentSettings,
-                    archiveDocumentMetadata,
-                    recipientParty,
-                    instanceOwnerParty,
-                    instanceOwnerClassification,
-                    applicationTitle,
-                    appId
-                ),
-                fiksArkivMessageType,
-                expectedAttachmentFilenames,
-                testIdentifier
-            );
+            Authenticated.User user => await user.LookupSelectedParty(),
+            Authenticated.Org org => (await org.LoadDetails()).Party,
+            Authenticated.ServiceOwner serviceOwner => (await serviceOwner.LoadDetails()).Party,
+            Authenticated.SystemUser systemUser => (await systemUser.LoadDetails()).Party,
+            Authenticated.None => null,
+            _ => throw new InvalidOperationException($"Unsupported authentication type: {auth.GetType().Name}"),
+        };
+
+        return authParty is null ? null : WithRegisterContactInfo(authParty);
+    }
+
+    // The lightweight auth party (TestAuthentication) only carries flat identity fields, whereas a real register
+    // lookup (IAltinnPartyClient.GetParty) returns the nested Person/Organisation + contact details that
+    // GetInstanceOwnerParty renders. Project the auth identity onto a fully-populated register party so the
+    // generated korrespondansepart keeps its personid/organisasjonid and contact information.
+    private static Party WithRegisterContactInfo(Party authParty)
+    {
+        var party = new Party
+        {
+            PartyId = authParty.PartyId,
+            PartyUuid = authParty.PartyUuid,
+            PartyTypeName = authParty.PartyTypeName,
+            Name = authParty.Name,
+            OrgNumber = authParty.OrgNumber,
+            SSN = authParty.SSN,
+        };
+
+        if (!string.IsNullOrEmpty(authParty.SSN))
+        {
+            party.Person = new Person
+            {
+                SSN = authParty.SSN,
+                TelephoneNumber = "phone-no",
+                MobileNumber = "mobile-no",
+                MailingAddress = "Street 1",
+                MailingPostalCode = "0123",
+                MailingPostalCity = "City",
+            };
+        }
+        else if (!string.IsNullOrEmpty(authParty.OrgNumber))
+        {
+            party.Organization = new Organization
+            {
+                OrgNumber = authParty.OrgNumber,
+                TelephoneNumber = "phone-no",
+                MobileNumber = "mobile-no",
+                MailingAddress = "Street 1",
+                MailingPostalCode = "0123",
+                MailingPostalCity = "City",
+            };
         }
 
+        return party;
+    }
+
+    internal sealed record TestCase(
+        string TestIdentifier,
+        FiksArkivSettings Settings,
+        Authenticated Auth,
+        FiksArkivRecipient Recipient,
+        IEnumerable<string> ExpectedAttachmentFilenames
+    )
+    {
         public override string ToString() => TestIdentifier;
 
         public static implicit operator object[](TestCase testCase) => [testCase];
     }
 
-    internal sealed record PayloadGeneratorFixture(
-        FiksArkivDefaultPayloadGenerator FiksArkivDefaultPayloadGenerator,
-        Mock<IAppMetadata> AppMetadataMock,
-        Mock<IDataClient> DataClientMock,
-        Mock<IFiksArkivConfigResolver> ConfigResolverMock,
-        FakeTimeProvider FakeTime,
-        Mock<ILogger<FiksArkivDefaultPayloadGenerator>> LoggerMock
-    )
-    {
-        public async Task<IReadOnlyList<FiksIOMessagePayload>> GeneratePayload(Instance instance, string messageType)
-        {
-            var payload = await FiksArkivDefaultPayloadGenerator.GeneratePayload(
-                "",
-                instance,
-                Factories.Recipient(),
-                messageType
-            );
-            return payload.ToList();
-        }
-
-        public static PayloadGeneratorFixture Create(
-            FiksArkivDataTypeSettings primaryDocumentSettings,
-            IReadOnlyList<FiksArkivDataTypeSettings>? attachmentSettings,
-            FiksArkivDocumentMetadata? archiveDocumentMetadata,
-            Korrespondansepart recipientParty,
-            Korrespondansepart? instanceOwnerParty,
-            Klassifikasjon instanceOwnerClassification,
-            string applicationTitle = "Test app",
-            string appId = "ttd/test-app"
-        )
-        {
-            var appMetadataMock = new Mock<IAppMetadata>();
-            var dataClientMock = new Mock<IDataClient>();
-            var configResolverMock = new Mock<IFiksArkivConfigResolver>();
-            var loggerMock = new Mock<ILogger<FiksArkivDefaultPayloadGenerator>>();
-            var fakeTime = new FakeTimeProvider(_now);
-
-            appMetadataMock.Setup(x => x.GetApplicationMetadata()).ReturnsAsync(new ApplicationMetadata(appId));
-
-            configResolverMock.SetupGet(x => x.PrimaryDocumentSettings).Returns(primaryDocumentSettings);
-            configResolverMock.SetupGet(x => x.AttachmentSettings).Returns(attachmentSettings ?? []);
-            configResolverMock
-                .Setup(x => x.GetApplicationTitle(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(applicationTitle);
-            configResolverMock
-                .Setup(x => x.GetArchiveDocumentMetadata(It.IsAny<Instance>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(archiveDocumentMetadata);
-            configResolverMock
-                .Setup(x => x.GetCorrelationId(It.IsAny<Instance>()))
-                .Returns("https://hostname/org/app/instances/instance-owner/instance-id");
-            configResolverMock
-                .Setup(x => x.GetRecipientParty(It.IsAny<Instance>(), It.IsAny<FiksArkivRecipient>()))
-                .Returns(recipientParty);
-            configResolverMock
-                .Setup(x => x.GetInstanceOwnerParty(It.IsAny<Instance>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(instanceOwnerParty);
-            configResolverMock
-                .Setup(x => x.GetInstanceOwnerClassification(It.IsAny<Authenticated>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(instanceOwnerClassification);
-
-            var payloadGenerator = new FiksArkivDefaultPayloadGenerator(
-                appMetadataMock.Object,
-                dataClientMock.Object,
-                Mock.Of<IAuthenticationContext>(),
-                loggerMock.Object,
-                Mock.Of<IHostEnvironment>(x => x.EnvironmentName == Environments.Development),
-                configResolverMock.Object,
-                Options.Create(Factories.FiksIOSettings(_fiksIOSenderAccount)),
-                fakeTime
-            );
-
-            dataClientMock
-                .Setup(x =>
-                    x.GetDataBytes(
-                        It.IsAny<int>(),
-                        It.IsAny<Guid>(),
-                        It.IsAny<Guid>(),
-                        It.IsAny<StorageAuthenticationMethod?>(),
-                        It.IsAny<CancellationToken>()
-                    )
-                )
-                .ReturnsAsync("Mocked content"u8.ToArray());
-
-            return new PayloadGeneratorFixture(
-                payloadGenerator,
-                appMetadataMock,
-                dataClientMock,
-                configResolverMock,
-                fakeTime,
-                loggerMock
-            );
-        }
-    }
-
     private static class Factories
     {
-        public static FiksIOSettings FiksIOSettings(Guid accountId) =>
+        public static FiksArkivRecipient Recipient(string identifier, string name, string? orgNumber = null) =>
+            new(Guid.Empty, identifier, name, orgNumber);
+
+        public static FiksArkivDataTypeSettings DocumentSettings(
+            string dataType,
+            string? filename = null,
+            string? formatCode = null,
+            FiksArkivCode? variant = null
+        ) =>
             new()
             {
-                AccountId = accountId,
-                IntegrationId = Guid.Empty,
-                IntegrationPassword = "-",
-                AccountPrivateKeyBase64 = "-",
+                DataType = dataType,
+                Filename = filename,
+                Format = formatCode is null ? null : new FiksArkivCode { Code = formatCode },
+                Variant = variant,
             };
 
-        public static Instance Instance(string id, IEnumerable<DataElement> dataElements) =>
-            new() { Id = id, Data = [.. dataElements] };
+        public static FiksArkivClassification InstanceOwnerClassification() =>
+            new() { Source = FiksArkivClassificationSource.InstanceOwner };
 
-        public static FiksArkivRecipient Recipient() => new(Guid.NewGuid(), "-", "-", "-");
-
-        public static FiksArkivDataTypeSettings DocumentSettings(string dataType, string? filename = null) =>
-            new() { DataType = dataType, Filename = filename };
-
-        public static FiksArkivDocumentMetadata Metadata(
-            string? systemId,
-            string? ruleId,
-            string? caseFileId,
-            string? caseFileTitle,
-            string? journalEntryTitle
-        ) => new(systemId, ruleId, caseFileId, caseFileTitle, journalEntryTitle);
-
-        public static Korrespondansepart RecipientParty(
-            string id,
-            string name,
-            string? orgNumber = null,
-            string? reference = null
-        ) => KorrespondansepartFactory.CreateRecipient(id, name, orgNumber, reference);
-
-        public static Korrespondansepart InstanceOwnerOwnerParty(
-            string id,
-            string name,
-            string? personId,
-            string? orgNumber,
-            string? phoneNumber,
-            string? mobileNumber,
-            string? address,
-            string? postcode,
-            string? city
-        )
-        {
-            var party = KorrespondansepartFactory.CreateSender(id, name, personId, orgNumber);
-            party.AddContactInfo(phoneNumber, mobileNumber, address, postcode, city);
-
-            return party;
-        }
-
-        public static Klassifikasjon InstanceOwnerClassification(Authenticated auth) =>
-            auth switch
+        public static FiksArkivClassification ConfiguredClassification(
+            string systemId,
+            string classificationId,
+            string title,
+            bool? isRestricted = null
+        ) =>
+            new()
             {
-                Authenticated.User user => KlassifikasjonFactory.CreateUser(user).GetAwaiter().GetResult(),
-                Authenticated.SystemUser systemUser => KlassifikasjonFactory.CreateSystemUser(systemUser),
-                Authenticated.ServiceOwner serviceOwner => KlassifikasjonFactory.CreateServiceOwner(serviceOwner),
-                Authenticated.Org org => KlassifikasjonFactory.CreateOrganization(org),
-                _ => throw new FiksArkivException(
-                    $"Could not determine submitter details from authentication context: {auth}"
-                ),
+                SystemId = systemId,
+                ClassificationId = classificationId,
+                Title = title,
+                IsRestricted = isRestricted,
             };
 
         public static DataElement DataElement(string dataType, string? filename, string? contentType) =>

--- a/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/Models/FiksArkivDocumentsTest.cs
+++ b/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/Models/FiksArkivDocumentsTest.cs
@@ -11,7 +11,7 @@ public class FiksArkivDocumentsTest
     private static FiksIOMessagePayload CreatePayload(string filename) => new(filename, Stream.Null);
 
     private MessagePayloadWrapper CreateMessagePayloadWrapper(string filename, Kode? code = null) =>
-        new(CreatePayload(filename), code ?? _dummyCode);
+        new(CreatePayload(filename), code ?? _dummyCode, FileFormat: null, FileVariant: null);
 
     [Fact]
     public void ToPaylods_ContainsAllDocuments_InTheCorrectOrder()

--- a/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/Models/FiksArkivSettingsTest.cs
+++ b/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/Models/FiksArkivSettingsTest.cs
@@ -1,11 +1,185 @@
+using System.Text;
 using Altinn.App.Clients.Fiks.Exceptions;
+using Altinn.App.Clients.Fiks.Extensions;
 using Altinn.App.Clients.Fiks.FiksArkiv.Models;
 using Altinn.Platform.Storage.Interface.Models;
+using Microsoft.Extensions.Configuration;
 
 namespace Altinn.App.Clients.Fiks.Tests.FiksArkiv.Models;
 
 public class FiksArkivSettingsTest
 {
+    [Theory]
+    [InlineData("sys", "cls", "title", null, null)]
+    [InlineData("sys", "cls", "title", true, null)]
+    [InlineData("sys", "cls", "title", false, null)]
+    [InlineData("", "cls", "title", null, "SystemId configuration is required")]
+    [InlineData("   ", "cls", "title", null, "SystemId configuration is required")]
+    [InlineData("sys", "", "title", null, "ClassificationId configuration is required")]
+    [InlineData("sys", "cls", "", null, "Title configuration is required")]
+    public void FiksArkivClassification_ValidatesCorrectly(
+        string systemId,
+        string classificationId,
+        string title,
+        bool? isRestricted,
+        string? expectedErrorMessage
+    )
+    {
+        // Arrange
+        var classification = new FiksArkivClassification
+        {
+            SystemId = systemId,
+            ClassificationId = classificationId,
+            Title = title,
+            IsRestricted = isRestricted,
+        };
+
+        // Act
+        var ex = Record.Exception(() => classification.Validate("TestSetting"));
+
+        // Assert
+        if (expectedErrorMessage is null)
+        {
+            Assert.Null(ex);
+            return;
+        }
+
+        Assert.NotNull(ex);
+        Assert.IsType<FiksArkivConfigurationException>(ex);
+        Assert.Contains(expectedErrorMessage, ex.Message);
+    }
+
+    [Fact]
+    public void FiksArkivClassification_WithSource_ValidatesWithoutExplicitFields()
+    {
+        // Arrange
+        var classification = new FiksArkivClassification { Source = FiksArkivClassificationSource.InstanceOwner };
+
+        // Act
+        var ex = Record.Exception(() => classification.Validate("TestSetting"));
+
+        // Assert
+        Assert.Null(ex);
+    }
+
+    [Theory]
+    [InlineData("InstanceOwner")]
+    [InlineData("instanceowner")] // config binder is case-insensitive
+    public void FiksArkivClassification_Source_BindsFromConfigurationString(string sourceValue)
+    {
+        // Arrange: bind via the same configuration binder used by .BindConfiguration() in production,
+        // proving the documented string form (not just the System.Text.Json numeric form) round-trips.
+        var json = $$"""
+            {
+                "FiksArkivSettings": {
+                    "metadata": {
+                        "caseFileClassifications": [
+                            { "source": "{{sourceValue}}" }
+                        ]
+                    }
+                }
+            }
+            """;
+        var configuration = BuildConfiguration(json);
+
+        // Act
+        var settings = configuration.GetSection("FiksArkivSettings").Get<FiksArkivSettings>();
+
+        // Assert
+        var classification = Assert.Single(settings!.Metadata!.CaseFileClassifications!);
+        Assert.Equal(FiksArkivClassificationSource.InstanceOwner, classification.Source);
+        Assert.Null(classification.SystemId);
+        Assert.Null(classification.ClassificationId);
+        Assert.Null(classification.Title);
+    }
+
+    [Fact]
+    public void FiksArkivClassification_ExplicitFields_BindFromConfiguration()
+    {
+        // Arrange
+        var json = """
+            {
+                "FiksArkivSettings": {
+                    "metadata": {
+                        "caseFileClassifications": [
+                            {
+                                "systemId": "custom-system",
+                                "classificationId": "custom-class",
+                                "title": "Custom Title",
+                                "isRestricted": true
+                            }
+                        ]
+                    }
+                }
+            }
+            """;
+        var configuration = BuildConfiguration(json);
+
+        // Act
+        var settings = configuration.GetSection("FiksArkivSettings").Get<FiksArkivSettings>();
+
+        // Assert
+        var classification = Assert.Single(settings!.Metadata!.CaseFileClassifications!);
+        Assert.Null(classification.Source);
+        Assert.Equal("custom-system", classification.SystemId);
+        Assert.Equal("custom-class", classification.ClassificationId);
+        Assert.Equal("Custom Title", classification.Title);
+        Assert.True(classification.IsRestricted);
+    }
+
+    [Theory]
+    [InlineData("sys", null, null)]
+    [InlineData(null, "cls", null)]
+    [InlineData(null, null, "title")]
+    public void FiksArkivClassification_WithSourceAndExplicitFields_Throws(
+        string? systemId,
+        string? classificationId,
+        string? title
+    )
+    {
+        // Arrange
+        var classification = new FiksArkivClassification
+        {
+            Source = FiksArkivClassificationSource.InstanceOwner,
+            SystemId = systemId,
+            ClassificationId = classificationId,
+            Title = title,
+        };
+
+        // Act
+        var ex = Record.Exception(() => classification.Validate("TestSetting"));
+
+        // Assert
+        Assert.NotNull(ex);
+        Assert.IsType<FiksArkivConfigurationException>(ex);
+        Assert.Contains("Source cannot be combined with", ex.Message);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void FiksArkivClassification_ToKlassifikasjon_MapsAllFields(bool? isRestricted)
+    {
+        // Arrange
+        var classification = new FiksArkivClassification
+        {
+            SystemId = "system-1",
+            ClassificationId = "class-1",
+            Title = "The Title",
+            IsRestricted = isRestricted,
+        };
+
+        // Act
+        var result = classification.ToKlassifikasjon();
+
+        // Assert
+        Assert.Equal("system-1", result.KlassifikasjonssystemID);
+        Assert.Equal("class-1", result.KlasseID);
+        Assert.Equal("The Title", result.Tittel);
+        Assert.Equal(isRestricted, result.ErSkjermet);
+    }
+
     [Theory]
     [InlineData("datatype1", "customfile.xml", null, "customfile.xml")]
     [InlineData("datatype2", null, ".pdf", "datatype2.pdf")]
@@ -57,5 +231,71 @@ public class FiksArkivSettingsTest
         Assert.NotNull(ex);
         Assert.IsType<FiksArkivConfigurationException>(ex);
         Assert.Contains(expectedErrorMessage, ex.Message);
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("PDF/A", null)]
+    [InlineData("anything goes verbatim", null)]
+    [InlineData("", "Format.Code cannot be empty or contain only whitespace")]
+    [InlineData("   ", "Format.Code cannot be empty or contain only whitespace")]
+    public void FiksArkivDataTypeSettings_ValidatesDocumentFormat(string? code, string? expectedErrorMessage)
+    {
+        // Arrange
+        var settings = new FiksArkivDataTypeSettings
+        {
+            DataType = "valid-datatype",
+            Format = code is null ? null : new FiksArkivCode { Code = code },
+        };
+
+        // Act
+        var ex = Record.Exception(() => settings.Validate("TestSetting", [new DataType { Id = "valid-datatype" }]));
+
+        // Assert
+        if (expectedErrorMessage is null)
+        {
+            Assert.Null(ex);
+            return;
+        }
+
+        Assert.NotNull(ex);
+        Assert.IsType<FiksArkivConfigurationException>(ex);
+        Assert.Contains(expectedErrorMessage, ex.Message);
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("P", null)]
+    [InlineData("A", null)]
+    [InlineData("", "Variant.Code cannot be empty or contain only whitespace")]
+    [InlineData("   ", "Variant.Code cannot be empty or contain only whitespace")]
+    public void FiksArkivDataTypeSettings_ValidatesDocumentVariant(string? code, string? expectedErrorMessage)
+    {
+        // Arrange
+        var settings = new FiksArkivDataTypeSettings
+        {
+            DataType = "valid-datatype",
+            Variant = code is null ? null : new FiksArkivCode { Code = code },
+        };
+
+        // Act
+        var ex = Record.Exception(() => settings.Validate("TestSetting", [new DataType { Id = "valid-datatype" }]));
+
+        // Assert
+        if (expectedErrorMessage is null)
+        {
+            Assert.Null(ex);
+            return;
+        }
+
+        Assert.NotNull(ex);
+        Assert.IsType<FiksArkivConfigurationException>(ex);
+        Assert.Contains(expectedErrorMessage, ex.Message);
+    }
+
+    private static IConfiguration BuildConfiguration(string json)
+    {
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        return new ConfigurationBuilder().AddJsonStream(stream).Build();
     }
 }

--- a/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/Models/MessagePayloadWrapperTest.cs
+++ b/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/Models/MessagePayloadWrapperTest.cs
@@ -1,0 +1,110 @@
+using Altinn.App.Clients.Fiks.FiksArkiv.Models;
+using Altinn.App.Clients.Fiks.FiksIO.Models;
+using KS.Fiks.Arkiv.Models.V1.Kodelister;
+
+namespace Altinn.App.Clients.Fiks.Tests.FiksArkiv.Models;
+
+public class MessagePayloadWrapperTest
+{
+    private static readonly Kode _dummyCode = new(".", string.Empty);
+
+    [Theory]
+    [InlineData("PDF/A")]
+    [InlineData("XML")]
+    [InlineData("anything-goes")]
+    public void GetFileFormat_UsesOverride_WhenFormatCodeIsProvided(string formatCode)
+    {
+        var wrapper = new MessagePayloadWrapper(
+            new FiksIOMessagePayload("document.pdf", Stream.Null),
+            _dummyCode,
+            FileFormat: new FiksArkivCode { Code = formatCode },
+            FileVariant: null
+        );
+
+        var result = wrapper.GetFileFormat();
+
+        Assert.Equal(formatCode, result.KodeProperty);
+    }
+
+    [Fact]
+    public void GetFileFormat_FallsBackToFileExtension_WhenFormatIsMissing()
+    {
+        var wrapper = new MessagePayloadWrapper(
+            new FiksIOMessagePayload("report.pdf", Stream.Null),
+            _dummyCode,
+            FileFormat: null,
+            FileVariant: null
+        );
+
+        var result = wrapper.GetFileFormat();
+
+        Assert.Equal("PDF", result.KodeProperty);
+    }
+
+    [Fact]
+    public void GetFileFormat_FallsBackToUppercasedFilename_WhenNoExtensionAndNoOverride()
+    {
+        var wrapper = new MessagePayloadWrapper(
+            new FiksIOMessagePayload("extensionless", Stream.Null),
+            _dummyCode,
+            FileFormat: null,
+            FileVariant: null
+        );
+
+        var result = wrapper.GetFileFormat();
+
+        Assert.Equal("EXTENSIONLESS", result.KodeProperty);
+    }
+
+    [Fact]
+    public void GetFileVariant_ReturnsNull_WhenVariantIsMissing()
+    {
+        var wrapper = new MessagePayloadWrapper(
+            new FiksIOMessagePayload("document.pdf", Stream.Null),
+            _dummyCode,
+            FileFormat: null,
+            FileVariant: null
+        );
+
+        var result = wrapper.GetFileVariant();
+
+        Assert.Null(result);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void GetFileVariant_OmitsDescription_WhenDescriptionIsMissing(string? description)
+    {
+        var wrapper = new MessagePayloadWrapper(
+            new FiksIOMessagePayload("document.pdf", Stream.Null),
+            _dummyCode,
+            FileFormat: null,
+            FileVariant: new FiksArkivCode { Code = "P", Description = description }
+        );
+
+        var result = wrapper.GetFileVariant();
+
+        Assert.NotNull(result);
+        Assert.Equal("P", result.KodeProperty);
+        Assert.Null(result.Beskrivelse);
+    }
+
+    [Fact]
+    public void GetFileVariant_MapsCodeAndDescription_WhenProvided()
+    {
+        var wrapper = new MessagePayloadWrapper(
+            new FiksIOMessagePayload("document.pdf", Stream.Null),
+            _dummyCode,
+            FileFormat: null,
+            FileVariant: new FiksArkivCode { Code = "A", Description = "Arkivformat" }
+        );
+
+        var result = wrapper.GetFileVariant();
+
+        Assert.NotNull(result);
+        Assert.Equal("A", result.KodeProperty);
+        Assert.Equal("Arkivformat", result.Beskrivelse);
+    }
+}

--- a/test/Altinn.App.Clients.Fiks.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Clients.Fiks.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -68,8 +68,8 @@ namespace Altinn.App.Clients.Fiks.FiksArkiv
         Altinn.App.Clients.Fiks.FiksArkiv.Models.FiksArkivDataTypeSettings PrimaryDocumentSettings { get; }
         System.Threading.Tasks.Task<string> GetApplicationTitle(System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task<Altinn.App.Clients.Fiks.FiksArkiv.Models.FiksArkivDocumentMetadata?> GetArchiveDocumentMetadata(Altinn.Platform.Storage.Interface.Models.Instance instance, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<KS.Fiks.Arkiv.Models.V1.Arkivering.Arkivmelding.Klassifikasjon>> GetCaseFileClassifications(Altinn.App.Core.Features.Auth.Authenticated auth, System.Threading.CancellationToken cancellationToken = default);
         string GetCorrelationId(Altinn.Platform.Storage.Interface.Models.Instance instance);
-        System.Threading.Tasks.Task<KS.Fiks.Arkiv.Models.V1.Arkivering.Arkivmelding.Klassifikasjon> GetInstanceOwnerClassification(Altinn.App.Core.Features.Auth.Authenticated auth, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task<KS.Fiks.Arkiv.Models.V1.Arkivering.Arkivmelding.Korrespondansepart?> GetInstanceOwnerParty(Altinn.Platform.Storage.Interface.Models.Instance instance, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task<Altinn.App.Clients.Fiks.FiksArkiv.Models.FiksArkivRecipient> GetRecipient(Altinn.Platform.Storage.Interface.Models.Instance instance, System.Threading.CancellationToken cancellationToken = default);
         KS.Fiks.Arkiv.Models.V1.Arkivering.Arkivmelding.Korrespondansepart GetRecipientParty(Altinn.Platform.Storage.Interface.Models.Instance instance, Altinn.App.Clients.Fiks.FiksArkiv.Models.FiksArkivRecipient recipient);
@@ -99,6 +99,32 @@ namespace Altinn.App.Clients.Fiks.FiksArkiv.Models
         [System.Text.Json.Serialization.JsonPropertyName("value")]
         public T Value { get; set; }
     }
+    public sealed class FiksArkivClassification : System.IEquatable<Altinn.App.Clients.Fiks.FiksArkiv.Models.FiksArkivClassification>
+    {
+        public FiksArkivClassification() { }
+        [System.Text.Json.Serialization.JsonPropertyName("classificationId")]
+        public string? ClassificationId { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("isRestricted")]
+        public bool? IsRestricted { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("source")]
+        public Altinn.App.Clients.Fiks.FiksArkiv.Models.FiksArkivClassificationSource? Source { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("systemId")]
+        public string? SystemId { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("title")]
+        public string? Title { get; set; }
+    }
+    public enum FiksArkivClassificationSource
+    {
+        InstanceOwner = 0,
+    }
+    public sealed class FiksArkivCode : System.IEquatable<Altinn.App.Clients.Fiks.FiksArkiv.Models.FiksArkivCode>
+    {
+        public FiksArkivCode() { }
+        [System.Text.Json.Serialization.JsonPropertyName("code")]
+        public required string Code { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("description")]
+        public string? Description { get; set; }
+    }
     public sealed class FiksArkivDataModelBinding : System.IEquatable<Altinn.App.Clients.Fiks.FiksArkiv.Models.FiksArkivDataModelBinding>
     {
         public FiksArkivDataModelBinding() { }
@@ -115,11 +141,16 @@ namespace Altinn.App.Clients.Fiks.FiksArkiv.Models
         public required string DataType { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("filename")]
         public string? Filename { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("format")]
+        public Altinn.App.Clients.Fiks.FiksArkiv.Models.FiksArkivCode? Format { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("variant")]
+        public Altinn.App.Clients.Fiks.FiksArkiv.Models.FiksArkivCode? Variant { get; set; }
         public string GetFilenameOrDefault(string defaultExtension = "xml") { }
     }
     public sealed class FiksArkivDocumentMetadata : System.IEquatable<Altinn.App.Clients.Fiks.FiksArkiv.Models.FiksArkivDocumentMetadata>
     {
-        public FiksArkivDocumentMetadata(string? SystemId, string? RuleId, string? CaseFileId, string? CaseFileTitle, string? JournalEntryTitle) { }
+        public FiksArkivDocumentMetadata(string? SystemId, string? RuleId, string? CaseFileId, string? CaseFileTitle, string? JournalEntryTitle, string? CaseFileAdministrativeUnit) { }
+        public string? CaseFileAdministrativeUnit { get; init; }
         public string? CaseFileId { get; init; }
         public string? CaseFileTitle { get; init; }
         public string? JournalEntryTitle { get; init; }
@@ -145,6 +176,10 @@ namespace Altinn.App.Clients.Fiks.FiksArkiv.Models
     public sealed class FiksArkivMetadataSettings : System.IEquatable<Altinn.App.Clients.Fiks.FiksArkiv.Models.FiksArkivMetadataSettings>
     {
         public FiksArkivMetadataSettings() { }
+        [System.Text.Json.Serialization.JsonPropertyName("caseFileAdministrativeUnit")]
+        public Altinn.App.Clients.Fiks.FiksArkiv.Models.FiksArkivBindableValue<string>? CaseFileAdministrativeUnit { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("caseFileClassifications")]
+        public System.Collections.Generic.IReadOnlyList<Altinn.App.Clients.Fiks.FiksArkiv.Models.FiksArkivClassification>? CaseFileClassifications { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("caseFileId")]
         public Altinn.App.Clients.Fiks.FiksArkiv.Models.FiksArkivBindableValue<string>? CaseFileId { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("caseFileTitle")]


### PR DESCRIPTION
⚠️ **DO NOT SQUASH MERGE THIS PR** ⚠️

This is a subtree sync PR. All commits must be preserved to maintain proper git subtree history.

**Required merge method:** Merge commit (NOT squash merge)

@coderabbitai ignore

---

Syncs app-lib-dotnet `main` at f2eea0a943 ([#1765](https://github.com/Altinn/app-lib-dotnet/pull/1765), Fiks Arkiv configurable case file classifications and document format codes) into `src/App/backend`. Upstream had no other commits since the previous sync point (87f40f47).

### How the Fiks Arkiv conflicts were resolved

The monorepo's Fiks Arkiv client is heavily reworked for v9 (unit-of-work reads, retry-stable execution reference time, mailbox-based reply handling), so four files conflicted and the merge was split in two commits:

- **573e2c71d9 — the mechanical subtree merge.** The payload generator and its test took the upstream side (arkivmelding generation semantics are owned upstream); the config resolver and the public API snapshot kept the monorepo side (v9 client mechanics). This commit deliberately does not compile on its own.
- **233b6ad41d — the semantic port.** This is the commit to review. Upstream's generation semantics land unchanged: opt-in classification list (`source: InstanceOwner` or explicit entries), per-document `format`/`variant` codes, configurable `caseFileAdministrativeUnit`, no dokumentobjekt `SystemID`, UTC timestamps. The monorepo's mechanics stay unchanged: documents are read through `IInstanceDataAccessor`, the data element is never mutated, configuration is validated on the generator, and every generated date derives from the workflow engine's execution reference time. That reference time is now normalized to UTC instead of converted to the host's local zone, which is where the two sides meet. The generator no longer takes a `TimeProvider` or the Fiks IO settings, since nothing in it reads the clock or the account id any more.

### Verification

- `Altinn.App.Clients.Fiks.Tests`: 255/255 pass. Upstream's seven arkivmelding snapshots are reproduced byte for byte through the accessor; the public API snapshot is regenerated.
- The monorepo's two accessor-specific checks are kept: all document bytes come from the unit of work with no Storage read, and a reference time with a non-UTC offset yields one UTC instant for every generated date.
- `CI=true dotnet build --no-incremental` is clean; `yarn spell:check` is clean.

### Follow-up (separate PR)

App backend `CHANGELOG.md` entry for the new Fiks Arkiv configuration and for the instance-owner classification now being opt-in.
