### PR TITLE
fix(app-libs): reference Altinn.App.Core from source in codelists and fileanalyzers

### DIFF
--- a/.github/workflows/app-codelists-tests.yml
+++ b/.github/workflows/app-codelists-tests.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'src/App/codelists/**'
       - 'src/App/PackageVersioning.props'
+      - 'src/App/AppCoreDependency.props'
       - '.github/workflows/app-codelists-tests.yml'
       - '!**/AGENTS.md'
       - '!**/CLAUDE.md'
@@ -43,7 +44,7 @@ jobs:
             10.0.x
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0  # MinVer needs full history/tags to compute the package version
+          fetch-depth: 0 # the version resolver needs full history and tags
           persist-credentials: false
       - name: Build
         working-directory: ${{ matrix.os.workingDir }}
@@ -53,3 +54,28 @@ jobs:
         working-directory: ${{ matrix.os.workingDir }}
         run: |
            dotnet test Altinn.Codelists.slnx -v m
+
+  verify-pinned-app-core:
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
+    name: Build against the pinned Altinn.App.Core
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        with:
+          dotnet-version: |
+            10.0.x
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0 # the version resolver needs full history and tags
+          persist-credentials: false
+      # In-repo builds compile against the Altinn.App.Core in this repository; a release compiles
+      # against the pinned package (see src/App/AppCoreDependency.props). This proves the pinned
+      # version still satisfies this component, so using a Core API newer than the pin fails here
+      # rather than at release time. Build only - the public API snapshot records the default
+      # configuration's assembly metadata attributes.
+      - name: Build against the pinned package
+        working-directory: src/App/codelists/
+        run: |
+           dotnet build solutions/Src.slnx -v m -p:UseAppLibsFromSource=false

--- a/.github/workflows/app-fileanalyzers-tests.yml
+++ b/.github/workflows/app-fileanalyzers-tests.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'src/App/fileanalyzers/**'
       - 'src/App/PackageVersioning.props'
+      - 'src/App/AppCoreDependency.props'
       - '.github/workflows/app-fileanalyzers-tests.yml'
       - '!**/AGENTS.md'
       - '!**/CLAUDE.md'
@@ -43,7 +44,7 @@ jobs:
             10.0.x
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0  # MinVer needs full history/tags to compute the package version
+          fetch-depth: 0 # the version resolver needs full history and tags
           persist-credentials: false
       - name: Build
         working-directory: ${{ matrix.os.workingDir }}
@@ -53,3 +54,28 @@ jobs:
         working-directory: ${{ matrix.os.workingDir }}
         run: |
            dotnet test Altinn.FileAnalyzers.slnx -v m
+
+  verify-pinned-app-core:
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
+    name: Build against the pinned Altinn.App.Core
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        with:
+          dotnet-version: |
+            10.0.x
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0 # the version resolver needs full history and tags
+          persist-credentials: false
+      # In-repo builds compile against the Altinn.App.Core in this repository; a release compiles
+      # against the pinned package (see src/App/AppCoreDependency.props). This proves the pinned
+      # version still satisfies this component, so using a Core API newer than the pin fails here
+      # rather than at release time. Build only - the public API snapshot records the default
+      # configuration's assembly metadata attributes.
+      - name: Build against the pinned package
+        working-directory: src/App/fileanalyzers/
+        run: |
+           dotnet build solutions/Src.slnx -v m -p:UseAppLibsFromSource=false

--- a/.github/workflows/app-frontend-cypress.yml
+++ b/.github/workflows/app-frontend-cypress.yml
@@ -9,6 +9,8 @@ on:
       - 'src/App/backend/**'
       - 'src/App/codelists/**'
       - 'src/App/fileanalyzers/**'
+      - 'src/App/AppCoreDependency.props'
+      - 'src/App/PackageVersioning.props'
       - 'src/Runtime/common/dotnet/**'
       - 'src/Runtime/localtest/**'
       - 'src/Runtime/pdf3/**'
@@ -106,7 +108,7 @@ jobs:
       - name: Resolve app process cache key
         id: app-process-cache-key
         shell: bash
-        run: echo "key=app-process-build-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('src/test/apps/**', 'src/App/backend/**', 'src/App/codelists/**', 'src/App/fileanalyzers/**', 'Directory.Build.props', 'Directory.Packages.props', 'global.json') }}" >> "$GITHUB_OUTPUT"
+        run: echo "key=app-process-build-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('src/test/apps/**', 'src/App/backend/**', 'src/App/codelists/**', 'src/App/fileanalyzers/**', 'src/App/AppCoreDependency.props', 'src/App/PackageVersioning.props', 'Directory.Build.props', 'Directory.Packages.props', 'global.json') }}" >> "$GITHUB_OUTPUT"
 
       - name: Cache app process outputs
         id: cache-app-process-outputs

--- a/.github/workflows/app-frontend-k6-browser.yml
+++ b/.github/workflows/app-frontend-k6-browser.yml
@@ -7,6 +7,8 @@ on:
       - 'src/App/backend/**'
       - 'src/App/codelists/**'
       - 'src/App/fileanalyzers/**'
+      - 'src/App/AppCoreDependency.props'
+      - 'src/App/PackageVersioning.props'
       - 'src/Runtime/common/dotnet/**'
       - 'src/Runtime/localtest/**'
       - 'src/Runtime/pdf3/**'

--- a/.github/workflows/release-codelists.yaml
+++ b/.github/workflows/release-codelists.yaml
@@ -146,20 +146,37 @@ jobs:
           assembly_version="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}.0"
           informational_version="$RELEASE_VERSION+$(git rev-parse --short=12 HEAD)"
 
+          # -p:UseAppLibsFromSource=false swaps the Altinn.App.Core ProjectReference for the
+          # pinned package, so the release compiles against exactly what the nuspec will declare.
+          # See src/App/AppCoreDependency.props.
           dotnet pack solutions/Src.slnx \
             -c Release \
             --output "${GITHUB_WORKSPACE}/build/release" \
+            -p:UseAppLibsFromSource=false \
             "-p:ReleasePackageVersion=${RELEASE_VERSION}" \
             "-p:ReleaseAssemblyVersion=${assembly_version}" \
             "-p:ReleaseInformationalVersion=${informational_version}"
         working-directory: src/App/codelists
 
-      # The Altinn.App.Core dependency version comes from Directory.Packages.props. Guard against
-      # it going missing, and against a source-derived `.dev.N` version — which is what a
-      # ProjectReference to the app backend would produce, and was never published to NuGet.
+      # The pack step above builds against the pinned Altinn.App.Core package, so the version the
+      # nuspec declares is the version the shipped assembly was compiled against. Assert exactly
+      # that. Merely rejecting a `.dev.N` version is not enough: `ReleasePackageVersion` is a global
+      # property, so a pack that forgot `-p:UseAppLibsFromSource=false` re-versions the referenced
+      # Core project too and emits *this component's* release version for Altinn.App.Core — a
+      # published version, and silently the wrong one.
       - name: Verify packed dependencies
         id: verify
         run: |
+          pinned_version="$(grep -oE '<PackageVersion Include="Altinn\.App\.Core" Version="[^"]*"' \
+            src/App/codelists/Directory.Packages.props | sed -E 's/.*Version="([^"]*)"/\1/')"
+
+          if [[ -z "$pinned_version" ]]; then
+            echo "::error::src/App/codelists/Directory.Packages.props does not pin Altinn.App.Core"
+            exit 1
+          fi
+
+          echo "Altinn.App.Core is pinned to $pinned_version"
+
           shopt -s nullglob
           packages=(build/release/*.nupkg)
 
@@ -183,8 +200,8 @@ jobs:
               | head -1 | sed -E 's/.*version="([^"]*)"/\1/')"
             echo "$package depends on Altinn.App.Core $app_core_version"
 
-            if [[ "$app_core_version" == *".dev."* ]]; then
-              echo "::error::$package depends on an unpublished Altinn.App.Core version"
+            if [[ "$app_core_version" != "$pinned_version" ]]; then
+              echo "::error::$package depends on Altinn.App.Core $app_core_version, not the pinned $pinned_version"
               failed=1
             fi
           done

--- a/.github/workflows/release-fileanalyzers.yaml
+++ b/.github/workflows/release-fileanalyzers.yaml
@@ -146,20 +146,37 @@ jobs:
           assembly_version="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}.0"
           informational_version="$RELEASE_VERSION+$(git rev-parse --short=12 HEAD)"
 
+          # -p:UseAppLibsFromSource=false swaps the Altinn.App.Core ProjectReference for the
+          # pinned package, so the release compiles against exactly what the nuspec will declare.
+          # See src/App/AppCoreDependency.props.
           dotnet pack solutions/Src.slnx \
             -c Release \
             --output "${GITHUB_WORKSPACE}/build/release" \
+            -p:UseAppLibsFromSource=false \
             "-p:ReleasePackageVersion=${RELEASE_VERSION}" \
             "-p:ReleaseAssemblyVersion=${assembly_version}" \
             "-p:ReleaseInformationalVersion=${informational_version}"
         working-directory: src/App/fileanalyzers
 
-      # The Altinn.App.Core dependency version comes from Directory.Packages.props. Guard against
-      # it going missing, and against a source-derived `.dev.N` version — which is what a
-      # ProjectReference to the app backend would produce, and was never published to NuGet.
+      # The pack step above builds against the pinned Altinn.App.Core package, so the version the
+      # nuspec declares is the version the shipped assembly was compiled against. Assert exactly
+      # that. Merely rejecting a `.dev.N` version is not enough: `ReleasePackageVersion` is a global
+      # property, so a pack that forgot `-p:UseAppLibsFromSource=false` re-versions the referenced
+      # Core project too and emits *this component's* release version for Altinn.App.Core — a
+      # published version, and silently the wrong one.
       - name: Verify packed dependencies
         id: verify
         run: |
+          pinned_version="$(grep -oE '<PackageVersion Include="Altinn\.App\.Core" Version="[^"]*"' \
+            src/App/fileanalyzers/Directory.Packages.props | sed -E 's/.*Version="([^"]*)"/\1/')"
+
+          if [[ -z "$pinned_version" ]]; then
+            echo "::error::src/App/fileanalyzers/Directory.Packages.props does not pin Altinn.App.Core"
+            exit 1
+          fi
+
+          echo "Altinn.App.Core is pinned to $pinned_version"
+
           shopt -s nullglob
           packages=(build/release/*.nupkg)
 
@@ -183,8 +200,8 @@ jobs:
               | head -1 | sed -E 's/.*version="([^"]*)"/\1/')"
             echo "$package depends on Altinn.App.Core $app_core_version"
 
-            if [[ "$app_core_version" == *".dev."* ]]; then
-              echo "::error::$package depends on an unpublished Altinn.App.Core version"
+            if [[ "$app_core_version" != "$pinned_version" ]]; then
+              echo "::error::$package depends on Altinn.App.Core $app_core_version, not the pinned $pinned_version"
               failed=1
             fi
           done

--- a/src/App/AppCoreDependency.props
+++ b/src/App/AppCoreDependency.props
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Shared Altinn.App.Core wiring for the sibling packages built on it in this repository:
+  Altinn.Codelists and Altinn.FileAnalyzers.
+
+  These packages ship a dependency on a *published* Altinn.App.Core, but they cannot reference it as
+  a package while building inside this repository. The test apps under src/test/apps reference the
+  app backend as projects, so a package reference here puts two Altinn.App.Core assemblies in each
+  app's graph: NuGet drops the project from the restore graph (a ProjectReference restores as
+  version 1.0.0, because PackageVersioning.props sets Version in a target that restore never runs,
+  so the 9.x package node wins the version unification) while MSBuild still passes the project's
+  output to the compiler. Whether that is loud or silent depends on the clone:
+
+    - Assembly versions differ (any clone with tags, so every developer machine): MSB3243 and then
+      CS1704, and the app does not build.
+    - Assembly versions match (a shallow CI clone resolves both to 9.0.0.0): the app builds, and
+      silently binds to the published Core instead of the one in this repository.
+
+  So the reference is a ProjectReference by default, and only a release pack builds against the
+  pinned package. The version the nuspec declares is then, by construction, the version the shipped
+  assembly was compiled against - and it comes from Directory.Packages.props, which is what Renovate
+  bumps.
+
+  Callers that pack for release pass:
+    UseAppLibsFromSource=false
+
+  Today those are the `Pack package` steps in .github/workflows/release-codelists.yaml and
+  release-fileanalyzers.yaml. Each has a `Verify packed dependencies` step that fails unless the
+  packed dependency matches the pin, so forgetting the property cannot ship: without it, pack emits
+  the *component's own* release version for Altinn.App.Core, because ReleasePackageVersion is passed
+  as a global property and so re-versions the referenced Core project too.
+-->
+<Project>
+
+  <PropertyGroup>
+    <UseAppLibsFromSource Condition="'$(UseAppLibsFromSource)' == ''">true</UseAppLibsFromSource>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(UseAppLibsFromSource)' == 'true'">
+    <ProjectReference Include="$(MSBuildThisFileDirectory)backend/src/Altinn.App.Core/Altinn.App.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(UseAppLibsFromSource)' != 'true'">
+    <PackageReference Include="Altinn.App.Core" />
+  </ItemGroup>
+
+</Project>

--- a/src/App/codelists/AGENTS.md
+++ b/src/App/codelists/AGENTS.md
@@ -30,4 +30,9 @@ dotnet test                           # run tests (test projects under test/)
 - Code lists are grouped by source (e.g. SSB). Each source exposes its own registration extension
   methods and supports custom option IDs and source-specific parameters (level filters, etc.).
 - This is a public, versioned NuGet package — treat the public API as a compatibility surface.
+- **The `Altinn.App.Core` reference has two shapes**, wired in `../AppCoreDependency.props`. In-repo
+  builds use a `ProjectReference` to the app backend, so the test apps under `src/test/apps` resolve
+  one Core rather than two; a release pack passes `-p:UseAppLibsFromSource=false` and compiles
+  against the version pinned in `Directory.Packages.props`, which is what the nuspec declares. Use a
+  Core API newer than that pin and the `Build against the pinned Altinn.App.Core` CI job fails.
 - See `README.md` for the current provider catalogue and configuration examples.

--- a/src/App/codelists/src/Altinn.Codelists/Altinn.Codelists.csproj
+++ b/src/App/codelists/src/Altinn.Codelists/Altinn.Codelists.csproj
@@ -16,10 +16,6 @@
     <InternalsVisibleTo Include="$(AssemblyName).Tests" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Altinn.App.Core" />
-  </ItemGroup>
-
   <Target Name="GenerateDependencyAssemblyAttributes" BeforeTargets="GetAssemblyAttributes">
     <ItemGroup>
       <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute" Condition="'%(PackageReference.Identity)' != '' and '%(PackageReference.PrivateAssets)' != 'all'">

--- a/src/App/codelists/src/Directory.Build.props
+++ b/src/App/codelists/src/Directory.Build.props
@@ -2,6 +2,7 @@
 <Project>
   <Import Project="../Directory.Build.props" />
   <Import Project="$(MSBuildThisFileDirectory)../../PackageVersioning.props" />
+  <Import Project="$(MSBuildThisFileDirectory)../../AppCoreDependency.props" />
 
   <ItemGroup>
     <None Include="../../README.md" Link="README.md" Pack="true" PackagePath="/" />

--- a/src/App/codelists/test/Altinn.Codelists.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/src/App/codelists/test/Altinn.Codelists.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -1,5 +1,4 @@
-﻿[assembly: System.Reflection.AssemblyMetadata("PackageReference.Altinn.App.Core", "")]
-[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/Altinn/altinn-studio")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/Altinn/altinn-studio")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v10.0", FrameworkDisplayName=".NET 10.0")]
 namespace Altinn.Codelists.Extensions
 {

--- a/src/App/fileanalyzers/AGENTS.md
+++ b/src/App/fileanalyzers/AGENTS.md
@@ -38,5 +38,10 @@ dotnet test                               # run tests (test projects under test/
 ## Working here
 
 - This is a public, versioned NuGet package — treat the public API as a compatibility surface.
+- **The `Altinn.App.Core` reference has two shapes**, wired in `../AppCoreDependency.props`. In-repo
+  builds use a `ProjectReference` to the app backend, so the test apps under `src/test/apps` resolve
+  one Core rather than two; a release pack passes `-p:UseAppLibsFromSource=false` and compiles
+  against the version pinned in `Directory.Packages.props`, which is what the nuspec declares. Use a
+  Core API newer than that pin and the `Build against the pinned Altinn.App.Core` CI job fails.
 - Each analyzer pairs with a corresponding validator (see the catalogue in `README.md`). New file types
   should follow the analyzer → standardized-result → validator flow.

--- a/src/App/fileanalyzers/src/Altinn.FileAnalyzers/Altinn.FileAnalyzers.csproj
+++ b/src/App/fileanalyzers/src/Altinn.FileAnalyzers/Altinn.FileAnalyzers.csproj
@@ -17,7 +17,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Altinn.App.Core" />
     <PackageReference Include="Mime-Detective" />
   </ItemGroup>
 

--- a/src/App/fileanalyzers/src/Directory.Build.props
+++ b/src/App/fileanalyzers/src/Directory.Build.props
@@ -2,6 +2,7 @@
 <Project>
   <Import Project="../Directory.Build.props" />
   <Import Project="$(MSBuildThisFileDirectory)../../PackageVersioning.props" />
+  <Import Project="$(MSBuildThisFileDirectory)../../AppCoreDependency.props" />
 
   <ItemGroup>
     <None Include="../../README.md" Link="README.md" Pack="true" PackagePath="/" />

--- a/src/App/fileanalyzers/test/Altinn.FileAnalyzers.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/src/App/fileanalyzers/test/Altinn.FileAnalyzers.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -1,5 +1,4 @@
-﻿[assembly: System.Reflection.AssemblyMetadata("PackageReference.Altinn.App.Core", "")]
-[assembly: System.Reflection.AssemblyMetadata("PackageReference.Mime-Detective", "")]
+﻿[assembly: System.Reflection.AssemblyMetadata("PackageReference.Mime-Detective", "")]
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/Altinn/altinn-studio")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v10.0", FrameworkDisplayName=".NET 10.0")]
 namespace Altinn.FileAnalyzers.MimeType


### PR DESCRIPTION
## Description

#20350 moved `Altinn.Codelists` and `Altinn.FileAnalyzers` from a `ProjectReference` on the app backend to a `PackageReference` pinned to `Altinn.App.Core 9.0.0-preview.5`. That breaks every in-repo test app that references both the backend projects and one of these two libraries — `frontend-test`, `payment-test` and `expression-validation-test`:

```
CSC : error CS1704: An assembly with the same simple name 'Altinn.App.Core' has already
been imported. Try removing one of the references (e.g. '~/.nuget/packages/
altinn.app.core/9.0.0-preview.5/lib/net10.0/Altinn.App.Core.dll')

warning MSB3243: No way to resolve conflict between "Altinn.App.Core, Version=9.0.0.51"
and "Altinn.App.Core, Version=9.0.0.0". Choosing … arbitrarily.
```

### Why CI did not catch it

Two things go wrong, and the second is the one that matters.

**Restore drops the local Core regardless of platform.** A `ProjectReference` restores as version **1.0.0** — `PackageVersioning.props` sets `Version` inside the `ResolvePackageVersionFromGit` target, which restore never runs — so NuGet unifies `Altinn.App.Core` project@1.0.0 with the transitive package@9.0.0-preview.5 and the package wins. `project.assets.json` says `Altinn.App.Core/9.0.0-preview.5 package`, and the app's output directory gets the nuget.org assembly. Meanwhile MSBuild still passes the project's own output to the compiler, because `ResolveProjectReferences` does not consult the assets file.

**Whether the duplicate is loud or silent depends on clone depth**, since that decides `AssemblyVersion`:

|                      | full clone, tags present                                       | shallow clone, no tags                                                        |
| -------------------- | -------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| local Core           | `9.0.0.51` — commit height past `app/v9.0.0-preview.5`         | `9.0.0.0` — `git describe` fails, falls back to `PackageDefaultBaseVersion`   |
| package Core         | `9.0.0.0`                                                      | `9.0.0.0`                                                                      |
| outcome              | MSB3243 + **CS1704, build fails**                              | **builds green, app binds to the published Core**                              |

`app-frontend-cypress.yml` checks out with `actions/checkout` and no `fetch-depth`, so its `Prepare app process outputs` job lands in the right-hand column and has been green. Its `dotnet build` of all 13 test apps succeeds, and those three apps have been running against published `9.0.0-preview.5` rather than the backend in this repository — so the Cypress and k6 suites stopped exercising local backend changes for them. Only three `Altinn.App.Core`/`Altinn.App.Api` commits have landed since that tag, which is why nothing has visibly broken yet.

### The fix

`src/App/AppCoreDependency.props`, shared by both components, makes the reference a `ProjectReference` by default and a `PackageReference` only when a release packs:

```xml
<PropertyGroup>
  <UseAppLibsFromSource Condition="'$(UseAppLibsFromSource)' == ''">true</UseAppLibsFromSource>
</PropertyGroup>

<ItemGroup Condition="'$(UseAppLibsFromSource)' == 'true'">
  <ProjectReference Include="$(MSBuildThisFileDirectory)backend/src/Altinn.App.Core/Altinn.App.Core.csproj" />
</ItemGroup>

<ItemGroup Condition="'$(UseAppLibsFromSource)' != 'true'">
  <PackageReference Include="Altinn.App.Core" />
</ItemGroup>
```

The release workflows pass `-p:UseAppLibsFromSource=false`, which is the point of doing it this way rather than pinning the dependency version at pack time: the release compiles against the pinned package, so the version the nuspec declares is by construction the version the shipped assembly was built against. The pin stays in `Directory.Packages.props`, so Renovate keeps bumping it as before.

The `PackageReference.Altinn.App.Core` line leaves both public API snapshots — that assembly metadata attribute is generated from `PackageReference` items, so it follows the reference.

### The release guard did not guard

The `Verify packed dependencies` step rejected an `Altinn.App.Core` dependency containing `.dev.`, on the premise that a `ProjectReference` packs an unpublished source-derived version. That premise is wrong: `ReleasePackageVersion` is passed as a **global** property, so it re-versions the referenced Core project too. Packing with the flag deliberately omitted declares `Altinn.App.Core 9.0.0-preview.2` — the component's *own* release version. Published, plausible, wrong, and the step exits 0.

It now requires the packed dependency to equal the pin in `Directory.Packages.props`, so omitting the flag cannot ship.

### Also included

- **A `Build against the pinned Altinn.App.Core` job** in both component workflows: builds with `-p:UseAppLibsFromSource=false`, so reaching for a Core API newer than the pin fails on the PR rather than at release time. Build only — the public API snapshot records the default configuration's attributes.
- **`src/App/AppCoreDependency.props` and `src/App/PackageVersioning.props` added** to the `paths` triggers of the two app-building workflows and to the Cypress app-process cache key. Without that, a change to how the apps resolve Core neither triggers those workflows nor invalidates the cached build.
- A note in both components' `AGENTS.md`, and a stale `fetch-depth: 0 # MinVer needs…` comment corrected — MinVer was removed in #20350.

I did **not** add `src/App/backend/**` to the two component workflows' triggers. It is not needed: the Cypress app-process job already triggers on `src/App/backend/**` and builds all test apps, which now build both components from source, so a Core change that breaks either one fails there. Adding it would fire six extra jobs on every backend PR for no new signal.

No changelog entry — the shipped packages are unchanged, so there is nothing here for a package consumer to read.

## Verification

- [x] Related issues are connected (if applicable) — none; found while investigating the `frontend-test` build failure
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

**The three broken apps build**, under `CI=true dotnet build --no-incremental`, and resolve Core from source: `project.assets.json` reports `Altinn.App.Core/1.0.0 project` for each, and the assembly in each app's output is the local build, `9.0.0-preview.5.dev.53+7ba4646b0a37`. Zero MSB and zero NU diagnostics. The remaining warnings are pre-existing app source noise (`CS0618`, `CS8632`, `CS8981`, `CS1574`, all in files under `src/test/apps`) that the compiler never reached before, because it stopped at CS1704.

**Both components pass in both configurations.** Default: 0 errors, codelists 41 passed / 3 pre-existing skips, fileanalyzers 5 passed and 0 warnings — matching #20350's baseline, public API snapshot test included, with no auto-accepted snapshot rewrites in `git status`. codelists' 32 `NU190x` audit warnings are unchanged and still attributed only to `Altinn.Codelists.Tests.csproj`. With `-p:UseAppLibsFromSource=false`, both build clean, so the pinned `9.0.0-preview.5` still satisfies both today.

**The packed package is unchanged.** Packing both components at the same base commit, before and after, the nuspecs are identical — `<dependency id="Altinn.App.Core" version="9.0.0-preview.5" exclude="Build,Analyzers" />` included — with the sole difference being the SourceLink `branch` attribute, which is a checkout artefact of comparing a named branch against a detached HEAD. `exclude="Build,Analyzers"` matches what published `Altinn.App.Api 9.0.0-preview.5` declares for the same dependency, and `Altinn.App.Core` ships no `build/` or `analyzers/` assets in any case.

**The strengthened guard was exercised against both outcomes**, extracted verbatim from the workflow and run under CI's shell (`bash -e -o pipefail`):

```
=== correct release ===
Altinn.App.Core is pinned to 9.0.0-preview.5
build/release/Altinn.Codelists.9.0.0-preview.2.nupkg depends on Altinn.App.Core 9.0.0-preview.5
build/release/Altinn.FileAnalyzers.9.0.0-preview.2.nupkg depends on Altinn.App.Core 9.0.0-preview.5
  exit=0

=== flag forgotten ===
Altinn.App.Core is pinned to 9.0.0-preview.5
::error::build/release/Altinn.Codelists.9.0.0-preview.2.nupkg depends on Altinn.App.Core 9.0.0-preview.2, not the pinned 9.0.0-preview.5
  exit=1
```

`yarn docs:validate` passes (37 files) and `yarn spell:quick` is clean. All six changed workflows parse, and both component workflows expose the new job. The five files Prettier reports were already unformatted at the base commit with the repo's own config, in ways unrelated to this change (`*x*` → `_x_` emphasis, `needs: [...]` wrapping); no CI workflow runs Prettier, so I left them rather than adding churn.

Not exercised: the release workflows end to end, since they need a merged changelog promotion PR — the pack, the guard and the nuspec were run locally as above, and the NuGet login and push steps are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build and Release Improvements**
  * Release packages are now built and validated against the explicitly pinned Altinn.App.Core version.
  * Dependency verification now detects mismatched or missing pinned versions before release.
  * Automated checks run when shared dependency or package-version settings change.
  * Test caches are refreshed when these settings change, helping ensure validation uses current outputs.

* **Documentation**
  * Added guidance explaining dependency behaviour for in-repository builds and release packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->