### PR TITLE
chore: release fileanalyzers v9.0.0-preview.1

### DIFF
--- a/src/App/fileanalyzers/CHANGELOG.md
+++ b/src/App/fileanalyzers/CHANGELOG.md
@@ -9,6 +9,8 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 ## [Unreleased]
 
+## [9.0.0-preview.1] - 2026-09-09
+
 ### Changed
 
 - Altinn.FileAnalyzers now builds on version 9 of the Altinn app libraries and targets .NET 10. Upgrade your app to `Altinn.App.Core` 9 before taking this version; apps still on version 8 should stay on Altinn.FileAnalyzers 8.0.0.


### PR DESCRIPTION
## Description

Prepare release v9.0.0-preview.1

- [Changed] Altinn.FileAnalyzers now builds on version 9 of the Altinn app libraries and targets .NET 10. Upgrade your app to `Altinn.App.Core` 9 before taking this version; apps still on version 8 should stay on Altinn.FileAnalyzers 8.0.0.

@coderabbitai ignore