### PR TITLE
fix(experimental): agent wait for systemd before configuring Podman 

### DIFF
--- a/src/experimental/agent/src/harness/claude_code/bootstrap/linux.rs
+++ b/src/experimental/agent/src/harness/claude_code/bootstrap/linux.rs
@@ -2,9 +2,9 @@
 
 use std::io::Cursor;
 
-use sandbox::{SandboxHandle, SandboxPath, execution::ExecutionSpec};
+use sandbox::{SandboxHandle, SandboxPath};
 
-use crate::Error;
+use crate::{Error, sandbox::platform::run_checked};
 
 use super::super::ACCESS_PLACEHOLDER;
 
@@ -98,21 +98,4 @@ pub(super) async fn configure(sandbox: &SandboxHandle, home: &str, instructions:
         run_checked(sandbox, "/usr/bin/chmod", ["644", instructions_path.as_str()]).await?;
     }
     Ok(())
-}
-
-async fn run_checked<const N: usize>(sandbox: &SandboxHandle, executable: &str, args: [&str; N]) -> Result<(), Error> {
-    let output = sandbox
-        .run_execution(ExecutionSpec::command(
-            SandboxPath::new(executable),
-            args.into_iter().map(str::to_owned),
-        ))
-        .await?;
-    if output.status.success() {
-        Ok(())
-    } else {
-        Err(Error::SandboxSetup(format!(
-            "command {executable:?} exited with code {}",
-            output.status.code
-        )))
-    }
 }

--- a/src/experimental/agent/src/harness/codex/bootstrap/linux.rs
+++ b/src/experimental/agent/src/harness/codex/bootstrap/linux.rs
@@ -2,9 +2,9 @@
 
 use std::io::Cursor;
 
-use sandbox::{SandboxHandle, SandboxPath, execution::ExecutionSpec};
+use sandbox::{SandboxHandle, SandboxPath};
 
-use crate::Error;
+use crate::{Error, sandbox::platform::run_checked};
 
 use super::super::{ACCESS_PLACEHOLDER, ACCOUNT_PLACEHOLDER, REFRESH_PLACEHOLDER};
 
@@ -95,21 +95,4 @@ pub(super) async fn configure(sandbox: &SandboxHandle, home: &str, instructions:
         run_checked(sandbox, "/usr/bin/chmod", ["644", instructions_path.as_str()]).await?;
     }
     Ok(())
-}
-
-async fn run_checked<const N: usize>(sandbox: &SandboxHandle, executable: &str, args: [&str; N]) -> Result<(), Error> {
-    let output = sandbox
-        .run_execution(ExecutionSpec::command(
-            SandboxPath::new(executable),
-            args.into_iter().map(str::to_owned),
-        ))
-        .await?;
-    if output.status.success() {
-        Ok(())
-    } else {
-        Err(Error::SandboxSetup(format!(
-            "command {executable:?} exited with code {}",
-            output.status.code
-        )))
-    }
 }

--- a/src/experimental/agent/src/sandbox/platform/linux.rs
+++ b/src/experimental/agent/src/sandbox/platform/linux.rs
@@ -16,6 +16,9 @@ const HOME_ARCHIVE: &str = "/tmp/agent-home.tar";
 const UTF8_LOCALE: &str = "C.UTF-8";
 const PORTABLE_TERMINAL: &str = "xterm-256color";
 const PODMAN: &str = "/usr/bin/podman";
+const SETUP_STDERR_LINES: usize = 3;
+const SYSTEMD_READY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(90);
+const SYSTEMD_READY_POLL: std::time::Duration = std::time::Duration::from_secs(1);
 // Podman reads these files when it creates containers. The default mount also
 // reaches Buildah RUN containers and exposes the guest's superset bundle at a
 // path no distro package owns. Distro trust paths are populated by an OCI hook
@@ -173,6 +176,7 @@ async fn configure_podman(sandbox: &SandboxHandle) -> Result<(), Error> {
         }
     }
 
+    wait_for_systemd(sandbox).await?;
     run_checked(
         sandbox,
         "/usr/bin/sudo",
@@ -213,6 +217,43 @@ async fn configure_podman(sandbox: &SandboxHandle) -> Result<(), Error> {
         ["-n", "/usr/bin/systemctl", "enable", "--now", "podman.socket"],
     )
     .await
+}
+
+/// Waits until systemd is PID 1 and has finished booting the guest.
+///
+/// Sandbox setup starts as soon as the Sandbox accepts Executions, which on an
+/// image-init guest is before the image entrypoint has become systemd; `systemctl`
+/// then reports "System has not been booted with systemd". `is-system-running
+/// --wait` blocks until startup finishes once systemd is up. It runs as root
+/// because the guest has no D-Bus system bus and only root reaches systemd's
+/// private socket. A `degraded` system counts as ready: a failed optional unit,
+/// such as a best-effort workspace clone, must not block the Podman configuration.
+async fn wait_for_systemd(sandbox: &SandboxHandle) -> Result<(), Error> {
+    let deadline = tokio::time::Instant::now() + SYSTEMD_READY_TIMEOUT;
+    loop {
+        let output = sandbox
+            .run_execution(ExecutionSpec::command(
+                SandboxPath::new("/usr/bin/sudo"),
+                ["-n", "/usr/bin/systemctl", "is-system-running", "--wait"].map(str::to_owned),
+            ))
+            .await?;
+        let state = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+        if output.status.success() || matches!(state.as_str(), "running" | "degraded") {
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            let last = if state.is_empty() {
+                String::from_utf8_lossy(&output.stderr).trim().to_owned()
+            } else {
+                state
+            };
+            return Err(Error::SandboxSetup(format!(
+                "systemd did not become ready within {}s: {last}",
+                SYSTEMD_READY_TIMEOUT.as_secs()
+            )));
+        }
+        tokio::time::sleep(SYSTEMD_READY_POLL).await;
+    }
 }
 
 async fn write_file(sandbox: &SandboxHandle, path: &str, contents: &[u8]) -> Result<(), Error> {
@@ -286,7 +327,16 @@ async fn sync_home(sandbox: &SandboxHandle, archive: Vec<u8>) -> Result<(), Erro
     run_checked(sandbox, "/usr/bin/tar", ["-xf", HOME_ARCHIVE, "-C", HOME]).await
 }
 
-async fn run_checked<const N: usize>(sandbox: &SandboxHandle, executable: &str, args: [&str; N]) -> Result<(), Error> {
+/// Runs one setup command in the Sandbox and fails with what it ran and what it printed.
+///
+/// # Errors
+///
+/// Returns an error when the Execution cannot start or exits unsuccessfully.
+pub(crate) async fn run_checked<const N: usize>(
+    sandbox: &SandboxHandle,
+    executable: &str,
+    args: [&str; N],
+) -> Result<(), Error> {
     let output = sandbox
         .run_execution(ExecutionSpec::command(
             SandboxPath::new(executable),
@@ -294,13 +344,29 @@ async fn run_checked<const N: usize>(sandbox: &SandboxHandle, executable: &str, 
         ))
         .await?;
     if output.status.success() {
-        Ok(())
-    } else {
-        Err(Error::SandboxSetup(format!(
-            "command {executable:?} exited with code {}",
-            output.status.code
-        )))
+        return Ok(());
     }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stderr = stderr.trim();
+    let detail = if stderr.is_empty() {
+        String::new()
+    } else {
+        let tail = stderr
+            .lines()
+            .rev()
+            .take(SETUP_STDERR_LINES)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect::<Vec<_>>()
+            .join(" | ");
+        format!(": {tail}")
+    };
+    Err(Error::SandboxSetup(format!(
+        "command `{executable} {}` exited with code {}{detail}",
+        args.join(" "),
+        output.status.code
+    )))
 }
 
 fn resolve_source(manifest_directory: &Path, source: &Path) -> Result<std::path::PathBuf, Error> {

--- a/src/experimental/agent/src/sandbox/platform/linux.rs
+++ b/src/experimental/agent/src/sandbox/platform/linux.rs
@@ -231,12 +231,27 @@ async fn configure_podman(sandbox: &SandboxHandle) -> Result<(), Error> {
 async fn wait_for_systemd(sandbox: &SandboxHandle) -> Result<(), Error> {
     let deadline = tokio::time::Instant::now() + SYSTEMD_READY_TIMEOUT;
     loop {
-        let output = sandbox
-            .run_execution(ExecutionSpec::command(
-                SandboxPath::new("/usr/bin/sudo"),
-                ["-n", "/usr/bin/systemctl", "is-system-running", "--wait"].map(str::to_owned),
+        // `--wait` blocks for as long as boot takes, so the deadline bounds the wait itself
+        // and a still-running check is killed rather than left behind in the guest.
+        let started = sandbox
+            .start_execution(::sandbox::execution::StartExecutionRequest::new(
+                ExecutionSpec::command(
+                    SandboxPath::new("/usr/bin/sudo"),
+                    ["-n", "/usr/bin/systemctl", "is-system-running", "--wait"].map(str::to_owned),
+                ),
             ))
             .await?;
+        let execution_id = started.id.clone();
+        let output = match tokio::time::timeout_at(deadline, started.collect()).await {
+            Ok(output) => output?,
+            Err(_elapsed) => {
+                let _ = sandbox.kill_execution(&execution_id).await;
+                return Err(Error::SandboxSetup(format!(
+                    "systemd did not finish booting within {}s",
+                    SYSTEMD_READY_TIMEOUT.as_secs()
+                )));
+            }
+        };
         let state = String::from_utf8_lossy(&output.stdout).trim().to_owned();
         if output.status.success() || matches!(state.as_str(), "running" | "degraded") {
             return Ok(());

--- a/src/experimental/agent/src/sandbox/platform/mod.rs
+++ b/src/experimental/agent/src/sandbox/platform/mod.rs
@@ -7,7 +7,7 @@ use ::sandbox::execution::ExecutionSpec;
 use crate::Error;
 
 pub use linux::Linux;
-pub(crate) use linux::{CONTAINER_HOST, HOME, WORKING_DIRECTORY};
+pub(crate) use linux::{CONTAINER_HOST, HOME, WORKING_DIRECTORY, run_checked};
 
 /// Builds the Agent-conventional Execution environment for one Sandbox OS.
 ///

--- a/src/experimental/agent/tests/platform_linux.rs
+++ b/src/experimental/agent/tests/platform_linux.rs
@@ -41,6 +41,14 @@ fn is_podman_presence_check(spec: &sandbox::execution::ExecutionSpec) -> bool {
     )
 }
 
+fn is_systemd_readiness_check(spec: &sandbox::execution::ExecutionSpec) -> bool {
+    matches!(
+        spec.program(),
+        Program::Command { executable, args }
+            if executable.as_str() == "/usr/bin/sudo" && args == &["-n", "/usr/bin/systemctl", "is-system-running", "--wait"]
+    )
+}
+
 fn completed(code: i32) -> Vec<ExecutionEvent> {
     vec![
         ExecutionEvent::Started { process_id: None },
@@ -90,6 +98,19 @@ fn assert_podman_setup_commands(executions: &[sandbox::execution::ExecutionSpec]
             .count()
     };
     assert_eq!(count(&["-n", "/usr/bin/systemctl", "daemon-reload"]), 2);
+    // systemd readiness is confirmed before the first systemctl call of a setup pass.
+    let daemon_reload = executions
+        .iter()
+        .position(|spec| matches!(spec.program(), Program::Command { args, .. } if args.contains(&"daemon-reload".to_owned())))
+        .expect("daemon-reload runs");
+    assert!(executions.iter().take(daemon_reload).any(is_systemd_readiness_check));
+    assert!(
+        executions
+            .iter()
+            .filter(|spec| is_systemd_readiness_check(spec))
+            .count()
+            >= 2
+    );
     assert_eq!(
         count(&["-n", "/usr/bin/systemctl", "enable", "--now", "podman.socket"]),
         2
@@ -247,6 +268,7 @@ async fn linux_setup_rewrites_configuration_without_owning_workspace_initializat
 }
 
 #[tokio::test(flavor = "local")]
+#[allow(clippy::too_many_lines)]
 async fn linux_setup_convergently_configures_podman_container_trust() {
     let directory = TempDir::new().expect("temporary directory");
     let home = directory.path().join("home");
@@ -289,6 +311,25 @@ async fn linux_setup_convergently_configures_podman_container_trust() {
         .await
         .expect("Sandbox");
 
+    // The first setup pass races the image init: systemd is not PID 1 yet, then boots degraded.
+    backend.queue_execution_events_matching(
+        is_systemd_readiness_check,
+        vec![
+            ExecutionEvent::Started { process_id: None },
+            ExecutionEvent::Stderr(
+                "System has not been booted with systemd as init system (PID 1). Can't operate.\n".into(),
+            ),
+            ExecutionEvent::Exited(ExitStatus { code: 1 }),
+        ],
+    );
+    backend.queue_execution_events_matching(
+        is_systemd_readiness_check,
+        vec![
+            ExecutionEvent::Started { process_id: None },
+            ExecutionEvent::Stdout("degraded\n".into()),
+            ExecutionEvent::Exited(ExitStatus { code: 1 }),
+        ],
+    );
     Linux.setup(&record, &sandbox).await.expect("first setup");
     sandbox
         .write_file(
@@ -348,6 +389,15 @@ async fn linux_setup_convergently_configures_podman_container_trust() {
     assert!(hook.contains("/.msb/tls/ca.pem"));
 
     assert_podman_setup_commands(&backend.execution_specs());
+    // Two setup passes; the first retried once while systemd was not yet PID 1.
+    assert_eq!(
+        backend
+            .execution_specs()
+            .iter()
+            .filter(|spec| is_systemd_readiness_check(spec))
+            .count(),
+        3
+    );
 }
 
 #[tokio::test(flavor = "local")]


### PR DESCRIPTION
## Description

Sandbox setup starts as soon as the guest accepts executions, which on an image-init guest is before the entrypoint has become systemd. The first `systemctl daemon-reload` then failed with "System has not been booted with systemd as init system" and setup succeeded only on the retry. Podman configuration now waits for `systemctl is-system-running --wait`.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Linux sandbox startup by waiting for system services to become ready before configuration.
  - Added retries for delayed service readiness.
  - Improved setup errors with the failed command, exit code, and relevant error output.
- **Tests**
  - Added coverage for system readiness checks, retries, and repeated setup attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->