### PR TITLE
fix(designer): leave empty combinations out of the data model schema

### DIFF
--- a/src/Designer/backend/src/DataModeling/Json/Keywords/InvalidJsonSchemaException.cs
+++ b/src/Designer/backend/src/DataModeling/Json/Keywords/InvalidJsonSchemaException.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+
+namespace Altinn.Studio.DataModeling.Json.Keywords;
+
+/// <summary>
+/// Represents errors thrown when a JSON schema cannot be read.
+/// </summary>
+[Serializable]
+public class InvalidJsonSchemaException(string message, Exception innerException) : Exception(message, innerException)
+{
+    public List<string> CustomErrorMessages { get; } = [innerException.Message];
+}

--- a/src/Designer/backend/src/DataModeling/Json/Keywords/JsonSchemaKeywords.cs
+++ b/src/Designer/backend/src/DataModeling/Json/Keywords/JsonSchemaKeywords.cs
@@ -25,7 +25,18 @@ public static class JsonSchemaKeywords
     /// <summary>
     /// Deserializes a JSON schema using reflection metadata so registered custom keywords are supported.
     /// </summary>
-    public static JsonSchema FromText(string jsonText) => JsonSchema.FromText(jsonText, s_serializerOptions);
+    /// <exception cref="InvalidJsonSchemaException">Thrown when the JSON is well formed but not a valid JSON schema.</exception>
+    public static JsonSchema FromText(string jsonText)
+    {
+        try
+        {
+            return JsonSchema.FromText(jsonText, s_serializerOptions);
+        }
+        catch (ArgumentException exception)
+        {
+            throw new InvalidJsonSchemaException("The JSON schema could not be read.", exception);
+        }
+    }
 
     /// <summary>
     /// Register custom keywords in

--- a/src/Designer/backend/src/Designer/Filters/DataModeling/DataModelingErrorCodes.cs
+++ b/src/Designer/backend/src/Designer/Filters/DataModeling/DataModelingErrorCodes.cs
@@ -8,5 +8,6 @@ public static class DataModelingErrorCodes
     public const string JsonSchemaConvertError = "DM_03";
     public const string ModelMetadataConvertError = "DM_04";
     public const string InvalidXmlError = "DM_05";
+    public const string InvalidJsonSchemaError = "DM_06";
     public const string ModelWithTheSameTypeNameExists = nameof(ModelWithTheSameTypeNameExists);
 }

--- a/src/Designer/backend/src/Designer/Filters/DataModeling/DataModelingExceptionFilterAttribute.cs
+++ b/src/Designer/backend/src/Designer/Filters/DataModeling/DataModelingExceptionFilterAttribute.cs
@@ -4,6 +4,7 @@ using Altinn.Studio.DataModeling.Converter.Csharp;
 using Altinn.Studio.DataModeling.Converter.Json;
 using Altinn.Studio.DataModeling.Converter.Metadata;
 using Altinn.Studio.DataModeling.Converter.Xml;
+using Altinn.Studio.DataModeling.Json.Keywords;
 using Altinn.Studio.Designer.Exceptions.DataModeling;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;
@@ -105,6 +106,21 @@ public class DataModelingExceptionFilterAttribute : ExceptionFilterAttribute
             )
             {
                 StatusCode = (int)HttpStatusCode.UnprocessableEntity,
+            };
+        }
+
+        if (context.Exception is InvalidJsonSchemaException invalidJsonSchemaException)
+        {
+            context.Result = new ObjectResult(
+                ProblemDetailsUtils.GenerateProblemDetails(
+                    context.Exception,
+                    DataModelingErrorCodes.InvalidJsonSchemaError,
+                    HttpStatusCode.BadRequest,
+                    invalidJsonSchemaException.CustomErrorMessages
+                )
+            )
+            {
+                StatusCode = (int)HttpStatusCode.BadRequest,
             };
         }
 

--- a/src/Designer/backend/tests/Designer.Tests/Controllers/DataModelsController/PutDatamodelTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Controllers/DataModelsController/PutDatamodelTests.cs
@@ -268,10 +268,7 @@ public class PutDatamodelTests
         Assert.Equal(DataModelingErrorCodes.InvalidJsonSchemaError, errorCode.ToString());
 
         var customErrorMessages = (JsonElement)problemDetails.Extensions["customErrorMessages"];
-        Assert.Equal(
-            "'anyOf' requires at least one subschema",
-            customErrorMessages.EnumerateArray().Single().GetString()
-        );
+        Assert.Contains("anyOf", customErrorMessages.EnumerateArray().Single().GetString());
     }
 
     private async Task FilesWithCorrectNameAndContentShouldBeCreated(string modelName)

--- a/src/Designer/backend/tests/Designer.Tests/Controllers/DataModelsController/PutDatamodelTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Controllers/DataModelsController/PutDatamodelTests.cs
@@ -21,6 +21,8 @@ using Altinn.Studio.DataModeling.Json;
 using Altinn.Studio.DataModeling.Json.Keywords;
 using Altinn.Studio.DataModeling.Utils;
 using Altinn.Studio.DataModeling.Validator.Json;
+using Altinn.Studio.Designer.Filters;
+using Altinn.Studio.Designer.Filters.DataModeling;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Controllers.DataModelsController.Utils;
 using Designer.Tests.Utils;
@@ -259,6 +261,12 @@ public class PutDatamodelTests
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 
         var problemDetails = JsonSerializer.Deserialize<ProblemDetails>(await response.Content.ReadAsStringAsync());
+
+        Assert.NotNull(problemDetails);
+
+        JsonElement errorCode = (JsonElement)problemDetails.Extensions[ProblemDetailsExtensionsCodes.ErrorCode];
+        Assert.Equal(DataModelingErrorCodes.InvalidJsonSchemaError, errorCode.ToString());
+
         var customErrorMessages = (JsonElement)problemDetails.Extensions["customErrorMessages"];
         Assert.Equal(
             "'anyOf' requires at least one subschema",

--- a/src/Designer/backend/tests/Designer.Tests/Controllers/DataModelsController/PutDatamodelTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Controllers/DataModelsController/PutDatamodelTests.cs
@@ -45,6 +45,9 @@ public class PutDatamodelTests
     private const string MinimumValidJsonSchema =
         "{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\",\"$id\":\"schema.json\",\"type\":\"object\",\"properties\":{\"rootType\":{\"$ref\":\"#/$defs/rootType\"}},\"$defs\":{\"rootType\":{\"properties\":{\"keyword\":{\"type\":\"string\"}}}}}";
 
+    private const string JsonSchemaWithCombinationWithoutSubschemas =
+        "{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\",\"$id\":\"schema.json\",\"type\":\"object\",\"properties\":{\"rootType\":{\"$ref\":\"#/$defs/rootType\"}},\"$defs\":{\"rootType\":{\"properties\":{\"keyword\":{\"type\":\"string\"},\"combination\":{\"anyOf\":[]}}}}}";
+
     private const string JsonSchemaThatWillNotCompile =
         "{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\",\"$id\":\"schema.json\",\"type\":\"object\",\"properties\":{\"root\":{\"$ref\":\"#/$defs/rootType\"}},\"$defs\":{\"rootType\":{\"properties\":{\"keyword\":{\"type\":\"string\"}}}}}";
 
@@ -227,6 +230,40 @@ public class PutDatamodelTests
 
         HttpResponseMessage response = await HttpClient.SendAsync(putRequest);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("testModel.schema.json", "ttd", "hvem-er-hvem", "testUser")]
+    public async Task InvalidJsonSchema_ShouldReturn_BadRequest_And_CustomErrorMessages(
+        string modelPath,
+        string org,
+        string repo,
+        string user
+    )
+    {
+        string url = $"{VersionPrefix(org, TargetTestRepository)}/datamodel?modelPath={modelPath}";
+
+        await CopyRepositoryForTest(org, repo, user, TargetTestRepository);
+
+        // Models saved before the frontend stopped sending empty combinations still contain them.
+        using var request = new HttpRequestMessage(HttpMethod.Put, url)
+        {
+            Content = new StringContent(
+                JsonSchemaWithCombinationWithoutSubschemas,
+                Encoding.UTF8,
+                MediaTypeNames.Application.Json
+            ),
+        };
+
+        var response = await HttpClient.SendAsync(request);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var problemDetails = JsonSerializer.Deserialize<ProblemDetails>(await response.Content.ReadAsStringAsync());
+        var customErrorMessages = (JsonElement)problemDetails.Extensions["customErrorMessages"];
+        Assert.Equal(
+            "'anyOf' requires at least one subschema",
+            customErrorMessages.EnumerateArray().Single().GetString()
+        );
     }
 
     private async Task FilesWithCorrectNameAndContentShouldBeCreated(string modelName)

--- a/src/Designer/frontend/app-development/hooks/mutations/useSchemaMutation.test.ts
+++ b/src/Designer/frontend/app-development/hooks/mutations/useSchemaMutation.test.ts
@@ -24,6 +24,35 @@ describe('useSchemaMutation', () => {
     await waitFor(() => result.current.isSuccess);
   });
 
+  it('Leaves combinations without subschemas out of the saved model but keeps them in the cache', async () => {
+    const saveDataModel = jest.fn();
+    const queryClient = createQueryClientMock();
+    const text = { type: 'string' };
+    const model = { type: 'object', properties: { text, combination: { anyOf: [] } } };
+    const {
+      renderHookResult: { result },
+    } = render({ saveDataModel }, queryClient);
+    result.current.mutate({ modelPath, model });
+    await waitFor(() => result.current.isSuccess);
+    expect(saveDataModel).toHaveBeenCalledWith(org, app, modelPath, {
+      type: 'object',
+      properties: { text },
+    });
+    expect(queryClient.getQueryData([QueryKey.JsonSchema, org, app, modelPath])).toEqual(model);
+  });
+
+  it('Sends the model unchanged when it has no combinations without subschemas', async () => {
+    const saveDataModel = jest.fn();
+    const model = { type: 'object', properties: { text: { type: 'string' } } };
+    const {
+      renderHookResult: { result },
+    } = render({ saveDataModel });
+    result.current.mutate({ modelPath, model });
+    await waitFor(() => result.current.isSuccess);
+    expect(saveDataModel).toHaveBeenCalledWith(org, app, modelPath, model);
+    expect(saveDataModel.mock.calls[0][3]).toBe(model);
+  });
+
   it('Updates the JsonSchema query cache', async () => {
     const queryClient = createQueryClientMock();
     const {

--- a/src/Designer/frontend/app-development/hooks/mutations/useSchemaMutation.ts
+++ b/src/Designer/frontend/app-development/hooks/mutations/useSchemaMutation.ts
@@ -3,6 +3,12 @@ import { QueryKey } from 'app-shared/types/QueryKey';
 import { useServicesContext } from 'app-shared/contexts/ServicesContext';
 import type { JsonSchema } from 'app-shared/types/JsonSchema';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
+import {
+  buildJsonSchema,
+  buildUiSchema,
+  isEmptyCombination,
+  removeEmptyCombinations,
+} from '@altinn/schema-model';
 
 export const useSchemaMutation = () => {
   const queryClient = useQueryClient();
@@ -12,10 +18,20 @@ export const useSchemaMutation = () => {
     mutationFn: async (args: { modelPath: string; model: JsonSchema }) => {
       const { modelPath, model } = args;
       queryClient.setQueryData([QueryKey.JsonSchema, org, app, modelPath], () => model);
-      await saveDataModel(org, app, modelPath, model);
+      await saveDataModel(org, app, modelPath, toValidJsonSchema(model));
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QueryKey.DataModelsMetadata, org, app] });
     },
   });
+};
+
+/**
+ * The editor keeps combinations without subschemas while the user works on them, but the backend
+ * rejects them.
+ */
+const toValidJsonSchema = (model: JsonSchema): JsonSchema => {
+  const nodes = buildUiSchema(model);
+  if (!nodes.some(isEmptyCombination)) return model;
+  return buildJsonSchema(removeEmptyCombinations(nodes));
 };

--- a/src/Designer/frontend/packages/schema-editor/src/classes/SavableSchemaModel.test.ts
+++ b/src/Designer/frontend/packages/schema-editor/src/classes/SavableSchemaModel.test.ts
@@ -5,6 +5,7 @@ import {
   uiSchemaNodesMock,
   definitionNodeMock,
   fieldNode1Mock,
+  toggableNodeMock,
 } from '../../test/mocks/uiSchemaMock';
 
 describe('SavableSchemaModel', () => {
@@ -54,7 +55,7 @@ describe('SavableSchemaModel', () => {
   describe('deleteNodeAndSave', () => {
     it('Deletes a node, saves the model once and returns the object', () => {
       const savableSchema = setupSchema();
-      const { schemaPointer } = fieldNode1Mock;
+      const { schemaPointer } = toggableNodeMock;
       const result = savableSchema.deleteNodeAndSave(schemaPointer);
       expect(savableSchema.hasNode(schemaPointer)).toBe(false);
       expect(save).toHaveBeenCalledTimes(1);

--- a/src/Designer/frontend/packages/schema-model/src/index.ts
+++ b/src/Designer/frontend/packages/schema-model/src/index.ts
@@ -13,6 +13,7 @@ export {
   isArray,
   isCombination,
   isDefinition,
+  isEmptyCombination,
   isField,
   isFieldOrCombination,
   isNodeValidParent,
@@ -25,6 +26,7 @@ export {
   splitPointerInBaseAndName,
 } from './lib/utils';
 export * from './lib/mutations/custom-properties';
+export { removeEmptyCombinations } from './lib/mutations/remove-empty-combinations';
 export * from './lib/mutations/ui-schema-reducers';
 export { mergePrefillConfig } from './lib/mappers/prefill';
 export { SchemaModel } from './lib/SchemaModel';

--- a/src/Designer/frontend/packages/schema-model/src/lib/SchemaModel/SchemaModel.test.ts
+++ b/src/Designer/frontend/packages/schema-model/src/lib/SchemaModel/SchemaModel.test.ts
@@ -631,6 +631,22 @@ describe('SchemaModel', () => {
       validateTestUiSchema(result.asArray());
     });
 
+    it('Renumbers the remaining children when a child of a combination is deleted', () => {
+      const model = schemaModel.deepClone();
+      const parentPointer = combinationNodeWithMultipleChildrenMock.schemaPointer;
+      const [firstChildPointer, secondChildPointer, thirdChildPointer] =
+        combinationNodeWithMultipleChildrenMock.children;
+      const secondChildTitle = model.getNodeBySchemaPointer(secondChildPointer).title;
+      const thirdChildTitle = model.getNodeBySchemaPointer(thirdChildPointer).title;
+      const result = model.deleteNode(firstChildPointer);
+      const parent = result.getNodeBySchemaPointer(parentPointer) as CombinationNode;
+      expect(parent.children).toEqual([firstChildPointer, secondChildPointer]);
+      expect(result.getNodeBySchemaPointer(firstChildPointer).title).toBe(secondChildTitle);
+      expect(result.getNodeBySchemaPointer(secondChildPointer).title).toBe(thirdChildTitle);
+      expect(result.hasNode(thirdChildPointer)).toBe(false);
+      validateTestUiSchema(result.asArray());
+    });
+
     it('Deletes the given node when it is an unused definition', () => {
       const model = schemaModel.deepClone();
       const result = model.deleteNode(unusedDefinitionMock.schemaPointer);

--- a/src/Designer/frontend/packages/schema-model/src/lib/SchemaModel/SchemaModel.ts
+++ b/src/Designer/frontend/packages/schema-model/src/lib/SchemaModel/SchemaModel.ts
@@ -400,7 +400,11 @@ export class SchemaModel extends SchemaModelBase {
       throw new Error('It is not possible to delete the root node.');
     if (this.hasReferringNodes(schemaPointer))
       throw new Error('Cannot delete a definition that is in use.');
-    return this.deleteNodeWithChildrenRecursively(schemaPointer);
+    const parent = this.getParentNode(schemaPointer);
+    this.deleteNodeWithChildrenRecursively(schemaPointer);
+    // The names of combination children are their indices, so the remaining ones must be renumbered.
+    if (isCombination(parent)) this.synchronizeCombinationChildPointers(parent);
+    return this;
   }
 
   private deleteNodeWithChildrenRecursively(schemaPointer: string): SchemaModel {

--- a/src/Designer/frontend/packages/schema-model/src/lib/SchemaModel/SchemaModelBase.ts
+++ b/src/Designer/frontend/packages/schema-model/src/lib/SchemaModel/SchemaModelBase.ts
@@ -102,7 +102,7 @@ export class SchemaModelBase {
     }
   }
 
-  protected getReferringNodes(schemaPointer: string): ReferenceNode[] {
+  public getReferringNodes(schemaPointer: string): ReferenceNode[] {
     const referringNodes: ReferenceNode[] = [];
     for (const node of this.nodeMap.values()) {
       if (isReference(node) && node.reference === schemaPointer) {

--- a/src/Designer/frontend/packages/schema-model/src/lib/build-json-schema.ts
+++ b/src/Designer/frontend/packages/schema-model/src/lib/build-json-schema.ts
@@ -15,11 +15,7 @@ import { sortNodesByChildren } from './mutations/sort-nodes';
 import { ROOT_POINTER } from './constants';
 import type { JsonSchema } from 'app-shared/types/JsonSchema';
 import { makePointerFromArray } from './pointerUtils';
-import { isCombination, isFieldOrCombination, isReference } from './utils';
-
-// Invalid according to the JSON Schema specification, which requires at least one subschema.
-const isEmptyCombination = (node: UiSchemaNode): boolean =>
-  isCombination(node) && node.children.length === 0;
+import { isEmptyCombination, isFieldOrCombination, isNotTheRootNode, isReference } from './utils';
 
 export const buildJsonSchema = (nodes: UiSchemaNodes): JsonSchema => {
   const out: JsonSchema = {};
@@ -32,7 +28,7 @@ export const buildJsonSchema = (nodes: UiSchemaNodes): JsonSchema => {
   const sortedUiSchemaNodes = sortNodesByChildren(nodes);
 
   sortedUiSchemaNodes
-    .filter((node) => node.schemaPointer !== ROOT_POINTER && !isEmptyCombination(node))
+    .filter((node) => isNotTheRootNode(node) && !isEmptyCombination(node))
     .forEach((node: UiSchemaNode) => {
       // Arrays need to be dealt with
       const nodePointer = node.schemaPointer.replace(ROOT_POINTER, '');

--- a/src/Designer/frontend/packages/schema-model/src/lib/build-json-schema.ts
+++ b/src/Designer/frontend/packages/schema-model/src/lib/build-json-schema.ts
@@ -15,7 +15,7 @@ import { sortNodesByChildren } from './mutations/sort-nodes';
 import { ROOT_POINTER } from './constants';
 import type { JsonSchema } from 'app-shared/types/JsonSchema';
 import { makePointerFromArray } from './pointerUtils';
-import { isEmptyCombination, isFieldOrCombination, isNotTheRootNode, isReference } from './utils';
+import { isFieldOrCombination, isNotTheRootNode, isReference } from './utils';
 
 export const buildJsonSchema = (nodes: UiSchemaNodes): JsonSchema => {
   const out: JsonSchema = {};
@@ -28,7 +28,7 @@ export const buildJsonSchema = (nodes: UiSchemaNodes): JsonSchema => {
   const sortedUiSchemaNodes = sortNodesByChildren(nodes);
 
   sortedUiSchemaNodes
-    .filter((node) => isNotTheRootNode(node) && !isEmptyCombination(node))
+    .filter((node) => isNotTheRootNode(node))
     .forEach((node: UiSchemaNode) => {
       // Arrays need to be dealt with
       const nodePointer = node.schemaPointer.replace(ROOT_POINTER, '');

--- a/src/Designer/frontend/packages/schema-model/src/lib/build-json-schema.ts
+++ b/src/Designer/frontend/packages/schema-model/src/lib/build-json-schema.ts
@@ -15,7 +15,11 @@ import { sortNodesByChildren } from './mutations/sort-nodes';
 import { ROOT_POINTER } from './constants';
 import type { JsonSchema } from 'app-shared/types/JsonSchema';
 import { makePointerFromArray } from './pointerUtils';
-import { isFieldOrCombination, isReference } from './utils';
+import { isCombination, isFieldOrCombination, isReference } from './utils';
+
+// Invalid according to the JSON Schema specification, which requires at least one subschema.
+const isEmptyCombination = (node: UiSchemaNode): boolean =>
+  isCombination(node) && node.children.length === 0;
 
 export const buildJsonSchema = (nodes: UiSchemaNodes): JsonSchema => {
   const out: JsonSchema = {};
@@ -28,7 +32,7 @@ export const buildJsonSchema = (nodes: UiSchemaNodes): JsonSchema => {
   const sortedUiSchemaNodes = sortNodesByChildren(nodes);
 
   sortedUiSchemaNodes
-    .filter((node) => node.schemaPointer !== ROOT_POINTER)
+    .filter((node) => node.schemaPointer !== ROOT_POINTER && !isEmptyCombination(node))
     .forEach((node: UiSchemaNode) => {
       // Arrays need to be dealt with
       const nodePointer = node.schemaPointer.replace(ROOT_POINTER, '');

--- a/src/Designer/frontend/packages/schema-model/src/lib/build.test.ts
+++ b/src/Designer/frontend/packages/schema-model/src/lib/build.test.ts
@@ -54,16 +54,15 @@ describe('build', () => {
     expect(validateSchema(jsonSchema)).toBeTruthy();
   });
 
-  test('A combination without subschemas is left out of the schema', () => {
-    const textProperty = { type: 'string' };
+  test('A combination without subschemas survives the round trip so that the editor can keep it', () => {
     const schema: JsonSchema = {
       type: 'object',
-      properties: { text: textProperty, combination: { anyOf: [] } },
+      properties: { text: { type: 'string' }, combination: { anyOf: [] } },
     };
 
     const jsonSchema = buildJsonSchema(buildUiSchema(schema));
 
-    expect(jsonSchema).toEqual({ type: 'object', properties: { text: textProperty } });
+    expect(jsonSchema).toEqual(schema);
   });
 
   test('that schema-editor mock data works', () => {

--- a/src/Designer/frontend/packages/schema-model/src/lib/build.test.ts
+++ b/src/Designer/frontend/packages/schema-model/src/lib/build.test.ts
@@ -54,6 +54,18 @@ describe('build', () => {
     expect(validateSchema(jsonSchema)).toBeTruthy();
   });
 
+  test('A combination without subschemas is left out of the schema', () => {
+    const textProperty = { type: 'string' };
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { text: textProperty, combination: { anyOf: [] } },
+    };
+
+    const jsonSchema = buildJsonSchema(buildUiSchema(schema));
+
+    expect(jsonSchema).toEqual({ type: 'object', properties: { text: textProperty } });
+  });
+
   test('that schema-editor mock data works', () => {
     const uiSchemaNodes = buildUiSchema(dataMock);
     const jsonSchema = buildJsonSchema(uiSchemaNodes);

--- a/src/Designer/frontend/packages/schema-model/src/lib/mutations/remove-empty-combinations.test.ts
+++ b/src/Designer/frontend/packages/schema-model/src/lib/mutations/remove-empty-combinations.test.ts
@@ -1,0 +1,76 @@
+import { removeEmptyCombinations } from './remove-empty-combinations';
+import { buildUiSchema } from '../build-ui-schema';
+import { buildJsonSchema } from '../build-json-schema';
+import type { JsonSchema } from 'app-shared/types/JsonSchema';
+import { validateTestUiSchema } from '../../../test/validateTestUiSchema';
+
+const roundTrip = (schema: JsonSchema): JsonSchema => {
+  const nodes = removeEmptyCombinations(buildUiSchema(schema));
+  validateTestUiSchema(nodes);
+  return JSON.parse(JSON.stringify(buildJsonSchema(nodes)));
+};
+
+describe('removeEmptyCombinations', () => {
+  const text = { type: 'string' };
+
+  it('Removes a combination without subschemas', () => {
+    const schema: JsonSchema = { type: 'object', properties: { text, combination: { anyOf: [] } } };
+    expect(roundTrip(schema)).toEqual({ type: 'object', properties: { text } });
+  });
+
+  it('Removes the combination from the required list of its parent', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      required: ['text', 'combination'],
+      properties: { text, combination: { anyOf: [] } },
+    };
+    expect(roundTrip(schema)).toEqual({ type: 'object', required: ['text'], properties: { text } });
+  });
+
+  it('Renumbers the remaining subschemas when a nested combination is removed', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { combination: { anyOf: [{ anyOf: [] }, text] } },
+    };
+    expect(roundTrip(schema)).toEqual({
+      type: 'object',
+      properties: { combination: { anyOf: [text] } },
+    });
+  });
+
+  it('Removes a combination whose only subschemas were empty combinations', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { text, combination: { oneOf: [{ anyOf: [] }, { allOf: [] }] } },
+    };
+    expect(roundTrip(schema)).toEqual({ type: 'object', properties: { text } });
+  });
+
+  it('Removes references to a removed definition', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { text, choice: { $ref: '#/$defs/Choice' } },
+      $defs: { Choice: { anyOf: [] }, Kept: text },
+    };
+    expect(roundTrip(schema)).toEqual({
+      type: 'object',
+      properties: { text },
+      $defs: { Kept: text },
+    });
+  });
+
+  it('Leaves a schema without empty combinations unchanged', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { text, combination: { anyOf: [text, { type: 'number' }] } },
+    };
+    expect(roundTrip(schema)).toEqual(schema);
+  });
+
+  it('Does not mutate the given nodes', () => {
+    const nodes = buildUiSchema({ type: 'object', properties: { combination: { anyOf: [] } } });
+    const copy = JSON.parse(JSON.stringify(nodes));
+    removeEmptyCombinations(nodes);
+    expect(nodes).toEqual(copy);
+  });
+});

--- a/src/Designer/frontend/packages/schema-model/src/lib/mutations/remove-empty-combinations.ts
+++ b/src/Designer/frontend/packages/schema-model/src/lib/mutations/remove-empty-combinations.ts
@@ -1,0 +1,26 @@
+import type { UiSchemaNodes } from '../../types';
+import { SchemaModel } from '../SchemaModel';
+import { isEmptyCombination } from '../utils';
+
+/**
+ * Returns a copy of the given nodes without combinations that have no subschemas, and without
+ * references to them. The editor keeps such combinations while the user is working on them, but
+ * they cannot be part of a valid JSON schema. A combination that becomes empty because its only
+ * subschemas were removed this way is removed as well.
+ */
+export const removeEmptyCombinations = (nodes: UiSchemaNodes): UiSchemaNodes => {
+  const model = SchemaModel.fromArray(nodes).deepClone();
+  let emptyCombination = model.asArray().find(isEmptyCombination);
+  while (emptyCombination) {
+    deleteNodeWithReferences(model, emptyCombination.schemaPointer);
+    emptyCombination = model.asArray().find(isEmptyCombination);
+  }
+  return model.asArray();
+};
+
+const deleteNodeWithReferences = (model: SchemaModel, schemaPointer: string): void => {
+  model
+    .getReferringNodes(schemaPointer)
+    .forEach((referringNode) => model.deleteNode(referringNode.schemaPointer));
+  model.deleteNode(schemaPointer);
+};

--- a/src/Designer/frontend/packages/schema-model/src/lib/utils.test.ts
+++ b/src/Designer/frontend/packages/schema-model/src/lib/utils.test.ts
@@ -3,6 +3,7 @@ import {
   createNodeBase,
   getUniqueNodePath,
   isDefinitionRoot,
+  isEmptyCombination,
   isNodeValidParent,
   replaceLastPointerSegment,
 } from './utils';
@@ -83,6 +84,16 @@ describe('utils', () => {
 
     it.each(testCases)('Returns %s when the node is %s', (expectedResult, caseKey) => {
       expect(isNodeValidParent(testData[caseKey])).toBe(expectedResult);
+    });
+  });
+
+  describe('isEmptyCombination', () => {
+    it('Returns true for a combination without children', () => {
+      expect(isEmptyCombination({ ...allOfNodeMock, children: [] })).toBe(true);
+    });
+
+    it('Returns false for a combination with children', () => {
+      expect(isEmptyCombination(allOfNodeMock)).toBe(false);
     });
   });
 

--- a/src/Designer/frontend/packages/schema-model/src/lib/utils.ts
+++ b/src/Designer/frontend/packages/schema-model/src/lib/utils.ts
@@ -92,6 +92,10 @@ export const isArray = (node: UiSchemaNode): boolean => node.isArray;
 export const isCombination = (node: UiSchemaNode): node is CombinationNode =>
   node.objectKind === ObjectKind.Combination;
 
+// Invalid according to the JSON Schema specification, which requires at least one subschema.
+export const isEmptyCombination = (node: UiSchemaNode): boolean =>
+  isCombination(node) && node.children.length === 0;
+
 export const isReference = (node: UiSchemaNode): node is ReferenceNode =>
   node.objectKind === ObjectKind.Reference;
 


### PR DESCRIPTION
Fixes the failing `data-model.spec.ts` runs in
https://github.com/Altinn/altinn-studio/actions/workflows/designer-frontend-run-playwright-on-pr.yaml
(`Allows to add a data model, include an object with properties and a combination … generate a C# model`).

## Why it failed

When a combination is added in the schema editor it is serialized as `"anyOf": []` until the user adds a subschema to it. The backend deserializes every schema it receives with JsonSchema.Net, and since the upgrade from 5.5.1 to 7.4.0 (#19917) the library rejects a combination without subschemas:

```
System.ArgumentException: 'anyOf' requires at least one subschema
```

The exception was not mapped, so both the autosave (`saveOnly=true`) and Generate (`saveOnly=false`) requests returned 500, and the success message the test waits for never appeared.

The test was flaky rather than failing every time because Generate reads the model from the query cache, which the 400 ms autosave debounce had not always updated yet. When Generate won the race it sent the previous, valid schema and the test passed.

## Fix

**Frontend** – `buildJsonSchema` leaves out a combination that has no subschemas. The combination is still visible in the editor and is written to the schema as soon as it gets its first subschema. It is not persisted until then, so it disappears on a page reload.

**Backend** – `JsonSchemaKeywords.FromText` wraps the library's `ArgumentException` in a new `InvalidJsonSchemaException`, which `DataModelingExceptionFilterAttribute` maps to **400** with the reason in `customErrorMessages` (error code `DM_06`) instead of a 500. This also gives a clear error for models that were stored with `anyOf: []` before this change; they heal on the next save.

## Why the frontend and not the backend

A combination without subschemas is not valid JSON Schema: the draft 2020-12 meta-schema defines `allOf`/`anyOf`/`oneOf` via `schemaArray`, which has `minItems: 1`. JsonSchema.Net 5.5.1 was lenient about it; 7.4.0 enforces the specification. The library is correct to reject it, and the backend is correct to treat the document as JSON Schema — so the request was invalid, and the fix belongs where the invalid document is produced.

The backend alternatives were considered and rejected:

- **Accept and store it.** The library cannot represent an empty combination (the keyword constructor throws), so the save path would have to write the payload without parsing it. Every other endpoint that reads the file (model metadata, preview, generation) parses it and would fail, so each of those would need to tolerate it as well. That spreads special handling of an invalid document across the backend and leaves invalid JSON Schema on disk for any other consumer.
- **Strip empty combinations before parsing.** Saves would succeed, but the stored file is the re-serialized parsed model, so the combination would be dropped from disk anyway — the same reload behaviour as this PR, with more backend code.
- **Configure the library to allow it.** Not possible; the check is in the keyword constructor, and the only lever is replacing the built-in keyword type, which the converters reference in ~75 places.

The editor is the only component that knows an empty combination is a transient editing state rather than part of the model, so it is the right place to leave it out. The backend change is limited to reporting invalid input properly.


## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid JSON Schemas now return a clear bad-request response with custom error details and a dedicated error code.
  - Empty combination entries are removed before saving, including related references and required-field entries.
  - Deleting fields from combination structures now correctly renumbers the remaining fields.
  - JSON Schema generation no longer incorrectly omits valid empty combination structures.
- **API**
  - Referring-node information is now available through the public schema-model interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->