### PR TITLE
chore: pdb unhealthyPodEvictionPolicy set to AlwaysAllow

### DIFF
--- a/src/Runtime/gateway/infra/kustomize/base/deployment.yaml
+++ b/src/Runtime/gateway/infra/kustomize/base/deployment.yaml
@@ -3,6 +3,7 @@ kind: PodDisruptionBudget
 metadata:
   name: gateway-pdb
 spec:
+  unhealthyPodEvictionPolicy: AlwaysAllow
   maxUnavailable: 1
   selector:
     matchLabels:

--- a/src/Runtime/pdf3/infra/kustomize/base/proxy.yaml
+++ b/src/Runtime/pdf3/infra/kustomize/base/proxy.yaml
@@ -3,6 +3,7 @@ kind: PodDisruptionBudget
 metadata:
   name: pdf3-proxy-pdb
 spec:
+  unhealthyPodEvictionPolicy: AlwaysAllow
   # Makes sure that during e.g. nodepool upgrades, when nodes are drained
   # we apply a constraint that at most 1 AZ (hopefully, depending on skew)
   # is disrupted at a time

--- a/src/Runtime/pdf3/infra/kustomize/base/worker.yaml
+++ b/src/Runtime/pdf3/infra/kustomize/base/worker.yaml
@@ -3,6 +3,7 @@ kind: PodDisruptionBudget
 metadata:
   name: pdf3-worker-pdb
 spec:
+  unhealthyPodEvictionPolicy: AlwaysAllow
   # Makes sure that during e.g. nodepool upgrades, when nodes are drained
   # we apply a constraint that at most 1 AZ (hopefully, depending on skew)
   # is disrupted at a time

--- a/src/Runtime/workflow-engine-app/infra/kustomize/base/deployment.yaml
+++ b/src/Runtime/workflow-engine-app/infra/kustomize/base/deployment.yaml
@@ -3,6 +3,7 @@ kind: PodDisruptionBudget
 metadata:
   name: workflow-engine-app-pdb
 spec:
+  unhealthyPodEvictionPolicy: AlwaysAllow
   maxUnavailable: 1
   selector:
     matchLabels:


### PR DESCRIPTION
## Description

this is seemingly a better default, doesnt make sense to have unhealthy pods blocking eviction that would enable e.g. 
scaledown.

Bengt on platform notified me of this

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Reliability**
  - Unhealthy pods can now be evicted during voluntary disruptions for gateway, PDF proxy, PDF worker, and workflow engine services.
  - This helps disruption handling proceed when affected pods are already unhealthy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->