### PR TITLE
fix: observability/otel collector netpols

### DIFF
--- a/infra/observability/base/network-policy.yaml
+++ b/infra/observability/base/network-policy.yaml
@@ -12,6 +12,9 @@ spec:
     - from:
         - namespaceSelector: {}
       ports:
+        # Linkerd rewrites meshed ingress to the proxy's inbound port.
+        - protocol: TCP
+          port: 4143
         - protocol: TCP
           port: 4317
         - protocol: TCP
@@ -33,6 +36,9 @@ spec:
             matchLabels:
               altinn.studio/otel-collector: otel-router
       ports:
+        # Linkerd rewrites meshed ingress to the proxy's inbound port.
+        - protocol: TCP
+          port: 4143
         - protocol: TCP
           port: 4317
         - protocol: TCP

--- a/infra/observability/runtime/overlay/patches/network-policy-labels.yaml
+++ b/infra/observability/runtime/overlay/patches/network-policy-labels.yaml
@@ -9,6 +9,9 @@ spec:
             matchLabels:
               altinn.studio/runtime: "true"
       ports:
+        # Linkerd rewrites meshed ingress to the proxy's inbound port.
+        - protocol: TCP
+          port: 4143
         - protocol: TCP
           port: 4317
         - protocol: TCP


### PR DESCRIPTION
## Description

missing ports causing some issues after a cluster update

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved observability traffic handling for Linkerd-meshed ingress connections.
  - Inbound traffic on TCP port 4143 is now permitted for the relevant observability services.
  - Existing access on TCP ports 4317 and 4318 remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->