### PR TITLE
chore: release codelists v9.0.0-preview.1

### DIFF
--- a/src/App/codelists/CHANGELOG.md
+++ b/src/App/codelists/CHANGELOG.md
@@ -9,6 +9,8 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+## [9.0.0-preview.1] - 2026-09-09
+
 ### Changed
 
 - Altinn.Codelists now builds on version 9 of the Altinn app libraries and targets .NET 10. Upgrade your app to `Altinn.App.Core` 9 before taking this version; apps still on version 8 should stay on Altinn.Codelists 8.0.3.


### PR DESCRIPTION
## Description

Prepare release v9.0.0-preview.1

- [Changed] Altinn.Codelists now builds on version 9 of the Altinn app libraries and targets .NET 10. Upgrade your app to `Altinn.App.Core` 9 before taking this version; apps still on version 8 should stay on Altinn.Codelists 8.0.3.

@coderabbitai ignore