### PR TITLE
fix(app-backend)!: correct typo in signing metric name

### DIFF
--- a/src/App/backend/CHANGELOG.md
+++ b/src/App/backend/CHANGELOG.md
@@ -9,6 +9,10 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+### Fixed
+
+- Breaking: the signing metric `altinn_app_lib_singing_get_service_owner_party` is now spelled `altinn_app_lib_signing_get_service_owner_party`. It counts the service owner party lookups an app makes when a signing task starts, and its name has carried the typo since the metric was added. Repoint any dashboard or alert matching the old name.
+
 ## [9.0.0-preview.5] - 2026-09-04
 
 ### Added

--- a/src/App/backend/src/Altinn.App.Core/Features/Telemetry/Signing/Telemetry.SigningService.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Telemetry/Signing/Telemetry.SigningService.cs
@@ -91,7 +91,7 @@ partial class Telemetry
     internal static class ServiceOwnerPartyConst
     {
         internal static readonly string MetricNameGetServiceOwnerParty = Metrics.CreateLibName(
-            "singing_get_service_owner_party"
+            "signing_get_service_owner_party"
         );
 
         [EnumExtensions(MetadataSource = MetadataSource.DisplayAttribute)]


### PR DESCRIPTION
## Description

[Metrics] Fixes spelling: `singing_get_service_owner_party` -> `signing_get_service_owner_party`.

## Related
- https://github.com/Altinn/app-lib-dotnet/pull/1590

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required) — one-word rename of a metric name constant; nothing reads the old name in this repo (`git grep get_service_owner_party` returns only the definition)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the spelling of the signing service-owner-party telemetry metric.
  - Dashboards and alerts using the previous metric name must be updated to use the corrected name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->