### PR TITLE
fix(maskinporten): skip well-known refresh on the localtest platform

### DIFF
--- a/src/App/backend/CHANGELOG.md
+++ b/src/App/backend/CHANGELOG.md
@@ -12,6 +12,7 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 ### Fixed
 
 - Breaking: the signing metric `altinn_app_lib_singing_get_service_owner_party` is now spelled `altinn_app_lib_signing_get_service_owner_party`. It counts the service owner party lookups an app makes when a signing task starts, and its name has carried the typo since the metric was added. Repoint any dashboard or alert matching the old name.
+- Running an app locally no longer logs Maskinporten errors at startup. The background refresh of Maskinporten's well-known metadata now only runs in deployed environments, where an app process is long-lived enough for the metadata to change under it. Apps that use Maskinporten locally are unaffected: the metadata is looked up the first time a token is requested, as before.
 
 ## [9.0.0-preview.5] - 2026-09-04
 

--- a/src/App/backend/src/Altinn.App.Core/Features/Maskinporten/MaskinportenWellKnownRefreshService.cs
+++ b/src/App/backend/src/Altinn.App.Core/Features/Maskinporten/MaskinportenWellKnownRefreshService.cs
@@ -1,3 +1,4 @@
+using Altinn.App.Core.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -9,6 +10,8 @@ namespace Altinn.App.Core.Features.Maskinporten;
 /// at startup and re-resolves it every <see cref="WellKnownRefreshInterval"/>, guarding against the upstream
 /// issuer changing during a long process lifetime. The request path itself never refreshes:
 /// see <see cref="MaskinportenClient.GetAudienceFromWellKnown"/>.</para>
+/// <para>Does not run on the localtest platform: a local app process lives for minutes, so there is no
+/// long-lived issuer drift to guard against, and the request path resolves the issuer on demand anyway.</para>
 /// <para>Must never fault or delay the host — everything is caught and logged at Debug only. Apps without
 /// Maskinporten configuration are skipped each iteration (<c>OptionsValidationException</c> from the settings
 /// read). A failed refresh keeps the last-known-good issuer and never stamps the client's fail-fast window.</para>
@@ -21,16 +24,19 @@ internal sealed class MaskinportenWellKnownRefreshService : BackgroundService
     internal static readonly TimeSpan WellKnownRefreshInterval = TimeSpan.FromHours(12);
 
     private readonly IServiceProvider _serviceProvider;
+    private readonly RuntimeEnvironment _runtimeEnvironment;
     private readonly ILogger<MaskinportenWellKnownRefreshService> _logger;
     private readonly TimeProvider _timeProvider;
 
     public MaskinportenWellKnownRefreshService(
         IServiceProvider serviceProvider,
+        RuntimeEnvironment runtimeEnvironment,
         ILogger<MaskinportenWellKnownRefreshService> logger,
         TimeProvider? timeProvider = null
     )
     {
         _serviceProvider = serviceProvider;
+        _runtimeEnvironment = runtimeEnvironment;
         _logger = logger;
         _timeProvider = timeProvider ?? TimeProvider.System;
     }
@@ -39,6 +45,18 @@ internal sealed class MaskinportenWellKnownRefreshService : BackgroundService
     {
         try
         {
+            // Warming up a 12-hour refresh cycle makes no sense in a process that lives for minutes, and
+            // an app run against localtest usually has no Maskinporten configuration at all — which would
+            // make every iteration log a skip. Callers still resolve the issuer on first use.
+            if (_runtimeEnvironment.IsLocaltestPlatform())
+            {
+                _logger.LogDebug(
+                    "Running on the localtest platform, skipping Maskinporten well-known refresh. "
+                        + "The issuer is resolved on demand instead."
+                );
+                return;
+            }
+
             using var timer = new PeriodicTimer(WellKnownRefreshInterval, _timeProvider);
             do
             {

--- a/src/App/backend/test/Altinn.App.Core.Tests/Features/Maskinporten/MaskinportenClientTest.cs
+++ b/src/App/backend/test/Altinn.App.Core.Tests/Features/Maskinporten/MaskinportenClientTest.cs
@@ -8,6 +8,7 @@ using Altinn.App.Core.Features.Maskinporten;
 using Altinn.App.Core.Features.Maskinporten.Constants;
 using Altinn.App.Core.Features.Maskinporten.Exceptions;
 using Altinn.App.Core.Features.Maskinporten.Models;
+using Altinn.App.Core.Internal;
 using Altinn.App.Core.Models;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Caching.Hybrid;
@@ -943,12 +944,42 @@ public class MaskinportenClientTests
         Assert.Equal(1, fetchCount());
     }
 
+    /// <summary>
+    /// A hostname that <see cref="RuntimeEnvironment.IsLocaltestPlatform"/> does not recognize as localtest,
+    /// i.e. an app deployed to a real environment. This is the default for the refresh service tests,
+    /// because a localtest app deliberately skips the refresh loop entirely.
+    /// </summary>
+    private const string DeployedHostName = "at22.altinn.cloud";
+
+    /// <summary>
+    /// The hostname a locally run app has, per the <c>GeneralSettings.HostName</c> default and everything
+    /// that configures it (studioctl, the app template, the apps under <c>src/test/apps</c>).
+    /// </summary>
+    private const string LocaltestHostName = "local.altinn.cloud";
+
+    /// <summary>
+    /// A <see cref="RuntimeEnvironment"/> that reports the given hostname. The hostname is the only input
+    /// to <see cref="RuntimeEnvironment.IsLocaltestPlatform"/>, which is what decides whether
+    /// <see cref="MaskinportenWellKnownRefreshService"/> runs its refresh loop at all.
+    /// </summary>
+    private static RuntimeEnvironment RuntimeEnvironmentFor(string hostName)
+    {
+        var generalSettings = new Mock<IOptionsMonitor<GeneralSettings>>();
+        generalSettings.Setup(x => x.CurrentValue).Returns(new GeneralSettings { HostName = hostName });
+        var platformSettings = new Mock<IOptionsMonitor<PlatformSettings>>();
+        platformSettings.Setup(x => x.CurrentValue).Returns(new PlatformSettings());
+
+        return new RuntimeEnvironment(generalSettings.Object, platformSettings.Object);
+    }
+
     private MaskinportenWellKnownRefreshService RefreshService(
         Fixture fixture,
-        ILogger<MaskinportenWellKnownRefreshService>? logger = null
+        ILogger<MaskinportenWellKnownRefreshService>? logger = null,
+        string hostName = DeployedHostName
     ) =>
         new(
             fixture.App.Services,
+            RuntimeEnvironmentFor(hostName),
             logger ?? fixture.App.Services.GetRequiredService<ILogger<MaskinportenWellKnownRefreshService>>(),
             fixture.FakeTime
         );
@@ -1152,8 +1183,9 @@ public class MaskinportenClientTests
     [Fact]
     public async Task WellKnownRefreshService_UnconfiguredSettings_SkipsSilently()
     {
-        // Arrange - Maskinporten is not configured, so the settings read inside the refresh throws
-        // OptionsValidationException, which the service must swallow at Debug level
+        // Arrange - a deployed app that does not use Maskinporten (the internal variant is unconfigured
+        // in nearly every app): the settings read inside the refresh throws OptionsValidationException,
+        // which the service must swallow at Debug level. Localtest is covered separately, by the gate.
         await using var fixture = Fixture.Create(configureMaskinporten: false);
         var fetchCount = SetupWellKnownEndpoint(
             fixture,
@@ -1183,6 +1215,44 @@ public class MaskinportenClientTests
     }
 
     [Fact]
+    public async Task WellKnownRefreshService_OnLocaltestPlatform_LeavesResolutionToTheRequestPath()
+    {
+        // Arrange - Maskinporten IS configured here, so the platform is the only thing that can stop
+        // the refresh loop, and a skipped refresh cannot be mistaken for a missing configuration
+        await using var fixture = Fixture.Create();
+        const string expectedIssuer = "https://issuer.maskinporten.no/";
+        var fetchCount = SetupWellKnownEndpoint(
+            fixture,
+            (_, _) => Task.FromResult(WellKnownSuccessResponse(expectedIssuer))
+        );
+        var logger = new RecordingLogger<MaskinportenWellKnownRefreshService>();
+        using var service = RefreshService(fixture, logger, hostName: LocaltestHostName);
+
+        // Act - ExecuteAsync returns as soon as it has seen the platform, so awaiting ExecuteTask is a
+        // deterministic "the gate has run" signal rather than a race against the first iteration
+        await service.StartAsync(CancellationToken.None);
+        await service.ExecuteTask!.WaitAsync(TimeSpan.FromSeconds(10));
+
+        // The loop is gone rather than merely idle: a full interval produces no refresh
+        fixture.FakeTime.Advance(MaskinportenWellKnownRefreshService.WellKnownRefreshInterval);
+        var fetchesBeforeCaller = fetchCount();
+
+        // ...and the warm-up was never load-bearing: a real caller still resolves the true issuer
+        var result = await fixture.Client(MaskinportenClient.VariantDefault).GetAudienceFromWellKnown();
+        await service.StopAsync(CancellationToken.None);
+
+        // Assert - nothing refreshed, one on-demand fetch, and a single self-explanatory Debug line
+        // instead of the per-variant skip entries an unconfigured localtest app used to produce
+        Assert.False(service.ExecuteTask.IsFaulted);
+        Assert.Equal(0, fetchesBeforeCaller);
+        Assert.Equal(expectedIssuer, result);
+        Assert.Equal(1, fetchCount());
+        var entry = Assert.Single(logger.Snapshot());
+        Assert.Equal(LogLevel.Debug, entry.Level);
+        Assert.Contains("localtest", entry.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task WellKnownRefreshService_ServiceResolutionFailureDoesNotFaultTheService()
     {
         // Arrange - a broken DI graph (client construction pulls IOptionsMonitor/IHttpClientFactory/
@@ -1195,6 +1265,7 @@ public class MaskinportenClientTests
         var logger = new RecordingLogger<MaskinportenWellKnownRefreshService>();
         using var service = new MaskinportenWellKnownRefreshService(
             provider.Object,
+            RuntimeEnvironmentFor(DeployedHostName),
             logger,
             new FakeTimeProvider(new DateTimeOffset(2024, 1, 1, 10, 0, 0, TimeSpan.Zero))
         );


### PR DESCRIPTION
Apps run locally logged two `OptionsValidationException` stack traces at startup — one per Maskinporten client variant — because the well-known refresh service warms up both variants and localtest apps rarely configure Maskinporten. The app template and every app under `src/test/apps` set `Default: "Debug"`, so the traces were in view locally and below the threshold everywhere else.

The refresh exists to catch the upstream issuer changing during a long process lifetime, which a local app process does not have. `ExecuteAsync` now returns early when `RuntimeEnvironment.IsLocaltestPlatform()`, mirroring `LocaltestValidation`.

Registration stays unconditional, so the `HostedServices` snapshot is unchanged and deployed apps keep the refresh loop. The request path already resolves the issuer on demand, so nothing needs the warm-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Local app runs no longer log Maskinporten errors during startup.
  * Background Maskinporten metadata refresh is now skipped in local environments, preventing unnecessary startup activity.
  * Local use continues to resolve issuer details when the first token is requested.

* **Documentation**
  * Updated the changelog to describe the environment-specific refresh behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->