### PR TITLE
feat(agent): report the Agent name as the Sandbox hostname

### DIFF
--- a/src/experimental/README.md
+++ b/src/experimental/README.md
@@ -63,7 +63,8 @@ scheduler, which serializes work per resource identity while allowing unrelated 
 
 Desired state is persisted before reconciliation. Wakeups provide low-latency progress, while startup and periodic
 scans ensure dropped notifications or daemon restarts do not lose work. Provider assignment is sticky for an Agent
-incarnation, and a reused Agent name never inherits resources from a deleted incarnation.
+incarnation, and a reused Agent name never inherits resources from a deleted incarnation. The Sandbox is named after the
+incarnation, while its guest hostname is the Agent name so shell prompts and logs identify the Agent.
 
 Sessions have platform-assigned identities independent of tmux and harness-native conversation IDs. Each Session binds
 immutably to one of its Agent's declared harness installations. Detaching leaves a Session running. An inactive,

--- a/src/experimental/agent/src/control_plane/resource.rs
+++ b/src/experimental/agent/src/control_plane/resource.rs
@@ -74,4 +74,14 @@ impl AgentRecord {
         ::sandbox::SandboxName::new(format!("agent-{}", self.id))
             .map_err(|error| Error::Database(format!("Agent ID cannot identify its Sandbox: {error}")))
     }
+
+    /// Derives the hostname the Sandbox reports: the Agent name.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error only if the validated Agent name cannot form a hostname.
+    pub fn sandbox_hostname(&self) -> Result<::sandbox::Hostname, Error> {
+        ::sandbox::Hostname::new(self.agent.metadata.name.clone())
+            .map_err(|error| Error::Database(format!("Agent name cannot be its Sandbox hostname: {error}")))
+    }
 }

--- a/src/experimental/agent/src/sandbox/microsandbox/mod.rs
+++ b/src/experimental/agent/src/sandbox/microsandbox/mod.rs
@@ -134,6 +134,7 @@ impl Provider for Adapter {
                 Err(error) => return Err(error.into()),
             };
             let request = EnsureSandboxRequest::new(sandbox_name, self.sandbox_spec(record))
+                .with_hostname(record.sandbox_hostname()?)
                 .with_mounts(Self::sandbox_mounts(record))
                 .with_environment(prepared.environment);
             let mut sandbox = ensure_with_progress(&self.service, &request, &progress).await?;

--- a/src/experimental/agent/tests/control_plane.rs
+++ b/src/experimental/agent/tests/control_plane.rs
@@ -135,6 +135,7 @@ impl Provider for MemoryProvider {
                 .service
                 .ensure(
                     &EnsureSandboxRequest::new(record.sandbox_name()?, spec)
+                        .with_hostname(record.sandbox_hostname()?)
                         .with_mounts(record.agent.spec.sandbox.resolved_mounts()),
                 )
                 .await

--- a/src/experimental/sandbox-microsandbox/src/backend.rs
+++ b/src/experimental/sandbox-microsandbox/src/backend.rs
@@ -328,8 +328,9 @@ impl MicrosandboxProvider {
             self.materialize_direct_root_image(&image).await?;
             step.complete(started.elapsed()).await;
         }
-        let mut builder =
-            Client::sandbox_builder(&record.runtime_name, image, record.resources)?.pull_policy(PullPolicy::Never);
+        let mut builder = Client::sandbox_builder(&record.runtime_name, image, record.resources)?
+            .pull_policy(PullPolicy::Never)
+            .hostname(record.hostname().as_str());
         builder = builder.envs(record.environment.clone());
         if record
             .network
@@ -665,6 +666,7 @@ impl SandboxRecord {
             init_system: self.init_system,
             id: self.id.clone(),
             name: self.name.clone(),
+            hostname: self.hostname(),
             resources: self.resources,
             state,
             mounts: self.mounts.clone(),

--- a/src/experimental/sandbox-microsandbox/src/state.rs
+++ b/src/experimental/sandbox-microsandbox/src/state.rs
@@ -1,8 +1,8 @@
 use std::{collections::BTreeMap, io::Write as _, path::PathBuf};
 
 use sandbox::{
-    SandboxId, SandboxName, SandboxResources, backend::CreateSandboxRequest, image::ResolvedImage, init::InitSystem,
-    mount::Mount, network::NetworkAttachment, volume::VolumeId,
+    Hostname, SandboxId, SandboxName, SandboxResources, backend::CreateSandboxRequest, image::ResolvedImage,
+    init::InitSystem, mount::Mount, network::NetworkAttachment, volume::VolumeId,
 };
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use sha2::{Digest as _, Sha256};
@@ -19,6 +19,10 @@ pub(crate) struct SandboxRecord {
     pub(crate) id: SandboxId,
     pub(crate) runtime_name: String,
     pub(crate) name: SandboxName,
+    /// Absent in records written before hostnames were persisted; those
+    /// Sandboxes report their name once their runtime is recreated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    hostname: Option<Hostname>,
     pub(crate) image: ResolvedImage,
     pub(crate) resources: SandboxResources,
     #[serde(default)]
@@ -36,6 +40,7 @@ impl SandboxRecord {
             runtime_name,
             id: request.id,
             name: request.name,
+            hostname: Some(request.hostname),
             image: request.image,
             resources: request.resources,
             init_system: request.init_system,
@@ -43,6 +48,11 @@ impl SandboxRecord {
             environment: request.environment,
             network: request.network,
         }
+    }
+
+    /// Returns the hostname the guest reports, defaulting to the Sandbox name.
+    pub(crate) fn hostname(&self) -> Hostname {
+        self.hostname.clone().unwrap_or_else(|| self.name.clone().into())
     }
 }
 
@@ -294,7 +304,7 @@ mod tests {
     use std::{collections::BTreeMap, path::PathBuf};
 
     use sandbox::{
-        ByteQuantity, CpuQuantity, Platform, RootFilesystem, SandboxName, SandboxResources,
+        ByteQuantity, CpuQuantity, Hostname, Platform, RootFilesystem, SandboxName, SandboxResources,
         backend::CreateSandboxRequest, image, init::InitSystem,
     };
 
@@ -335,6 +345,7 @@ mod tests {
         SandboxRecord::new(CreateSandboxRequest {
             id: sandbox_id(id),
             name: sandbox_name(),
+            hostname: Hostname::new("worker-host").expect("test hostname should be valid"),
             image: image(),
             resources: resources(),
             init_system: InitSystem::Backend,
@@ -370,6 +381,21 @@ mod tests {
                 .expect("record should be found by identifier"),
             record
         );
+    }
+
+    #[tokio::test(flavor = "local")]
+    async fn records_without_a_persisted_hostname_report_the_sandbox_name() {
+        let mut record = sandbox_record("00000000-0000-4000-8000-000000000005");
+        assert_eq!(record.hostname().as_str(), "worker-host");
+
+        let mut serialized = serde_json::to_value(&record).expect("record should serialize");
+        let fields = serialized.as_object_mut().expect("record should be an object");
+        assert!(fields.remove("hostname").is_some(), "hostname should be persisted");
+        let legacy: SandboxRecord = serde_json::from_value(serialized).expect("legacy record should deserialize");
+        assert_eq!(legacy.hostname().as_str(), "worker");
+
+        record.hostname = None;
+        assert_eq!(legacy, record);
     }
 
     #[tokio::test(flavor = "local")]

--- a/src/experimental/sandbox-microsandbox/tests/runtime.rs
+++ b/src/experimental/sandbox-microsandbox/tests/runtime.rs
@@ -5,8 +5,8 @@ use std::{io::Cursor, path::PathBuf, rc::Rc};
 use bytes::Bytes;
 use futures_util::StreamExt as _;
 use sandbox::{
-    ByteQuantity, CpuQuantity, EnsureSandboxRequest, OperationEvent, Platform, RetentionPolicy, RootFilesystem,
-    Sandbox, SandboxEvent, SandboxName, SandboxResources, SandboxService, SandboxSpec, SandboxState,
+    ByteQuantity, CpuQuantity, EnsureSandboxRequest, Hostname, OperationEvent, Platform, RetentionPolicy,
+    RootFilesystem, Sandbox, SandboxEvent, SandboxName, SandboxResources, SandboxService, SandboxSpec, SandboxState,
     backend::SandboxBackend as _,
     execution::{self, ExecutionSpec, StartExecutionRequest},
     image::ImageSource,
@@ -48,6 +48,7 @@ async fn retained_lifecycle_execution_files_and_volumes() {
             retention_policy: RetentionPolicy::Retain,
         },
     )
+    .with_hostname(Hostname::new("integration-host").expect("test hostname should be valid"))
     .with_mounts([Mount::Volume {
         id: home.id.clone(),
         target: sandbox::SandboxPath::new("/workspace"),
@@ -58,6 +59,7 @@ async fn retained_lifecycle_execution_files_and_volumes() {
         .expect("Sandbox should be built and started");
     assert_provisioning_progress(&events);
     assert_eq!(sandbox.state, SandboxState::Running);
+    assert_hostname(backend.as_ref(), &sandbox, "integration-host").await;
     assert_direct_root_filesystem(backend.as_ref(), &sandbox).await;
     assert_nested_container_networking(backend.as_ref(), &sandbox).await;
 
@@ -100,6 +102,13 @@ async fn retained_lifecycle_execution_files_and_volumes() {
     assert_immediate_restart_and_delete(&backend, &request, &sandbox).await;
     assert_build_cache_reused(backend, &request, &home.id).await;
     assert_reference_image_resolves(reference_backend_home).await;
+}
+
+async fn assert_hostname(backend: &MicrosandboxProvider, sandbox: &Sandbox, expected: &str) {
+    assert_eq!(sandbox.hostname.as_str(), expected);
+    let output = run(backend, &sandbox.id, shell("hostname")).await;
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), expected);
 }
 
 async fn assert_direct_root_filesystem(backend: &MicrosandboxProvider, sandbox: &Sandbox) {
@@ -212,6 +221,7 @@ async fn assert_reference_image_resolves(backend_home: PathBuf) {
     let output = run(backend.as_ref(), &sandbox.id, shell("cat /etc/alpine-release")).await;
     assert!(output.status.success());
     assert!(String::from_utf8_lossy(&output.stdout).starts_with("3.22."));
+    assert_hostname(backend.as_ref(), &sandbox, "reference-worker").await;
 
     service
         .release(request.name(), request.spec().retention_policy)

--- a/src/experimental/sandbox/src/backend.rs
+++ b/src/experimental/sandbox/src/backend.rs
@@ -11,7 +11,8 @@ use uuid::Uuid;
 pub use crate::feature::SandboxBackendCapabilities;
 
 use crate::{
-    Error, PendingOperation, Platform, RootFilesystem, SandboxName, SandboxPath, execution, file_transfer, image,
+    Error, Hostname, PendingOperation, Platform, RootFilesystem, SandboxName, SandboxPath, execution, file_transfer,
+    image,
     init::InitSystem,
     mount::Mount,
     network,
@@ -114,6 +115,8 @@ pub struct CreateSandboxRequest {
     pub image: image::ResolvedImage,
     /// The stable caller-provided name.
     pub name: SandboxName,
+    /// Hostname reported inside the Sandbox, resolved by the lifecycle owner.
+    pub hostname: Hostname,
     /// Desired mutable compute and writable root filesystem resources.
     pub resources: SandboxResources,
     /// Process responsible for initializing the Sandbox after backend setup.
@@ -135,6 +138,8 @@ pub struct Sandbox {
     pub id: SandboxId,
     /// The caller-provided name.
     pub name: SandboxName,
+    /// Hostname the Sandbox reports to its guest.
+    pub hostname: Hostname,
     /// Current desired compute and writable root filesystem resources.
     pub resources: SandboxResources,
     /// Process responsible for initializing the Sandbox after backend setup.

--- a/src/experimental/sandbox/src/lib.rs
+++ b/src/experimental/sandbox/src/lib.rs
@@ -26,7 +26,7 @@ pub mod volume;
 
 pub use backend::{LocalFuture, Sandbox, SandboxId, SandboxResources, SandboxState};
 pub use feature::{SandboxCapabilities, SandboxFeature, SandboxFeatureSet};
-pub use name::{InvalidSandboxName, MAX_SANDBOX_NAME_BYTES, SandboxName};
+pub use name::{Hostname, InvalidHostname, InvalidSandboxName, MAX_SANDBOX_NAME_BYTES, SandboxName};
 pub use path::SandboxPath;
 pub use platform::Platform;
 pub use progress::{

--- a/src/experimental/sandbox/src/memory.rs
+++ b/src/experimental/sandbox/src/memory.rs
@@ -326,6 +326,7 @@ impl SandboxBackend for Provider {
                     image: request.image,
                     init_system: request.init_system,
                     name: request.name,
+                    hostname: request.hostname,
                     resources: request.resources,
                     state: SandboxState::Stopped,
                     mounts: request.mounts,

--- a/src/experimental/sandbox/src/name.rs
+++ b/src/experimental/sandbox/src/name.rs
@@ -90,6 +90,72 @@ impl<'de> Deserialize<'de> for SandboxName {
     }
 }
 
+/// The hostname a Sandbox reports to its guest.
+///
+/// Hostnames share the portable DNS-1123 label form of [`SandboxName`], which
+/// keeps them within the Linux UTS limit and usable as a DNS label. A Sandbox
+/// defaults to its own name as hostname; a caller supplies a different value
+/// when the user-facing identity differs from the Sandbox name.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
+pub struct Hostname(SandboxName);
+
+impl Hostname {
+    /// Validates and creates a Sandbox hostname.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error unless the value is a lowercase DNS label of at most
+    /// [`MAX_SANDBOX_NAME_BYTES`] bytes.
+    pub fn new(value: impl Into<String>) -> Result<Self, InvalidHostname> {
+        SandboxName::new(value).map(Self).map_err(InvalidHostname)
+    }
+
+    /// Returns the hostname as text.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl From<SandboxName> for Hostname {
+    fn from(name: SandboxName) -> Self {
+        Self(name)
+    }
+}
+
+impl AsRef<str> for Hostname {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl fmt::Display for Hostname {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl FromStr for Hostname {
+    type Err = InvalidHostname;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::new(value)
+    }
+}
+
+/// Why a value cannot be used as a Sandbox hostname.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InvalidHostname(InvalidSandboxName);
+
+impl fmt::Display for InvalidHostname {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "hostname is not a portable DNS label: {}", self.0)
+    }
+}
+
+impl std::error::Error for InvalidHostname {}
+
 /// Why a value cannot be used as a portable Sandbox name.
 #[derive(Clone, Debug, Eq, Error, PartialEq)]
 pub enum InvalidSandboxName {

--- a/src/experimental/sandbox/src/service.rs
+++ b/src/experimental/sandbox/src/service.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{
-    PendingOperation, Platform, Sandbox, SandboxCapabilities, SandboxFeature, SandboxFeatureSet, SandboxName,
+    Hostname, PendingOperation, Platform, Sandbox, SandboxCapabilities, SandboxFeature, SandboxFeatureSet, SandboxName,
     SandboxPath, SandboxResources, SandboxState,
     backend::{SandboxBackend, SandboxBackendCapabilities},
     execution, file_transfer, image,
@@ -341,6 +341,8 @@ impl SandboxSpec {
 pub struct EnsureSandboxRequest {
     /// Stable Sandbox name.
     name: SandboxName,
+    /// Hostname overriding the Sandbox name inside the guest.
+    hostname: Option<Hostname>,
     /// Desired backend-neutral configuration.
     spec: SandboxSpec,
     /// Attachments contributed by the caller or a higher platform layer.
@@ -357,11 +359,22 @@ impl EnsureSandboxRequest {
     pub const fn new(name: SandboxName, spec: SandboxSpec) -> Self {
         Self {
             name,
+            hostname: None,
             spec,
             mounts: Vec::new(),
             environment: std::collections::BTreeMap::new(),
             required_features: SandboxFeatureSet::new(),
         }
+    }
+
+    /// Reports a hostname other than the Sandbox name inside the guest.
+    ///
+    /// The hostname is applied when the Sandbox is created; an existing Sandbox
+    /// keeps the hostname it was created with.
+    #[must_use]
+    pub fn with_hostname(mut self, hostname: Hostname) -> Self {
+        self.hostname = Some(hostname);
+        self
     }
 
     /// Adds filesystem attachments materialized with the Sandbox.
@@ -389,6 +402,12 @@ impl EnsureSandboxRequest {
     #[must_use]
     pub const fn name(&self) -> &SandboxName {
         &self.name
+    }
+
+    /// Returns the hostname the guest reports, defaulting to the Sandbox name.
+    #[must_use]
+    pub fn hostname(&self) -> Hostname {
+        self.hostname.clone().unwrap_or_else(|| self.name.clone().into())
     }
 
     /// Returns the desired Sandbox configuration.
@@ -649,6 +668,7 @@ impl SandboxService {
                     .create(crate::backend::CreateSandboxRequest {
                         id: id.clone(),
                         name: request.name.clone(),
+                        hostname: request.hostname(),
                         image,
                         resources: request.spec.resources,
                         init_system: request.spec.init_system,

--- a/src/experimental/sandbox/tests/name.rs
+++ b/src/experimental/sandbox/tests/name.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::expect_used)]
 
-use sandbox::{InvalidSandboxName, MAX_SANDBOX_NAME_BYTES, SandboxName};
+use sandbox::{Hostname, InvalidSandboxName, MAX_SANDBOX_NAME_BYTES, SandboxName};
 
 #[test]
 fn accepts_portable_dns_labels() {
@@ -46,4 +46,25 @@ fn deserialization_cannot_bypass_validation() {
         serde_json::to_string(&name).expect("name should serialize"),
         r#""worker-1""#
     );
+}
+
+#[test]
+fn hostnames_share_the_portable_label_rules() {
+    let hostname = Hostname::new("agent-test").expect("portable hostname should be accepted");
+    assert_eq!(hostname.as_str(), "agent-test");
+    assert_eq!(hostname.to_string(), "agent-test");
+    assert_eq!(
+        Hostname::from(SandboxName::new("worker").expect("valid name")).as_str(),
+        "worker"
+    );
+
+    for value in ["", "Worker", "worker_name", "worker.example.com"] {
+        let error = Hostname::new(value).expect_err("non-label hostname should be rejected");
+        assert!(
+            error.to_string().starts_with("hostname is not a portable DNS label: "),
+            "{value:?}: {error}"
+        );
+    }
+    assert!(Hostname::new("a".repeat(MAX_SANDBOX_NAME_BYTES + 1)).is_err());
+    assert!(serde_json::from_str::<Hostname>(r#""Worker""#).is_err());
 }

--- a/src/experimental/sandbox/tests/service.rs
+++ b/src/experimental/sandbox/tests/service.rs
@@ -5,7 +5,7 @@ use std::{future::poll_fn, io::Cursor, path::PathBuf, pin::Pin, rc::Rc};
 use bytes::Bytes;
 use futures_core::Stream as _;
 use sandbox::{
-    ByteQuantity, CpuQuantity, EnsureSandboxRequest, Error, OperationEvent, PendingOperation, Platform,
+    ByteQuantity, CpuQuantity, EnsureSandboxRequest, Error, Hostname, OperationEvent, PendingOperation, Platform,
     RetentionPolicy, RootFilesystem, RootFilesystemMode, SandboxEvent, SandboxFeature, SandboxName, SandboxPath,
     SandboxPhase, SandboxResources, SandboxService, SandboxSpec,
     execution::{ExecutionEvent, ExecutionSpec, ExitStatus, StartExecutionRequest},
@@ -48,6 +48,34 @@ fn resources(cpu: &str, memory: &str, root_filesystem: &str) -> SandboxResources
                 .expect("test root filesystem should be valid"),
         ),
     )
+}
+
+#[tokio::test(flavor = "local")]
+async fn ensure_defaults_the_hostname_to_the_sandbox_name() {
+    let backend = Rc::new(memory::Provider::new());
+    let service = SandboxService::new(backend);
+    let request = request();
+    assert_eq!(request.hostname().as_str(), "worker");
+
+    let sandbox = service.ensure(&request).await.expect("ensure");
+    assert_eq!(sandbox.snapshot().hostname, Hostname::from(sandbox_name()));
+}
+
+#[tokio::test(flavor = "local")]
+async fn ensure_creates_the_sandbox_with_an_explicit_hostname() {
+    let backend = Rc::new(memory::Provider::new());
+    let service = SandboxService::new(backend);
+    let hostname = Hostname::new("agent-test").expect("test hostname should be valid");
+    let request = request().with_hostname(hostname.clone());
+    assert_eq!(request.hostname(), hostname);
+
+    let sandbox = service.ensure(&request).await.expect("ensure");
+    assert_eq!(sandbox.name(), &sandbox_name());
+    assert_eq!(sandbox.snapshot().hostname, hostname);
+    assert_eq!(
+        service.inspect(request.name()).await.expect("inspect").hostname,
+        hostname
+    );
 }
 
 #[tokio::test(flavor = "local")]


### PR DESCRIPTION
## Description

Fixes the first item of #20154: the hostname inside an Agent Sandbox was the Microsandbox runtime name, `sandbox-<uuid>`. It is now the Agent name (`metadata.name`), which is already validated as a DNS-1123 label and therefore a valid hostname.

- `sandbox`: adds a portable `Hostname` type (same DNS-1123 label rules as `SandboxName`). `EnsureSandboxRequest::with_hostname` overrides the default, which is the Sandbox name; `CreateSandboxRequest` and the `Sandbox` view carry the resolved hostname.
- `sandbox-microsandbox`: persists the hostname in the Sandbox record and passes it to the runtime builder. Records written before this change have no hostname and keep their current runtime hostname until the runtime is recreated (`agentctl delete` + `apply`).
- `agent`: the Sandbox keeps its per-incarnation name `agent-<id>` so a reused Agent name never adopts a deleted incarnation's Sandbox, and the guest hostname is set to the Agent name.

## Demo

A small Agent named `demo-agent` is applied with `--wait`, listed, and then `agentctl exec` prints the hostname and `user@host:pwd` from inside the Sandbox: `agent@demo-agent` instead of `sandbox-<uuid>`. The image was built once beforehand so the recording shows a cached build and a fresh Sandbox creation.

![agentctl apply --wait, get agents and exec showing agent@demo-agent](https://github.com/user-attachments/assets/f23ceb0c-43f2-4683-b3a7-e263e2a4785a)

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings (`make fmt lint build test`)
- [x] Manual testing done (required): `make test-e2e` boots real Sandboxes; the new assertions check `hostname` inside the guest for both an explicit hostname and the Sandbox-name default. In the Podman-backed development Sandbox the network and backend suites pass and the hostname assertions pass, but the runtime test then fails on the pre-existing `CACHED` BuildKit-marker assertion, which Podman's Docker-compatible API does not emit. The same runtime test fails identically on unmodified `main` in that environment, so the failure is environmental; CI runs against Docker.
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
