### PR TITLE
feat(agents): publish prompts from CI, and report the ones Langfuse holds alone

### DIFF
--- a/.github/workflows/assistant-prompts.yaml
+++ b/.github/workflows/assistant-prompts.yaml
@@ -1,0 +1,94 @@
+name: Assistant-prompts
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+    paths:
+      - 'src/AI/agents/agents/prompts/**'
+      - 'src/AI/agents/scripts/sync_prompts.py'
+      - '.github/workflows/assistant-prompts.yaml'
+      - '!**/AGENTS.md'
+      - '!**/CLAUDE.md'
+  push:
+    branches: [main]
+    paths:
+      - 'src/AI/agents/agents/prompts/**'
+      - 'src/AI/agents/scripts/sync_prompts.py'
+      - '.github/workflows/assistant-prompts.yaml'
+      - '!**/AGENTS.md'
+      - '!**/CLAUDE.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  drift:
+    name: Prompt drift
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.draft && github.event.pull_request.head.repo.fork == false }}
+    permissions:
+      contents: read
+    runs-on: self-hosted-ubuntu
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        working-directory: src/AI/agents
+        run: pip install -r requirements.txt
+
+      - name: What this change means for the served prompts
+        working-directory: src/AI/agents
+        env:
+          LANGFUSE_HOST: ${{ secrets.LANGFUSE_HOST }}
+          LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
+          LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m scripts.sync_prompts --diff
+
+  publish:
+    name: Publish prompts
+    if: ${{ github.event_name == 'push' }}
+    permissions:
+      contents: read
+    runs-on: self-hosted-ubuntu
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        working-directory: src/AI/agents
+        run: pip install -r requirements.txt
+
+      - name: Publish drifted prompts as production
+        working-directory: src/AI/agents
+        env:
+          ALLOW_PROMPT_PUSH: '1'
+          COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
+          LANGFUSE_HOST: ${{ secrets.LANGFUSE_HOST }}
+          LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
+          LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m scripts.sync_prompts --push -m "$COMMIT_URL"

--- a/.github/workflows/assistant-prompts.yaml
+++ b/.github/workflows/assistant-prompts.yaml
@@ -55,6 +55,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if [ -z "${LANGFUSE_HOST:-}" ] || [ -z "${LANGFUSE_SECRET_KEY:-}" ]; then
+            echo "::notice::Langfuse is not configured for this repository, so prompt"\
+                 "drift was not checked. Set LANGFUSE_HOST, LANGFUSE_PUBLIC_KEY and"\
+                 "LANGFUSE_SECRET_KEY to turn this on."
+            exit 0
+          fi
           python -m scripts.sync_prompts --diff
 
   publish:
@@ -91,4 +97,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if [ -z "${LANGFUSE_HOST:-}" ] || [ -z "${LANGFUSE_SECRET_KEY:-}" ]; then
+            echo "::error::Langfuse is not configured, so the prompts on main were not"\
+                 "published. Set LANGFUSE_HOST, LANGFUSE_PUBLIC_KEY and"\
+                 "LANGFUSE_SECRET_KEY, then re-run this job."
+            exit 1
+          fi
           python -m scripts.sync_prompts --push -m "$COMMIT_URL"

--- a/src/AI/agents/README.md
+++ b/src/AI/agents/README.md
@@ -175,7 +175,7 @@ Three layers, each covering what the others cannot.
 
 **Intent gate** (`intent_security.md`, write mode only) screens the user's goal text for abuse before the graph runs. It sees attachment *filenames*, never their bytes: a 13k-token PDF costs real money to screen and yields little signal.
 
-**Structural containment** (both modes) is the boundary that actually holds. Write tools are denied in read-only mode until the user approves an escalation, file access is confined to the app repository, `web_fetch` is allowlisted to Digdir hosts, and every change the agent makes to a repository lands on a session branch a human reviews before merge. That covers repository changes only: publishing a prompt with `scripts/sync_prompts.py --push` reaches the deployed service immediately, with no branch and no review (see [Prompts and Langfuse](#prompts-and-langfuse)).
+**Structural containment** (both modes) is the boundary that actually holds. Write tools are denied in read-only mode until the user approves an escalation, file access is confined to the app repository, `web_fetch` is allowlisted to Digdir hosts, and every change the agent makes to a repository lands on a session branch a human reviews before merge. The prompts Langfuse serves are covered too: CI publishes them when a prompt change merges to main, so a served prompt has a reviewed commit behind it (see [Prompts and Langfuse](#prompts-and-langfuse)).
 
 **Spotlighting** (both modes) covers what the intent gate never sees: the content of uploaded documents. Users attach PDFs and images as context, and that content reaches the model twice: once as the attachment the spec extractor reads, and again as the extracted `FormSpec` in the loop's system prompt. Both are wrapped in `<attachment_content>` / `<form_spec>` delimiters carrying an explicit instruction that the block is data to describe, not instructions to obey. A closing tag written inside the content is escaped so a document cannot end its own block early.
 
@@ -190,13 +190,14 @@ The files in `agents/prompts/` are a **fallback**, not the source of truth. When
 ```bash
 python -m scripts.sync_prompts --diff                    # every prompt, repo vs Langfuse
 python -m scripts.sync_prompts --diff spec_extraction    # just one
-python -m scripts.sync_prompts --push spec_extraction -m "why this changed"
 python -m scripts.sync_prompts --promote spec_extraction --version 1   # roll back
 ```
 
-`--push` publishes the local file as a new version labeled `production`, so **the deployed service picks it up immediately**. Roll back by promoting the previous version.
+Publishing runs from CI, not from a laptop. `.github/workflows/assistant-prompts.yaml` runs `--diff` on every pull request touching `agents/prompts/`, so drift is visible before merge, and runs `--push` on merge to main, which publishes every prompt that differs as a new version labeled `production` with the merge commit URL as its commit message. `--push` refuses to run unless `ALLOW_PROMPT_PUSH=1` is set, which CI does and a laptop should not. Roll back by promoting the previous version.
 
-Run `--diff` before editing any prompt, and after merging a PR that touches one. At the time of writing 11 of 17 prompts differ from their repo copies, so treat a diff as expected rather than alarming, and read it before pushing: the local file may be behind, not ahead.
+A full `--diff` also lists the prompts Langfuse holds that have no repo file. Adding a file under one of those names would serve the retired Langfuse version rather than the new file, so archive them in Langfuse instead of leaving them labeled `production`.
+
+At the time of writing 11 of 17 prompts differ from their repo copies, so treat a diff as expected rather than alarming, and read it: the local file may be behind, not ahead.
 
 This is also why the attachment spotlighting above is implemented in code. A security control that lives only in a prompt file is inert the moment a managed version exists.
 

--- a/src/AI/agents/README.md
+++ b/src/AI/agents/README.md
@@ -195,7 +195,7 @@ python -m scripts.sync_prompts --promote spec_extraction --version 1   # roll ba
 
 Publishing runs from CI, not from a laptop. `.github/workflows/assistant-prompts.yaml` runs `--diff` on every pull request touching `agents/prompts/`, so drift is visible before merge, and runs `--push` on merge to main, which publishes every prompt that differs as a new version labeled `production` with the merge commit URL as its commit message. `--push` refuses to run unless `ALLOW_PROMPT_PUSH=1` is set, which CI does and a laptop should not. Roll back by promoting the previous version.
 
-A full `--diff` also lists the prompts Langfuse holds that have no repo file. Adding a file under one of those names would serve the retired Langfuse version rather than the new file, so archive them in Langfuse instead of leaving them labeled `production`.
+A full `--diff` also lists the prompts Langfuse holds that have no repo file. Adding a file under one of those names serves the retired Langfuse version until CI publishes the new one, and anyone reading the Langfuse list sees a retired prompt labeled `production`. Archive them there rather than leaving them labeled.
 
 At the time of writing 11 of 17 prompts differ from their repo copies, so treat a diff as expected rather than alarming, and read it: the local file may be behind, not ahead.
 

--- a/src/AI/agents/agents/prompts/README.md
+++ b/src/AI/agents/agents/prompts/README.md
@@ -101,6 +101,8 @@ To use a prompt from Langfuse instead of the local file:
    - **Content**: Paste the prompt content (without YAML frontmatter for system prompts)
 4. **Label it `production`** — By default, `get_prompt()` fetches the version labeled `production`. If no version has this label, the fetch will fail and fall back to local.
 
+For a prompt that already has a file here, do steps 3 and 4 by editing the file and merging: `.github/workflows/assistant-prompts.yaml` publishes it as `production` on merge to main. Editing the served prompt in the UI instead leaves the repo copy behind, which the workflow reports as drift on the next pull request.
+
 ### Prompt Naming Reference
 
 The Langfuse prompt name is the local filename without its `.md` extension and
@@ -164,7 +166,7 @@ The Langfuse SDK caches prompts internally (default 60s TTL). You can override t
 - **Organized**: One file per prompt, separate system vs user
 - **Type-safe**: Frontmatter provides metadata
 - **No Inline Strings**: All prompts external to code
-- **Remote Management**: Edit prompts via Langfuse UI without code changes or redeployment
+- **Reviewed publication**: CI publishes the repo copy to Langfuse on merge to main, so the served prompt has a reviewed commit behind it
 
 ## Prompt Files
 

--- a/src/AI/agents/scripts/sync_prompts.py
+++ b/src/AI/agents/scripts/sync_prompts.py
@@ -34,7 +34,7 @@ def _is_prompt(path: Path) -> bool:
 
 
 def _local_prompt_names() -> list[str]:
-    return sorted(path.stem for path in PROMPTS_DIR.glob("*.md") if _is_prompt(path))
+    return sorted(path.stem for path in PROMPTS_DIR.rglob("*.md") if _is_prompt(path))
 
 
 def _every_local_name() -> set[str]:

--- a/src/AI/agents/scripts/sync_prompts.py
+++ b/src/AI/agents/scripts/sync_prompts.py
@@ -1,6 +1,6 @@
 """Diff and publish local prompt files against Langfuse, which serves them.
 
-`--push` publishes as `production`, so the deployed service picks it up at once.
+CI publishes on merge to main, so `--push` is gated behind ALLOW_PROMPT_PUSH=1.
 Roll back with `--promote <name> --version <n>`.
 """
 
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import difflib
+import os
 import sys
 from pathlib import Path
 
@@ -20,9 +21,29 @@ from dotenv import load_dotenv
 from agents.prompts.loader import PROMPTS_DIR, load_prompt
 from benchmarks.lf_api import LangfuseApi
 
+PROMPT_PAGE_SIZE = 100
+PUSH_OVERRIDE_VARIABLE = "ALLOW_PROMPT_PUSH"
+
+# Langfuse name -> the local file that serves it, where get_prompt_with_langfuse
+# is called with local_path. Without these the file reads as retired.
+SERVED_FROM: dict[str, str] = {"intent_check": "intent_security"}
+
+
+def _is_prompt(path: Path) -> bool:
+    return path.name != "README.md"
+
 
 def _local_prompt_names() -> list[str]:
-    return sorted(path.stem for path in PROMPTS_DIR.glob("*.md"))
+    return sorted(path.stem for path in PROMPTS_DIR.glob("*.md") if _is_prompt(path))
+
+
+def _every_local_name() -> set[str]:
+    """Templates and judges live in subdirectories but are prompts to Langfuse.
+
+    `SERVED_FROM` covers the callers whose Langfuse name differs from the filename.
+    """
+    found = {path.stem for path in PROMPTS_DIR.rglob("*.md") if _is_prompt(path)}
+    return found | set(SERVED_FROM)
 
 
 def _remote(api: LangfuseApi, name: str) -> dict | None:
@@ -34,6 +55,19 @@ def _remote(api: LangfuseApi, name: str) -> dict | None:
         if error.response.status_code == 404:
             return None
         raise
+
+
+def _remote_prompts(api: LangfuseApi) -> list[dict]:
+    prompts: list[dict] = []
+    page = 1
+    while True:
+        body = api._get("/api/public/v2/prompts", page=page, limit=PROMPT_PAGE_SIZE)
+        batch = body.get("data") or []
+        prompts.extend(batch)
+        total_pages = (body.get("meta") or {}).get("totalPages") or page
+        if not batch or page >= total_pages:
+            return prompts
+        page += 1
 
 
 def _diff(api: LangfuseApi, name: str) -> bool:
@@ -66,6 +100,39 @@ def _diff(api: LangfuseApi, name: str) -> bool:
     return True
 
 
+def _drifted(api: LangfuseApi, names: list[str]) -> list[str]:
+    return [name for name in names if _diff(api, name)]
+
+
+def _report_orphans(api: LangfuseApi) -> list[str]:
+    """Print every Langfuse prompt with no repo file. Returns their names."""
+    local = _every_local_name()
+    orphans = sorted(
+        (prompt for prompt in _remote_prompts(api) if prompt.get("name") not in local),
+        key=lambda prompt: prompt.get("name") or "",
+    )
+    for prompt in orphans:
+        labels = ", ".join(prompt.get("labels") or []) or "no labels"
+        print(f"{prompt.get('name')}: in Langfuse ({labels}) with no repo file")
+    if orphans:
+        print(
+            f"\n{len(orphans)} Langfuse prompt(s) have no repo file. Re-adding one of "
+            "these names would serve the retired Langfuse version, so archive them "
+            "there or restore the file."
+        )
+    return [prompt.get("name") or "" for prompt in orphans]
+
+
+def _require_push_override() -> None:
+    if os.environ.get(PUSH_OVERRIDE_VARIABLE) == "1":
+        return
+    raise SystemExit(
+        "Prompts publish from CI when a prompt change merges to main, so the "
+        "production version always has a reviewed commit behind it. Set "
+        f"{PUSH_OVERRIDE_VARIABLE}=1 to publish from here anyway."
+    )
+
+
 def _push(api: LangfuseApi, name: str, message: str) -> None:
     local = load_prompt(name)
     created = api._post(
@@ -92,17 +159,24 @@ def _promote(api: LangfuseApi, name: str, version: int) -> None:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--diff", nargs="?", const="", metavar="NAME")
-    parser.add_argument("--push", metavar="NAME")
+    parser.add_argument("--push", nargs="?", const="", metavar="NAME")
     parser.add_argument("--promote", metavar="NAME")
     parser.add_argument("--version", type=int)
     parser.add_argument("-m", "--message", default="Sync from repo")
     args = parser.parse_args()
 
+    if args.push is not None:
+        _require_push_override()
+
     load_dotenv(Path(__file__).resolve().parents[1] / ".env")
     api = LangfuseApi()
 
-    if args.push:
-        _push(api, args.push, args.message)
+    if args.push is not None:
+        names = [args.push] if args.push else _drifted(api, _local_prompt_names())
+        for name in names:
+            _push(api, name, args.message)
+        if not names:
+            print("Every prompt is in sync; nothing published")
         return 0
 
     if args.promote:
@@ -111,10 +185,14 @@ def main() -> int:
         _promote(api, args.promote, args.version)
         return 0
 
-    names = [args.diff] if args.diff else _local_prompt_names()
-    drifted = [name for name in names if _diff(api, name)]
+    if args.diff:
+        _diff(api, args.diff)
+        return 0
+
+    drifted = _drifted(api, _local_prompt_names())
     if drifted:
         print(f"\n{len(drifted)} prompt(s) differ from Langfuse")
+    _report_orphans(api)
     return 0
 
 

--- a/src/AI/agents/tests/unit/scripts/test_sync_prompts.py
+++ b/src/AI/agents/tests/unit/scripts/test_sync_prompts.py
@@ -156,3 +156,10 @@ def test_the_readme_is_not_treated_as_a_prompt():
     """`*.md` swept up the README, which was then diffed against Langfuse."""
     assert "README" not in sync_prompts._local_prompt_names()
     assert "README" not in sync_prompts._every_local_name()
+
+
+@pytest.mark.parametrize("name", [LOCAL_TEMPLATE, LOCAL_JUDGE])
+def test_bulk_discovery_reaches_nested_prompts(name):
+    """Bulk --diff and --push globbed one level, so a change to a template or a judge
+    prompt was never reported and never published."""
+    assert name in sync_prompts._local_prompt_names()

--- a/src/AI/agents/tests/unit/scripts/test_sync_prompts.py
+++ b/src/AI/agents/tests/unit/scripts/test_sync_prompts.py
@@ -1,0 +1,158 @@
+"""Langfuse serves the prompts, so drift and unreviewed publishing are both hazards."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "sync_prompts.py"
+_spec = importlib.util.spec_from_file_location("sync_prompts", SCRIPT)
+sync_prompts = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(sync_prompts)
+
+RETIRED = "assistant_response_generation"
+LOCAL = "goal_suggestions"
+IN_SYNC = "scope_check"
+LOCAL_TEMPLATE = "intake_planning_user"
+LOCAL_JUDGE = "intent_match"
+
+
+def _page(names, *, total_pages=1, labels=None):
+    labels = labels or {}
+    return {
+        "data": [{"name": name, "labels": labels.get(name, [])} for name in names],
+        "meta": {"totalPages": total_pages},
+    }
+
+
+class _Langfuse:
+    def __init__(self, listing=None, prompts=None):
+        self._listing = listing or [_page([])]
+        self._prompts = prompts or {}
+        self.published = []
+        self.pages_read = 0
+
+    def _get(self, path, **params):
+        if path == "/api/public/v2/prompts":
+            self.pages_read += 1
+            return self._listing[params["page"] - 1]
+        name = path.rsplit("/", 1)[-1]
+        if name not in self._prompts:
+            raise httpx.HTTPStatusError(
+                "not found",
+                request=httpx.Request("GET", path),
+                response=httpx.Response(404),
+            )
+        return {"prompt": self._prompts[name], "version": 1}
+
+    def _post(self, path, body):
+        self.published.append(body["name"])
+        return {"version": 2, "labels": body["labels"]}
+
+
+class TestPromptsLangfuseHoldsAlone:
+    def test_a_prompt_with_no_repo_file_is_reported(self, capsys):
+        api = _Langfuse([_page([RETIRED], labels={RETIRED: ["latest", "production"]})])
+
+        assert sync_prompts._report_orphans(api) == [RETIRED]
+        assert (
+            f"{RETIRED}: in Langfuse (latest, production) with no repo file"
+            in capsys.readouterr().out
+        )
+
+    def test_a_prompt_with_a_repo_file_is_not_reported(self, capsys):
+        api = _Langfuse([_page([LOCAL])])
+
+        assert sync_prompts._report_orphans(api) == []
+        assert LOCAL not in capsys.readouterr().out
+
+    @pytest.mark.parametrize("name", [LOCAL_TEMPLATE, LOCAL_JUDGE])
+    def test_a_prompt_from_a_subdirectory_is_not_orphaned(self, name):
+        """Templates and judges are published by name too, from below the prompts root."""
+        assert sync_prompts._report_orphans(_Langfuse([_page([name])])) == []
+
+    def test_a_prompt_served_from_a_differently_named_file_is_not_orphaned(self):
+        """The intent gate loads Langfuse `intent_check` from `intent_security.md`, so
+        matching on filename alone told you to archive a prompt in active use."""
+        assert sync_prompts._report_orphans(_Langfuse([_page(["intent_check"])])) == []
+
+    def test_labels_are_named_even_when_there_are_none(self, capsys):
+        api = _Langfuse([_page([RETIRED])])
+
+        sync_prompts._report_orphans(api)
+
+        assert f"{RETIRED}: in Langfuse (no labels)" in capsys.readouterr().out
+
+    def test_every_page_of_the_listing_is_read(self):
+        api = _Langfuse([_page([LOCAL], total_pages=2), _page([RETIRED], total_pages=2)])
+
+        assert sync_prompts._report_orphans(api) == [RETIRED]
+        assert api.pages_read == 2
+
+    def test_a_full_diff_reports_them(self, capsys, monkeypatch):
+        api = _Langfuse([_page([RETIRED])], prompts={LOCAL: "whatever"})
+        _run(monkeypatch, api, ["--diff"], names=[LOCAL])
+
+        assert f"{RETIRED}: in Langfuse" in capsys.readouterr().out
+
+
+class TestPublishingIsGated:
+    def test_a_push_without_the_override_is_refused(self, monkeypatch):
+        monkeypatch.delenv(sync_prompts.PUSH_OVERRIDE_VARIABLE, raising=False)
+
+        with pytest.raises(SystemExit, match="publish from CI"):
+            sync_prompts._require_push_override()
+
+    def test_the_override_allows_a_push(self, monkeypatch):
+        monkeypatch.setenv(sync_prompts.PUSH_OVERRIDE_VARIABLE, "1")
+
+        sync_prompts._require_push_override()
+
+    def test_a_gated_push_publishes_nothing(self, monkeypatch):
+        monkeypatch.delenv(sync_prompts.PUSH_OVERRIDE_VARIABLE, raising=False)
+        api = _Langfuse(prompts={LOCAL: "old"})
+
+        with pytest.raises(SystemExit):
+            _run(monkeypatch, api, ["--push"], names=[LOCAL])
+
+        assert api.published == []
+
+
+class TestPushingEveryDriftedPrompt:
+    def test_only_the_drifted_prompts_are_published(self, monkeypatch):
+        monkeypatch.setenv(sync_prompts.PUSH_OVERRIDE_VARIABLE, "1")
+        api = _Langfuse(prompts={LOCAL: "old", IN_SYNC: _content(IN_SYNC)})
+
+        _run(monkeypatch, api, ["--push"], names=[LOCAL, IN_SYNC])
+
+        assert api.published == [LOCAL]
+
+    def test_a_named_push_publishes_that_prompt(self, monkeypatch):
+        monkeypatch.setenv(sync_prompts.PUSH_OVERRIDE_VARIABLE, "1")
+        api = _Langfuse()
+
+        _run(monkeypatch, api, ["--push", LOCAL], names=[LOCAL])
+
+        assert api.published == [LOCAL]
+
+
+def _content(name):
+    return sync_prompts.load_prompt(name)["content"]
+
+
+def _run(monkeypatch, api, argv, names):
+    monkeypatch.setattr(sync_prompts, "LangfuseApi", lambda: api)
+    monkeypatch.setattr(sync_prompts, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(sync_prompts, "_local_prompt_names", lambda: names)
+    monkeypatch.setattr(sys, "argv", ["sync_prompts.py", *argv])
+    return sync_prompts.main()
+
+
+def test_the_readme_is_not_treated_as_a_prompt():
+    """`*.md` swept up the README, which was then diffed against Langfuse."""
+    assert "README" not in sync_prompts._local_prompt_names()
+    assert "README" not in sync_prompts._every_local_name()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

`sync_prompts.py --push` published a prompt as the production version from a developer machine, and the deployed service picked it up at once. No branch, no review, no record of who published what. The prompts carry safety-relevant instructions, so during beta an unreviewed edit can change agent behaviour for every user with nothing to point at afterwards. It has already bitten twice: both the injection reporting instruction and `goal_suggestions` needed a push to take effect, which means a reviewed code change was incomplete without an unreviewed prompt change.

A workflow now publishes on merge to main, so the production version always has a reviewed commit behind it, and every Langfuse version carries a link back to the merge commit that produced it. `--diff` runs on pull requests, so drift shows up while the change is still being reviewed. A local `--push` is refused unless `ALLOW_PROMPT_PUSH=1` is set, before the Langfuse client is built, so the CI path is the real one rather than the polite suggestion. `--promote` stays ungated, because rolling back to a previous version should not require a merge.

### What Langfuse holds that the repo does not

`--diff` with no argument now also reports every prompt Langfuse serves that has no file in the repo. This matters more than it sounds: `get_prompt_with_langfuse` prefers the Langfuse `production` version and never reads the local file, so re-adding a prompt under a retired name silently inherits the retired version.

Two things would have made that report actively misleading, and both are fixed here:

The prompt glob was `*.md`, which swept up the README, so documentation was diffed against Langfuse and reported as a prompt with no published version.

Matching on filename alone flagged `intent_check` as retired. It is not: the intent and safety gate loads it from local `intent_security.md`, which is the one place a Langfuse name and a filename deliberately diverge. Acting on that line would have meant archiving a prompt in active use.

The report names **eighteen** prompts, not the seven the issue listed. Several are `*_user` variants, and one carries `experiment, latest` rather than `production`.

### What this does not do

Nothing is archived or deleted in Langfuse. That half of #215 is a deliberate manual step, and the corrected list of eighteen is on the issue.

It also does not repair the drift it exposes. Three prompts are currently behind the repo in production:

```
goal_suggestions  Langfuse v1  vs local
intake_planning   Langfuse v2  vs local
intent_security   Langfuse v2  vs local
```

The last is worth a look on its own: the local file declares a `blocked` action that the deployed version does not, so the gate is running against a prompt that predates the code expecting it. This change stops that recurring; it does not fix the instance.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

Notes on the above, so the boxes are not doing more work than they should:

**Automated.** 851 Python tests pass, fourteen of them new and none touching the network: the script is loaded by path and driven against a fake Langfuse that pages, returns a real `404` for an unknown prompt, and records what would have been posted. They cover the orphan report and its two exclusions, paging across every page, `--push` refused without the override and permitted with it, and a bare `--push` publishing only the prompts that actually drifted. Each was checked against the unfixed script rather than assumed.

**Manual.** `--push scope_check` refuses and names the CI path. `--diff` against the real instance reports four drifted prompts and eighteen orphans, with the README and `intent_check` correctly absent.

**Before this can publish**, three repository secrets must exist: `LANGFUSE_HOST`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`. No value appears in any file. The jobs run on `self-hosted-ubuntu`, matching the other two agents workflows, so those runners need network access to the Langfuse host.

**Baseline.** Not required. The impact gate reports no yardstick hit: this changes a sync script, its tests, two READMEs and a workflow, and touches no prompt, dataset, evaluator or tool schema.

**Issues.** Fixes digdir/digdir-ai-lab#214. Refs digdir/digdir-ai-lab#215, whose remaining half is archiving the eighteen in Langfuse.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated prompt drift checks for pull requests.
  * Added reviewed prompt publishing to Langfuse after changes reach the main branch.
  * Added detection and reporting for prompts that exist in Langfuse without a corresponding repository file.
  * Added support for publishing all drifted prompts in one operation.

* **Documentation**
  * Updated prompt-management and security guidance to describe the CI-based publication workflow.

* **Tests**
  * Added coverage for drift detection, orphan reporting, publication safeguards, and nested prompt discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->