### PR TITLE
feat: gitea runner maxpods to 4 by default

### DIFF
--- a/charts/gitea-org-runner-config/templates/helm-release.yaml
+++ b/charts/gitea-org-runner-config/templates/helm-release.yaml
@@ -57,7 +57,7 @@ spec:
 
     # Per-org concurrency caps. Default applies to every org; overrides
     # keyed by org name take precedence.
-    maxConcurrentDefault: {{ .Values.maxConcurrentDefault | default 2 }}
+    maxConcurrentDefault: {{ .Values.maxConcurrentDefault | default 4 }}
     maxConcurrentOverrides:
       {{- toYaml (.Values.maxConcurrentOverrides | default dict) | nindent 6 }}
 

--- a/charts/gitea-org-runner-config/values.yaml
+++ b/charts/gitea-org-runner-config/values.yaml
@@ -15,7 +15,5 @@ shareWorkspace:
 # `maxConcurrentDefault` applies to every org; `maxConcurrentOverrides` keys
 # named exceptions per org. Overrides for orgs absent from the active
 # environment's runners list are harmlessly ignored.
-maxConcurrentDefault: 2
-maxConcurrentOverrides:
-  brg: 2
-  ssb: 2
+maxConcurrentDefault: 4
+maxConcurrentOverrides: {}

--- a/charts/gitea-org-runner/values.yaml
+++ b/charts/gitea-org-runner/values.yaml
@@ -97,7 +97,7 @@ keda:
 # Per-org concurrency caps. The chart applies maxConcurrentDefault to every
 # org unless overridden by an explicit entry in maxConcurrentOverrides.
 # maxConcurrentOverrides is keyed by org code (matching runners[].name).
-maxConcurrentDefault: 2
+maxConcurrentDefault: 4
 maxConcurrentOverrides: {}
 
 # List of orgs to render a ScaledJob for. Populated by the consumer (typically


### PR DESCRIPTION
## Description

This mainly affects scheduling and not cost (since we have no mechanism to limit here, just queue based on concurrency)

```
Assuming 112 runner slots across 16 nodes (16 * 7 = 112):

- Max 4 pods: 28 owners × 4 = 112 runners — fits exactly, 0 slots left.
- Max 5 pods: 22 owners × 5 = 110 runners — fits, 2 slots left.
- Max 6 pods: 18 owners × 6 = 108 runners — fits, 4 slots left.
```

So with this, 28 serviceowners would have to saturate their maxPods for us to hit nodepool max size

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the default maximum number of concurrent runner jobs per organisation from 2 to 4.
  * Organisation-specific concurrency overrides remain supported.
  * Existing organisation-specific overrides have been replaced with the shared default limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->