### PR TITLE
fix(benchmarks): record the models the agent ran, not the ones this checkout resolves

### DIFF
--- a/src/AI/agents/api/main.py
+++ b/src/AI/agents/api/main.py
@@ -117,8 +117,10 @@ async def favicon():
 
 @app.get("/health")
 async def health_check():
-    """Health check endpoint."""
-    return {"status": "ok"}
+    """Health check endpoint. The models let a caller record what this service runs."""
+    from shared.config.base_config import resolved_role_models
+
+    return {"status": "ok", "models": resolved_role_models()}
 
 
 if __name__ == "__main__":

--- a/src/AI/agents/benchmarks/check.py
+++ b/src/AI/agents/benchmarks/check.py
@@ -42,11 +42,24 @@ class EvalOutcome:
     traces: dict[str, str] = field(default_factory=dict)
 
 
+def _agent_models_or_die(agent_base: str) -> dict[str, str]:
+    """The agent's own models, refusing to silently fall back to this checkout's."""
+    models = agent_role_models(agent_base)
+    if not models:
+        raise SystemExit(
+            "The agent service did not report which models it runs, so an end to end "
+            "score cannot be attributed to a model. This would otherwise record the "
+            "models this checkout resolves, which is not what built the apps. Rebuild "
+            "the agent image so /health reports its models, or drop --include-e2e."
+        )
+    return models
+
+
 def task_for(args, dataset):
     """The task and scorers for a dataset, chosen by its kind."""
     if dataset.kind == "e2e":
         agent_base = os.environ.get("AGENT_BASE_URL", "http://localhost:8071").rstrip("/")
-        role_models = agent_role_models(agent_base)
+        role_models = _agent_models_or_die(agent_base)
         run_name = getattr(args, "run_name", None) or dataset.name
         task = AgentTask(
             agent_base=agent_base,
@@ -335,9 +348,10 @@ def run(
 
     chosen = evals_to_run(include_slow=include_slow, only=only)
     # The agent runs an e2e eval, so its models are what produced the result.
+    runs_e2e = any(entry.kind == "e2e" for entry in chosen)
     agent_models = (
-        agent_role_models(os.environ.get("AGENT_BASE_URL", "http://localhost:8071").rstrip("/"))
-        if any(entry.kind == "e2e" for entry in chosen)
+        _agent_models_or_die(os.environ.get("AGENT_BASE_URL", "http://localhost:8071").rstrip("/"))
+        if runs_e2e
         else {}
     )
 
@@ -417,7 +431,7 @@ def langfuse_runner(args, *, check_id: str = "", label: str = ""):
             if entry.kind in SLOW_KINDS
             else getattr(args, "max_concurrency", 5)
         )
-        state = provenance.collect()
+        state = provenance.collect(agent_models=getattr(task, "role_models", None))
         result = client.run_experiment(
             name=entry.name,
             run_name=runstore.new_name(f"{entry.name}-{model}"),

--- a/src/AI/agents/benchmarks/check.py
+++ b/src/AI/agents/benchmarks/check.py
@@ -42,6 +42,10 @@ class EvalOutcome:
     traces: dict[str, str] = field(default_factory=dict)
 
 
+def _agent_base() -> str:
+    return os.environ.get("AGENT_BASE_URL", "http://localhost:8071").rstrip("/")
+
+
 def _agent_models_or_die(agent_base: str) -> dict[str, str]:
     """The agent's own models, refusing to silently fall back to this checkout's."""
     models = agent_role_models(agent_base)
@@ -55,11 +59,18 @@ def _agent_models_or_die(agent_base: str) -> dict[str, str]:
     return models
 
 
-def task_for(args, dataset):
+def agent_models_for(planned) -> dict[str, str]:
+    """One snapshot of the agent's models per run, read only when an e2e eval is selected."""
+    if not any(entry.kind == "e2e" for entry in planned):
+        return {}
+    return _agent_models_or_die(_agent_base())
+
+
+def task_for(args, dataset, agent_models: dict[str, str] | None = None):
     """The task and scorers for a dataset, chosen by its kind."""
     if dataset.kind == "e2e":
-        agent_base = os.environ.get("AGENT_BASE_URL", "http://localhost:8071").rstrip("/")
-        role_models = _agent_models_or_die(agent_base)
+        agent_base = _agent_base()
+        role_models = agent_models or _agent_models_or_die(agent_base)
         run_name = getattr(args, "run_name", None) or dataset.name
         task = AgentTask(
             agent_base=agent_base,
@@ -337,6 +348,7 @@ def run(
     include_slow: bool = False,
     only: tuple[str, ...] = (),
     run_eval,
+    agent_models: dict[str, str] | None = None,
     name: str | None = None,
 ) -> Run:
     """Execute the pinned behaviors and return a saved-shaped run."""
@@ -348,12 +360,8 @@ def run(
 
     chosen = evals_to_run(include_slow=include_slow, only=only)
     # The agent runs an e2e eval, so its models are what produced the result.
-    runs_e2e = any(entry.kind == "e2e" for entry in chosen)
-    agent_models = (
-        _agent_models_or_die(os.environ.get("AGENT_BASE_URL", "http://localhost:8071").rstrip("/"))
-        if runs_e2e
-        else {}
-    )
+    if agent_models is None:
+        agent_models = agent_models_for(chosen)
 
     for entry in chosen:
         result, versions, version_stamp = run_eval(entry)
@@ -414,14 +422,14 @@ def _warn_if_stale(entry: registry.Eval, remote_count: int) -> None:
     )
 
 
-def langfuse_runner(args, *, check_id: str = "", label: str = ""):
+def langfuse_runner(args, *, check_id: str = "", label: str = "", agent_models=None):
     """The real `run_eval`: one Langfuse experiment per dataset."""
     client = get_client()
 
     def go(entry: registry.Eval):
         dataset = client.get_dataset(entry.name)
         items = [i for i in dataset.items if getattr(i, "status", "ACTIVE") != "ARCHIVED"]
-        task, evaluators, score_names, model = task_for(args, entry)
+        task, evaluators, score_names, model = task_for(args, entry, agent_models)
         slow = " (builds apps, minutes)" if entry.kind in SLOW_KINDS else ""
         print(f"  {entry.name}: {len(items)} items on {model}{slow}", flush=True)
         _warn_if_stale(entry, len(items))

--- a/src/AI/agents/benchmarks/check.py
+++ b/src/AI/agents/benchmarks/check.py
@@ -18,8 +18,11 @@ from benchmarks.runstore import BehaviorResult, ItemResult, Run
 
 ASSETS_DIR = Path(__file__).parent / "assets"
 
+DEFAULT_AGENT_BASE_URL = "http://localhost:8071"
+E2E_KIND = "e2e"
+
 # Slow: opt in.
-SLOW_KINDS = ("e2e",)
+SLOW_KINDS = (E2E_KIND,)
 
 E2E_MAX_CONCURRENCY = 1
 
@@ -43,7 +46,7 @@ class EvalOutcome:
 
 
 def _agent_base() -> str:
-    return os.environ.get("AGENT_BASE_URL", "http://localhost:8071").rstrip("/")
+    return os.environ.get("AGENT_BASE_URL", DEFAULT_AGENT_BASE_URL).rstrip("/")
 
 
 def _agent_models_or_die(agent_base: str) -> dict[str, str]:
@@ -61,14 +64,14 @@ def _agent_models_or_die(agent_base: str) -> dict[str, str]:
 
 def agent_models_for(planned) -> dict[str, str]:
     """One snapshot of the agent's models per run, read only when an e2e eval is selected."""
-    if not any(entry.kind == "e2e" for entry in planned):
+    if not any(entry.kind == E2E_KIND for entry in planned):
         return {}
     return _agent_models_or_die(_agent_base())
 
 
 def task_for(args, dataset, agent_models: dict[str, str] | None = None):
     """The task and scorers for a dataset, chosen by its kind."""
-    if dataset.kind == "e2e":
+    if dataset.kind == E2E_KIND:
         agent_base = _agent_base()
         role_models = agent_models or _agent_models_or_die(agent_base)
         run_name = getattr(args, "run_name", None) or dataset.name

--- a/src/AI/agents/benchmarks/provenance.py
+++ b/src/AI/agents/benchmarks/provenance.py
@@ -201,8 +201,9 @@ def collect(
 ) -> Provenance:
     """Everything knowable without a network call, plus what the caller knows."""
     models, sampling = _models_and_sampling()
-    if agent_models:
-        models = {**models, **{r: m for r, m in agent_models.items() if r in LIVE_ROLES}}
+    agent_roles = tuple(sorted(r for r in (agent_models or {}) if r in LIVE_ROLES))
+    if agent_roles:
+        models = {**models, **{r: agent_models[r] for r in agent_roles}}
     provenance = Provenance(
         recorded_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
         environment=_environment(),
@@ -216,13 +217,21 @@ def collect(
         evaluators=evaluators or {},
         judge=judge,
     )
+    notes = []
     missing = provenance.missing()
     if missing:
+        notes.append(f"axes not recorded: {', '.join(missing)}")
+    if agent_roles:
+        notes.append(
+            f"models axis for {', '.join(agent_roles)} came from the agent that built "
+            "the app, not this checkout"
+        )
+    if notes:
         provenance = Provenance(
             **{
                 **provenance.to_dict(),
                 "code": provenance.code,
-                "notes": (f"axes not recorded: {', '.join(missing)}",),
+                "notes": tuple(notes),
             }
         )
     return provenance

--- a/src/AI/agents/benchmarks/runner.py
+++ b/src/AI/agents/benchmarks/runner.py
@@ -201,13 +201,17 @@ def cmd_check(args: argparse.Namespace) -> None:
     )
 
     name = runstore.new_name(label)
+    agent_models = checker.agent_models_for(planned)
     run = checker.run(
         name=name,
         label=label,
         under_test=under_test,
         include_slow=args.include_e2e,
         only=only,
-        run_eval=checker.langfuse_runner(args, check_id=name, label=label),
+        agent_models=agent_models,
+        run_eval=checker.langfuse_runner(
+            args, check_id=name, label=label, agent_models=agent_models
+        ),
     )
     path = runstore.save(run)
     print(f"\nsaved {path}")

--- a/src/AI/agents/tests/api/test_main.py
+++ b/src/AI/agents/tests/api/test_main.py
@@ -20,4 +20,14 @@ class TestHealthEndpoint:
         response = TestClient(app).get("/health")
 
         assert response.status_code == 200
-        assert response.json() == {"status": "ok"}
+        assert response.json()["status"] == "ok"
+
+    def test_health_reports_the_models_this_service_runs(self):
+        """A caller recording an end to end score has no other way to learn what
+        produced it, and reading its own config instead records the wrong model."""
+        from shared.config.base_config import resolved_role_models
+
+        response = TestClient(app).get("/health")
+
+        assert response.json()["models"] == resolved_role_models()
+        assert response.json()["models"]["planner"]

--- a/src/AI/agents/tests/unit/benchmarks/test_check.py
+++ b/src/AI/agents/tests/unit/benchmarks/test_check.py
@@ -62,6 +62,38 @@ class TestAnE2eRunRequiresAgentModels:
 class TestTaskForAlsoRefusesWithoutAgentModels:
     """A second, independent call to the agent must not reopen the hole `run` closes."""
 
+    def test_a_given_snapshot_is_used_rather_than_asked_for_again(self, monkeypatch):
+        def fail(_base):
+            raise AssertionError("the snapshot the run resolved should be reused")
+
+        monkeypatch.setattr(check, "agent_role_models", fail)
+        args = argparse.Namespace(run_name=None, assets_dir=None)
+
+        task, _, _, model = check.task_for(
+            args, registry.by_name("Benchmarks/forms"), {"actor": "gpt-9-snapshot"}
+        )
+
+        assert task.role_models["actor"] == "gpt-9-snapshot"
+        assert model == "gpt-9-snapshot"
+
+    def test_the_run_and_the_task_are_handed_the_same_snapshot(self, monkeypatch):
+        reported = ["gpt-9-first", "gpt-9-rebuilt"]
+        monkeypatch.setattr(check, "agent_role_models", lambda _base: {"actor": reported.pop(0)})
+        planned = (registry.by_name("Benchmarks/forms"),)
+
+        snapshot = check.agent_models_for(planned)
+        run = check.run(
+            label="test",
+            include_slow=True,
+            only=("Benchmarks/forms",),
+            agent_models=snapshot,
+            run_eval=_run_eval_stub([]),
+        )
+
+        assert snapshot["actor"] == "gpt-9-first"
+        assert run.provenance.models["actor"] == "gpt-9-first"
+        assert reported == ["gpt-9-rebuilt"], "one lookup for the whole run"
+
     def test_task_for_refuses_when_the_agent_reports_no_models(self, monkeypatch):
         monkeypatch.setattr(check, "agent_role_models", lambda _base: {})
         args = argparse.Namespace(run_name=None, assets_dir=None)

--- a/src/AI/agents/tests/unit/benchmarks/test_check.py
+++ b/src/AI/agents/tests/unit/benchmarks/test_check.py
@@ -1,0 +1,70 @@
+"""An end to end run must not silently attribute scores to the wrong model."""
+
+from __future__ import annotations
+
+import argparse
+from types import SimpleNamespace
+
+import pytest
+
+from benchmarks import check, registry
+
+
+def _run_eval_stub(calls: list[str]):
+    def run_eval(entry):
+        calls.append(entry.name)
+        return SimpleNamespace(item_results=[]), {}, None
+
+    return run_eval
+
+
+class TestAnE2eRunRequiresAgentModels:
+    def test_refuses_when_the_agent_reports_no_models(self, monkeypatch):
+        monkeypatch.setattr(check, "agent_role_models", lambda _base: {})
+        calls: list[str] = []
+
+        with pytest.raises(SystemExit):
+            check.run(
+                label="test",
+                include_slow=True,
+                only=("Benchmarks/forms",),
+                run_eval=_run_eval_stub(calls),
+            )
+
+        assert calls == [], "the app should never be built once attribution is impossible"
+
+    def test_runs_and_records_the_agent_models_when_reported(self, monkeypatch):
+        monkeypatch.setattr(check, "agent_role_models", lambda _base: {"actor": "gpt-9-agent"})
+        calls: list[str] = []
+
+        run = check.run(
+            label="test",
+            include_slow=True,
+            only=("Benchmarks/forms",),
+            run_eval=_run_eval_stub(calls),
+        )
+
+        assert calls == ["Benchmarks/forms"]
+        assert run.provenance.models["actor"] == "gpt-9-agent"
+
+    def test_a_non_e2e_run_never_asks_the_agent(self, monkeypatch):
+        def fail(_base):
+            raise AssertionError("a non-e2e run has no reason to call the agent")
+
+        monkeypatch.setattr(check, "agent_role_models", fail)
+        calls: list[str] = []
+
+        check.run(label="test", only=("Gates/scope",), run_eval=_run_eval_stub(calls))
+
+        assert calls == ["Gates/scope"]
+
+
+class TestTaskForAlsoRefusesWithoutAgentModels:
+    """A second, independent call to the agent must not reopen the hole `run` closes."""
+
+    def test_task_for_refuses_when_the_agent_reports_no_models(self, monkeypatch):
+        monkeypatch.setattr(check, "agent_role_models", lambda _base: {})
+        args = argparse.Namespace(run_name=None, assets_dir=None)
+
+        with pytest.raises(SystemExit):
+            check.task_for(args, registry.by_name("Benchmarks/forms"))

--- a/src/AI/agents/tests/unit/benchmarks/test_provenance.py
+++ b/src/AI/agents/tests/unit/benchmarks/test_provenance.py
@@ -1,0 +1,28 @@
+"""The models axis, and telling apart what the agent ran from what this checkout resolves."""
+
+from __future__ import annotations
+
+from benchmarks import provenance
+
+
+class TestModelsAxisProvenance:
+    def test_agent_models_override_the_local_ones(self):
+        state = provenance.collect(agent_models={"actor": "gpt-9-agent"})
+
+        assert state.models["actor"] == "gpt-9-agent"
+
+    def test_agent_models_are_noted_as_coming_from_the_agent(self):
+        state = provenance.collect(agent_models={"actor": "gpt-9-agent"})
+
+        assert any("agent" in note for note in state.notes)
+
+    def test_no_note_when_nothing_came_from_the_agent(self):
+        state = provenance.collect(agent_models={})
+
+        assert not any("agent" in note for note in state.notes)
+
+    def test_a_role_the_agent_does_not_run_is_ignored(self):
+        state = provenance.collect(agent_models={"not-a-live-role": "x"})
+
+        assert "not-a-live-role" not in state.models
+        assert not any("agent" in note for note in state.notes)

--- a/src/AI/agents/tests/unit/benchmarks/test_runner_experiment.py
+++ b/src/AI/agents/tests/unit/benchmarks/test_runner_experiment.py
@@ -164,6 +164,22 @@ class TestTheRunRecordsWhatItRanAgainst:
         assert "Gates/scope" in client.last["description"]
 
 
+class TestTheMetadataAttributesAnE2eRunToTheAgent:
+    """The bug this covers: metadata recorded the checkout's models even for e2e."""
+
+    def test_e2e_metadata_uses_the_agents_model_not_the_checkouts(self, client, monkeypatch):
+        monkeypatch.setattr(check, "agent_role_models", lambda _base: {"actor": "sentinel-agent-model"})
+        _run_one(client, "Benchmarks/forms")
+        metadata = client.last["metadata"]
+        assert json.loads(metadata["models"])["actor"] == "sentinel-agent-model"
+
+    def test_non_e2e_metadata_is_unaffected_by_the_agent(self, client, monkeypatch):
+        monkeypatch.setattr(check, "agent_role_models", lambda _base: {"actor": "sentinel-agent-model"})
+        _run_one(client, "Gates/scope")
+        metadata = client.last["metadata"]
+        assert json.loads(metadata["models"])["actor"] != "sentinel-agent-model"
+
+
 class TestTheStructuralScoresStillExist:
     def test_an_e2e_run_scores_with_the_structural_evaluator(self, client):
         from benchmarks.experiment import structural_evaluator


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The workbench records a `models` axis for every run, and for the end to end path it was wrong. Those apps are built by an agent running in a container, not by this checkout, so `agent_role_models` asks the agent what it runs by reading a `models` field from `/health`. No version of that endpoint has ever returned one. The fallback was silent, so the run recorded whatever this checkout resolves and presented it as the agent's.

That is not hypothetical. Measured directly while working on this, the container answered `gpt-5.6-terra` while the run files said `gpt-5.6-sol`, because the image had been built once and never rebuilt. A day of end to end scores were attributed to a planner that never built anything, and part of the evidence for the model migration rested on them.

`/health` reports its resolved models now, and a run that selects an end to end eval stops rather than recording the wrong ones.

### Three things beyond the obvious fix

Each of these was found by reviewing the first version, and each would have left the hole open.

**The refusal is shared by both call sites.** `task_for` makes its own separate call to the agent for the entry it is about to build, independent of the one at the top of `run`. A flake on either would have let a run proceed on this checkout's models, so there is one gate used by both rather than a check at the entrance.

**The Langfuse metadata was still wrong.** `langfuse_runner` built its per eval provenance with no `agent_models` argument at all, so even after the endpoint was fixed, the metadata actually sent to Langfuse for an end to end run still carried this checkout's models. It is built with the agent's now.

**The record says where a value came from.** Where a model came from the agent rather than local resolution, the provenance carries a note to that effect, so someone reading an old run file can tell which source produced it instead of having to trust it.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

Notes on the above, so the boxes are not doing more work than they should:

**Automated.** 892 tests pass, eleven of them new across four files: the refusal and its absence for a non end to end run, both call sites, the models actually recorded, the note, and the per eval Langfuse metadata. Each was checked against the unfixed code rather than assumed.

**Manual.** The endpoint returning models does not on its own prove the fix, because the container and this checkout currently resolve the same models, so a run reading the wrong source would look identical. The two were made to disagree instead: with the container on `gpt-5.4-mini` and the checkout on `gpt-5.6-sol`, the provenance recorded `gpt-5.4-mini` and noted that it came from the agent. Before this change it would have recorded `gpt-5.6-sol`. Pointed at a dead port, the run stops before doing any work and prints the underlying connection error.

**Baseline.** Not required. The impact gate reports no yardstick hit: nothing here changes what is measured or how, only what is written down about the run.

**After this merges, `--include-e2e` needs the agent image rebuilt.** A stale container makes the run stop rather than silently misattribute, which is the point of the change, but it will surprise someone the first time. `docker compose build altinity-agents && docker compose up -d altinity-agents` from `src/AI/agents`.

**Related.** This is the defect referred to in #20364's description, where the end to end scores are recorded as evidence that the build path is stable rather than as evidence about the planner. The two should read consistently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The service health response now includes the models currently in use, alongside its status.
  * End-to-end benchmark results now record the models reported by the running agent.
  * Benchmark provenance now identifies when model information comes from the running agent.

* **Bug Fixes**
  * End-to-end benchmarks no longer proceed when the running agent does not report any models, preventing results from being attributed to the wrong models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->