### PR TITLE
fix: inherit Codex approval policy from the environment

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,3 +1,1 @@
-# Repo-local config for Codex CLI.
-# Command approvals are defined in .codex/rules/default.rules to mirror Claude's allow list.
-approval_policy = "on-request"
+# Inherit approval policy from the environment's Codex configuration.


### PR DESCRIPTION
## Description

Remove the repository-level `approval_policy = "on-request"` setting from Codex configuration.

The project setting overrode the approval policy supplied by agent sandbox environments. Leaving the setting unset lets each environment choose its intended policy, while `.codex/rules/default.rules` continues to define command-specific rules.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

Verified that Codex runs in this repository with the environment-provided approval policy and can perform local Git operations without an approval prompt. `git diff --check origin/main...HEAD` passes. `yarn spell:quick` passes with no changed worktree files to check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the local configuration to clarify that approval settings are inherited from the environment.
  * Removed the local approval policy setting and its accompanying rules documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->