### PR TITLE
fix(lhci-server): move base image to Debian bookworm and drop unused build toolchain

### DIFF
--- a/src/lhci-server/Dockerfile
+++ b/src/lhci-server/Dockerfile
@@ -1,9 +1,4 @@
-FROM node:24-bullseye-slim@sha256:7af27dbbe7d3e4512b83a49b8831463d5cbfdd2dce22675af73558f5ad66e8ef
-
-RUN apt-get update --fix-missing && \
-    apt-get install -y python3 build-essential && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+FROM node:24-bookworm-slim@sha256:ba849c60be29959425b8734d57b8b4b7d56f98edd9504c9af091d5281095a71e
 
 RUN corepack enable
 


### PR DESCRIPTION
## Description

`Deploy LHCI Server` has been failing at `docker build` since 2026-09-04-ish
([run 34115551524](https://github.com/Altinn/altinn-studio/actions/runs/34115551524)):

```
E: Failed to fetch http://deb.debian.org/debian-security/.../libperl5.32_5.32.1-4+deb11u5_amd64.deb  404  Not Found
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
exit code: 100
```

Debian 11 "bullseye" reached LTS end-of-life on 2026-08-31. Its `bullseye-security` index is
frozen but still served, so `apt-get update` succeeds while the `.deb` files have been removed
from the pool — `apt-get install` then 404s. This does not recover on its own; re-running the
workflow does not help.

Changes:

1. Base image `node:24-bullseye-slim` → `node:24-bookworm-slim` (re-pinned by digest).
2. Removed the `apt-get install python3 build-essential` layer. Nothing here compiles: the
   lockfile has no native modules (no `sqlite3`, `node-gyp`, `prebuild-install`, `node-addon-api`),
   the only `sqlite` reference is an optional peer dep of `sequelize`, and `pg-native` is
   likewise optional and not installed — `server.js` uses Postgres via the pure-JS `pg` driver.
   Leftover from an earlier sqlite setup.

With no apt usage left, the image is just a Node runtime.

## Verification

Built for `linux/amd64` with `--no-cache`: `yarn --immutable` installs 321 packages, no build
step, no compiler invoked (31s, 274 MB). Smoke tested the image against a throwaway
`postgres:16-alpine` — migrations ran, project row created, `GET /v1/projects` returns 200
authed and 401 unauthed.

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the server container’s underlying operating system image.
  * Removed installation of Python and build tools from the container setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->