### PR TITLE
chore(agents): stop the preview package shadowing its own module

### DIFF
--- a/src/AI/agents/agents/prompts/README.md
+++ b/src/AI/agents/agents/prompts/README.md
@@ -124,6 +124,9 @@ get_prompt_with_langfuse("intake_planning")
 | `templates/spec_extraction_user.md` | `spec_extraction_user`      |
 | `templates/semantic_query_user.md`  | `semantic_query_user`       |
 
+One exception: the intent gate loads Langfuse prompt `intent_check` from local
+`intent_security.md`. Pass `local_path` when the two names diverge.
+
 ### LLM-as-a-judge prompts
 
 The files under `llm-as-a-judge/` are NOT loaded by application code.

--- a/src/AI/agents/agents/prompts/loader.py
+++ b/src/AI/agents/agents/prompts/loader.py
@@ -89,7 +89,10 @@ def _system_message(compiled: Any) -> Optional[str]:
 
 
 def get_prompt_with_langfuse(prompt_name: str, local_path: str | None = None) -> tuple[str, object]:
-    """Return ``(compiled_content, raw_langfuse_prompt)`` for use with LLM calls."""
+    """Return ``(compiled_content, raw_langfuse_prompt)`` for use with LLM calls.
+
+    ``local_path`` names the fallback ``.md`` when it differs from ``prompt_name``.
+    """
     lf_prompt = get_raw_langfuse_prompt(prompt_name)
     if lf_prompt is not None:
         try:

--- a/src/AI/agents/agents/services/preview/__init__.py
+++ b/src/AI/agents/agents/services/preview/__init__.py
@@ -4,11 +4,11 @@ Shared engine used by the `preview_render_check` loop tool and the
 benchmark suite's preview check.
 """
 
+from . import render_check
 from .render_check import (
     PageRenderResult,
     PreviewCheckUnavailable,
     read_page_order,
-    render_check,
     swap_layout_in_preview_url,
 )
 

--- a/src/AI/agents/tests/unit/services/preview/test_package_imports.py
+++ b/src/AI/agents/tests/unit/services/preview/test_package_imports.py
@@ -1,0 +1,31 @@
+"""The submodule and the function share a name; the function must not shadow it."""
+
+from __future__ import annotations
+
+import inspect
+
+
+def test_render_check_attribute_is_the_module():
+    import agents.services.preview.render_check as rc
+
+    assert inspect.ismodule(rc)
+
+
+def test_render_check_function_is_reachable_on_the_module():
+    import agents.services.preview.render_check as rc
+
+    assert callable(rc.render_check)
+
+
+def test_package_still_re_exports_the_other_engine_symbols():
+    from agents.services.preview import (
+        PageRenderResult,
+        PreviewCheckUnavailable,
+        read_page_order,
+        swap_layout_in_preview_url,
+    )
+
+    assert PageRenderResult is not None
+    assert PreviewCheckUnavailable is not None
+    assert callable(read_page_order)
+    assert callable(swap_layout_in_preview_url)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

`import agents.services.preview.render_check` returned a function rather than the module. `__init__.py` re-exported the `render_check` function by name, and that overwrites the attribute Python sets on the parent package when the submodule is imported, permanently. Anyone reaching for the module got the function instead, which is the kind of thing you lose twenty minutes to and then work around rather than fix.

The package now imports the submodule and re-exports only the other engine symbols, so `agents.services.preview.render_check` is the module and `render_check.render_check` is the function. No caller needed changing: every one already imports through the submodule path, which was unaffected.

### The other half of the issue was wrong, and the real defect was next to it

The issue also reported `local_path` in the prompt loader as having no remaining caller, and asked for it to be removed. It has a caller: `llm_client.py:777` loads Langfuse prompt `intent_check` from local `intent_security.md`, which is the intent and safety gate. Deleting the parameter would have broken it.

What is missing is documentation rather than the parameter. The prompt README's naming table asserts that the Langfuse name and the local filename always match, and names no exception, which is exactly what makes the parameter look dead to anyone reading the docs first. The table now records the one case where they diverge, and the loader says in a line what the parameter is for.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

Notes on the above, so the boxes are not doing more work than they should:

**Automated.** 840 Python tests pass. Three new ones pin the import shape so the shadowing cannot come back: the package attribute is the module, the function is reachable on it, and the other re-exported symbols still resolve. Two of the three fail against the previous `__init__.py`, checked rather than assumed.

**Manual.** The bug and the fix are one line each, run from the two checkouts:

```
python -c "import agents.services.preview.render_check as rc; print(type(rc))"
```

`<class 'function'>` before, `<class 'module'>` after, with `rc.render_check` still callable.

**Blast radius.** Every import of this package across the repo goes through `agents.services.preview.render_check`, the submodule path, which this change does not affect. Nothing imports `render_check` from the package, so no caller depended on the shadowed shape.

**Issues.** Fixes digdir/digdir-ai-lab#220. Note for whoever filed it: the first bullet is not actionable as written, since the parameter is in use.