### PR TITLE
feat: agent visualization/evidence tools for PRs

### DIFF
--- a/.github/workflows/agents-images.yaml
+++ b/.github/workflows/agents-images.yaml
@@ -95,3 +95,25 @@ jobs:
             --target "${TARGET}" \
             "$@" \
             agents
+
+      # The multi-platform build above only pushes. Load the native image separately (fully
+      # cached by the step above) and exercise the pull request evidence tooling in it.
+      - name: Smoke test amd64 image
+        env:
+          IMAGE_REPOSITORY: ${{ matrix.repository }}
+          TARGET: ${{ matrix.variant }}
+        run: |
+          set -eu
+          docker buildx build \
+            --provenance=false \
+            --sbom=false \
+            --cache-from "type=registry,ref=${IMAGE_REPOSITORY}:buildcache" \
+            --file agents/Dockerfile \
+            --platform linux/amd64 \
+            --target "${TARGET}" \
+            --load \
+            --tag "agent-${TARGET}:smoke" \
+            agents
+          docker run --rm --init --ipc=host --security-opt seccomp=unconfined --entrypoint bash \
+            --volume "${PWD}/agents/smoke.sh:/smoke.sh:ro" \
+            "agent-${TARGET}:smoke" /smoke.sh "${TARGET}"

--- a/agents/Dockerfile
+++ b/agents/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
         build-essential \
         ca-certificates \
         curl \
+        fonts-liberation \
         git \
         jq \
         libicu-dev \
@@ -63,7 +64,7 @@ RUN case "${TARGETARCH}" in \
     && rm -f /tmp/dotnet-install.sh /tmp/go.tar.gz /tmp/node.tar.xz
 
 ARG YARN_VERSION=4.18.0
-ARG GH_VERSION=2.98.0
+ARG GH_VERSION=2.100.0
 
 ENV COREPACK_HOME=/usr/local/share/corepack
 
@@ -73,8 +74,8 @@ RUN mkdir -p "${COREPACK_HOME}" \
     && chmod -R a+rX "${COREPACK_HOME}"
 
 RUN case "${TARGETARCH}" in \
-        amd64) GH_SHA256=3b8ac6b30336802fc1a858d7c084e11cdf24ac1a761ca90b68022d7d729208de ;; \
-        arm64) GH_SHA256=cf689084f3a3618f7eae4a2420d335d74626d65f5e594b9828d125d69f800d86 ;; \
+        amd64) GH_SHA256=e4d4bb4498e8d007abe545b6568926793ace1b6447da598294a610018cb164be ;; \
+        arm64) GH_SHA256=ea4e7a581a32ccad6cc7923cb1576ac5859ba4b9a16ab22eb8f8a96e78e2e961 ;; \
         *) echo "unsupported target architecture: ${TARGETARCH}" >&2; exit 1 ;; \
     esac \
     && GH_ARCHIVE="gh_${GH_VERSION}_linux_${TARGETARCH}.tar.gz" \
@@ -90,6 +91,36 @@ RUN case "${TARGETARCH}" in \
 # directory is resynchronized from the host on every sandbox setup.
 RUN git config --system credential.https://github.com.helper '!/usr/local/bin/gh auth git-credential' \
     && git config --system credential.https://gist.github.com.helper '!/usr/local/bin/gh auth git-credential'
+
+# Terminal evidence for pull requests: asciinema records a command, agg renders the cast to a GIF
+# with a system font (Liberation Mono from fonts-liberation above is in its default family list).
+# Both are static single binaries published per architecture without checksum files, so the
+# digests are pinned here and must move together with the version.
+ARG ASCIINEMA_VERSION=3.2.1
+ARG AGG_VERSION=1.9.0
+
+RUN case "${TARGETARCH}" in \
+        amd64) RUST_ARCH=x86_64; \
+            ASCIINEMA_SHA256=1b405bbda565b33c3c4718de67fedc3535580603c0694b1ff3fb04f363430a20; \
+            AGG_SHA256=f111e315cd71056b116302342553dd765b7297579ed511f111d0cedb442aeda6 ;; \
+        arm64) RUST_ARCH=aarch64; \
+            ASCIINEMA_SHA256=b516a6d896844c0ffbc96e0a55afe4cbcc79216abde0fc64fdda4e39bee421ea; \
+            AGG_SHA256=2b4be407b97e00e1c313a41d154ced8fa3d02c560c8f47a0db4950a2576444c9 ;; \
+        *) echo "unsupported target architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL \
+        "https://github.com/asciinema/asciinema/releases/download/v${ASCIINEMA_VERSION}/asciinema-${RUST_ARCH}-unknown-linux-gnu" \
+        -o /tmp/asciinema \
+    && echo "${ASCIINEMA_SHA256}  /tmp/asciinema" | sha256sum -c - \
+    && install -m 0755 /tmp/asciinema /usr/local/bin/asciinema \
+    && curl -fsSL \
+        "https://github.com/asciinema/agg/releases/download/v${AGG_VERSION}/agg-${RUST_ARCH}-unknown-linux-gnu" \
+        -o /tmp/agg \
+    && echo "${AGG_SHA256}  /tmp/agg" | sha256sum -c - \
+    && install -m 0755 /tmp/agg /usr/local/bin/agg \
+    && rm -f /tmp/asciinema /tmp/agg \
+    && asciinema --version \
+    && agg --version
 
 ARG CODEX_VERSION=0.149.1
 ARG CLAUDE_CODE_VERSION=2.1.260
@@ -133,10 +164,12 @@ ENTRYPOINT ["/usr/lib/systemd/systemd"]
 
 FROM base AS full
 
-ARG PLAYWRIGHT_VERSION=1.62.1
+ARG PLAYWRIGHT_CLI_VERSION=0.1.19
 ARG RUST_VERSION=1.97.1
 
 ENV CARGO_HOME=/usr/local/cargo
+# Standalone scripts resolve the globally installed `playwright` package from any directory.
+ENV NODE_PATH=/usr/local/lib/node_modules
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
 ENV RUSTUP_HOME=/usr/local/rustup
 ENV PATH=/usr/local/cargo/bin:${PATH}
@@ -147,6 +180,7 @@ RUN apt-get update \
     && apt-get install --yes --no-install-recommends \
         aardvark-dns \
         clang \
+        ffmpeg \
         iproute2 \
         lldb \
         linux-perf \
@@ -162,11 +196,32 @@ RUN apt-get update \
     && rustup default "${RUST_VERSION}" \
     && rustup component add clippy rustfmt
 
-RUN npm install --global "playwright@${PLAYWRIGHT_VERSION}" \
+# Playwright ties every package version to one Chromium build. The browser CLI owns the version:
+# the `playwright` package is installed at exactly the version the CLI depends on, so the CLI,
+# standalone scripts and the single browser under PLAYWRIGHT_BROWSERS_PATH cannot drift apart.
+# The bundled skill is installed user-wide where Claude Code and Codex look for skills;
+# `playwright-cli install --skills` would otherwise write it per working directory. Root-owned
+# build caches under the agent home would deny the agent user its own cache directories later.
+RUN npm install --global "@playwright/cli@${PLAYWRIGHT_CLI_VERSION}" \
+    && PLAYWRIGHT_VERSION="$(node -p "require('${NODE_PATH}/@playwright/cli/package.json').dependencies.playwright")" \
+    && test -n "${PLAYWRIGHT_VERSION}" \
+    && npm install --global "playwright@${PLAYWRIGHT_VERSION}" \
+    && test "$(node -p "require('playwright/package.json').version")" = "${PLAYWRIGHT_VERSION}" \
     && playwright install --with-deps chromium \
     && chmod -R a+rX "${PLAYWRIGHT_BROWSERS_PATH}" \
-    && rm -rf /var/lib/apt/lists/* \
-    && playwright --version
+    && playwright --version \
+    && playwright-cli --version \
+    && for skills in /home/agent/.claude/skills /home/agent/.agents/skills; do \
+        mkdir -p "${skills}" \
+        && cp -R "${NODE_PATH}/@playwright/cli/skills/playwright-cli" "${skills}/playwright-cli"; \
+    done \
+    && chown -R agent:agent /home/agent/.claude /home/agent/.agents \
+    && rm -rf /var/lib/apt/lists/* /home/agent/.npm /home/agent/.cache \
+    && if find /home/agent ! -user agent -print -quit | grep -q .; then \
+        echo "build left files under /home/agent not owned by agent" >&2; exit 1; \
+    fi
+
+COPY --chmod=0755 common/bin/video-to-gif common/bin/media-preview /usr/local/bin/
 
 ARG FLUX_VERSION=2.9.4
 ARG HELM_VERSION=3.21.1
@@ -217,7 +272,8 @@ RUN case "${TARGETARCH}" in \
     && kind version \
     && kubectl version --client \
     && helm version --short \
-    && flux --version
+    && flux --version \
+    && ffmpeg -version
 
 ENV RUSTUP_TOOLCHAIN=${RUST_VERSION}
 

--- a/agents/README.md
+++ b/agents/README.md
@@ -2,11 +2,14 @@
 
 Choose a Claude Code development environment:
 
-| Variant    | Additional tools                                        |
-| ---------- | ------------------------------------------------------- |
-| `minimal`  | .NET, Node.js and Go                                    |
-| `full`     | Rust, Podman, kind, kubectl, Helm and Flux              |
-| `worktree` | Full image with the current checkout mounted read-write |
+| Variant    | Additional tools                                                   |
+| ---------- | ------------------------------------------------------------------ |
+| `minimal`  | .NET, Node.js, Go, GitHub CLI, asciinema and agg                   |
+| `full`     | Rust, Podman, kind, kubectl, Helm, Flux, Playwright CLI and ffmpeg |
+| `worktree` | Full image with the current checkout mounted read-write            |
+
+Every variant installs the `pr-evidence` skill from `agents/skills`: screenshots and clips through Playwright, terminal
+recordings through asciinema, uploaded with `gh pr create --attach`.
 
 The host needs hardware virtualization. Docker is required only for manifests that build an image locally; these
 released variants use registry references. Install the released Agent CLI on Linux or macOS:
@@ -38,8 +41,10 @@ repository one, so add `Gists: Read and write` when the Agent must create or pus
 Organization approval may be required.
 
 Copy the chosen variant's `.env.sample` to `.env` and set `GITHUB_TOKEN` there. The token remains
-on the host and is substituted only for authorized GitHub requests. The worktree variant does not
-receive a token because its host checkout is mounted into the Agent.
+on the host and is substituted only for authorized GitHub requests, including attachment uploads to
+`uploads.github.com`. Inside the Agent the variable holds an inert placeholder with the fine-grained
+token prefix, which `gh` needs before it will attach files. The worktree variant does not receive a
+token because its host checkout is mounted into the Agent, so it cannot attach files to pull requests.
 
 From the repository root, configure and start an Agent:
 

--- a/agents/common/bin/media-preview
+++ b/agents/common/bin/media-preview
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Reports what a capture contains so it can be checked before it is attached to a pull request.
+#
+#   media-preview FILE [FILE...]
+#
+# Prints dimensions, duration and size for each file. For a video or GIF it also writes
+# FILE.preview.png, a contact sheet of eight evenly spaced frames, which an agent can read as an
+# image to see what the clip actually shows.
+set -euo pipefail
+
+[ $# -ge 1 ] || { sed -n '2,8p' "$0" >&2; exit 64; }
+
+status=0
+for file in "$@"; do
+    if [ ! -r "$file" ]; then
+        echo "media-preview: cannot read $file" >&2
+        status=66
+        continue
+    fi
+    if ! probe="$(ffprobe -v error -select_streams v:0 \
+        -show_entries stream=width,height,nb_frames:format=duration,size \
+        -of default=noprint_wrappers=1 "$file")"; then
+        echo "media-preview: $file is not a media file ffprobe understands" >&2
+        status=65
+        continue
+    fi
+    width="$(sed -n 's/^width=//p' <<<"$probe")"
+    height="$(sed -n 's/^height=//p' <<<"$probe")"
+    duration="$(sed -n 's/^duration=//p' <<<"$probe")"
+    size="$(sed -n 's/^size=//p' <<<"$probe")"
+    printf '%s: %sx%s, %s s, %s bytes\n' "$file" "$width" "$height" "${duration:-0}" "$size"
+
+    frames="$(ffprobe -v error -count_frames -select_streams v:0 \
+        -show_entries stream=nb_read_frames -of csv=p=0 "$file" 2>/dev/null || echo 1)"
+    if [ "${frames:-1}" -gt 1 ]; then
+        sheet="${file}.preview.png"
+        step=$(( (frames + 7) / 8 ))
+        ffmpeg -hide_banner -loglevel error -y -i "$file" \
+            -vf "select=not(mod(n\,${step})),scale=480:-1,tile=4x2" -frames:v 1 "$sheet"
+        printf '  contact sheet: %s (%d frames sampled every %d)\n' "$sheet" "$frames" "$step"
+    fi
+done
+exit "$status"

--- a/agents/common/bin/video-to-gif
+++ b/agents/common/bin/video-to-gif
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Converts a browser recording (WebM/MP4) to a GIF that stays readable under GitHub's 10 MB limit.
+#
+#   video-to-gif [--start SECONDS] [--duration SECONDS] [--width PIXELS] [--fps N] INPUT OUTPUT.gif
+#
+# Two ffmpeg passes: the first computes a palette from the selected interval, the second dithers
+# against it. A single-pass conversion uses a generic palette and produces both larger and worse
+# GIFs. The defaults match the evidence guidelines: 1280 px wide, 12 fps, whole clip.
+set -euo pipefail
+
+usage() {
+    sed -n '2,6p' "$0" >&2
+    exit 64
+}
+
+start=""
+duration=""
+width=1280
+fps=12
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --start) start="$2"; shift 2 ;;
+        --duration) duration="$2"; shift 2 ;;
+        --width) width="$2"; shift 2 ;;
+        --fps) fps="$2"; shift 2 ;;
+        --help | -h) usage ;;
+        --*) echo "video-to-gif: unknown option $1" >&2; usage ;;
+        *) break ;;
+    esac
+done
+
+[ $# -eq 2 ] || usage
+input="$1"
+output="$2"
+
+[ -r "$input" ] || { echo "video-to-gif: cannot read $input" >&2; exit 66; }
+case "$output" in
+    *.gif) ;;
+    *) echo "video-to-gif: output must end in .gif" >&2; exit 64 ;;
+esac
+
+trim=()
+[ -n "$start" ] && trim+=(-ss "$start")
+[ -n "$duration" ] && trim+=(-t "$duration")
+
+filters="fps=${fps},scale=${width}:-1:flags=lanczos"
+palette="$(mktemp --suffix=.png)"
+trap 'rm -f "$palette"' EXIT
+
+ffmpeg -hide_banner -loglevel error -y "${trim[@]}" -i "$input" \
+    -vf "${filters},palettegen=stats_mode=diff" "$palette"
+ffmpeg -hide_banner -loglevel error -y "${trim[@]}" -i "$input" -i "$palette" \
+    -lavfi "${filters} [x]; [x][1:v] paletteuse=dither=bayer:bayer_scale=5:diff_mode=rectangle" \
+    "$output"
+
+size="$(stat -c %s "$output")"
+printf '%s: %d frames at %s fps, %s bytes\n' "$output" \
+    "$(ffprobe -v error -count_frames -select_streams v:0 -show_entries stream=nb_read_frames -of csv=p=0 "$output")" \
+    "$fps" "$size"
+if [ "$size" -gt $((8 * 1024 * 1024)) ]; then
+    echo "video-to-gif: larger than 8 MB; shorten the interval, lower --fps or --width, or attach an MP4 instead" >&2
+    exit 1
+fi

--- a/agents/full/agent.yaml
+++ b/agents/full/agent.yaml
@@ -19,7 +19,8 @@ spec:
   home:
     source: home
   instructions:
-    source: ../instructions.md
+    - source: ../instructions.md
+    - source: environment.md
   skills:
     - source: ../skills/pr-evidence
   harnesses:

--- a/agents/full/agent.yaml
+++ b/agents/full/agent.yaml
@@ -20,6 +20,8 @@ spec:
     source: home
   instructions:
     source: ../instructions.md
+  skills:
+    - source: ../skills/pr-evidence
   harnesses:
     - type: claudeCode
       auth: mediated
@@ -29,10 +31,14 @@ spec:
     #   auth: mediated
   secrets:
     - environment: GITHUB_TOKEN
+      # gh only attaches files with a token it classifies by prefix; the inert placeholder
+      # therefore carries the fine-grained PAT prefix and is far shorter than a real token.
+      placeholder: github_pat_AGENT_MEDIATED_GITHUB_TOKEN
       allowedHosts:
         - github.com
         - api.github.com
         - gist.github.com
+        - uploads.github.com
   network:
     mode: mediated
     allow: all

--- a/agents/full/environment.md
+++ b/agents/full/environment.md
@@ -1,0 +1,14 @@
+## This computer
+
+.NET, Node.js with Yarn, Go, Rust, the GitHub CLI, Podman with `docker` and `/run/docker.sock` as compatibility
+surfaces, kind, kubectl, Helm and Flux.
+
+Pull request evidence: `asciinema` and `agg` for terminal recordings; `playwright-cli` with Chromium (open it with
+`--browser chromium`), `ffmpeg`, and the `video-to-gif` and `media-preview` helpers for browser captures.
+
+Containers receive mediated CA configuration automatically. Build steps receive the full CA bundle at
+`/run/agent/tls/ca-bundle.pem` and common system trust paths. A current Buildah bug drops default environment variables
+from build stages, so tools that ignore the system store need a step-scoped variable such as
+`RUN NODE_EXTRA_CA_CERTS=/run/agent/tls/ca-bundle.pem npm ci` or `RUN NODE_OPTIONS=--use-openssl-ca npm ci`. Kind's
+`KIND_EXPERIMENTAL_PROVIDER=podman` mode is installed but unverified; do not assume nested kind containers inherit the
+Agent's mediated CA trust.

--- a/agents/instructions.md
+++ b/agents/instructions.md
@@ -80,8 +80,8 @@ When asked to create or update a pull request:
   `--body-file` rather than relying on interactive inference.
 - Use a conventional commit-style title such as `feat:`, `fix:`, or `chore:` and follow the repository template.
 - Explain what changed, why it changed, and how it was verified.
-- Include screenshots for relevant user-interface changes and command/output evidence for CLI behavior changes; see
-  the evidence workflow below.
+- Show visible results instead of describing them: screenshots for user-interface changes, recordings for terminal
+  behavior, attached to the pull request. The `pr-evidence` skill has the workflow and the tool commands.
 - For `Altinn/altinn-studio`, push a feature branch to `origin` and target `main`; never merge it yourself.
 - For repositories without direct write access, configure or use a fork and target the upstream default branch.
 - Keep each pull request focused. Use separate, dependent pull requests when independent review or rollout is useful.
@@ -93,40 +93,12 @@ When asked to create or update a pull request:
 When posting multiline GitHub comments from a shell, pass the body through stdin or `--body-file`; do not embed literal
 `\n` escapes in ordinary double-quoted strings.
 
-### Evidence
-
-Visible changes are shown, not described. Screenshots are the default; a short GIF for an interaction; an asciinema
-recording rendered with `agg` for terminal behavior. One or two images or one clip should explain the result. Backend-only
-changes keep using test output. The `pr-evidence` skill has the capture recipes and the tool commands.
-
-1. Identify the visible result that demonstrates the change, and for a visual fix capture the base revision too.
-2. Start the app or command with the repository's test data; never capture personal data or secret values.
-3. Capture with `playwright-cli` (full image) or `asciinema`, at a fixed viewport or terminal size.
-4. Convert with `video-to-gif` or `agg` and inspect the result with `media-preview` or by reading the image.
-5. Store everything under `/home/agent/code/.artifacts/<task>/<run>/` with a `capture.md` recording revisions,
-   commands and dimensions, and write the pull request body there with local image references.
-6. Run `gh pr create` or `gh pr edit` from that directory with one `--attach` per file; `gh` uploads the files and
-   rewrites the references. Then read the pull request body back and confirm the attachments rendered.
-
-`gh` uploads before it creates or edits. When every upload fails nothing is created; when some fail, the pull request
-exists with the successful ones and `gh` exits nonzero: retry only the missing files with `gh pr edit --attach`, never
-repeat `gh pr create`. Attaching requires a GitHub token binding with write access to the repository.
-
 ## Environment
 
 Real secrets are host-mediated. Never search for, print, copy, or persist their values.
 
-Both images provide `asciinema` and `agg` for terminal recordings. The full image additionally provides Podman, with
-`docker` and `/run/docker.sock` as compatibility surfaces, plus Rust, kind, kubectl, Helm, Flux, `playwright-cli` with
-Chromium, ffmpeg and the `video-to-gif` and `media-preview` helpers. The minimal image does not provide container,
-Kubernetes, or browser tooling. Detect available tools before relying on them.
-
-When Podman is available, containers receive mediated CA configuration automatically. Build steps receive the full CA
-bundle at `/run/agent/tls/ca-bundle.pem` and common system trust paths. A current Buildah bug drops default environment
-variables from build stages, so tools that ignore the system store need a step-scoped variable such as
-`RUN NODE_EXTRA_CA_CERTS=/run/agent/tls/ca-bundle.pem npm ci` or `RUN NODE_OPTIONS=--use-openssl-ca npm ci`. Kind's
-`KIND_EXPERIMENTAL_PROVIDER=podman` mode is installed but unverified; do not assume nested kind containers inherit the
-Agent's mediated CA trust.
+The tools installed on this computer are listed in the section that follows this shared text. Detect a tool before
+relying on it.
 
 Store reusable local scripts under `/home/agent/code/.scripts/` and downloaded reference repositories or source
 material under `/home/agent/code/.reference/`. Check for existing material before downloading another copy.

--- a/agents/instructions.md
+++ b/agents/instructions.md
@@ -80,7 +80,8 @@ When asked to create or update a pull request:
   `--body-file` rather than relying on interactive inference.
 - Use a conventional commit-style title such as `feat:`, `fix:`, or `chore:` and follow the repository template.
 - Explain what changed, why it changed, and how it was verified.
-- Include screenshots for relevant user-interface changes and command/output evidence for CLI behavior changes.
+- Include screenshots for relevant user-interface changes and command/output evidence for CLI behavior changes; see
+  the evidence workflow below.
 - For `Altinn/altinn-studio`, push a feature branch to `origin` and target `main`; never merge it yourself.
 - For repositories without direct write access, configure or use a fork and target the upstream default branch.
 - Keep each pull request focused. Use separate, dependent pull requests when independent review or rollout is useful.
@@ -92,13 +93,33 @@ When asked to create or update a pull request:
 When posting multiline GitHub comments from a shell, pass the body through stdin or `--body-file`; do not embed literal
 `\n` escapes in ordinary double-quoted strings.
 
+### Evidence
+
+Visible changes are shown, not described. Screenshots are the default; a short GIF for an interaction; an asciinema
+recording rendered with `agg` for terminal behavior. One or two images or one clip should explain the result. Backend-only
+changes keep using test output. The `pr-evidence` skill has the capture recipes and the tool commands.
+
+1. Identify the visible result that demonstrates the change, and for a visual fix capture the base revision too.
+2. Start the app or command with the repository's test data; never capture personal data or secret values.
+3. Capture with `playwright-cli` (full image) or `asciinema`, at a fixed viewport or terminal size.
+4. Convert with `video-to-gif` or `agg` and inspect the result with `media-preview` or by reading the image.
+5. Store everything under `/home/agent/code/.artifacts/<task>/<run>/` with a `capture.md` recording revisions,
+   commands and dimensions, and write the pull request body there with local image references.
+6. Run `gh pr create` or `gh pr edit` from that directory with one `--attach` per file; `gh` uploads the files and
+   rewrites the references. Then read the pull request body back and confirm the attachments rendered.
+
+`gh` uploads before it creates or edits. When every upload fails nothing is created; when some fail, the pull request
+exists with the successful ones and `gh` exits nonzero: retry only the missing files with `gh pr edit --attach`, never
+repeat `gh pr create`. Attaching requires a GitHub token binding with write access to the repository.
+
 ## Environment
 
 Real secrets are host-mediated. Never search for, print, copy, or persist their values.
 
-The full image provides Podman, with `docker` and `/run/docker.sock` as compatibility surfaces, plus Rust, kind,
-kubectl, Helm, Flux, and Playwright with Chromium. The minimal image does not provide container, Kubernetes, or browser
-tooling. Detect available tools before relying on them.
+Both images provide `asciinema` and `agg` for terminal recordings. The full image additionally provides Podman, with
+`docker` and `/run/docker.sock` as compatibility surfaces, plus Rust, kind, kubectl, Helm, Flux, `playwright-cli` with
+Chromium, ffmpeg and the `video-to-gif` and `media-preview` helpers. The minimal image does not provide container,
+Kubernetes, or browser tooling. Detect available tools before relying on them.
 
 When Podman is available, containers receive mediated CA configuration automatically. Build steps receive the full CA
 bundle at `/run/agent/tls/ca-bundle.pem` and common system trust paths. A current Buildah bug drops default environment

--- a/agents/minimal/agent.yaml
+++ b/agents/minimal/agent.yaml
@@ -19,7 +19,8 @@ spec:
   home:
     source: home
   instructions:
-    source: ../instructions.md
+    - source: ../instructions.md
+    - source: environment.md
   skills:
     - source: ../skills/pr-evidence
   harnesses:

--- a/agents/minimal/agent.yaml
+++ b/agents/minimal/agent.yaml
@@ -20,6 +20,8 @@ spec:
     source: home
   instructions:
     source: ../instructions.md
+  skills:
+    - source: ../skills/pr-evidence
   harnesses:
     - type: claudeCode
       auth: mediated
@@ -29,10 +31,14 @@ spec:
     #   auth: mediated
   secrets:
     - environment: GITHUB_TOKEN
+      # gh only attaches files with a token it classifies by prefix; the inert placeholder
+      # therefore carries the fine-grained PAT prefix and is far shorter than a real token.
+      placeholder: github_pat_AGENT_MEDIATED_GITHUB_TOKEN
       allowedHosts:
         - github.com
         - api.github.com
         - gist.github.com
+        - uploads.github.com
   network:
     mode: mediated
     allow: all

--- a/agents/minimal/environment.md
+++ b/agents/minimal/environment.md
@@ -1,0 +1,7 @@
+## This computer
+
+.NET, Node.js with Yarn, Go and the GitHub CLI. No container, Kubernetes or browser tooling: changes that need a running
+container stack or a browser cannot be verified here, so say so instead of working around it.
+
+Pull request evidence: `asciinema` and `agg` for terminal recordings. Browser screenshots and clips are not possible on
+this computer.

--- a/agents/skills/pr-evidence/SKILL.md
+++ b/agents/skills/pr-evidence/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: pr-evidence
+description: Capture screenshots, browser clips and terminal recordings for a pull request and attach them with gh. Use when a change has a visible or terminal-observable result that the pull request should show.
+---
+
+# Pull request evidence
+
+How to capture screenshots, browser clips and terminal recordings and attach them to a pull request. The Agent
+instructions say when evidence is expected; this skill says how to produce it.
+
+## What to capture
+
+| Change                                         | Default evidence                              |
+| ---------------------------------------------- | --------------------------------------------- |
+| Layout, styling or a visible state             | One focused PNG screenshot                    |
+| Visual bug fix                                 | Before and after PNGs, same viewport and data |
+| Interaction or transition                      | Browser GIF of 5 to 15 seconds                |
+| CLI output or interactive terminal behavior    | asciinema recording rendered to GIF           |
+| Longer interaction that is unreadable as a GIF | MP4 (WebM converted with ffmpeg)              |
+
+One or two images or one short clip should explain the result. Backend-only changes keep using test output and text.
+Before and after captures come from the actual base and changed revisions, not from mocked states.
+
+## Artifacts
+
+Keep captures outside the checkout, one directory per task and run:
+
+```text
+/home/agent/code/.artifacts/<task>/<run>/
+  capture.md        revisions, commands, viewport or terminal size, the scenario shown
+  before.png after.png
+  browser.webm interaction.gif
+  terminal.cast terminal.gif
+  pr-body.md
+```
+
+`capture.md` makes the evidence reproducible: which commit each capture came from, how the app or command was started,
+which test data was used. Never capture real personal data or secrets; use the repository's test users and fixtures.
+
+## Browser: screenshots
+
+The full image has `playwright-cli` with Chromium. Use one named session per task so parallel work does not share a
+browser, and a fixed viewport so before and after images line up.
+
+```sh
+export PLAYWRIGHT_CLI_SESSION=<task>
+playwright-cli open --browser chromium http://localhost:8080/   # only Chromium is installed
+playwright-cli resize 1280 720
+playwright-cli snapshot                                   # find element refs
+playwright-cli click e12
+playwright-cli screenshot --filename=after.png            # whole page at 1280x720
+playwright-cli screenshot e7 --filename=after-panel.png   # one element
+playwright-cli close
+```
+
+`playwright-cli --help` lists every command; the `playwright-cli` skill under `~/.claude/skills` has references for
+sessions, storage state, request mocking and video.
+
+## Browser: clips
+
+Record to WebM, then convert to GIF. For a scripted scenario, write the steps as Playwright code and run it against the
+session so pauses and typing speed are deliberate:
+
+```sh
+playwright-cli open --browser chromium http://localhost:8080/
+playwright-cli resize 1280 720
+playwright-cli video-start browser.webm
+playwright-cli run-code --filename=scenario.js
+playwright-cli video-stop
+video-to-gif --fps 12 browser.webm interaction.gif
+media-preview interaction.gif                             # writes interaction.gif.preview.png
+```
+
+`scenario.js` exports an async function taking `page`, for example:
+
+```js
+async (page) => {
+  await page.getByRole('textbox', { name: 'Search' }).pressSequentially('skatt', { delay: 80 });
+  await page.waitForTimeout(800);
+  await page.getByRole('button', { name: 'Filter' }).click();
+  await page.waitForTimeout(1500);
+};
+```
+
+Standalone Playwright scripts also work: `node capture.js` with `require('playwright')` resolves the image's global
+package and reuses the installed Chromium.
+
+`video-to-gif` trims with `--start` and `--duration`, scales with `--width` and fails when the result exceeds 8 MB.
+GitHub accepts images and GIFs up to 10 MB. When a GIF cannot stay readable within that, convert to MP4 instead:
+
+```sh
+ffmpeg -i browser.webm -c:v libx264 -pix_fmt yuv420p -movflags +faststart -an interaction.mp4
+```
+
+Look at the result before attaching it: read the PNG, or the contact sheet `media-preview` writes for a clip.
+
+## Terminal
+
+Record the demonstrated command, not the whole coding session. Fix the terminal size so the GIF has a predictable
+shape and set a title for the frame.
+
+```sh
+asciinema rec --window-size 100x30 --command 'studioctl app run --help' --title 'studioctl app run' terminal.cast
+agg --cols 100 --rows 30 --font-size 14 --theme monokai terminal.cast terminal.gif
+```
+
+For an interactive demonstration omit `--command`, perform the steps, and exit the shell; `--idle-time-limit 2` in
+`asciinema rec` collapses long pauses. `agg --help` lists speed, theme and font options; Liberation Mono is
+installed and covers Norwegian characters.
+
+## Attaching to the pull request
+
+Write the body with local Markdown image references, then run `gh` from the artifact directory. Attachments are
+uploaded first and the matching references are rewritten to the hosted URLs.
+
+```sh
+cd /home/agent/code/.artifacts/<task>/<run>
+gh pr create --repo Altinn/altinn-studio --base main --head <branch> \
+  --title 'fix: preserve selection when filtering' --body-file pr-body.md \
+  --attach ./before.png --attach ./after.png
+gh pr edit <number> --body-file pr-body.md --attach ./interaction.gif
+```
+
+Each `--attach` takes one file; add `#caption` after the path to set the alt text. Up to 50 files per command.
+
+Failure behavior matters:
+
+- If no attachment uploads, `gh` stops before creating or editing the pull request.
+- If some upload and some fail, the pull request is created or edited with the successful ones and `gh` exits nonzero.
+  Read the pull request back, then retry only the missing files with `gh pr edit --attach`; do not run `gh pr create`
+  again.
+- Uploading needs a token `gh` recognizes as a personal access token or OAuth token and write access to the target
+  repository. The inert `GITHUB_TOKEN` in a GitHub-enabled Agent satisfies the first; an Agent without a token binding
+  cannot attach files.
+
+Finish by reading the pull request body (`gh pr view <number> --json body -q .body`) and confirming every image
+reference is a hosted `github.com` URL rather than a local path.

--- a/agents/skills/pr-evidence/SKILL.md
+++ b/agents/skills/pr-evidence/SKILL.md
@@ -10,13 +10,13 @@ instructions say when evidence is expected; this skill says how to produce it.
 
 ## What to capture
 
-| Change                                         | Default evidence                              |
-| ---------------------------------------------- | --------------------------------------------- |
-| Layout, styling or a visible state             | One focused PNG screenshot                    |
-| Visual bug fix                                 | Before and after PNGs, same viewport and data |
-| Interaction or transition                      | Browser GIF of 5 to 15 seconds                |
-| CLI output or interactive terminal behavior    | asciinema recording rendered to GIF           |
-| Longer interaction that is unreadable as a GIF | MP4 (WebM converted with ffmpeg)              |
+| Change                                         | Default evidence                           |
+| ---------------------------------------------- | ------------------------------------------ |
+| Layout, styling or a visible state             | One focused PNG screenshot                 |
+| Visual bug fix                                 | Before and after PNG images, same viewport |
+| Interaction or transition                      | Browser GIF of 5 to 15 seconds             |
+| CLI output or interactive terminal behavior    | asciinema recording rendered to GIF        |
+| Longer interaction that is unreadable as a GIF | MP4 (WebM converted with ffmpeg)           |
 
 One or two images or one short clip should explain the result. Backend-only changes keep using test output and text.
 Before and after captures come from the actual base and changed revisions, not from mocked states.

--- a/agents/skills/pr-evidence/SKILL.md
+++ b/agents/skills/pr-evidence/SKILL.md
@@ -39,8 +39,9 @@ which test data was used. Never capture real personal data or secrets; use the r
 
 ## Browser: screenshots
 
-The full image has `playwright-cli` with Chromium. Use one named session per task so parallel work does not share a
-browser, and a fixed viewport so before and after images line up.
+Browser capture needs `playwright-cli`; when it is not on `PATH`, this computer has no browser and the pull request
+gets terminal or textual evidence instead. Use one named session per task so parallel work does not share a browser,
+and a fixed viewport so before and after images line up.
 
 ```sh
 export PLAYWRIGHT_CLI_SESSION=<task>
@@ -53,8 +54,8 @@ playwright-cli screenshot e7 --filename=after-panel.png   # one element
 playwright-cli close
 ```
 
-`playwright-cli --help` lists every command; the `playwright-cli` skill under `~/.claude/skills` has references for
-sessions, storage state, request mocking and video.
+`playwright-cli --help` lists every command; the `playwright-cli` skill has references for sessions, storage state,
+request mocking and video.
 
 ## Browser: clips
 
@@ -96,17 +97,23 @@ Look at the result before attaching it: read the PNG, or the contact sheet `medi
 
 ## Terminal
 
-Record the demonstrated command, not the whole coding session. Fix the terminal size so the GIF has a predictable
-shape and set a title for the frame.
+Record the demonstrated commands, not the whole coding session. A GIF only shows something when output appears over
+time: a single command whose output lands at once renders as one static frame. Script the demonstration so the viewer
+sees each command line before its output and give the output time to be read.
 
 ```sh
-asciinema rec --window-size 100x30 --command 'studioctl app run --help' --title 'studioctl app run' terminal.cast
+cat > demo.sh <<'DEMO'
+step() { printf '\033[1;34m$ %s\033[0m\n' "$*"; sleep 1; "$@"; sleep 2; }
+step studioctl app run --help
+step studioctl app list
+DEMO
+asciinema rec --window-size 100x30 --idle-time-limit 3 --command 'bash demo.sh' terminal.cast
 agg --cols 100 --rows 30 --font-size 14 --theme monokai terminal.cast terminal.gif
+media-preview terminal.gif                                # check that the frames differ
 ```
 
-For an interactive demonstration omit `--command`, perform the steps, and exit the shell; `--idle-time-limit 2` in
-`asciinema rec` collapses long pauses. `agg --help` lists speed, theme and font options; Liberation Mono is
-installed and covers Norwegian characters.
+For an interactive demonstration omit `--command`, perform the steps, and exit the shell. `agg --help` lists speed,
+theme and font options; Liberation Mono is installed and covers Norwegian characters.
 
 ## Attaching to the pull request
 

--- a/agents/smoke.sh
+++ b/agents/smoke.sh
@@ -34,12 +34,14 @@ test -z "$foreign" || fail "entries under /home/agent not owned by agent:"$'\n'"
 
 echo "## terminal recording"
 asciinema rec --headless --quiet --window-size 80x24 --title 'smoke' \
-    --command 'printf "\033[1;32mgrønn\033[0m \033[34mblå\033[0m æøå ÆØÅ\n"; printf "linje 1\nlinje 2\033[1A\033[5Cinnskutt\n\n"; printf "█▓▒░ ✓ ✗\n"' \
+    --command 'printf "\033[1;34m$ demo\033[0m\n"; sleep 0.4; printf "\033[1;32mgrønn\033[0m \033[34mblå\033[0m æøå ÆØÅ\n"; sleep 0.4; printf "linje 1\nlinje 2\033[1A\033[5Cinnskutt\n\n"; sleep 0.4; printf "█▓▒░ ✓ ✗\n"; sleep 0.4' \
     terminal.cast
 test -s terminal.cast || fail "asciinema produced no cast"
 grep -q 'æøå' terminal.cast || fail "cast lacks the Norwegian fixture text"
 agg --cols 80 --rows 24 terminal.cast terminal.gif
 head -c 6 terminal.gif | grep -q '^GIF8' || fail "agg did not write a GIF"
+frames="$(grep -c '^\[' terminal.cast || true)"
+test "${frames:-0}" -ge 4 || fail "cast has $frames timed events; the fixture should produce output over time"
 echo "terminal.gif: $(stat -c %s terminal.gif) bytes"
 
 [ "$variant" = full ] || finish

--- a/agents/smoke.sh
+++ b/agents/smoke.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Smoke-tests the pull request evidence tooling inside a freshly built Agent image.
+#
+#   docker run --rm --init --ipc=host --security-opt seccomp=unconfined --entrypoint bash \
+#     -v "$PWD/agents/smoke.sh:/smoke.sh:ro" <image> /smoke.sh <minimal|full> [KEEP_DIR]
+#
+# With KEEP_DIR (a writable mount), the produced media is copied there for inspection.
+#
+# Runs as the image's `agent` user. Every variant records a terminal fixture with colors, cursor
+# movement and Norwegian characters and renders it to a GIF. The full variant also drives
+# Chromium through playwright-cli, converts the recording and inspects it with the helpers, in a
+# directory whose name contains a space. Chromium needs the host IPC namespace and an unconfined
+# seccomp profile under Docker; inside a Sandbox it runs on a real kernel and needs neither.
+set -euo pipefail
+
+variant="${1:?usage: smoke.sh <minimal|full> [KEEP_DIR]}"
+keep="${2:-}"
+work="$(mktemp -d "${TMPDIR:-/tmp}/smoke with space.XXXXXX")"
+cd "$work"
+fail() { echo "smoke: $*" >&2; exit 1; }
+finish() {
+    [ -n "$keep" ] && cp -- *.gif *.png *.cast *.webm "$keep"/ 2>/dev/null
+    echo "smoke: $variant ok"
+    exit 0
+}
+
+echo "## versions"
+gh --version | head -1
+asciinema --version
+agg --version
+test "$(id -un)" = agent || fail "expected to run as agent, got $(id -un)"
+foreign="$(find /home/agent ! -user agent)"
+test -z "$foreign" || fail "entries under /home/agent not owned by agent:"$'\n'"$foreign"
+
+echo "## terminal recording"
+asciinema rec --headless --quiet --window-size 80x24 --title 'smoke' \
+    --command 'printf "\033[1;32mgrønn\033[0m \033[34mblå\033[0m æøå ÆØÅ\n"; printf "linje 1\nlinje 2\033[1A\033[5Cinnskutt\n\n"; printf "█▓▒░ ✓ ✗\n"' \
+    terminal.cast
+test -s terminal.cast || fail "asciinema produced no cast"
+grep -q 'æøå' terminal.cast || fail "cast lacks the Norwegian fixture text"
+agg --cols 80 --rows 24 terminal.cast terminal.gif
+head -c 6 terminal.gif | grep -q '^GIF8' || fail "agg did not write a GIF"
+echo "terminal.gif: $(stat -c %s terminal.gif) bytes"
+
+[ "$variant" = full ] || finish
+
+echo "## playwright"
+browsers=(/opt/ms-playwright/chromium-*)
+test "${#browsers[@]}" -eq 1 || fail "expected exactly one Chromium build, found: ${browsers[*]}"
+cli_playwright="$(node -p "require('/usr/local/lib/node_modules/@playwright/cli/package.json').dependencies.playwright")"
+global_playwright="$(node -p "require('playwright/package.json').version")"
+test "$cli_playwright" = "$global_playwright" \
+    || fail "playwright-cli depends on playwright $cli_playwright but $global_playwright is installed"
+
+cat > fixture.html <<'HTML'
+<!doctype html><meta charset="utf-8"><title>smoke</title>
+<style>body{font:32px sans-serif;margin:40px}button{font-size:28px;padding:12px 24px}</style>
+<h1>Skjema for søknad om støtte</h1>
+<button id="b" onclick="document.getElementById('o').textContent='Sendt inn ✓'">Send inn</button>
+<p id="o">Ikke sendt</p>
+HTML
+
+# playwright-cli blocks file: URLs, so the fixture is served over loopback.
+node -e 'require("http").createServer((q,r)=>{r.setHeader("content-type","text/html; charset=utf-8");r.end(require("fs").readFileSync(process.argv[1]))}).listen(8321,"127.0.0.1")' fixture.html &
+server=$!
+trap 'kill "$server" 2>/dev/null' EXIT
+sleep 1
+
+export PLAYWRIGHT_CLI_SESSION=smoke
+playwright-cli open --browser chromium http://127.0.0.1:8321/
+playwright-cli resize 1280 720
+playwright-cli screenshot --filename=before.png
+playwright-cli video-start browser.webm
+playwright-cli run-code "async page => { await page.waitForTimeout(500); await page.click('#b'); await page.waitForTimeout(1000); }"
+playwright-cli video-stop
+playwright-cli screenshot --filename=after.png
+playwright-cli close
+
+echo "## media helpers"
+node -e "require('playwright'); console.log('require(\"playwright\") resolves from', process.cwd())"
+for image in before.png after.png; do
+    IFS=, read -r width height < <(ffprobe -v error -select_streams v:0 -show_entries stream=width,height -of csv=p=0 "$image")
+    test "$width" = 1280 && test "$height" = 720 || fail "$image is ${width}x${height}, expected 1280x720"
+done
+video-to-gif --fps 10 browser.webm interaction.gif
+media-preview before.png interaction.gif
+test -s interaction.gif.preview.png || fail "media-preview wrote no contact sheet"
+media-preview "$work/missing.png" && fail "media-preview accepted a missing file"
+finish

--- a/agents/worktree/agent.yaml
+++ b/agents/worktree/agent.yaml
@@ -24,7 +24,8 @@ spec:
   home:
     source: home
   instructions:
-    source: ../instructions.md
+    - source: ../instructions.md
+    - source: ../full/environment.md
   skills:
     - source: ../skills/pr-evidence
   harnesses:

--- a/agents/worktree/agent.yaml
+++ b/agents/worktree/agent.yaml
@@ -25,6 +25,8 @@ spec:
     source: home
   instructions:
     source: ../instructions.md
+  skills:
+    - source: ../skills/pr-evidence
   harnesses:
     - type: claudeCode
       auth: mediated

--- a/renovate.json
+++ b/renovate.json
@@ -44,6 +44,14 @@
       "matchStrings": ["ARG CODEX_VERSION=(?<currentValue>[\\w.-]+)"],
       "datasourceTemplate": "npm",
       "depNameTemplate": "@openai/codex"
+    },
+    {
+      "customType": "regex",
+      "description": "Track the Playwright CLI installed into the full Agent image; it pins the playwright package and browser build",
+      "managerFilePatterns": ["/^agents/Dockerfile$/"],
+      "matchStrings": ["ARG PLAYWRIGHT_CLI_VERSION=(?<currentValue>[\\w.-]+)"],
+      "datasourceTemplate": "npm",
+      "depNameTemplate": "@playwright/cli"
     }
   ],
   "separateMultipleMajor": true,

--- a/src/experimental/agent/examples/minimal/agent.yaml
+++ b/src/experimental/agent/examples/minimal/agent.yaml
@@ -19,7 +19,7 @@ spec:
   home:
     source: home
   instructions:
-    source: instructions.md
+    - source: instructions.md
   harnesses:
     - type: claudeCode
       version: "2.1.239"

--- a/src/experimental/agent/examples/self-dev/Dockerfile
+++ b/src/experimental/agent/examples/self-dev/Dockerfile
@@ -45,12 +45,20 @@ RUN apt-get update \
     && chmod -R a+rX /usr/local/cargo /usr/local/rustup
 
 ARG TARGETARCH
-ARG GH_VERSION=2.98.0
+ARG GH_VERSION=2.100.0
+ARG ASCIINEMA_VERSION=3.2.1
+ARG AGG_VERSION=1.9.0
 ARG NODE_VERSION=22.23.2
 
 RUN case "${TARGETARCH}" in \
-        amd64) NODE_ARCH=x64; GH_SHA256=3b8ac6b30336802fc1a858d7c084e11cdf24ac1a761ca90b68022d7d729208de ;; \
-        arm64) NODE_ARCH=arm64; GH_SHA256=cf689084f3a3618f7eae4a2420d335d74626d65f5e594b9828d125d69f800d86 ;; \
+        amd64) NODE_ARCH=x64; RUST_ARCH=x86_64; \
+            GH_SHA256=e4d4bb4498e8d007abe545b6568926793ace1b6447da598294a610018cb164be; \
+            ASCIINEMA_SHA256=1b405bbda565b33c3c4718de67fedc3535580603c0694b1ff3fb04f363430a20; \
+            AGG_SHA256=f111e315cd71056b116302342553dd765b7297579ed511f111d0cedb442aeda6 ;; \
+        arm64) NODE_ARCH=arm64; RUST_ARCH=aarch64; \
+            GH_SHA256=ea4e7a581a32ccad6cc7923cb1576ac5859ba4b9a16ab22eb8f8a96e78e2e961; \
+            ASCIINEMA_SHA256=b516a6d896844c0ffbc96e0a55afe4cbcc79216abde0fc64fdda4e39bee421ea; \
+            AGG_SHA256=2b4be407b97e00e1c313a41d154ced8fa3d02c560c8f47a0db4950a2576444c9 ;; \
         *) echo "unsupported target architecture: ${TARGETARCH}" >&2; exit 1 ;; \
     esac \
     && NODE_ARCHIVE="node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" \
@@ -65,9 +73,21 @@ RUN case "${TARGETARCH}" in \
     && echo "${GH_SHA256}  /tmp/gh.tar.gz" | sha256sum -c - \
     && tar -xzf /tmp/gh.tar.gz -C /tmp \
     && install -m 0755 "/tmp/gh_${GH_VERSION}_linux_${TARGETARCH}/bin/gh" /usr/local/bin/gh \
-    && rm -rf /tmp/node.tar.xz /tmp/gh.tar.gz "/tmp/gh_${GH_VERSION}_linux_${TARGETARCH}" \
+    && curl -fsSL \
+        "https://github.com/asciinema/asciinema/releases/download/v${ASCIINEMA_VERSION}/asciinema-${RUST_ARCH}-unknown-linux-gnu" \
+        -o /tmp/asciinema \
+    && echo "${ASCIINEMA_SHA256}  /tmp/asciinema" | sha256sum -c - \
+    && install -m 0755 /tmp/asciinema /usr/local/bin/asciinema \
+    && curl -fsSL \
+        "https://github.com/asciinema/agg/releases/download/v${AGG_VERSION}/agg-${RUST_ARCH}-unknown-linux-gnu" \
+        -o /tmp/agg \
+    && echo "${AGG_SHA256}  /tmp/agg" | sha256sum -c - \
+    && install -m 0755 /tmp/agg /usr/local/bin/agg \
+    && rm -rf /tmp/node.tar.xz /tmp/gh.tar.gz "/tmp/gh_${GH_VERSION}_linux_${TARGETARCH}" /tmp/asciinema /tmp/agg \
     && node --version \
-    && gh --version
+    && gh --version \
+    && asciinema --version \
+    && agg --version
 
 # Route GitHub credentials through the gh CLI so plain git commands authenticate with the
 # host-mediated token.

--- a/src/experimental/agent/examples/self-dev/README.md
+++ b/src/experimental/agent/examples/self-dev/README.md
@@ -23,5 +23,5 @@ The worktree variant mounts the whole checkout, so its secret file must live out
 agentctl apply -f worktree/agent.yaml --env-file ~/.agent/self-dev.env
 ```
 
-Inside a running Agent, `instructions.md` tells the harness how to build, test and run the platform nested, and how to
-record `agentctl` demonstrations with asciinema and attach them to pull requests.
+Inside a running Agent, `instructions.md` tells the harness how to build, test and run the platform nested, and the
+`pr-evidence` skill how to record `agentctl` demonstrations and attach them to pull requests.

--- a/src/experimental/agent/examples/self-dev/README.md
+++ b/src/experimental/agent/examples/self-dev/README.md
@@ -23,4 +23,5 @@ The worktree variant mounts the whole checkout, so its secret file must live out
 agentctl apply -f worktree/agent.yaml --env-file ~/.agent/self-dev.env
 ```
 
-Inside a running Agent, `instructions.md` tells the harness how to build, test and run the platform nested.
+Inside a running Agent, `instructions.md` tells the harness how to build, test and run the platform nested, and how to
+record `agentctl` demonstrations with asciinema and attach them to pull requests.

--- a/src/experimental/agent/examples/self-dev/checkout/agent.yaml
+++ b/src/experimental/agent/examples/self-dev/checkout/agent.yaml
@@ -21,6 +21,8 @@ spec:
     source: home
   instructions:
     source: ../instructions.md
+  skills:
+    - source: ../../../../../../agents/skills/pr-evidence
   harnesses:
     - type: claudeCode
       auth: mediated
@@ -29,9 +31,13 @@ spec:
       auth: mediated
   secrets:
     - environment: GITHUB_TOKEN
+      # gh only attaches files with a token it classifies by prefix; the inert placeholder
+      # therefore carries the fine-grained PAT prefix and is far shorter than a real token.
+      placeholder: github_pat_AGENT_MEDIATED_GITHUB_TOKEN
       allowedHosts:
         - github.com
         - api.github.com
+        - uploads.github.com
   network:
     mode: mediated
     allow: all

--- a/src/experimental/agent/examples/self-dev/checkout/agent.yaml
+++ b/src/experimental/agent/examples/self-dev/checkout/agent.yaml
@@ -20,9 +20,9 @@ spec:
   home:
     source: home
   instructions:
-    source: ../instructions.md
+    - source: ../instructions.md
   skills:
-    - source: ../../../../../../agents/skills/pr-evidence
+    - source: ../skills/pr-evidence
   harnesses:
     - type: claudeCode
       auth: mediated

--- a/src/experimental/agent/examples/self-dev/instructions.md
+++ b/src/experimental/agent/examples/self-dev/instructions.md
@@ -5,7 +5,10 @@ You develop the experimental agent platform under `src/experimental` in the chec
 checkout (`mount | grep altinn-studio`), the host sees your edits directly; otherwise work on a branch and push it.
 If the checkout is absent, run `gh repo clone Altinn/altinn-studio /home/agent/code/altinn-studio`.
 
-Read `src/experimental/AGENTS.md` first. `make help` in `src/experimental` lists the targets; run
+Read `src/experimental/AGENTS.md` first. Pull requests that change `agentctl` output or the TUI include a terminal
+recording, as the `pr-evidence` skill describes: `asciinema rec --window-size 120x36 --command '<agentctl ...>' demo.cast`, `agg demo.cast demo.gif`, then
+`gh pr create --attach ./demo.gif` with a matching image reference in the body. Keep recordings under
+`/home/agent/code/.artifacts/`, never in the checkout. `make help` in `src/experimental` lists the targets; run
 `make fmt lint build test` before reporting completion. `make test-e2e` and `make user-install` work here too: the
 Sandbox has `/dev/kvm` and Podman.
 

--- a/src/experimental/agent/examples/self-dev/instructions.md
+++ b/src/experimental/agent/examples/self-dev/instructions.md
@@ -6,9 +6,7 @@ checkout (`mount | grep altinn-studio`), the host sees your edits directly; othe
 If the checkout is absent, run `gh repo clone Altinn/altinn-studio /home/agent/code/altinn-studio`.
 
 Read `src/experimental/AGENTS.md` first. Pull requests that change `agentctl` output or the TUI include a terminal
-recording, as the `pr-evidence` skill describes: `asciinema rec --window-size 120x36 --command '<agentctl ...>' demo.cast`, `agg demo.cast demo.gif`, then
-`gh pr create --attach ./demo.gif` with a matching image reference in the body. Keep recordings under
-`/home/agent/code/.artifacts/`, never in the checkout. `make help` in `src/experimental` lists the targets; run
+recording; the `pr-evidence` skill describes how to record and attach it. `make help` in `src/experimental` lists the targets; run
 `make fmt lint build test` before reporting completion. `make test-e2e` and `make user-install` work here too: the
 Sandbox has `/dev/kvm` and Podman.
 

--- a/src/experimental/agent/examples/self-dev/nested/agent.yaml
+++ b/src/experimental/agent/examples/self-dev/nested/agent.yaml
@@ -21,6 +21,8 @@ spec:
     source: home
   instructions:
     source: ../instructions.md
+  skills:
+    - source: ../../../../../../agents/skills/pr-evidence
   harnesses:
     - type: claudeCode
       auth: mediated
@@ -29,9 +31,13 @@ spec:
       auth: mediated
   secrets:
     - environment: GITHUB_TOKEN
+      # gh only attaches files with a token it classifies by prefix; the inert placeholder
+      # therefore carries the fine-grained PAT prefix and is far shorter than a real token.
+      placeholder: github_pat_AGENT_MEDIATED_GITHUB_TOKEN
       allowedHosts:
         - github.com
         - api.github.com
+        - uploads.github.com
   network:
     mode: mediated
     allow: all

--- a/src/experimental/agent/examples/self-dev/nested/agent.yaml
+++ b/src/experimental/agent/examples/self-dev/nested/agent.yaml
@@ -20,9 +20,9 @@ spec:
   home:
     source: home
   instructions:
-    source: ../instructions.md
+    - source: ../instructions.md
   skills:
-    - source: ../../../../../../agents/skills/pr-evidence
+    - source: ../skills/pr-evidence
   harnesses:
     - type: claudeCode
       auth: mediated

--- a/src/experimental/agent/examples/self-dev/skills/pr-evidence/SKILL.md
+++ b/src/experimental/agent/examples/self-dev/skills/pr-evidence/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: pr-evidence
+description: Record agentctl and agentd behavior with asciinema, render it to a GIF with agg and attach it to a pull request with gh. Use when a change alters what a user sees in the terminal.
+---
+
+# Pull request evidence
+
+Changes to `agentctl` output, provisioning progress or the TUI are shown in the pull request as a terminal recording.
+Backend-only changes keep using test output and text.
+
+## Artifacts
+
+Keep captures outside the checkout, one directory per task and run:
+
+```text
+/home/agent/code/.artifacts/<task>/<run>/
+  capture.md        the commit recorded, the commands, the terminal size, the scenario shown
+  demo.cast demo.gif
+  pr-body.md
+```
+
+Never capture secret values. The placeholders in this Sandbox are inert, but the recording still should not show them.
+
+## Recording
+
+A GIF only shows something when output appears over time. Script the demonstration so each command line is visible
+before its output, and give output time to be read. `agentctl` commands that wait, such as `apply --wait`, already
+produce movement.
+
+```sh
+cat > demo.sh <<'DEMO'
+step() { printf '\033[1;34m$ %s\033[0m\n' "$*"; sleep 1; "$@"; sleep 2; }
+step agentctl apply -f agent.yaml --wait
+step agentctl get agents
+DEMO
+asciinema rec --window-size 120x36 --idle-time-limit 3 --command 'bash demo.sh' demo.cast
+agg --cols 120 --rows 36 --font-size 14 --theme monokai demo.cast demo.gif
+```
+
+For the TUI or another interactive flow omit `--command`, perform the steps in the recorded shell, and exit it. Keep
+recordings under 15 seconds of playback; `--idle-time-limit` collapses waits. `agg --help` lists speed and theme
+options. Aim below 8 MB; GitHub accepts GIFs up to 10 MB.
+
+Look at the result before attaching it: `agg` prints the frame count, and a GIF with one frame shows nothing.
+
+## Attaching to the pull request
+
+Write the body with a local image reference and run `gh` from the artifact directory; the file is uploaded and the
+reference rewritten to the hosted URL.
+
+```sh
+cd /home/agent/code/.artifacts/<task>/<run>
+gh pr create --repo Altinn/altinn-studio --base main --head <branch> \
+  --title 'feat(experimental): ...' --body-file pr-body.md --attach './demo.gif#agentctl apply --wait'
+gh pr edit <number> --body-file pr-body.md --attach ./demo.gif
+```
+
+- If no attachment uploads, `gh` stops before creating or editing the pull request.
+- If some upload and some fail, the pull request exists with the successful ones and `gh` exits nonzero. Retry only
+  the missing files with `gh pr edit --attach`; never repeat `gh pr create`.
+- Uploading needs write access to the repository through the mediated `GITHUB_TOKEN`.
+
+Finish by reading the body back (`gh pr view <number> --json body -q .body`) and confirming the reference is a hosted
+`github.com` URL.

--- a/src/experimental/agent/examples/self-dev/worktree/agent.yaml
+++ b/src/experimental/agent/examples/self-dev/worktree/agent.yaml
@@ -26,6 +26,8 @@ spec:
     source: home
   instructions:
     source: ../instructions.md
+  skills:
+    - source: ../../../../../../agents/skills/pr-evidence
   harnesses:
     - type: claudeCode
       auth: mediated
@@ -34,9 +36,13 @@ spec:
       auth: mediated
   secrets:
     - environment: GITHUB_TOKEN
+      # gh only attaches files with a token it classifies by prefix; the inert placeholder
+      # therefore carries the fine-grained PAT prefix and is far shorter than a real token.
+      placeholder: github_pat_AGENT_MEDIATED_GITHUB_TOKEN
       allowedHosts:
         - github.com
         - api.github.com
+        - uploads.github.com
   network:
     mode: mediated
     allow: all

--- a/src/experimental/agent/examples/self-dev/worktree/agent.yaml
+++ b/src/experimental/agent/examples/self-dev/worktree/agent.yaml
@@ -25,9 +25,9 @@ spec:
   home:
     source: home
   instructions:
-    source: ../instructions.md
+    - source: ../instructions.md
   skills:
-    - source: ../../../../../../agents/skills/pr-evidence
+    - source: ../skills/pr-evidence
   harnesses:
     - type: claudeCode
       auth: mediated

--- a/src/experimental/agent/src/control_plane/service.rs
+++ b/src/experimental/agent/src/control_plane/service.rs
@@ -324,6 +324,9 @@ fn validate_immutable_fields(current: &AgentRecord, desired: &Agent) -> Result<(
     if current.agent.spec.instructions != desired.spec.instructions {
         return Err(Error::Immutable("spec.instructions"));
     }
+    if current.agent.spec.skills != desired.spec.skills {
+        return Err(Error::Immutable("spec.skills"));
+    }
     let current_kinds = current
         .agent
         .spec

--- a/src/experimental/agent/src/harness/claude_code/bootstrap/linux.rs
+++ b/src/experimental/agent/src/harness/claude_code/bootstrap/linux.rs
@@ -8,7 +8,13 @@ use crate::{Error, sandbox::platform::run_checked};
 
 use super::super::ACCESS_PLACEHOLDER;
 
-pub(super) async fn configure(sandbox: &SandboxHandle, home: &str, instructions: Option<&[u8]>) -> Result<(), Error> {
+pub(super) async fn configure(
+    sandbox: &SandboxHandle,
+    home: &str,
+    instructions: Option<&[u8]>,
+    skills: &[crate::harness::Skill],
+) -> Result<(), Error> {
+    let skills_path = format!("{home}/.claude/skills");
     let config = format!("{home}/.claude");
     let hooks_path = format!("{config}/hooks");
     let credentials_path = format!("{config}/.credentials.json");
@@ -97,5 +103,5 @@ pub(super) async fn configure(sandbox: &SandboxHandle, home: &str, instructions:
         .await?;
         run_checked(sandbox, "/usr/bin/chmod", ["644", instructions_path.as_str()]).await?;
     }
-    Ok(())
+    crate::harness::skills::install_linux(sandbox, &skills_path, skills).await
 }

--- a/src/experimental/agent/src/harness/claude_code/bootstrap/mod.rs
+++ b/src/experimental/agent/src/harness/claude_code/bootstrap/mod.rs
@@ -6,6 +6,7 @@ pub(super) async fn configure_linux(
     sandbox: &sandbox::SandboxHandle,
     home: &str,
     instructions: Option<&[u8]>,
+    skills: &[crate::harness::Skill],
 ) -> Result<(), crate::Error> {
-    linux::configure(sandbox, home, instructions).await
+    linux::configure(sandbox, home, instructions, skills).await
 }

--- a/src/experimental/agent/src/harness/claude_code/mod.rs
+++ b/src/experimental/agent/src/harness/claude_code/mod.rs
@@ -98,8 +98,9 @@ pub(super) async fn bootstrap_linux(
     sandbox: &sandbox::SandboxHandle,
     home: &str,
     instructions: Option<&[u8]>,
+    skills: &[crate::harness::Skill],
 ) -> Result<(), Error> {
-    bootstrap::configure_linux(sandbox, home, instructions).await
+    bootstrap::configure_linux(sandbox, home, instructions, skills).await
 }
 
 pub(super) async fn verify_linux(

--- a/src/experimental/agent/src/harness/codex/bootstrap/linux.rs
+++ b/src/experimental/agent/src/harness/codex/bootstrap/linux.rs
@@ -8,7 +8,13 @@ use crate::{Error, sandbox::platform::run_checked};
 
 use super::super::{ACCESS_PLACEHOLDER, ACCOUNT_PLACEHOLDER, REFRESH_PLACEHOLDER};
 
-pub(super) async fn configure(sandbox: &SandboxHandle, home: &str, instructions: Option<&[u8]>) -> Result<(), Error> {
+pub(super) async fn configure(
+    sandbox: &SandboxHandle,
+    home: &str,
+    instructions: Option<&[u8]>,
+    skills: &[crate::harness::Skill],
+) -> Result<(), Error> {
+    let skills_path = format!("{home}/.agents/skills");
     let config = format!("{home}/.codex");
     let hooks_path = format!("{config}/hooks");
     let auth_path = format!("{config}/auth.json");
@@ -94,5 +100,5 @@ pub(super) async fn configure(sandbox: &SandboxHandle, home: &str, instructions:
         .await?;
         run_checked(sandbox, "/usr/bin/chmod", ["644", instructions_path.as_str()]).await?;
     }
-    Ok(())
+    crate::harness::skills::install_linux(sandbox, &skills_path, skills).await
 }

--- a/src/experimental/agent/src/harness/codex/bootstrap/mod.rs
+++ b/src/experimental/agent/src/harness/codex/bootstrap/mod.rs
@@ -6,6 +6,7 @@ pub(super) async fn configure_linux(
     sandbox: &sandbox::SandboxHandle,
     home: &str,
     instructions: Option<&[u8]>,
+    skills: &[crate::harness::Skill],
 ) -> Result<(), crate::Error> {
-    linux::configure(sandbox, home, instructions).await
+    linux::configure(sandbox, home, instructions, skills).await
 }

--- a/src/experimental/agent/src/harness/codex/mod.rs
+++ b/src/experimental/agent/src/harness/codex/mod.rs
@@ -122,8 +122,9 @@ pub(super) async fn bootstrap_linux(
     sandbox: &sandbox::SandboxHandle,
     home: &str,
     instructions: Option<&[u8]>,
+    skills: &[crate::harness::Skill],
 ) -> Result<(), Error> {
-    bootstrap::configure_linux(sandbox, home, instructions).await
+    bootstrap::configure_linux(sandbox, home, instructions, skills).await
 }
 
 pub(super) async fn verify_linux(

--- a/src/experimental/agent/src/harness/mod.rs
+++ b/src/experimental/agent/src/harness/mod.rs
@@ -8,6 +8,9 @@ use crate::{Error, persistence};
 mod claude_code;
 mod codex;
 mod session_start;
+mod skills;
+
+pub(crate) use skills::{Skill, SkillFile};
 
 /// Supported harnesses.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -189,10 +192,11 @@ pub(crate) async fn bootstrap_linux(
     sandbox: &sandbox::SandboxHandle,
     home: &str,
     instructions: Option<&[u8]>,
+    skills: &[Skill],
 ) -> Result<(), Error> {
     match harness {
-        Harness::ClaudeCode => claude_code::bootstrap_linux(sandbox, home, instructions).await,
-        Harness::Codex => codex::bootstrap_linux(sandbox, home, instructions).await,
+        Harness::ClaudeCode => claude_code::bootstrap_linux(sandbox, home, instructions, skills).await,
+        Harness::Codex => codex::bootstrap_linux(sandbox, home, instructions, skills).await,
     }
 }
 

--- a/src/experimental/agent/src/harness/skills.rs
+++ b/src/experimental/agent/src/harness/skills.rs
@@ -1,0 +1,79 @@
+//! Skill installation shared by the Linux harness bootstraps.
+//!
+//! A skill is a directory holding `SKILL.md`, read on the host from `spec.skills`. Each harness
+//! discovers skills in its own user-level directory, so the adapter chooses the root and this
+//! module does the placement.
+
+use std::io::Cursor;
+
+use sandbox::{SandboxHandle, SandboxPath, execution::ExecutionSpec};
+
+use crate::Error;
+
+/// One skill directory read on the host, keyed by its directory name.
+pub(crate) struct Skill {
+    pub(crate) name: String,
+    /// Regular files below the skill directory, as `/`-separated relative paths.
+    pub(crate) files: Vec<SkillFile>,
+}
+
+/// One regular file of a skill.
+pub(crate) struct SkillFile {
+    pub(crate) relative_path: String,
+    pub(crate) contents: Vec<u8>,
+}
+
+/// Writes every skill below `root` as `root/<name>/<relative path>`, owned by the image user.
+///
+/// Directories are created as the image user. Runtime file transfer writes as the Sandbox
+/// supervisor, so exactly the written files are chowned afterwards: no recursive ownership walk.
+pub(super) async fn install_linux(sandbox: &SandboxHandle, root: &str, skills: &[Skill]) -> Result<(), Error> {
+    for skill in skills {
+        let target = format!("{root}/{}", skill.name);
+        run_checked(sandbox, "/usr/bin/mkdir", ["-p".to_owned(), target.clone()]).await?;
+        let mut written = Vec::with_capacity(skill.files.len());
+        for file in &skill.files {
+            let path = format!("{target}/{}", file.relative_path);
+            if let Some((parent, _)) = file.relative_path.rsplit_once('/') {
+                run_checked(
+                    sandbox,
+                    "/usr/bin/mkdir",
+                    ["-p".to_owned(), format!("{target}/{parent}")],
+                )
+                .await?;
+            }
+            sandbox
+                .write_file(
+                    &SandboxPath::new(path.clone()),
+                    Box::pin(Cursor::new(file.contents.clone())),
+                )
+                .await?;
+            written.push(path);
+        }
+        if written.is_empty() {
+            continue;
+        }
+        let mut chown = vec!["/usr/bin/chown".to_owned(), "agent:agent".to_owned()];
+        chown.extend(written);
+        run_checked(sandbox, "/usr/bin/sudo", chown).await?;
+    }
+    Ok(())
+}
+
+async fn run_checked(
+    sandbox: &SandboxHandle,
+    executable: &str,
+    args: impl IntoIterator<Item = String>,
+) -> Result<(), Error> {
+    let output = sandbox
+        .run_execution(ExecutionSpec::command(SandboxPath::new(executable), args))
+        .await?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(Error::SandboxSetup(format!(
+            "command {executable:?} exited with code {}",
+            output.status.code
+        )))
+    }
+}

--- a/src/experimental/agent/src/lib.rs
+++ b/src/experimental/agent/src/lib.rs
@@ -21,8 +21,8 @@ pub use controller::{FailureKind, ReconcileFailure};
 pub use harness::{Harness, HarnessAuthMode, HarnessSpec};
 pub use manifest::{
     API_VERSION, Agent, Condition, ConditionStatus, HomeSpec, InstructionsSpec, KIND, Metadata, MountSpec,
-    NetworkAllow, NetworkMode, NetworkSpec, PlatformManifestSpec, Provenance, SandboxManifestSpec, SecretSpec, Spec,
-    Status,
+    NetworkAllow, NetworkMode, NetworkSpec, PlatformManifestSpec, Provenance, SandboxManifestSpec, SecretSpec,
+    SkillSpec, Spec, Status,
 };
 
 use thiserror::Error;

--- a/src/experimental/agent/src/manifest.rs
+++ b/src/experimental/agent/src/manifest.rs
@@ -87,9 +87,9 @@ pub struct Spec {
     pub sandbox: SandboxManifestSpec,
     /// Host directory synchronized into the sandbox user's home at bootstrap.
     pub home: HomeSpec,
-    /// Optional Agent-wide guidance installed through every declared Harness Adapter.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub instructions: Option<InstructionsSpec>,
+    /// Agent-wide guidance installed through every declared Harness Adapter, concatenated in order.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub instructions: Vec<InstructionsSpec>,
     /// Skill directories installed through every declared Harness Adapter.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub skills: Vec<SkillSpec>,
@@ -310,26 +310,16 @@ impl Spec {
         if self.home.source.as_os_str().is_empty() {
             return Err(Error::Invalid("spec.home.source must not be empty".into()));
         }
-        if self
+        if let Some(index) = self
             .instructions
-            .as_ref()
-            .is_some_and(|instructions| instructions.source.as_os_str().is_empty())
+            .iter()
+            .position(|instructions| instructions.source.as_os_str().is_empty())
         {
-            return Err(Error::Invalid("spec.instructions.source must not be empty".into()));
+            return Err(Error::Invalid(format!(
+                "spec.instructions[{index}].source must not be empty"
+            )));
         }
-        let mut skill_names = std::collections::BTreeSet::new();
-        for (index, skill) in self.skills.iter().enumerate() {
-            let Some(name) = skill.name() else {
-                return Err(Error::Invalid(format!(
-                    "spec.skills[{index}].source must end in the skill's directory name"
-                )));
-            };
-            if !skill_names.insert(name) {
-                return Err(Error::Invalid(format!(
-                    "spec.skills[{index}] duplicates skill {name:?}"
-                )));
-            }
-        }
+        self.validate_skills()?;
         if self.harnesses.is_empty() {
             return Err(Error::Invalid("spec.harnesses must not be empty".into()));
         }
@@ -394,6 +384,25 @@ impl Spec {
     }
 }
 
+impl Spec {
+    fn validate_skills(&self) -> Result<(), Error> {
+        let mut skill_names = std::collections::BTreeSet::new();
+        for (index, skill) in self.skills.iter().enumerate() {
+            let Some(name) = skill.name() else {
+                return Err(Error::Invalid(format!(
+                    "spec.skills[{index}].source must end in the skill's directory name"
+                )));
+            };
+            if !skill_names.insert(name) {
+                return Err(Error::Invalid(format!(
+                    "spec.skills[{index}] duplicates skill {name:?}"
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
 fn valid_sandbox_path(path: &str) -> bool {
     path.starts_with('/')
         && path != "/"
@@ -411,7 +420,7 @@ pub struct HomeSpec {
     pub source: std::path::PathBuf,
 }
 
-/// Harness-neutral Agent-wide instruction source.
+/// One harness-neutral instruction file; several are concatenated in manifest order.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct InstructionsSpec {

--- a/src/experimental/agent/src/manifest.rs
+++ b/src/experimental/agent/src/manifest.rs
@@ -90,6 +90,9 @@ pub struct Spec {
     /// Optional Agent-wide guidance installed through every declared Harness Adapter.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub instructions: Option<InstructionsSpec>,
+    /// Skill directories installed through every declared Harness Adapter.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skills: Vec<SkillSpec>,
     /// Harness installations available to Sessions in this Agent.
     pub harnesses: Vec<HarnessSpec>,
     /// Host-owned values made available only through mediated requests.
@@ -314,6 +317,19 @@ impl Spec {
         {
             return Err(Error::Invalid("spec.instructions.source must not be empty".into()));
         }
+        let mut skill_names = std::collections::BTreeSet::new();
+        for (index, skill) in self.skills.iter().enumerate() {
+            let Some(name) = skill.name() else {
+                return Err(Error::Invalid(format!(
+                    "spec.skills[{index}].source must end in the skill's directory name"
+                )));
+            };
+            if !skill_names.insert(name) {
+                return Err(Error::Invalid(format!(
+                    "spec.skills[{index}] duplicates skill {name:?}"
+                )));
+            }
+        }
         if self.harnesses.is_empty() {
             return Err(Error::Invalid("spec.harnesses must not be empty".into()));
         }
@@ -401,6 +417,25 @@ pub struct HomeSpec {
 pub struct InstructionsSpec {
     /// Host file, resolved relative to the manifest directory.
     pub source: std::path::PathBuf,
+}
+
+/// One skill directory installed for every declared harness.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct SkillSpec {
+    /// Host directory holding `SKILL.md`, resolved relative to the manifest directory.
+    pub source: std::path::PathBuf,
+}
+
+impl SkillSpec {
+    /// Returns the skill name: the final component of the source directory.
+    #[must_use]
+    pub fn name(&self) -> Option<&str> {
+        self.source
+            .file_name()?
+            .to_str()
+            .filter(|name| !name.is_empty() && *name != ".")
+    }
 }
 
 /// One host-owned value exposed to Sandbox processes only as an inert environment placeholder.

--- a/src/experimental/agent/src/sandbox/platform/linux.rs
+++ b/src/experimental/agent/src/sandbox/platform/linux.rs
@@ -279,20 +279,30 @@ async fn write_file(sandbox: &SandboxHandle, path: &str, contents: &[u8]) -> Res
         .map_err(Error::from)
 }
 
+/// Concatenates the instruction files in manifest order, each terminated by a newline and
+/// separated by a blank line, so independent documents read as sections of one file.
 async fn read_instructions(record: &control_plane::AgentRecord) -> Result<Option<Vec<u8>>, Error> {
-    let Some(spec) = &record.agent.spec.instructions else {
-        return Ok(None);
-    };
-    let source = if spec.source.is_absolute() {
-        spec.source.clone()
-    } else {
-        record.source_directory.join(&spec.source)
-    };
-    let metadata = tokio::fs::metadata(&source).await?;
-    if !metadata.is_file() {
-        return Err(Error::Invalid("spec.instructions.source must identify a file".into()));
+    let mut combined = Vec::new();
+    for (index, spec) in record.agent.spec.instructions.iter().enumerate() {
+        let source = if spec.source.is_absolute() {
+            spec.source.clone()
+        } else {
+            record.source_directory.join(&spec.source)
+        };
+        let metadata = tokio::fs::metadata(&source).await?;
+        if !metadata.is_file() {
+            return Err(Error::Invalid(format!(
+                "spec.instructions[{index}].source must identify a file"
+            )));
+        }
+        let contents = tokio::fs::read(source).await?;
+        if !combined.is_empty() {
+            combined.push(b'\n');
+        }
+        combined.extend_from_slice(contents.strip_suffix(b"\n").unwrap_or(&contents));
+        combined.push(b'\n');
     }
-    tokio::fs::read(source).await.map(Some).map_err(Error::from)
+    Ok((!combined.is_empty()).then_some(combined))
 }
 
 async fn read_skills(record: &control_plane::AgentRecord) -> Result<Vec<harness::Skill>, Error> {

--- a/src/experimental/agent/src/sandbox/platform/linux.rs
+++ b/src/experimental/agent/src/sandbox/platform/linux.rs
@@ -397,17 +397,24 @@ fn walk_source(
         if relative.as_os_str().is_empty() {
             continue;
         }
-        if entry.file_type().is_some_and(|kind| kind.is_symlink()) {
+        // Only directories and regular files are carried into the Sandbox. A symbolic link would
+        // point at host content outside the source, and reading a FIFO or device would block setup.
+        let kind = entry
+            .file_type()
+            .ok_or_else(|| Error::Invalid(format!("{field} entry {} has no file type", relative.display())))?;
+        if kind.is_symlink() {
             return Err(Error::Invalid(format!(
                 "{field} contains unsupported symbolic link {}",
                 relative.display()
             )));
         }
-        visit(
-            relative,
-            entry.path(),
-            entry.file_type().is_some_and(|kind| kind.is_dir()),
-        )?;
+        if !kind.is_dir() && !kind.is_file() {
+            return Err(Error::Invalid(format!(
+                "{field} contains unsupported non-regular file {}",
+                relative.display()
+            )));
+        }
+        visit(relative, entry.path(), kind.is_dir())?;
     }
     Ok(())
 }

--- a/src/experimental/agent/src/sandbox/platform/linux.rs
+++ b/src/experimental/agent/src/sandbox/platform/linux.rs
@@ -152,8 +152,9 @@ impl Linux {
         let archive = archive_home(record.source_directory.clone(), record.agent.spec.home.source.clone()).await?;
         sync_home(sandbox, archive).await?;
         let instructions = read_instructions(record).await?;
+        let skills = read_skills(record).await?;
         for installation in &record.agent.spec.harnesses {
-            harness::bootstrap_linux(installation.kind, sandbox, HOME, instructions.as_deref()).await?;
+            harness::bootstrap_linux(installation.kind, sandbox, HOME, instructions.as_deref(), &skills).await?;
         }
         Ok(())
     }
@@ -294,16 +295,82 @@ async fn read_instructions(record: &control_plane::AgentRecord) -> Result<Option
     tokio::fs::read(source).await.map(Some).map_err(Error::from)
 }
 
-async fn archive_home(manifest_directory: std::path::PathBuf, source: std::path::PathBuf) -> Result<Vec<u8>, Error> {
-    tokio::task::spawn_blocking(move || archive_home_blocking(&manifest_directory, &source))
-        .await
-        .map_err(|error| Error::Daemon(format!("Agent home scan task failed: {error}")))?
+async fn read_skills(record: &control_plane::AgentRecord) -> Result<Vec<harness::Skill>, Error> {
+    let mut skills = Vec::with_capacity(record.agent.spec.skills.len());
+    for (index, spec) in record.agent.spec.skills.iter().enumerate() {
+        let field = format!("spec.skills[{index}].source");
+        let name = spec
+            .name()
+            .ok_or_else(|| Error::Invalid(format!("{field} must end in the skill's directory name")))?;
+        let source = resolve_source(&record.source_directory, &spec.source, &field)?;
+        if !source.join("SKILL.md").is_file() {
+            return Err(Error::Invalid(format!("{field} must contain SKILL.md")));
+        }
+        let files = tokio::task::spawn_blocking(move || read_skill_files(&source, &field))
+            .await
+            .map_err(|error| Error::Daemon(format!("Agent skill scan task failed: {error}")))??;
+        skills.push(harness::Skill {
+            name: name.to_owned(),
+            files,
+        });
+    }
+    Ok(skills)
 }
 
-fn archive_home_blocking(manifest_directory: &Path, source: &Path) -> Result<Vec<u8>, Error> {
-    let source = resolve_source(manifest_directory, source)?;
+fn read_skill_files(source: &Path, field: &str) -> Result<Vec<harness::SkillFile>, Error> {
+    let mut files = Vec::new();
+    walk_source(source, field, |relative, path, is_dir| {
+        if is_dir {
+            return Ok(());
+        }
+        let relative_path = relative
+            .components()
+            .map(|component| component.as_os_str().to_str())
+            .collect::<Option<Vec<_>>>()
+            .ok_or_else(|| Error::Invalid(format!("{field} contains a non-UTF-8 file name")))?
+            .join("/");
+        files.push(harness::SkillFile {
+            relative_path,
+            contents: std::fs::read(path)?,
+        });
+        Ok(())
+    })?;
+    Ok(files)
+}
+
+async fn archive_home(manifest_directory: std::path::PathBuf, source: std::path::PathBuf) -> Result<Vec<u8>, Error> {
+    let source = resolve_source(&manifest_directory, &source, "spec.home.source")?;
+    archive_directory(source, "spec.home.source".to_owned()).await
+}
+
+/// Archives a resolved host directory on a blocking thread; `field` names the manifest field in errors.
+async fn archive_directory(source: std::path::PathBuf, field: String) -> Result<Vec<u8>, Error> {
+    let task = format!("Agent {field} scan task failed");
+    tokio::task::spawn_blocking(move || archive_directory_blocking(&source, &field))
+        .await
+        .map_err(|error| Error::Daemon(format!("{task}: {error}")))?
+}
+
+fn archive_directory_blocking(source: &Path, field: &str) -> Result<Vec<u8>, Error> {
     let mut archive = tar::Builder::new(Vec::new());
-    for result in WalkBuilder::new(&source)
+    walk_source(source, field, |relative, path, is_dir| {
+        if is_dir {
+            archive.append_dir(relative, path)?;
+        } else {
+            archive.append_path_with_name(path, relative)?;
+        }
+        Ok(())
+    })?;
+    archive.into_inner().map_err(Error::from)
+}
+
+/// Visits every entry below `source` with its relative path, rejecting symbolic links.
+fn walk_source(
+    source: &Path,
+    field: &str,
+    mut visit: impl FnMut(&Path, &Path, bool) -> Result<(), Error>,
+) -> Result<(), Error> {
+    for result in WalkBuilder::new(source)
         .hidden(false)
         .ignore(false)
         .git_ignore(false)
@@ -312,27 +379,27 @@ fn archive_home_blocking(manifest_directory: &Path, source: &Path) -> Result<Vec
         .follow_links(false)
         .build()
     {
-        let entry = result.map_err(|error| Error::Invalid(format!("cannot traverse spec.home.source: {error}")))?;
+        let entry = result.map_err(|error| Error::Invalid(format!("cannot traverse {field}: {error}")))?;
         let relative = entry
             .path()
-            .strip_prefix(&source)
-            .map_err(|_| Error::Invalid("spec.home.source traversal escaped its root".into()))?;
+            .strip_prefix(source)
+            .map_err(|_| Error::Invalid(format!("{field} traversal escaped its root")))?;
         if relative.as_os_str().is_empty() {
             continue;
         }
         if entry.file_type().is_some_and(|kind| kind.is_symlink()) {
             return Err(Error::Invalid(format!(
-                "spec.home.source contains unsupported symbolic link {}",
+                "{field} contains unsupported symbolic link {}",
                 relative.display()
             )));
         }
-        if entry.file_type().is_some_and(|kind| kind.is_dir()) {
-            archive.append_dir(relative, entry.path())?;
-        } else {
-            archive.append_path_with_name(entry.path(), relative)?;
-        }
+        visit(
+            relative,
+            entry.path(),
+            entry.file_type().is_some_and(|kind| kind.is_dir()),
+        )?;
     }
-    archive.into_inner().map_err(Error::from)
+    Ok(())
 }
 
 async fn sync_home(sandbox: &SandboxHandle, archive: Vec<u8>) -> Result<(), Error> {
@@ -384,7 +451,7 @@ pub(crate) async fn run_checked<const N: usize>(
     )))
 }
 
-fn resolve_source(manifest_directory: &Path, source: &Path) -> Result<std::path::PathBuf, Error> {
+fn resolve_source(manifest_directory: &Path, source: &Path, field: &str) -> Result<std::path::PathBuf, Error> {
     let source = if source.is_absolute() {
         source.to_path_buf()
     } else {
@@ -392,7 +459,7 @@ fn resolve_source(manifest_directory: &Path, source: &Path) -> Result<std::path:
     };
     let source = std::fs::canonicalize(source)?;
     if !source.is_dir() {
-        return Err(Error::Invalid("spec.home.source must identify a directory".into()));
+        return Err(Error::Invalid(format!("{field} must identify a directory")));
     }
     Ok(source)
 }

--- a/src/experimental/agent/tests/manifest.rs
+++ b/src/experimental/agent/tests/manifest.rs
@@ -2,6 +2,8 @@
 
 mod support;
 
+use std::path::PathBuf;
+
 use agent::{API_VERSION, Harness, KIND, SecretSpec, manifest};
 use sandbox::RootFilesystemMode;
 
@@ -122,7 +124,18 @@ fn decodes_the_self_development_manifest() {
     assert_eq!(agent.spec.secrets.len(), 1);
     assert_eq!(agent.spec.secrets[0].environment, "GITHUB_TOKEN");
     assert_eq!(agent.spec.secrets[0].source(), "GITHUB_TOKEN");
-    assert_eq!(agent.spec.secrets[0].placeholder, None);
+    assert_eq!(
+        agent.spec.secrets[0].placeholder.as_deref(),
+        Some("github_pat_AGENT_MEDIATED_GITHUB_TOKEN")
+    );
+    assert!(
+        agent.spec.secrets[0]
+            .allowed_hosts
+            .iter()
+            .any(|host| host == "uploads.github.com")
+    );
+    assert_eq!(agent.spec.skills.len(), 1);
+    assert_eq!(agent.spec.skills[0].name(), Some("pr-evidence"));
     assert_eq!(agent.spec.harnesses.len(), 2);
     assert!(agent.spec.harnesses[0].default);
     assert_eq!(agent.spec.harnesses[0].kind, Harness::ClaudeCode);
@@ -307,4 +320,33 @@ fn status_tolerates_unknown_fields_inside_provenance() {
         provenance.manifest_path.as_deref(),
         Some(std::path::Path::new("/source/worker.yml"))
     );
+}
+
+#[test]
+fn rejects_skills_without_a_directory_name_or_with_duplicate_names() {
+    let mut agent = support::agent("worker");
+    agent.spec.skills = vec![agent::SkillSpec {
+        source: PathBuf::from("skills/.."),
+    }];
+    let error = agent.validate().expect_err("a source ending in .. has no skill name");
+    assert!(matches!(error, agent::Error::Invalid(message) if message.starts_with("spec.skills[0].source")));
+
+    agent.spec.skills = vec![
+        agent::SkillSpec {
+            source: PathBuf::from("skills/evidence"),
+        },
+        agent::SkillSpec {
+            source: PathBuf::from("../shared/evidence/"),
+        },
+    ];
+    let error = agent
+        .validate()
+        .expect_err("two skills with the same directory name collide");
+    assert!(
+        matches!(error, agent::Error::Invalid(message) if message == "spec.skills[1] duplicates skill \"evidence\"")
+    );
+
+    agent.spec.skills.pop();
+    agent.validate().expect("one named skill is valid");
+    assert_eq!(agent.spec.skills[0].name(), Some("evidence"));
 }

--- a/src/experimental/agent/tests/platform_linux.rs
+++ b/src/experimental/agent/tests/platform_linux.rs
@@ -137,10 +137,17 @@ async fn linux_setup_rewrites_configuration_without_owning_workspace_initializat
     let home = directory.path().join("home");
     std::fs::create_dir_all(&home).expect("home directory");
     std::fs::write(directory.path().join("instructions.md"), "test instructions").expect("instruction file");
+    let skill = directory.path().join("skills").join("evidence");
+    std::fs::create_dir_all(skill.join("references")).expect("skill directory");
+    std::fs::write(skill.join("SKILL.md"), "---\nname: evidence\n---\ncapture").expect("skill file");
+    std::fs::write(skill.join("references").join("gif.md"), "palette").expect("skill reference");
     let agent_id: AgentId = "38f41de4-6ff7-4679-ae46-678bc61e4dcb".parse().expect("Agent ID");
     let mut resource = support::agent("worker");
     resource.metadata.generation = 1;
     resource.spec.home.source = home;
+    resource.spec.skills = vec![agent::SkillSpec {
+        source: PathBuf::from("skills/evidence"),
+    }];
     resource.spec.harnesses[0].default = true;
     resource.spec.harnesses.push(agent::HarnessSpec {
         kind: agent::Harness::Codex,
@@ -208,6 +215,12 @@ async fn linux_setup_rewrites_configuration_without_owning_workspace_initializat
     assert_eq!(instructions, b"test instructions");
     let codex_instructions = read_file(&sandbox, "/home/agent/.codex/AGENTS.md").await;
     assert_eq!(codex_instructions, b"test instructions");
+    for root in ["/home/agent/.claude/skills", "/home/agent/.agents/skills"] {
+        let skill = read_file(&sandbox, &format!("{root}/evidence/SKILL.md")).await;
+        assert_eq!(skill, b"---\nname: evidence\n---\ncapture");
+        let reference = read_file(&sandbox, &format!("{root}/evidence/references/gif.md")).await;
+        assert_eq!(reference, b"palette");
+    }
     let codex_auth: serde_json::Value =
         serde_json::from_slice(&read_file(&sandbox, "/home/agent/.codex/auth.json").await).expect("Codex auth JSON");
     assert_eq!(codex_auth["auth_mode"], "chatgpt");

--- a/src/experimental/agent/tests/platform_linux.rs
+++ b/src/experimental/agent/tests/platform_linux.rs
@@ -528,6 +528,9 @@ async fn linux_setup_rejects_a_declared_harness_version_mismatch_before_injectio
     );
 }
 
+// The host is what holds the FIFO; Windows has no mkfifo, and the Linux Sandbox setup runs the same
+// walker on every host, so one Unix host exercising it is enough.
+#[cfg(unix)]
 #[tokio::test(flavor = "local")]
 async fn linux_setup_rejects_a_skill_tree_with_a_fifo_instead_of_blocking() {
     let directory = TempDir::new().expect("temporary directory");

--- a/src/experimental/agent/tests/platform_linux.rs
+++ b/src/experimental/agent/tests/platform_linux.rs
@@ -527,3 +527,62 @@ async fn linux_setup_rejects_a_declared_harness_version_mismatch_before_injectio
         "verification must happen before injection"
     );
 }
+
+#[tokio::test(flavor = "local")]
+async fn linux_setup_rejects_a_skill_tree_with_a_fifo_instead_of_blocking() {
+    let directory = TempDir::new().expect("temporary directory");
+    let home = directory.path().join("home");
+    std::fs::create_dir_all(&home).expect("home directory");
+    let skill = directory.path().join("skills").join("evidence");
+    std::fs::create_dir_all(&skill).expect("skill directory");
+    std::fs::write(skill.join("SKILL.md"), "capture").expect("skill file");
+    let status = std::process::Command::new("mkfifo")
+        .arg(skill.join("pipe"))
+        .status()
+        .expect("mkfifo runs");
+    assert!(status.success());
+    let mut resource = support::agent("worker");
+    resource.metadata.generation = 1;
+    resource.spec.home.source = home;
+    resource.spec.instructions.clear();
+    resource.spec.skills = vec![agent::SkillSpec {
+        source: PathBuf::from("skills/evidence"),
+    }];
+    let record = AgentRecord {
+        id: "38f41de4-6ff7-4679-ae46-678bc61e4dcb".parse().expect("Agent ID"),
+        source_directory: directory.path().to_path_buf(),
+        manifest_path: None,
+        env_file: None,
+        agent: resource,
+    };
+    let backend = Rc::new(memory::Provider::new());
+    backend.queue_execution_events_matching(
+        is_claude_version,
+        vec![
+            ExecutionEvent::Started { process_id: None },
+            ExecutionEvent::Stdout("2.1.239 (Claude Code)\n".into()),
+            ExecutionEvent::Exited(ExitStatus { code: 0 }),
+        ],
+    );
+    backend.queue_execution_events_matching(is_podman_presence_check, completed(1));
+    let service = SandboxService::new(backend);
+    let spec = record
+        .agent
+        .spec
+        .sandbox
+        .resolve_from(&record.source_directory, &Platform::native("linux").architecture);
+    let sandbox = service
+        .ensure(&EnsureSandboxRequest::new(
+            record.sandbox_name().expect("Sandbox name"),
+            spec,
+        ))
+        .await
+        .expect("Sandbox");
+
+    let error = Linux.setup(&record, &sandbox).await.expect_err("FIFO must be rejected");
+
+    assert!(
+        matches!(&error, agent::Error::Invalid(message) if message.contains("non-regular file pipe")),
+        "unexpected error: {error:?}"
+    );
+}

--- a/src/experimental/agent/tests/platform_linux.rs
+++ b/src/experimental/agent/tests/platform_linux.rs
@@ -136,7 +136,12 @@ async fn linux_setup_rewrites_configuration_without_owning_workspace_initializat
     let directory = TempDir::new().expect("temporary directory");
     let home = directory.path().join("home");
     std::fs::create_dir_all(&home).expect("home directory");
-    std::fs::write(directory.path().join("instructions.md"), "test instructions").expect("instruction file");
+    std::fs::write(directory.path().join("instructions.md"), "test instructions\n").expect("instruction file");
+    std::fs::write(
+        directory.path().join("environment.md"),
+        "# Environment\n\nhas a browser\n",
+    )
+    .expect("environment file");
     let skill = directory.path().join("skills").join("evidence");
     std::fs::create_dir_all(skill.join("references")).expect("skill directory");
     std::fs::write(skill.join("SKILL.md"), "---\nname: evidence\n---\ncapture").expect("skill file");
@@ -148,6 +153,9 @@ async fn linux_setup_rewrites_configuration_without_owning_workspace_initializat
     resource.spec.skills = vec![agent::SkillSpec {
         source: PathBuf::from("skills/evidence"),
     }];
+    resource.spec.instructions.push(agent::InstructionsSpec {
+        source: PathBuf::from("environment.md"),
+    });
     resource.spec.harnesses[0].default = true;
     resource.spec.harnesses.push(agent::HarnessSpec {
         kind: agent::Harness::Codex,
@@ -212,9 +220,9 @@ async fn linux_setup_rewrites_configuration_without_owning_workspace_initializat
     let preserved = read_file(&sandbox, "/home/agent/.claude/.claude.json").await;
     assert_eq!(preserved, mutable_state);
     let instructions = read_file(&sandbox, "/home/agent/.claude/CLAUDE.md").await;
-    assert_eq!(instructions, b"test instructions");
+    assert_eq!(instructions, b"test instructions\n\n# Environment\n\nhas a browser\n");
     let codex_instructions = read_file(&sandbox, "/home/agent/.codex/AGENTS.md").await;
-    assert_eq!(codex_instructions, b"test instructions");
+    assert_eq!(codex_instructions, instructions);
     for root in ["/home/agent/.claude/skills", "/home/agent/.agents/skills"] {
         let skill = read_file(&sandbox, &format!("{root}/evidence/SKILL.md")).await;
         assert_eq!(skill, b"---\nname: evidence\n---\ncapture");

--- a/src/experimental/agent/tests/support/mod.rs
+++ b/src/experimental/agent/tests/support/mod.rs
@@ -50,6 +50,7 @@ pub(crate) fn agent(name: &str) -> Agent {
             instructions: Some(InstructionsSpec {
                 source: PathBuf::from("instructions.md"),
             }),
+            skills: vec![],
             harnesses: vec![HarnessSpec {
                 kind: Harness::ClaudeCode,
                 version: Some("2.1.239".into()),

--- a/src/experimental/agent/tests/support/mod.rs
+++ b/src/experimental/agent/tests/support/mod.rs
@@ -47,9 +47,9 @@ pub(crate) fn agent(name: &str) -> Agent {
             home: HomeSpec {
                 source: PathBuf::from("home"),
             },
-            instructions: Some(InstructionsSpec {
+            instructions: vec![InstructionsSpec {
                 source: PathBuf::from("instructions.md"),
-            }),
+            }],
             skills: vec![],
             harnesses: vec![HarnessSpec {
                 kind: Harness::ClaudeCode,


### PR DESCRIPTION
## Description

Lets the altinn-studio use playwright/cli and asciinema to record in addition to screenshots. Adds a skill for this and some instruction on when/how to record "evidence in PR".

example: https://github.com/Altinn/altinn-studio/pull/20347

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agents can now combine multiple instruction sources and install reusable skills.
  * Added PR evidence support for screenshots, browser recordings and terminal captures.
  * Added media preview and video-to-GIF utilities.
  * Full environments now include browser, recording and multimedia tools; minimal environments include terminal-recording tools.
  * GitHub attachment uploads are supported through mediated authentication.
* **Bug Fixes**
  * Improved validation rejects duplicate skills and invalid skill sources.
* **Tests**
  * Added smoke tests covering tool availability, evidence capture and generated media.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->