### PR TITLE
fix: agents run the workspace clone outside the boot transaction

### DIFF
--- a/agents/common/workspace-init.service
+++ b/agents/common/workspace-init.service
@@ -2,10 +2,13 @@
 Description=Initialize the Altinn Studio Agent workspace
 Wants=network-online.target
 After=network-online.target
-Before=multi-user.target
 
 [Service]
-Type=oneshot
+# One best-effort clone started at boot; an existing checkout already has `.git`, so the script
+# exits without touching it. `Type=exec` completes the start job once the clone has been spawned,
+# keeping the clone out of the boot transaction so that `systemctl is-system-running --wait` does
+# not wait for it.
+Type=exec
 User=agent
 Group=agent
 Environment=HOME=/home/agent

--- a/agents/common/workspace-init.service
+++ b/agents/common/workspace-init.service
@@ -5,7 +5,7 @@ After=network-online.target
 
 [Service]
 # One best-effort clone started at boot; an existing checkout already has `.git`, so the script
-# exits without touching it. `Type=exec` completes the start job once the clone has been spawned,
+# exits without touching it. `Type=exec` completes the start job once the script has been started,
 # keeping the clone out of the boot transaction so that `systemctl is-system-running --wait` does
 # not wait for it.
 Type=exec

--- a/src/experimental/agent/examples/self-dev/Dockerfile
+++ b/src/experimental/agent/examples/self-dev/Dockerfile
@@ -118,8 +118,9 @@ RUN { getent group kvm >/dev/null || groupadd --system kvm; } \
 COPY tmpfiles.conf /usr/lib/tmpfiles.d/agent-dev.conf
 COPY --chown=agent:agent --chmod=0600 claude-state.json /home/agent/.claude/.claude.json
 
-# One best-effort clone at boot for the checkout variants; a bind-mounted checkout already has
-# `.git`, so the unit exits without touching it.
+# One best-effort clone started at boot for the checkout variants; a bind-mounted checkout already
+# has `.git`, so the unit exits without touching it. The unit runs outside the boot transaction so
+# the host's systemd readiness check does not wait for the clone.
 COPY workspace-init.service /etc/systemd/system/agent-workspace-init.service
 COPY --chmod=0755 workspace-init.sh /usr/local/libexec/agent-workspace-init
 

--- a/src/experimental/agent/examples/self-dev/Dockerfile
+++ b/src/experimental/agent/examples/self-dev/Dockerfile
@@ -118,9 +118,6 @@ RUN { getent group kvm >/dev/null || groupadd --system kvm; } \
 COPY tmpfiles.conf /usr/lib/tmpfiles.d/agent-dev.conf
 COPY --chown=agent:agent --chmod=0600 claude-state.json /home/agent/.claude/.claude.json
 
-# One best-effort clone started at boot for the checkout variants; a bind-mounted checkout already
-# has `.git`, so the unit exits without touching it. The unit runs outside the boot transaction so
-# the host's systemd readiness check does not wait for the clone.
 COPY workspace-init.service /etc/systemd/system/agent-workspace-init.service
 COPY --chmod=0755 workspace-init.sh /usr/local/libexec/agent-workspace-init
 

--- a/src/experimental/agent/examples/self-dev/workspace-init.service
+++ b/src/experimental/agent/examples/self-dev/workspace-init.service
@@ -6,7 +6,7 @@ After=network-online.target
 [Service]
 # One best-effort clone started at boot for the checkout variants; a bind-mounted checkout already
 # has `.git`, so the script exits without touching it. `Type=exec` completes the start job once the
-# clone has been spawned, keeping the clone out of the boot transaction so that
+# script has been started, keeping the clone out of the boot transaction so that
 # `systemctl is-system-running --wait` does not wait for it.
 Type=exec
 User=agent

--- a/src/experimental/agent/examples/self-dev/workspace-init.service
+++ b/src/experimental/agent/examples/self-dev/workspace-init.service
@@ -4,10 +4,10 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-# `Type=exec` completes the start job as soon as the clone has been spawned. As a oneshot ordered
-# before `multi-user.target` the clone was part of the boot transaction, and the host's
-# `systemctl is-system-running --wait` readiness check timed out on every first boot because the
-# clone outlives its deadline. Podman setup does not depend on the checkout.
+# One best-effort clone started at boot for the checkout variants; a bind-mounted checkout already
+# has `.git`, so the script exits without touching it. `Type=exec` completes the start job once the
+# clone has been spawned, keeping the clone out of the boot transaction so that
+# `systemctl is-system-running --wait` does not wait for it.
 Type=exec
 User=agent
 Group=agent

--- a/src/experimental/agent/examples/self-dev/workspace-init.service
+++ b/src/experimental/agent/examples/self-dev/workspace-init.service
@@ -2,10 +2,13 @@
 Description=Initialize the Agent workspace checkout
 Wants=network-online.target
 After=network-online.target
-Before=multi-user.target
 
 [Service]
-Type=oneshot
+# `Type=exec` completes the start job as soon as the clone has been spawned. As a oneshot ordered
+# before `multi-user.target` the clone was part of the boot transaction, and the host's
+# `systemctl is-system-running --wait` readiness check timed out on every first boot because the
+# clone outlives its deadline. Podman setup does not depend on the checkout.
+Type=exec
 User=agent
 Group=agent
 Environment=HOME=/home/agent


### PR DESCRIPTION
## Problem

`agent-workspace-init.service` was a `Type=oneshot` unit ordered `Before=multi-user.target`, so the `gh repo clone Altinn/altinn-studio` it runs was part of the boot transaction. Sandbox setup waits with `systemctl is-system-running --wait`, which blocks until that transaction completes. The clone takes longer than the 90s readiness deadline, so every first boot of a checkout-based Agent reported `systemd did not finish booting within 90s`, flipped the condition to failed, and only succeeded on the next reconcile pass.

## Change

Applied to both copies of the unit:

- `agents/common/workspace-init.service`, installed by the `minimal` and `full` images in `agents/Dockerfile`
- `src/experimental/agent/examples/self-dev/workspace-init.service`, installed by the self-dev image

In each, drop `Before=multi-user.target` and switch to `Type=exec`, so the start job completes once the clone process is spawned. The unit is still enabled and started at boot, and still ends up `failed` if the clone exits non-zero, so diagnostics are unchanged. The behaviour description now lives in the unit file rather than the Dockerfile.

`agent-full-hosts-init.service` stays in the boot transaction; it only appends two `/etc/hosts` lines.

Podman setup does not depend on the checkout; the readiness check already treats `degraded` as ready for exactly this reason.

No `agentctl` or TUI output changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace initialisation now starts cloning in the background during boot.
  * System readiness checks no longer wait for the workspace clone to finish.
  * Boot ordering is no longer tied to completion of the workspace initialisation task.

* **Documentation**
  * Added comments clarifying checkout behaviour and the updated boot-time execution semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->