### PR TITLE
fix(studioctl): use report api for semantic compilation output

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -18,6 +18,10 @@ Section ordering: Added, Changed, Fixed, Removed, Security, Deprecated.
 
 - `studioctl app upgrade v9` removes `moveToNextTask` from the Fiks Arkiv `successHandling` and `errorHandling` settings in your appsettings files. A Fiks Arkiv task in v9 always moves the process on once the archiving is decided, so the setting no longer exists; left in place it would be ignored without notice. Where it was `false`, the upgrade reports a TODO explaining what changes: a success that used to leave the instance on the task now moves on with the success action, and a rejection that used to fail the task now moves on with the error action, `reject` by default. The upgrade also reports a TODO for a Fiks Arkiv task that is not followed by an exclusive gateway, since the v9 app refuses to start until one separates a confirmed archiving from a rejected one.
 
+### Fixed
+
+- `studioctl app upgrade v9` no longer fails immediately with `Upgrade output writer is not configured.` This broke every v9 upgrade in 0.1.0-preview.23. The compilation the upgrade runs for exact API detection now reports as its own `Semantic analysis` step, marked OK when the app compiled and WARN with the reason when the upgrade falls back to syntax-based detection.
+
 ## [0.1.0-preview.23] - 2026-09-04
 
 ### Added

--- a/src/cli/studioctl-server-tests/Upgrade/v8Tov9/V8CompilationLoaderTests.cs
+++ b/src/cli/studioctl-server-tests/Upgrade/v8Tov9/V8CompilationLoaderTests.cs
@@ -1,3 +1,4 @@
+using Altinn.Studio.Cli.Upgrade;
 using Altinn.Studio.Cli.Upgrade.v8Tov9.CSharpApiMigration;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -6,9 +7,9 @@ namespace Studioctl.Tests.Upgrade.v8Tov9;
 
 /// <summary>
 /// Covers the usability gates that decide between exact semantic detection and the syntax fallback
-/// (<see cref="V8CompilationLoader.EvaluateCompilation"/>). The restore/design-time-build plumbing
-/// around them needs a real SDK and network and is exercised manually; the gates are what encode the
-/// "graceful fallback" contract, so they are pinned offline here.
+/// (<see cref="V8CompilationLoader.EvaluateCompilation"/>), and how the outcome is reported into the
+/// upgrade run. The restore/design-time-build plumbing needs a real SDK and network and is exercised
+/// manually; the gates are what encode the "graceful fallback" contract, so they are pinned offline here.
 /// </summary>
 public sealed class V8CompilationLoaderTests
 {
@@ -110,5 +111,78 @@ public sealed class V8CompilationLoaderTests
 
         Assert.NotNull(result.Compilation);
         Assert.Null(result.UnavailableReason);
+    }
+
+    [Fact]
+    public async Task LoadAsync_ReportsUsableCompilation_AsOkOnItsOwnStep()
+    {
+        var report = new UpgradeReport();
+        var compilation = Compile(ProbeTypeSource);
+
+        SemanticAnalysis result;
+        using (UpgradeConsole.Use(report, TextWriter.Null))
+        {
+            result = await V8CompilationLoader.LoadAsync(() =>
+                Task.FromResult(new SemanticAnalysis(compilation, null))
+            );
+        }
+
+        Assert.Same(compilation, result.Compilation);
+        var step = Assert.Single(report.Steps);
+        Assert.Equal("Semantic analysis", step.Name);
+        var message = Assert.Single(step.Messages);
+        Assert.Equal(UpgradeMessageStatus.Ok, message.Status);
+        Assert.Contains("exact symbol information", message.Text);
+    }
+
+    [Fact]
+    public async Task LoadAsync_ReportsUnavailableAnalysis_AsWarningWithTheReason()
+    {
+        var report = new UpgradeReport();
+
+        SemanticAnalysis result;
+        using (UpgradeConsole.Use(report, TextWriter.Null))
+        {
+            result = await V8CompilationLoader.LoadAsync(() =>
+                Task.FromResult(SemanticAnalysis.Unavailable("the project produced no compilation"))
+            );
+        }
+
+        Assert.Null(result.Compilation);
+        var message = Assert.Single(Assert.Single(report.Steps).Messages);
+        Assert.Equal(UpgradeMessageStatus.Warning, message.Status);
+        Assert.Contains("falling back to syntax-based detection", message.Text);
+        Assert.Contains("the project produced no compilation", message.Text);
+    }
+
+    [Fact]
+    public async Task LoadAsync_ReportsLoadFailure_AsWarningInsteadOfThrowing()
+    {
+        var report = new UpgradeReport();
+
+        SemanticAnalysis result;
+        using (UpgradeConsole.Use(report, TextWriter.Null))
+        {
+            result = await V8CompilationLoader.LoadAsync(() =>
+                throw new InvalidOperationException("MSBuild could not be located")
+            );
+        }
+
+        Assert.Null(result.Compilation);
+        Assert.Equal("MSBuild could not be located", result.UnavailableReason);
+        var message = Assert.Single(Assert.Single(report.Steps).Messages);
+        Assert.Equal(UpgradeMessageStatus.Warning, message.Status);
+        Assert.Contains("MSBuild could not be located", message.Text);
+    }
+
+    [Fact]
+    public async Task LoadAsync_PropagatesCancellation()
+    {
+        using (UpgradeConsole.Use(new UpgradeReport(), TextWriter.Null))
+        {
+            await Assert.ThrowsAsync<OperationCanceledException>(() =>
+                V8CompilationLoader.LoadAsync(() => throw new OperationCanceledException())
+            );
+        }
     }
 }

--- a/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/CSharpApiMigration/V8CompilationLoader.cs
+++ b/src/cli/studioctl-server/Studioctl/Upgrade/v8Tov9/CSharpApiMigration/V8CompilationLoader.cs
@@ -42,28 +42,27 @@ internal static class V8CompilationLoader
     /// </summary>
     private const string V8ProbeTypeMetadataName = "Altinn.App.Core.Features.IProcessTaskEnd";
 
-    public static async Task<SemanticAnalysis> LoadAsync(
+    private const string StepName = "Semantic analysis";
+
+    public static Task<SemanticAnalysis> LoadAsync(
         string projectFolder,
         string projectFile,
         CancellationToken cancellationToken
-    )
+    ) => LoadAsync(() => LoadCoreAsync(projectFolder, projectFile, cancellationToken));
+
+    /// <summary>
+    /// Runs <paramref name="loadCore"/> and reports its outcome as the <c>Semantic analysis</c> step of
+    /// the current upgrade run. Separated from the restore/design-time-build plumbing so the reporting
+    /// can be exercised without an SDK or network.
+    /// </summary>
+    internal static async Task<SemanticAnalysis> LoadAsync(Func<Task<SemanticAnalysis>> loadCore)
     {
-        await UpgradeConsole.Out.WriteLineAsync(
-            "Compiling the app against its current packages for exact detection..."
-        );
+        UpgradeConsole.BeginStep(StepName);
         var timer = Stopwatch.StartNew();
+        SemanticAnalysis result;
         try
         {
-            var result = await LoadCoreAsync(projectFolder, projectFile, cancellationToken);
-            timer.Stop();
-            await UpgradeConsole.Out.WriteLineAsync(
-                result.Compilation is not null
-                    ? $"  Compiled in {timer.Elapsed.TotalSeconds:0.0}s - detection uses exact symbol information."
-                    : $"  Semantic analysis unavailable after {timer.Elapsed.TotalSeconds:0.0}s - falling back to "
-                        + $"syntax-based detection ({result.UnavailableReason}). The upgrade still runs; detection "
-                        + "may over-report."
-            );
-            return result;
+            result = await loadCore();
         }
         catch (OperationCanceledException)
         {
@@ -71,15 +70,26 @@ internal static class V8CompilationLoader
         }
         catch (Exception exception)
         {
-            timer.Stop();
-            var result = SemanticAnalysis.Unavailable(exception.Message);
-            await UpgradeConsole.Out.WriteLineAsync(
-                $"  Semantic analysis unavailable after {timer.Elapsed.TotalSeconds:0.0}s - falling back to "
+            result = SemanticAnalysis.Unavailable(exception.Message);
+        }
+        timer.Stop();
+
+        if (result.Compilation is not null)
+        {
+            UpgradeConsole.Ok(
+                $"Compiled the app against its current packages in {timer.Elapsed.TotalSeconds:0.0}s - "
+                    + "detection uses exact symbol information."
+            );
+        }
+        else
+        {
+            UpgradeConsole.Warning(
+                $"Semantic analysis unavailable after {timer.Elapsed.TotalSeconds:0.0}s - falling back to "
                     + $"syntax-based detection ({result.UnavailableReason}). The upgrade still runs; detection "
                     + "may over-report."
             );
-            return result;
         }
+        return result;
     }
 
     private static async Task<SemanticAnalysis> LoadCoreAsync(


### PR DESCRIPTION
## Description

Every `studioctl app upgrade v9` in 0.1.0-preview.23 fails with `Upgrade output writer is not configured.` before changing anything.

#19894 moved the v9 upgrade to report mode, which has no standard-output writer. #19934 then added `V8CompilationLoader`, which still wrote through `UpgradeConsole.Out`. preview.23 is the first release with both.

The loader now reports through the report API as its own `Semantic analysis` step: OK when the app compiled, WARN with the reason when falling back to syntax-based detection. The reporting is split from the restore/build plumbing so it can be tested in report mode, which is the gap that let this through.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required) - reproduced on a v8 app, confirmed the upgrade completes after the fix
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
